### PR TITLE
Update getting started guide with tip to uninstall global package

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,6 +87,15 @@ For help with setting up `pipx`, see:
 
 https://pipx.pypa.io/stable/installation/
 
+When installing `ttnn-visualizer` in a virtual environment, ensure that it is not installed with the system Python
+also. Having the package installed at the system level and in a virtual environment at the same time can lead to an
+issue where files are imported from the system package when running in the virtual environment, causing version
+mismatches.
+
+If you run into any issue with an unexpected TTNN Visualizer version appearing in the browser, different from the
+package version installed in your virtual env, ensure you have uninstalled the system package by running
+`pip uninstall ttnn-visualizer` outside of the virtual env.
+
 ## Installing as a Python Wheel
 
 The application is designed to run on the user's local system, with a minimum supported Python version of `3.10`.


### PR DESCRIPTION
This PR updates the getting started guide to add advice to try uninstalling the ttnn-package from the system Python when experiencing apparent version mismatches.

This problem has affected multiple people and it is not obvious what the problem is.

When the `ttnn-visualizer` command is run in the virtual environment, it can currently start flask from the system/globally installed package. Even when you are 100% sure you have run `ttnn-visualizer` from the venv, the way it starts flask and does the imports from `ttnn_visualizer` package can cause it to use the globally installed ttnn-visualizer, instead of the ones in the virtual env that `ttnn-visualizer` is run from.

We need to review how flask is started to ensure that if `ttnn-visualizer` is run from a venv, that it starts flask from the venv also, even if a different version of the `ttnn-visualizer` package has been globally installed. But until then, we will update the README with the advice to make sure it's not installed in both places.
