### PR TITLE
Refactor/Avoid 404 calls

### DIFF
--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import classNames from 'classnames';
-import { Button, Collapse, Icon, NumberRange, Tooltip } from '@blueprintjs/core';
+import { Button, Collapse, NumberRange, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useEffect, useState } from 'react';
 import { useAtomValue } from 'jotai';
@@ -15,7 +15,7 @@ import {
     performanceRangeAtom,
     selectedOperationRangeAtom,
 } from '../store/app';
-import { useGetDeviceOperationListPerf } from '../hooks/useAPI';
+import SyncStatus from './SyncStatus';
 import Range from './RangeSlider';
 import ROUTES from '../definitions/Routes';
 import 'styles/components/FooterInfobar.scss';
@@ -31,9 +31,6 @@ function FooterInfobar() {
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const location = useLocation();
 
-    const useGetDeviceOperationListPerfResult = useGetDeviceOperationListPerf();
-
-    const isInSync = useGetDeviceOperationListPerfResult.length > 0;
     const isOperationDetails = location.pathname.includes(`${ROUTES.OPERATIONS}/`);
     const isPerformanceRoute = location.pathname === ROUTES.PERFORMANCE;
     const isNPE = location.pathname.includes(`${ROUTES.NPE}`);
@@ -91,27 +88,7 @@ function FooterInfobar() {
                                 <strong>Performance:</strong> {activePerformanceReport}
                             </span>
                         ))}
-                    {activeProfilerReport && activePerformanceReport && (
-                        <span>
-                            {isInSync ? (
-                                <strong>
-                                    <Icon
-                                        icon={IconNames.TickCircle}
-                                        className='intent-ok'
-                                    />{' '}
-                                    Profiler and perf reports synchronised
-                                </strong>
-                            ) : (
-                                <strong>
-                                    <Icon
-                                        icon={IconNames.ISSUE}
-                                        className='intent-not-ok'
-                                    />{' '}
-                                    Profiler and perf reports can&apos;t be synchronized
-                                </strong>
-                            )}
-                        </span>
-                    )}
+                    {activeProfilerReport && activePerformanceReport && <SyncStatus />}
                 </div>
 
                 {(operationRange || performanceRange) && (
@@ -132,13 +109,15 @@ function FooterInfobar() {
                 )}
             </div>
 
-            <Collapse
-                className='slider-container'
-                isOpen={sliderIsOpen}
-                keepChildrenMounted
-            >
-                <Range />
-            </Collapse>
+            {(operationRange || performanceRange) && (
+                <Collapse
+                    className='slider-container'
+                    isOpen={sliderIsOpen}
+                    keepChildrenMounted
+                >
+                    <Range />
+                </Collapse>
+            )}
         </footer>
     );
 }

--- a/src/components/OperationList.tsx
+++ b/src/components/OperationList.tsx
@@ -14,13 +14,18 @@ import Collapsible from './Collapsible';
 import OperationArguments from './OperationArguments';
 import LoadingSpinner from './LoadingSpinner';
 import 'styles/components/ListView.scss';
-import { DeviceOperationMapping, useGetDeviceOperationListPerf, useOperationsList } from '../hooks/useAPI';
+import { useOperationsList } from '../hooks/useAPI';
 import ROUTES from '../definitions/Routes';
-import { expandedOperationsAtom, selectedOperationRangeAtom, shouldCollapseAllOperationsAtom } from '../store/app';
+import {
+    activePerformanceReportAtom,
+    expandedOperationsAtom,
+    selectedOperationRangeAtom,
+    shouldCollapseAllOperationsAtom,
+} from '../store/app';
 import { OperationDescription } from '../model/APIData';
 import ListItem from './ListItem';
 import { formatSize } from '../functions/math';
-import { getCoreColour, getOpToOpGapColour } from '../functions/perfFunctions';
+import OperationListPerfData from './OperationListPerfData';
 
 const PLACEHOLDER_ARRAY_SIZE = 10;
 const OPERATION_EL_HEIGHT = 39; // Height in px of each list item
