### PR TITLE
Change report path cli arg to take a path instead of the report db file

### DIFF
--- a/backend/ttnn_visualizer/sessions.py
+++ b/backend/ttnn_visualizer/sessions.py
@@ -274,13 +274,13 @@ def create_instance_from_local_paths(report_path, profiler_path):
     _report_path = Path(report_path)
     _profiler_path = Path(profiler_path)
 
-    if not _report_path.exists():
+    if not _report_path.exists() or not _report_path.is_dir():
         raise InvalidReportPath()
 
-    if not _profiler_path.exists():
+    if not _profiler_path.exists() or not _profiler_path.is_dir():
         raise InvalidProfilerPath()
 
-    report_name = _report_path.parts[-2] if len(_report_path.parts) > 2 else ""
+    report_name = _report_path.parts[-1] if len(_report_path.parts) > 2 else ""
     profile_name = _profiler_path.parts[-1] if len(_profiler_path.parts) > 2 else ""
     session_data = InstanceTable(
         instance_id=create_random_instance_id(),
@@ -289,7 +289,7 @@ def create_instance_from_local_paths(report_path, profiler_path):
             "profile_name": profile_name,
             "npe_name": None,
         },
-        report_path=report_path,
+        report_path=f"{report_path}/db.sqlite",
         profiler_path=profiler_path,
         remote_connection=None,
         remote_folder=None,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,5 +115,13 @@ The default behaviour is to sync the files to your local machine, but you may al
 
 The `ttnn-visualizer` command supports two CLI arguments for passing custom data paths:
 
-* `--report-path` - specify the local path to `db.sqlite` file containing the report
+* `--report-path` - specify the local path to the folder containing the report
 * `--profiler-path` - specify the local path to the folder containing the profiler data
+
+These options allow you to pass the folders when starting the visualizer, instead of uploading the report and profiler
+data files from the browser after loading the site. This can be used for starting `ttnn-visualizer` from other tools
+with the data preloaded, or for restarting the visualizer with the same data, without having to upload it again.
+
+```bash
+ttnn-visualizer --report-path ~/Downloads/report/generated/ttnn/reports/17274205533343344897 --profiler-path ~/Downloads/report/generated/profiler/reports/2025_02_24_23_17_27
+```


### PR DESCRIPTION
This PR modifies the `--report-path` CLI arg to take a folder, instead of the path to the `db.sqlite` file.

This option was recently added In PR #433. The `--report-path` CLI arg originally took the path to the `db.sqlite` file, as this is what is technically stored in the `report_path` column in the `instances` table in the ttnn db.

For consistency, however, it's been decided that both of the CLI args that were added, `--report-path` and `-profiler-data`, should take directories, for consistency between them and because in the frontend a user uploads a directory.
