### PR TITLE
Add PyYAML to pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "python-dotenv==1.0.1",
     "sqlalchemy==2.0.34",
     "flask-socketio==5.4.1",
-    "flask-sqlalchemy==3.1.1"
+    "flask-sqlalchemy==3.1.1",
+    "PyYAML==6.0.2"
 ]
 
 classifiers = [


### PR DESCRIPTION
Add `PyYAML==6.0.2` to the dependencies used when installing the wheel. This dependency was already listed in the `requirements.txt` file used during local dev, but is not being used when installing the wheel.

[Closes #325]