### PR TITLE
Refactor/Operation name now available in buffers by operation call

### DIFF
--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -1,6 +1,6 @@
 import { HotkeysProvider } from '@blueprintjs/core';
 import { Table2 as BlueprintTable, Cell, Column } from '@blueprintjs/table';
-import { useBuffers, useOperationsList } from '../../hooks/useAPI';
+import { useBuffers } from '../../hooks/useAPI';
 import { BufferType, BufferTypeLabel } from '../../model/BufferType';
 import LoadingSpinner from '../LoadingSpinner';
 import '@blueprintjs/table/lib/css/table.css';
@@ -26,19 +26,18 @@ interface Buffer {
 }
 
 function BufferSummaryTable() {
-    const { data: operations } = useOperationsList();
     const { data: buffersByOperation, isLoading: isLoadingBuffers } = useBuffers(BufferType.L1);
 
     let listOfBuffers: Buffer[] = [];
 
-    if (buffersByOperation && operations) {
+    if (buffersByOperation) {
         listOfBuffers = buffersByOperation
             .map((operation) =>
                 operation.buffers
                     .map((buffer) => ({
                         ...buffer,
                         operationId: operation.id,
-                        operationName: operations.find((op) => op.id === operation.id)?.name,
+                        operationName: operation.name,
                     }))
                     .flat(),
             )

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -56,6 +56,7 @@ const fetchOperations = async (): Promise<OperationDescription[]> => {
 export interface BuffersByOperationData {
     buffers: Buffer[];
     id: number;
+    name: string;
 }
 
 export interface DeviceData {


### PR DESCRIPTION
API now returns the operation name so we no longer need to look up all operations in the buffer summary table.