### PR TITLE
Fix/Many consumer tensors not calculated correctly

### DIFF
--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -168,7 +168,7 @@ const TensorList = () => {
                             intent={Intent.DANGER}
                             outlined={showHighConsumerTensors}
                         >
-                            {fetchedTensors?.filter((tensor) => tensor.consumers.length > MAX_NUM_CONSUMERS).length}
+                            {filteredTensorList?.filter((tensor) => tensor.consumers.length > MAX_NUM_CONSUMERS).length}
                         </Button>
                     </Tooltip>
 


### PR DESCRIPTION
When filtering the tensor list, the flagged tensors with too many consumers was not using the filtered list of tensors and so could be inaccurate.