### PR TITLE
Add advice list to perf report response

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -565,7 +565,8 @@ class OpsPerformanceReportQueries:
         "input_0_memory",
         "inner_dim_block_size",
         "output_subblock_h",
-        "output_subblock_w"
+        "output_subblock_w",
+        "advice",
     ]
 
     DEFAULT_SIGNPOST = None
@@ -573,6 +574,7 @@ class OpsPerformanceReportQueries:
     DEFAULT_MIN_PERCENTAGE = 0.5
     DEFAULT_ID_RANGE = None
     DEFAULT_NO_ADVICE = False
+    DEFAULT_TRACING_MODE = False
 
     @classmethod
     def generate_report(cls, session):
@@ -587,6 +589,7 @@ class OpsPerformanceReportQueries:
             cls.DEFAULT_ID_RANGE,
             csv_output_file,
             cls.DEFAULT_NO_ADVICE,
+            cls.DEFAULT_TRACING_MODE,
         )
 
         report = []
@@ -596,9 +599,14 @@ class OpsPerformanceReportQueries:
                 reader = csv.reader(csvfile, delimiter=",")
                 next(reader, None)
                 for row in reader:
-                    report.append({
-                        column: row[index] for index, column in enumerate(cls.REPORT_COLUMNS)
-                    })
+                    processed_row = {
+                        column: row[index] for index, column in enumerate(cls.REPORT_COLUMNS) if index < len(row)
+                    }
+                    if "advice" in processed_row and processed_row["advice"]:
+                        processed_row["advice"] = processed_row["advice"].split(" • ")
+                    else:
+                        processed_row["advice"] = []
+                    report.append(processed_row)
         except csv.Error as e:
             raise DataFormatError() from e
         finally:

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -16,7 +16,7 @@ wheel
 build
 PyYAML==6.0.2
 python-dotenv==1.0.1
-tt-perf-report==1.0.0
+tt-perf-report==1.0.3
 
 # Dev dependencies
 mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "flask-sqlalchemy==3.1.1",
     "PyYAML==6.0.2",
     "python-dotenv==1.0.1",
-    "tt-perf-report==1.0.0"
+    "tt-perf-report==1.0.3"
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR modifies the response from the `/api/profiler/perf-results/report` API to include a new `advice` property, which is a list of string messages. The field will be populated with advice messages for matmul operations, and it will be an empty list for any other operation.

Support for this feature was added in tt-perf-report already, merged and published to PyPI as version 1.0.3:

https://github.com/tenstorrent/tt-perf-report/pull/4

The tt-perf-report script was modified to include an advice column in the CSV, separated by bullet points. The change here parses the CSV column back into a list, and the visualizer frontend will only see the JSON list in the response like this:

```
    {
        "advice": [
            "No output subblock size found",
            "If your matmuls are not FLOP-bound use HiFi4 with BF16 activations for full accuracy"
        ],
        "bound": "SLOW",
        "cores": "12",
        "device_time": "17.372",
        "dram": "120.72023946580703",
        "dram_percent": "41.91674981451633",
        "dram_sharded": "True",
        "flops": "7.72609532581165",
        "flops_percent": "31.3220080776148",
        "id": "39",
        "inner_dim_block_size": "2",
        "input_0_datatype": "BFLOAT16",
        "input_0_memory": "DEV_1_L1_WIDTH_SHARDED",
        "input_1_datatype": "BFLOAT8_B",
        "math_fidelity": "HiFi2 BF16 x BFP8 => BF16",
        "op_code": "Matmul 32 x 1024 x 2048",
        "op_to_op_gap": "880699.565",
        "output_datatype": "BFLOAT16",
        "output_subblock_h": "",
        "output_subblock_w": "",
        "total_percent": "1.6586169241751751"
    },
```