### PR TITLE
fix empty collapsible behaviour to allow events pass through to button children when empty

### DIFF
--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -18,6 +18,7 @@ interface CollapsibleProps {
     contentClassName?: string;
     keepChildrenMounted?: boolean;
     onExpandToggle?: () => void;
+    isDisabled?: boolean;
 }
 
 const Collapsible: React.FC<React.PropsWithChildren<CollapsibleProps>> = ({
@@ -30,6 +31,7 @@ const Collapsible: React.FC<React.PropsWithChildren<CollapsibleProps>> = ({
     keepChildrenMounted = true,
     onExpandToggle,
     children,
+    isDisabled = false,
 }) => {
     const [isOpenState, setIsOpenState] = React.useState(isOpen);
     useEffect(() => {
@@ -44,12 +46,16 @@ const Collapsible: React.FC<React.PropsWithChildren<CollapsibleProps>> = ({
                     <Button
                         size='small'
                         variant='minimal'
-                        onClick={() => {
-                            if (onExpandToggle) {
-                                onExpandToggle();
-                            }
-                            setIsOpenState(!isOpenState);
-                        }}
+                        onClick={
+                            !isDisabled
+                                ? () => {
+                                      if (onExpandToggle) {
+                                          onExpandToggle();
+                                      }
+                                      setIsOpenState(!isOpenState);
+                                  }
+                                : undefined
+                        }
                         endIcon={icon}
                     >
                         {label}

--- a/src/scss/components/Collapsible.scss
+++ b/src/scss/components/Collapsible.scss
@@ -35,7 +35,11 @@
     &.empty-collapsible {
         .collapsible-controls {
             [type='button'] {
-                pointer-events: none;
+                cursor: default;
+
+                &:hover {
+                    background: none;
+                }
             }
 
             .bp5-icon.bp5-icon-caret-up,


### PR DESCRIPTION

<img width="947" alt="image" src="https://github.com/user-attachments/assets/c2d00cc9-0651-4fcb-8b5d-857106c3e6ab" />
