### PR TITLE
Update README to include installation from pypi instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A tool for visualizing the Tenstorrent Neural Network model (TT-NN)
 
 ## Quick Start
 
-TTNN-Visualizer can be installed from PyPI:
+TT-NN Visualizer can be installed from PyPI:
 
 `pip install ttnn-visualizer`
 
@@ -32,7 +32,7 @@ After installation run `ttnn-visualizer` to start the application.
 It is recommended to do this within a virtual environment. The minimum Python version is 3.12.
 
 Please see the [getting started](https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md) guide
-for further information on getting up and running with TTNN-Visualizer.
+for further information on getting up and running with TT-NN Visualizer.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ A tool for visualizing the Tenstorrent Neural Network model (TT-NN)
 
 </div>
 
+## Quick Start
+
+TTNN-Visualizer can be installed from PyPI:
+
+`pip install ttnn-visualizer`
+
+After installation run `ttnn-visualizer` to start the application.
+
+It is recommended to do this within a virtual environment. The minimum Python version is 3.12.
+
+Please see the [getting started](https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md) guide
+for further information on getting up and running with TTNN-Visualizer.
+
 ## Features
 
 For the latest updates and features, please see [releases](https://github.com/tenstorrent/ttnn-visualizer/releases).
@@ -72,10 +85,6 @@ https://github.com/user-attachments/assets/d00a2629-0bd1-4ee1-bb12-bd796d85221d
 | NPE |  |
 |-----------------------------------------------|------------------------------------------|
 | <img width="400" alt="NPE" src="https://github.com/user-attachments/assets/1f4441c6-9d9e-4834-9e71-edec1955243c" /> | <img width="400" alt="NPE" src="https://github.com/user-attachments/assets/7159992e-7691-41cf-a152-8bc6a3606ade" /> |
-
-## Getting started
-
-How to [get started](https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md) with TT-NN Visualizer.
 
 ## Remote Querying
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,42 @@ Network-on-chip performance estimator data can be loaded separately on the `/npe
 
 To generate this data for your model, refer to the [tt-npe documentation](https://github.com/tenstorrent/tt-npe).
 
+## Installing from PyPI
+
+TTNN-Visualizer can be installed from PyPI:
+
+`pip install ttnn-visualizer`
+
+After installation run `ttnn-visualizer` to start the application.
+
+It is recommended to do this within a virtual environment. The minimum Python version is 3.12. Pyenv can be used
+to ensure the application runs with a supported version of Python:
+
+```bash
+mkdir ttnn-visualizer
+cd ttnn-visualizer
+pyenv local 3.12 # Optional step if using pyenv to manage versions
+python -m venv .env
+source .env/bin/activate
+pip install ttnn-visualizer
+ttnn-visualizer 
+```
+
+For pyenv installation instructions, see: 
+
+https://github.com/pyenv/pyenv
+
+If you have `pipx` installed on your system, it can be used to simplify the above steps:
+
+```bash
+pipx install ttnn-visualizer
+ttnn-visualizer
+```
+
+For help with setting up `pipx`, see:
+
+https://pipx.pypa.io/stable/installation/
+
 ## Installing as a Python Wheel
 
 The application is designed to run on user local system and has python requirement of `3.12.3`.


### PR DESCRIPTION
This PR updates the README to have instructions on installing from PyPI.

I removed the previous "Getting Started" section, and replaced it with "Quick Start" at the top, with a link to the getting started page.

I've put more detailed instructions in a new section of the getting started guide. I've left the original instructions on downloading the wheel file from GitHub releases intact, although it may be redundant to have both.
