### PR TITLE
Fix pm ideal ns to use right row number

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -622,7 +622,10 @@ class OpsPerformanceReportQueries:
                         processed_row["advice"] = []
 
                     for key, value in cls.PASSTHROUGH_COLUMNS.items():
-                        processed_row[key] = ops_perf_results[int(row[0])][value]
+                        op_id = int(row[0])
+                        idx = op_id - 2 # IDs in result column one correspond to row numbers in ops perf results csv
+                        processed_row[key] = ops_perf_results[idx][value]
+
                     report.append(processed_row)
         except csv.Error as e:
             raise DataFormatError() from e


### PR DESCRIPTION
Further testing after #429 was merged revealed that the `pm_ideal_ns` field was not using the value from the right row in the original `ops_perf_report_<date>.csv` file. It was not immediately obvious in the first round of testing, since many rows have the same `pm_ideal_ns` value, so the first round of testing showed the expected value in many cases, but only as a fluke since the wrong row being used often had the same value.

This bug was in dev only and only for a couple of hours. No hot fix in main required.
