### PR TITLE
Publish releases to PyPI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -82,3 +82,22 @@ jobs:
               asset_path: ${{ env.wheel_name }}
               asset_name: ${{env.wheel_file_name}}
               asset_content_type: application/octet-stream
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ttnn-visualizer
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-wheel
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./src/assets/tt-logo-dark.svg">
-  <img alt="" src="./src/assets/tt-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tenstorrent/ttnn-visualizer/refs/heads/main/src/assets/tt-logo-dark.svg">
+  <img alt="" src="https://raw.githubusercontent.com/tenstorrent/ttnn-visualizer/refs/heads/main/src/assets/tt-logo.svg">
 </picture>
 
 A tool for visualizing the Tenstorrent Neural Network model (TT-NN)
@@ -75,11 +75,11 @@ https://github.com/user-attachments/assets/d00a2629-0bd1-4ee1-bb12-bd796d85221d
 
 ## Getting started
 
-How to [get started](./docs/getting-started.md) with TT-NN Visualizer.
+How to [get started](https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md) with TT-NN Visualizer.
 
 ## Remote Querying
 
-Use [remote querying](./docs/remote-querying.md) instead of syncing the report data to your local file system.
+Use [remote querying](https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/remote-querying.md) instead of syncing the report data to your local file system.
 
 ## Sample reports
 
@@ -104,4 +104,4 @@ Unzip the files into their own directories and select them with the local folder
 
 ## Contributing
 
-How to run [TT-NN Visualizer](./docs/contributing.md) from source.
+How to run [TT-NN Visualizer](https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/contributing.md) from source.

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -1,3 +1,4 @@
+Flask==3.1.0
 gunicorn~=22.0.0
 uvicorn==0.30.1
 paramiko~=3.4.0
@@ -11,7 +12,7 @@ flask-sqlalchemy
 flask-socketio
 gevent==24.10.2
 flask-session
-pandas
+pandas==2.2.3
 wheel
 build
 PyYAML==6.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,20 +6,20 @@ description = "TT Visualizer"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "flask",
-    "pandas",
+    "Flask==3.1.0",
+    "Flask-Cors==4.0.1",
+    "Flask-Static-Digest==0.4.1",
+    "Flask-SocketIO==5.4.1",
+    "Flask-SQLAlchemy==3.1.1",
+    "pandas==2.2.3",
     "gunicorn~=22.0.0",
     "paramiko~=3.4.0",
-    "flask_cors==4.0.1",
     "pydantic==2.7.3",
     "pydantic_core==2.18.4",
-    "flask_static_digest==0.4.1",
     "setuptools==65.5.0",
     "gevent===24.10.2",
     "python-dotenv==1.0.1",
     "sqlalchemy==2.0.34",
-    "flask-socketio==5.4.1",
-    "flask-sqlalchemy==3.1.1",
     "PyYAML==6.0.2",
     "python-dotenv==1.0.1",
     "tt-perf-report==1.0.4"


### PR DESCRIPTION
This PR modifies the build-wheels workflow to publish to PyPI when releases are made.

It preserves the existing functionality of uploading the wheel to the GitHub release, but it will now be published on PyPI also.

The publishing to PyPI will happen when GitHub releases are made, after the wheel is uploaded to GitHub.
