### PR TITLE
Performance Report API

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Union, Optional
 import pandas as pd
 from tt_perf_report import perf_report
 
+from ttnn_visualizer.exceptions import DataFormatError
 from ttnn_visualizer.models import TabSession
 from ttnn_visualizer.ssh_client import get_client
 
@@ -590,14 +591,17 @@ class OpsPerformanceReportQueries:
 
         report = []
 
-        with open(csv_output_file, newline="") as csvfile:
-            reader = csv.reader(csvfile, delimiter=",")
-            next(reader, None)
-            for row in reader:
-                report.append({
-                    column: row[index] for index, column in enumerate(cls.REPORT_COLUMNS)
-                })
-
-        os.unlink(csv_output_file)
+        try:
+            with open(csv_output_file, newline="") as csvfile:
+                reader = csv.reader(csvfile, delimiter=",")
+                next(reader, None)
+                for row in reader:
+                    report.append({
+                        column: row[index] for index, column in enumerate(cls.REPORT_COLUMNS)
+                    })
+        except csv.Error as e:
+            raise DataFormatError() from e
+        finally:
+            os.unlink(csv_output_file)
 
         return report

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -562,7 +562,7 @@ class OpsPerformanceReportQueries:
         "input_0_datatype",
         "input_1_datatype",
         "dram_sharded",
-        "input_0_Memory",
+        "input_0_memory",
         "inner_dim_block_size",
         "output_subblock_h",
         "output_subblock_w"

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-
+import csv
 import os
+import tempfile
+from io import StringIO
 from pathlib import Path
 from typing import List, Dict, Union, Optional
 
 import pandas as pd
+from tt_perf_report import perf_report
 
 from ttnn_visualizer.models import TabSession
 from ttnn_visualizer.ssh_client import get_client
@@ -449,6 +452,28 @@ class OpsPerformanceQueries:
         "CompileProgram_TT_HOST_FUNC [ns]",
         "HWCommandQueue_write_buffer_TT_HOST_FUNC [ns]",
     ]
+    REPORT_COLUMNS = [
+        "id",
+        "total_percent",
+        "bound",
+        "op_code",
+        "device_time",
+        "op_to_op_gap",
+        "cores",
+        "dram",
+        "dram_percent",
+        "flops",
+        "flops_percent",
+        "math_fidelity",
+        "output_datatype",
+        "input_0_datatype",
+        "input_1_datatype",
+        "dram_sharded",
+        "input_0_Memory",
+        "inner_dim_block_size",
+        "output_subblock_h",
+        "output_subblock_w"
+    ]
 
     def __init__(self, session: TabSession):
         """
@@ -511,6 +536,33 @@ class OpsPerformanceQueries:
         else:
             path = OpsPerformanceQueries.get_remote_ops_perf_file_path(session)
             return read_remote_file(session.remote_connection, path)
+
+    @classmethod
+    def generate_report(cls, session):
+        raw_csv = OpsPerformanceQueries.get_raw_csv(session)
+        csv_file = StringIO(raw_csv)
+        signpost = None
+        ignore_signposts = None
+        min_percentage = 0.5
+        id_range = None
+        csv_output_file = tempfile.mktemp(suffix=".csv")
+        no_advice = False
+        perf_report.generate_perf_report(
+            csv_file, signpost, ignore_signposts, min_percentage, id_range, csv_output_file, no_advice)
+
+        report = []
+
+        with open(csv_output_file, newline="") as csvfile:
+            reader = csv.reader(csvfile, delimiter=",")
+            next(reader, None)
+            for row in reader:
+                report.append({
+                    column: row[index] for index, column in enumerate(cls.REPORT_COLUMNS)
+                })
+
+        os.unlink(csv_output_file)
+
+        return report
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """

--- a/backend/ttnn_visualizer/exceptions.py
+++ b/backend/ttnn_visualizer/exceptions.py
@@ -34,3 +34,7 @@ class RemoteSqliteException(Exception):
 
 class DatabaseFileNotFoundException(Exception):
     pass
+
+
+class DataFormatError(Exception):
+    pass

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -1,4 +1,3 @@
-
 gunicorn~=22.0.0
 uvicorn==0.30.1
 paramiko~=3.4.0
@@ -17,6 +16,7 @@ wheel
 build
 PyYAML==6.0.2
 python-dotenv==1.0.1
+tt-perf-report==1.0.0
 
 # Dev dependencies
 mypy

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -14,7 +14,7 @@ import yaml
 from flask import Blueprint, Response, jsonify
 from flask import request, current_app
 
-from ttnn_visualizer.csv_queries import DeviceLogProfilerQueries, OpsPerformanceQueries
+from ttnn_visualizer.csv_queries import DeviceLogProfilerQueries, OpsPerformanceQueries, OpsPerformanceReportQueries
 from ttnn_visualizer.decorators import with_session
 from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import RemoteConnectionException
@@ -392,7 +392,7 @@ def get_profiler_perf_results_data_raw(session: TabSession):
 def get_profiler_perf_results_report(session: TabSession):
     if not session.profiler_path:
         return Response(status=HTTPStatus.NOT_FOUND)