@@ -36,7 +41,6 @@ const OperationList = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const { data: fetchedOperations, error, isLoading } = useOperationsList();
-    const perfData = useGetDeviceOperationListPerf();
     const scrollElementRef = useRef<HTMLDivElement>(null);
 
     const [filterQuery, setFilterQuery] = useState('');
@@ -48,6 +52,7 @@ const OperationList = () => {
     const [shouldCollapseAll, setShouldCollapseAll] = useAtom(shouldCollapseAllOperationsAtom);
     const [expandedOperations, setExpandedOperations] = useAtom(expandedOperationsAtom);
     const selectedOperationRange = useAtomValue(selectedOperationRangeAtom);
+    const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
 
     // TODO: Figure out an initial scroll position based on last used operation
     const virtualizer = useVirtualizer({
@@ -143,9 +148,7 @@ const OperationList = () => {
 
             setFilteredOperationsList(operations);
         }
-
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [operationsWithRange, filterQuery, shouldSortByID, shouldSortDuration, perfData, selectedOperationRange]);
+    }, [operationsWithRange, filterQuery, shouldSortByID, shouldSortDuration, selectedOperationRange]);
 
     useEffect(() => {
         const initialOperationId = location.state?.previousOperationId;
@@ -330,74 +333,10 @@ const OperationList = () => {
                                                 <p className='monospace'>
                                                     Python execution time: {formatSize(operation.duration)} s
                                                 </p>
-                                                <div className='perf-data'>
-                                                    {perfData
-                                                        ?.filter(
-                                                            (perf: DeviceOperationMapping) => perf.id === operation.id,
-                                                        )
-                                                        .map(
-                                                            (perf) =>
-                                                                perf.perfData && (
-                                                                    <Fragment key={perf.id + perf.operationName}>
-                                                                        <strong>{perf.perfData?.raw_op_code}</strong>
-                                                                        <div>
-                                                                            <span
-                                                                                className={classNames(
-                                                                                    'monospace',
-                                                                                    getCoreColour(perf.perfData?.cores),
-                                                                                )}
-                                                                            >
-                                                                                {parseInt(perf.perfData?.cores, 10)}{' '}
-                                                                                core
-                                                                                {parseInt(perf.perfData?.cores, 10) >
-                                                                                    1 && 's'}
-                                                                            </span>
-                                                                            , execution time{' '}
-                                                                            <span className='monospace'>
-                                                                                {formatSize(
-                                                                                    parseFloat(
-                                                                                        perf.perfData?.device_time,
-                                                                                    ),
-                                                                                )}{' '}
-                                                                                µs
-                                                                            </span>{' '}
-                                                                            <span className='monospace'>
-                                                                                (
-                                                                                {formatSize(
-                                                                                    parseFloat(
-                                                                                        perf.perfData?.total_percent,
-                                                                                    ),
-                                                                                )}{' '}
-                                                                                %)
-                                                                            </span>
-                                                                            {perf.perfData?.op_to_op_gap && (
-                                                                                <>
-                                                                                    ,{' '}
-                                                                                    <span
-                                                                                        className={classNames(
-                                                                                            'monospace',
-                                                                                            getOpToOpGapColour(
-                                                                                                perf.perfData
-                                                                                                    .op_to_op_gap,
-                                                                                            ),
-                                                                                        )}
-                                                                                    >
-                                                                                        {formatSize(
-                                                                                            parseFloat(
-                                                                                                perf.perfData
-                                                                                                    .op_to_op_gap,
-                                                                                            ),
-                                                                                        )}{' '}
-                                                                                        µs
-                                                                                    </span>{' '}
-                                                                                    op-to-op gap.
-                                                                                </>
-                                                                            )}
-                                                                        </div>
-                                                                    </Fragment>
-                                                                ),
-                                                        )}
-                                                </div>
+
+                                                {activePerformanceReport && (
+                                                    <OperationListPerfData operation={operation} />
+                                                )}
 
                                                 {operation.arguments && (
                                                     <OperationArguments

--- a/src/components/OperationListPerfData.tsx
+++ b/src/components/OperationListPerfData.tsx
@@ -1,0 +1,58 @@
+import classNames from 'classnames';
+import { Fragment } from 'react/jsx-runtime';
+import { formatSize } from '../functions/math';
+import { getCoreColour, getOpToOpGapColour } from '../functions/perfFunctions';
+import { DeviceOperationMapping, useGetDeviceOperationListPerf } from '../hooks/useAPI';
+import { OperationDescription } from '../model/APIData';
+
+interface OperationListPerfDataProps {
+    operation: OperationDescription;
+}
+
+const OperationListPerfData = ({ operation }: OperationListPerfDataProps) => {
+    const perfData = useGetDeviceOperationListPerf();
+
+    return (
+        <div className='perf-data'>
+            {perfData
+                ?.filter((perf: DeviceOperationMapping) => perf.id === operation.id)
+                .map(
+                    (perf) =>
+                        perf.perfData && (
+                            <Fragment key={perf.id + perf.operationName}>
+                                <strong>{perf.perfData?.raw_op_code}</strong>
+                                <div>
+                                    <span className={classNames('monospace', getCoreColour(perf.perfData?.cores))}>
+                                        {parseInt(perf.perfData?.cores, 10)} core
+                                        {parseInt(perf.perfData?.cores, 10) > 1 && 's'}
+                                    </span>
+                                    , execution time{' '}
+                                    <span className='monospace'>
+                                        {formatSize(parseFloat(perf.perfData?.device_time))} µs
+                                    </span>{' '}
+                                    <span className='monospace'>
+                                        ({formatSize(parseFloat(perf.perfData?.total_percent))} %)
+                                    </span>
+                                    {perf.perfData?.op_to_op_gap && (
+                                        <>
+                                            ,{' '}
+                                            <span
+                                                className={classNames(
+                                                    'monospace',
+                                                    getOpToOpGapColour(perf.perfData.op_to_op_gap),
+                                                )}
+                                            >
+                                                {formatSize(parseFloat(perf.perfData.op_to_op_gap))} µs
+                                            </span>{' '}
+                                            op-to-op gap.
+                                        </>
+                                    )}
+                                </div>
+                            </Fragment>
+                        ),
+                )}
+        </div>
+    );
+};
+
+export default OperationListPerfData;

--- a/src/components/SyncStatus.tsx
+++ b/src/components/SyncStatus.tsx
@@ -1,0 +1,32 @@
+import { Icon } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { useGetDeviceOperationListPerf } from '../hooks/useAPI';
+
+const SyncStatus = () => {
+    const useGetDeviceOperationListPerfResult = useGetDeviceOperationListPerf();
+    const isInSync = useGetDeviceOperationListPerfResult.length > 0;
+
+    return (
+        <span>
+            {isInSync ? (
+                <strong>
+                    <Icon
+                        icon={IconNames.TickCircle}
+                        className='intent-ok'
+                    />{' '}
+                    Profiler and perf reports synchronised
+                </strong>
+            ) : (
+                <strong>
+                    <Icon
+                        icon={IconNames.ISSUE}
+                        className='intent-not-ok'
+                    />{' '}
+                    Profiler and perf reports can&apos;t be synchronized
+                </strong>
+            )}
+        </span>
+    );
+};
+
+export default SyncStatus;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -379,7 +379,7 @@ export const useOperationListRange = (): NumberRange | null => {
     );
 };
 
-export const fetchNpeOpTrace = async () => {
+const fetchNpeOpTrace = async () => {
     const response = await axiosInstance.get<NPEData>('/api/npe');
     return response?.data;
 };


### PR DESCRIPTION
Moves hooks into components in a way that they are only called when required, avoiding fetch errors when we don't have active reports, for example.