### PR TITLE
Filter out host ops

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -592,6 +592,7 @@ class OpsPerformanceReportQueries:
             cls.DEFAULT_NO_ADVICE,
             cls.DEFAULT_TRACING_MODE,
             True,
+            True,
         )
 
         report = []

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -16,7 +16,7 @@ wheel
 build
 PyYAML==6.0.2
 python-dotenv==1.0.1
-tt-perf-report==1.0.4
+tt-perf-report==1.0.6
 
 # Dev dependencies
 mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "flask-sqlalchemy==3.1.1",
     "PyYAML==6.0.2",
     "python-dotenv==1.0.1",
-    "tt-perf-report==1.0.4"
+    "tt-perf-report==1.0.6"
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR modifies the `/api/profiler/perf-results/report` API so that it does not return host ops. A corresponding [PR](https://github.com/tenstorrent/tt-perf-report/pull/8) was made in tt-perf-report to add the `--no-host-ops` flag and was published to PyPI in version 1.0.6.