-    report = OpsPerformanceQueries.generate_report(session)
+    report = OpsPerformanceReportQueries.generate_report(session)
     return jsonify(report), 200
 
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -16,6 +16,7 @@ from flask import request, current_app
 
 from ttnn_visualizer.csv_queries import DeviceLogProfilerQueries, OpsPerformanceQueries, OpsPerformanceReportQueries
 from ttnn_visualizer.decorators import with_session
+from ttnn_visualizer.exceptions import DataFormatError
 from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import RemoteConnectionException
 from ttnn_visualizer.file_uploads import (
@@ -392,7 +393,12 @@ def get_profiler_perf_results_data_raw(session: TabSession):
 def get_profiler_perf_results_report(session: TabSession):
     if not session.profiler_path:
         return Response(status=HTTPStatus.NOT_FOUND)
-    report = OpsPerformanceReportQueries.generate_report(session)
+
+    try:
+        report = OpsPerformanceReportQueries.generate_report(session)
+    except DataFormatError:
+        return Response(status=HTTPStatus.UNPROCESSABLE_ENTITY)
+
     return jsonify(report), 200
 
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -387,6 +387,15 @@ def get_profiler_perf_results_data_raw(session: TabSession):
     )
 
 
+@api.route("/profiler/perf-results/report", methods=["GET"])
+@with_session
+def get_profiler_perf_results_report(session: TabSession):
+    if not session.profiler_path:
+        return Response(status=HTTPStatus.NOT_FOUND)
+    report = OpsPerformanceQueries.generate_report(session)
+    return jsonify(report), 200
+
+
 @api.route("/profiler/device-log/raw", methods=["GET"])
 @with_session
 def get_profiler_data_raw(session: TabSession):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "flask-socketio==5.4.1",
     "flask-sqlalchemy==3.1.1",
     "PyYAML==6.0.2",
-    "python-dotenv==1.0.1"
+    "python-dotenv==1.0.1",
+    "tt-perf-report==1.0.0"
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR adds a new API endpoint `/api/profiler/perf-results/report`, which takes the `ops_perf_results_*.csv` file, and returns a report generated with tt-perf-report.

It uses the same input CSV file that is used by the `/profiler/perf-results/raw` endpoint, and it makes use of the existing code to download that file. But instead of returning the original CSV file, it runs it through tt-perf-report, and takes the output CSV file, and turns it into a JSON response, where each line of the CSV is represented as an object.

You can get the report from cURL like this:

`curl 'http://localhost:5173/api/profiler/perf-results/report?tabId=r5lr5xs95ai'`

Where the `tabId` would be the same `tabId` already used by the frontend for other features. There is nowhere in this PR that takes a new csv parameter, since the source file is already there and can already be uploaded from the UI. Except now it processes it with the `tt-perf-report` package from PyPI, instead of returning the raw data from the `ops_perf_results_*.csv` file.

The following is truncated output from the new endpoint to show the format of its response:

```
curl -s 'http://localhost:5173/api/profiler/perf-results/report?tabId=r5lr5xs95ai' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Referer: http://localhost:5173/performance' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' | python -m json.tool
[
    {
        "bound": "",
        "cores": "1",
        "device_time": "4.534",
        "dram": "None",
        "dram_percent": "None",
        "dram_sharded": "BFLOAT16",
        "flops": "None",
        "flops_percent": "None",
        "id": "2",
        "inner_dim_block_size": "DEV_0_DRAM_INTERLEAVED",
        "input_0_datatype": "BFLOAT16",
        "input_0_memory": "False",
        "input_1_datatype": "UINT32",
        "math_fidelity": "UINT32",
        "op_code": "Embeddings",
        "op_to_op_gap": "None",
        "output_datatype": " BF16 => BF16",
        "output_subblock_h": "None",
        "output_subblock_w": "None",
        "total_percent": "8.537923423325384e-06"
    },
    {
        "bound": "",
        "cores": "1",
        "device_time": "4.641",
        "dram": "None",
        "dram_percent": "None",
        "dram_sharded": "BFLOAT16",
        "flops": "None",
        "flops_percent": "None",
        "id": "4",
        "inner_dim_block_size": "DEV_0_DRAM_INTERLEAVED",
        "input_0_datatype": "BFLOAT16",
        "input_0_memory": "False",
        "input_1_datatype": "UINT32",
        "math_fidelity": "UINT32",
        "op_code": "Embeddings",
        "op_to_op_gap": "18755.338",
        "output_datatype": " BF16 => BF16",
        "output_subblock_h": "None",
        "output_subblock_w": "None",
        "total_percent": "0.035326701395057857"
    },
    {
        "bound": "",
        "cores": "64",
        "device_time": "9.557",
        "dram": "None",
        "dram_percent": "None",
        "dram_sharded": "False",
        "flops": "None",
        "flops_percent": "None",
        "id": "7",
        "inner_dim_block_size": "None",
        "input_0_datatype": "BFLOAT16",
        "input_0_memory": "DEV_1_DRAM_INTERLEAVED",
        "input_1_datatype": "nan",
        "math_fidelity": "BF16 => BF16",
        "op_code": "Transpose",
        "op_to_op_gap": "708678.341",
        "output_datatype": "BFLOAT16",
        "output_subblock_h": "None",
        "output_subblock_w": "None",
        "total_percent": "1.3345220564978897"
    },
...
```