### PR TITLE
Fix/Not so empty plots

### DIFF
--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -416,7 +416,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                         'empty-plot':
                                             chartData.length === 0 &&
                                             cbChartDataByOperation.size === 0 &&
-                                            l1Small.memory.length > 0,
+                                            l1Small.memory.length === 0,
                                     })}
                                     isZoomedIn={zoomedInViewMainMemory}
                                     plotZoomRange={[


### PR DESCRIPTION
Plots with no L1s but other data like CBs were being styled as "empty".

Fixed state
<img width="1210" alt="Screenshot 2024-11-11 at 10 02 48 AM" src="https://github.com/user-attachments/assets/6c905160-84eb-41b6-b4a8-966189b269cb">
