### PR TITLE
Update getting started guide to show --include-deps arg with pipx

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,7 +79,7 @@ https://github.com/pyenv/pyenv
 If you have `pipx` installed on your system, it can be used to simplify the above steps:
 
 ```bash
-pipx install ttnn-visualizer
+pipx install --include-deps ttnn-visualizer
 ttnn-visualizer
 ```
 


### PR DESCRIPTION
This PR modifies the getting started guide to include the `--include-deps` argument when running `pipx`.

Without this argument, `pipx install ttnn-visualizer` succeeds, but when running `ttnn-visualizer` afterwards, there may be an error about gunicorn not being found:

```
pyenv: gunicorn: command not found
```

This is because by default, `pipx install` does not install the binaries of dependencies. `backend/ttnn_visualizer/app.py` launches the `gunicorn` command as a subprocess, and it needs to be installed and in the path for that to work.

There should be a way around having to include the `--include-deps` arg, but for now this is a temporary work around until we can ensure gunicorn can be run successfully without it.
