### PR TITLE
Fix/Range Slider Bounds

### DIFF
--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -17,21 +17,21 @@ import ROUTES from '../definitions/Routes';
 import 'styles/components/RangeSlider.scss';
 import {
     useGetDeviceOperationListPerf,
-    useNormalizedPerformance,
     useOperationListRange,
     useOperationsList,
     useOptoPerfIdFiltered,
     usePerformanceRange,
+    usePerformanceReport,
 } from '../hooks/useAPI';
 import { OperationDescription } from '../model/APIData';
-import { RowData } from '../definitions/PerfTable';
+import { PerfTableRow } from '../definitions/PerfTable';
 import LoadingSpinner from './LoadingSpinner';
 
 const RANGE_STEP = 25;
 
 function Range() {
     const { data: operations } = useOperationsList();
-    const perfData = useNormalizedPerformance();
+    const { data: perfData } = usePerformanceReport();
     const location = useLocation();
     const listPerf = useGetDeviceOperationListPerf();
     const isInSync = listPerf?.length > 0;
@@ -293,10 +293,10 @@ const getOperationLabel = (selectedId: number, operations?: OperationDescription
         : selectedId.toString();
 };
 
-const getPerformanceLabel = (selectedId: number, data?: RowData[], isTooltip?: boolean): string => {
-    const matchingRow = data?.find((r) => r.ORIGINAL_ID === selectedId);
+const getPerformanceLabel = (selectedId: number, data?: PerfTableRow[], isTooltip?: boolean): string => {
+    const matchingRow = data?.find((r) => parseInt(r.id, 10) === selectedId);
 
-    return matchingRow && isTooltip ? `${matchingRow.ORIGINAL_ID}\xA0${matchingRow['OP CODE']}` : selectedId.toString();
+    return matchingRow && isTooltip ? `${matchingRow.id}\xA0${matchingRow.raw_op_code}` : selectedId.toString();
 };
 
 export default Range;

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -109,9 +109,9 @@ export const PerformanceReport: FC<PerformanceReportProps> = ({ data }) => {
 
     const visibleHeaders = [
         ...TABLE_HEADERS.slice(0, OP_ID_INSERTION_POINT),
-        ...(opIdsMap.length > 0 ? [{ label: 'OP', key: 'op' }] : [{}]),
+        ...(opIdsMap.length > 0 ? [{ label: 'OP', key: 'op' }] : []),
         ...TABLE_HEADERS.slice(OP_ID_INSERTION_POINT, HIGH_DISPATCH_INSERTION_POINT),
-        ...(hiliteHighDispatch ? [{ label: 'Slow', key: 'high_dispatch' }] : [{}]),
+        ...(hiliteHighDispatch ? [{ label: 'Slow', key: 'high_dispatch' }] : []),
         ...TABLE_HEADERS.slice(HIGH_DISPATCH_INSERTION_POINT),
     ] as TableHeader[];
 
@@ -158,7 +158,7 @@ export const PerformanceReport: FC<PerformanceReportProps> = ({ data }) => {
                     <tbody>
                         {getFilteredRows.map((row, i) => (
                             <Fragment key={i}>
-                                <tr key={i}>
+                                <tr>
                                     {visibleHeaders.map((header) => (
                                         <td
                                             key={header.key}

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -726,7 +726,8 @@ export const usePerformanceReport = () => {
         if (response.data) {
             const df: PerfTableRow[] = response.data
                 .slice()
-                .filter((r) => !r.op_code?.includes('(torch)') && !(r.op_code === ''));
+                .filter((r) => !r.op_code?.includes('(torch)') && !(r.op_code === ''))
+                .sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)); // tt-perf-report doesn't sort by ID but we need to
 
             response.data = df;
         }

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -591,8 +591,12 @@ export const usePerformanceRange = (): NumberRange | null => {
 
     return useMemo(
         () =>
-            perfData?.length ? [parseInt(perfData[0].id, 10), parseInt(perfData[perfData.length - 1].id, 10)] : null,
-
+            perfData?.length
+                ? [
+                      Math.min(...perfData.map((data) => parseInt(data.id, 10))),
+                      Math.max(...perfData.map((data) => parseInt(data.id, 10))),
+                  ]
+                : null,
         [perfData],
     );
 };
@@ -726,8 +730,7 @@ export const usePerformanceReport = () => {
         if (response.data) {
             const df: PerfTableRow[] = response.data
                 .slice()
-                .filter((r) => !r.op_code?.includes('(torch)') && !(r.op_code === ''))
-                .sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)); // tt-perf-report doesn't sort by ID but we need to
+                .filter((r) => !r.op_code?.includes('(torch)') && !(r.op_code === ''));
 
             response.data = df;
         }


### PR DESCRIPTION
Bringing in some changes pending in https://github.com/tenstorrent/ttnn-visualizer/pull/420.

RangeSlider now uses the tt-perf-report data but sorts it by ID.