### PR TITLE
Add raw op code to perf results report

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -567,6 +567,7 @@ class OpsPerformanceReportQueries:
         "output_subblock_h",
         "output_subblock_w",
         "advice",
+        "raw_op_code"
     ]
 
     DEFAULT_SIGNPOST = None
@@ -590,6 +591,7 @@ class OpsPerformanceReportQueries:
             csv_output_file,
             cls.DEFAULT_NO_ADVICE,
             cls.DEFAULT_TRACING_MODE,
+            True,
         )
 
         report = []

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -16,7 +16,7 @@ wheel
 build
 PyYAML==6.0.2
 python-dotenv==1.0.1
-tt-perf-report==1.0.3
+tt-perf-report==1.0.4
 
 # Dev dependencies
 mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "flask-sqlalchemy==3.1.1",
     "PyYAML==6.0.2",
     "python-dotenv==1.0.1",
-    "tt-perf-report==1.0.3"
+    "tt-perf-report==1.0.4"
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR adds a new field in the response from the `/api/profiler/perf-results/report` API, called `raw_op_code`. This field has the original op code value, without any extra manipulation by tt-perf-report.

The corresponding change to `tt-perf-report` was made here:
https://github.com/tenstorrent/tt-perf-report/pull/6

In the case of Matmul op codes, for example, tt-perf-report returns the Matmul op code with the size, like `Matmul 32 x 1024 x 2048`. The `raw_op_code` field being added here will allow the visualizer to show the original op code without the size, in this case.