### PR TITLE
fix incorrectly reported number of cores and math associated with that

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -18,7 +18,7 @@ import { formatSize, prettyPrintAddress, toReadableShape } from '../../functions
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
 import { useGetTensorSizesById } from '../../hooks/useAPI';
-import { L1_DEFAULT_MEMORY_SIZE } from '../../definitions/L1MemorySize';
+import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1MemorySize';
 
 // TODO: this component definitely needs to be broken down into smaller components
 
@@ -240,8 +240,9 @@ const DeviceOperationsFullRender: React.FC<{
 
                     if (nodeType === NodeType.buffer_allocate) {
                         const buffer = node.params;
-                        const numCores = parseInt(buffer.num_cores, 10) || 1;
-                        const bufferSize = parseInt(buffer.size, 10) / numCores;
+                        const defaultNumberCores = buffer.type === DeviceOperationTypes.L1 ? L1_NUM_CORES : 1;
+                        const cores = parseInt(buffer.num_cores, 10) || defaultNumberCores;
+                        const bufferSize = parseInt(buffer.size, 10) / cores;
                         operationContent = (
                             <DeviceOperationNode
                                 _node={node}
@@ -256,7 +257,7 @@ const DeviceOperationsFullRender: React.FC<{
                                             address: parseInt(buffer.address, 10),
                                             size: bufferSize,
                                         }}
-                                        numCores={numCores}
+                                        numCores={cores}
                                         key={buffer.address}
                                         memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
                                         selectedTensorAddress={selectedAddress}
@@ -281,9 +282,9 @@ const DeviceOperationsFullRender: React.FC<{
                         //     );
                     } else if (nodeType === NodeType.buffer_deallocate) {
                         const buffer = node.params;
-
                         const size = parseInt(buffer.size, 10);
-                        const cores = parseInt(buffer.num_cores, 10) || 1;
+                        const defaultNumberCores = buffer.type === DeviceOperationTypes.L1 ? L1_NUM_CORES : 1;
+                        const cores = parseInt(buffer.num_cores, 10) || defaultNumberCores;
                         const bufferSize = size / cores;
                         operationContent = (
                             <DeviceOperationNode

--- a/src/definitions/L1MemorySize.ts
+++ b/src/definitions/L1MemorySize.ts
@@ -1,1 +1,2 @@
 export const L1_DEFAULT_MEMORY_SIZE = 1499136; // 1.43MB   this is a fallback value only for when there is no devices information
+export const L1_NUM_CORES = 64;

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import { DeviceOperationTypes, Node, NodeType } from '../model/APIData';
+import { L1_NUM_CORES } from '../definitions/L1MemorySize';
 
 export type AllocationDetails = {
     id: number;
@@ -73,7 +74,8 @@ export function processMemoryAllocations(
         }
 
         if (node.node_type === NodeType.buffer_allocate && node.params.type === DeviceOperationTypes.L1) {
-            const numCores = parseInt(node.params.num_cores, 10) || 1;
+            const defaultNumberCores = node.params.type === DeviceOperationTypes.L1 ? L1_NUM_CORES : 1;
+            const numCores = parseInt(node.params.num_cores, 10) || defaultNumberCores;
             const totalSize = parseInt(node.params.size, 10);
             totalBuffer += totalSize / numCores;
         }
@@ -86,7 +88,8 @@ export function processMemoryAllocations(
             const connectionIndex = node.connections ? node.connections[0] : -1;
             const connectedNode = graph[connectionIndex];
             if (connectionIndex >= 0 && connectedNode && connectedNode.params.type === 'L1') {
-                const numCores = parseInt(node.params.num_cores, 10) || 1;
+                const defaultNumberCores = node.params.type === DeviceOperationTypes.L1 ? L1_NUM_CORES : 1;
+                const numCores = parseInt(node.params.num_cores, 10) || defaultNumberCores;
                 const size = parseInt(node.params.size, 10) / numCores;
                 totalBuffer -= size;
             }

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -20,7 +20,7 @@ import { BufferType } from './BufferType';
 import { DRAM_MEMORY_SIZE } from '../definitions/DRAMMemorySize';
 import { CONDENSED_PLOT_CHUNK_COLOR, PlotDataCustom, PlotDataOverrides } from '../definitions/PlotConfigurations';
 import getChartData from '../functions/getChartData';
-import { L1_DEFAULT_MEMORY_SIZE } from '../definitions/L1MemorySize';
+import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../definitions/L1MemorySize';
 
 export class OperationDetails implements Partial<OperationDetailsData> {
     id: number;
@@ -176,12 +176,12 @@ export class OperationDetails implements Partial<OperationDetailsData> {
 
                         if (deviceOp) {
                             if (node.params.type === DeviceOperationTypes.L1) {
+                                const cores = parseInt(node.params.num_cores, 10) || L1_NUM_CORES;
                                 deviceOp.bufferList.push({
                                     address: parseInt(node.params.address, 10),
-                                    size: parseInt(node.params.size, 10) / parseInt(node.params.num_cores, 10),
+                                    size: parseInt(node.params.size, 10) / cores,
                                     layout: node.params.layout,
                                     type: node.params.type,
-                                    // tensorId: this.getTensorForAddress(parseInt(node.params.address, 10))?.id,
                                 });
                             }
                         }


### PR DESCRIPTION
this addresses buffers that are reported to be sharded across 0 cores on L1 which is obviously impossible. we are now defaulting those to 64 which is likely incorrect, the data needs to be updated to return correct number of cores.

```
TODO: we should probably also mark buffers in question to indicated incomplete data
```