### PR TITLE
Decouple Profile Files from Reports

### DIFF
--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -47,7 +47,7 @@ def extract_report_name(files):
 def save_uploaded_files(
     files,
     target_directory,
-    report_name,
+    report_name=None,
 ):
     """
     Save uploaded files to the target directory.

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -67,17 +67,10 @@ def get_profiler_path(
         # Default to local directory if no remote connection is present
         base_dir = local_dir
 
-    # Ensure report_name is provided or defaults to active_report's report_name
-    if report_name:
-        if not remote_connection:
-            profile_dir = base_dir / report_name / "profiler"
-        else:
-            profile_dir = base_dir / "profiler"
-
+    if not remote_connection:
+        profile_dir = base_dir / "profiles"
     else:
-        raise ValueError(
-            "A report_name must be provided to determine the profiler path."
-        )
+        profile_dir = base_dir / "profiler"
 
     # Construct the profiler path
     profiler_path = profile_dir / profile_name

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -445,7 +445,6 @@ def create_report_files():
 def create_profile_files():
     files = request.files.getlist("files")
     report_directory = Path(current_app.config["LOCAL_DATA_DIRECTORY"])
-    report_name = request.values.get("reportName", None)
     tab_id = request.args.get("tabId")
 
     if not validate_files(
@@ -458,12 +457,10 @@ def create_profile_files():
             message="Invalid project directory.",
         ).model_dump()
 
-    logger.info(
-        f"Writing profile files to {report_directory / report_name / 'profiler'}"
-    )
+    logger.info(f"Writing profile files to {report_directory} / 'profiles'")
 
     # Construct the base directory with report_name first
-    target_directory = report_directory / report_name / "profiler"
+    target_directory = report_directory / "profiles"
     target_directory.mkdir(parents=True, exist_ok=True)
 
     if files:
@@ -483,7 +480,6 @@ def create_profile_files():
     save_uploaded_files(
         updated_files,
         str(report_directory),
-        report_name,
     )
 
     update_tab_session(


### PR DESCRIPTION
Changes profiles to be stored in profiles directory, independent of reports. Path logic no longer uses report name to resolve path to the profiler directory.