### PR TITLE
Add device addresses to tensor model

### DIFF
--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -114,10 +114,10 @@ class Tensor(SerializeableDataclass):
     device_id: int
     address: int
     buffer_type: BufferType
+    device_addresses: list[int]
 
     def __post_init__(self):
         self.memory_config = parse_memory_config(self.memory_config)
-
 
 @dataclasses.dataclass
 class InputTensor(SerializeableDataclass):

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -48,6 +48,7 @@ class TestSerializers(unittest.TestCase):
                 1,
                 1000,
                 BufferType.DRAM,
+                [25],
             ),
             Tensor(
                 2,
@@ -58,6 +59,7 @@ class TestSerializers(unittest.TestCase):
                 2,
                 2000,
                 BufferType.L1,
+                [50],
             ),
         ]
         devices = [
@@ -103,6 +105,7 @@ class TestSerializers(unittest.TestCase):
                         "device_id": 1,
                         "address": 1000,
                         "buffer_type": 0,
+                        "device_addresses": [25],
                     }
                 ],
                 "outputs": [
@@ -119,6 +122,7 @@ class TestSerializers(unittest.TestCase):
                         "device_id": 1,
                         "address": 1000,
                         "buffer_type": 0,
+                        "device_addresses": [50],
                     }
                 ],
             }
@@ -140,6 +144,7 @@ class TestSerializers(unittest.TestCase):
                 1,
                 1000,
                 BufferType.DRAM,
+                [25],
             )
         }
 
@@ -162,6 +167,7 @@ class TestSerializers(unittest.TestCase):
                     "device_id": 1,
                     "address": 1000,
                     "buffer_type": 0,
+                    "device_addresses": [25],
                 }
             ]
         }
@@ -205,6 +211,7 @@ class TestSerializers(unittest.TestCase):
                 1,
                 1000,
                 BufferType.DRAM,
+                [200, 300]
             )
         ]
         devices = [
@@ -256,6 +263,7 @@ class TestSerializers(unittest.TestCase):
                     "operation_id": 1,
                     "producers": [2],
                     "shape": "shape1",
+                    "device_addresses": [200, 300]
                 }
             ],
             "l1_sizes": [256],
@@ -275,6 +283,7 @@ class TestSerializers(unittest.TestCase):
                     "output_index": 0,
                     "producers": [2],
                     "shape": "shape1",
+                    "device_addresses": [200, 300],
                 }
             ],
             "stack_trace": "trace1",
@@ -354,6 +363,7 @@ class TestSerializers(unittest.TestCase):
                 1,
                 1000,
                 BufferType.DRAM,
+                [500, 1500],
             ),
             Tensor(
                 2,
@@ -364,6 +374,7 @@ class TestSerializers(unittest.TestCase):
                 2,
                 2000,
                 BufferType.L1,
+                [2000, 2500],
             ),
         ]
         producers_consumers = [
@@ -385,6 +396,7 @@ class TestSerializers(unittest.TestCase):
                 "buffer_type": 0,
                 "consumers": [3],
                 "producers": [2],
+                "device_addresses": [500, 1500],
             },
             {
                 "id": 2,
@@ -397,6 +409,7 @@ class TestSerializers(unittest.TestCase):
                 "buffer_type": 1,
                 "consumers": [],
                 "producers": [],
+                "device_addresses": [2000, 2500],
             },
         ]
 


### PR DESCRIPTION
This PR modifies the Flask API to read values in from the `device_tensors` table that was added in TT-Metal, and return them with the tensor objects in the JSON responses.

For more context, see:

https://github.com/tenstorrent/tt-metal/pull/17293

They will appear in a property called `device_addresses`. The list index corresponds to the device id, and the value is the buffer address on that device.

In the ordinary case, the device ids will be sequential, but there is handling in this PR to add null values to the list in any edge case where the device ids did not run sequentially from 0 in the database.

To ensure backwards compatibility with reports generated by TT-Metal prior to merging of the above PR, there is exception handling to catch when the `device_tensors` table does not exist. In that case the `device_addresses` list will still come back with the tensor objects, but it will be empty.