### PR TITLE
Fix/reveal xaxis zero tick

### DIFF
--- a/src/components/operation-details/MemoryPlotRenderer.tsx
+++ b/src/components/operation-details/MemoryPlotRenderer.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react';
 import Plot from 'react-plotly.js';
 import { Config, Layout, PlotData } from 'plotly.js';
 import { useAtomValue } from 'jotai';
-import classNames from 'classnames';
 import { PlotConfiguration, PlotMouseEventCustom } from '../../definitions/PlotConfigurations';
 import { selectedAddressAtom, showHexAtom } from '../../store/app';
 import { getDimmedColour, getLightlyDimmedColour } from '../../functions/colour';
@@ -49,7 +48,6 @@ const MemoryPlotRenderer: React.FC<MemoryPlotRendererProps> = ({
             fixedrange: true,
             zeroline: false,
             color: 'white',
-            automargin: true,
             gridcolor: configuration.gridColour || '#999',
             side: configuration.xAxis?.side || 'bottom',
             ...tickFormat,
@@ -130,7 +128,7 @@ const MemoryPlotRenderer: React.FC<MemoryPlotRendererProps> = ({
             {title ? <h3 className='plot-title'>{title}</h3> : null}
 
             <Plot
-                className={classNames('memory-plot', { 'show-hex': showHex })}
+                className='memory-plot'
                 data={augmentedChart}
                 layout={layout}
                 config={config}

--- a/src/scss/components/OperationDetailsComponent.scss
+++ b/src/scss/components/OperationDetailsComponent.scss
@@ -11,13 +11,12 @@
         margin-right: 10px;
 
         &.js-plotly-plot {
-            .plotly .main-svg {
-                left: -8px;
-            }
-
-            &.show-hex {
-                .plotly .main-svg {
-                    left: -16px;
+            .xaxislayer-above {
+                // Fixes the issue where the first x-axis tick is not visible (thanks Plotly)
+                .xtick:first-child text {
+                    /* stylelint-disable-next-line declaration-no-important */
+                    opacity: 1 !important; // Need this to overwrite inline style
+                    text-anchor: start;
                 }
             }
         }


### PR DESCRIPTION
Adds some CSS to reposition the first tick label and override some unhelpful plotly styles.

<img width="320" alt="Screenshot 2024-11-07 at 11 31 12 AM" src="https://github.com/user-attachments/assets/980acec4-d1f8-4947-8880-7aeeb1d00f19">

