### PR TITLE
Fix/Grouped bar data is cut off

### DIFF
--- a/src/components/performance/PerfCoreCountUtilizationChart.tsx
+++ b/src/components/performance/PerfCoreCountUtilizationChart.tsx
@@ -11,7 +11,7 @@ import { PlotConfiguration } from '../../definitions/PlotConfigurations';
 import PerfChart from './PerfChart';
 import { activePerformanceReportAtom, comparisonPerformanceReportAtom } from '../../store/app';
 import getPlotLabel from '../../functions/getPlotLabel';
-import getMaxArrayLength from '../../functions/getMaxArrayLength';
+import { getAxisUpperRange } from '../../functions/perfFunctions';
 import { getPrimaryDataColours, getSecondaryDataColours } from '../../definitions/PerformancePlotColours';
 
 interface PerfCoreCountUtilizationChartProps {
@@ -65,7 +65,7 @@ function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCoun
         showLegend: true,
         xAxis: {
             title: { text: 'Operation' },
-            range: [0, getMaxArrayLength(datasets, comparisonReport)],
+            range: [0, getAxisUpperRange(datasets, !!comparisonReport)],
         },
         yAxis: {
             title: { text: 'Core Count' },

--- a/src/components/performance/PerfCoreCountUtilizationChart.tsx
+++ b/src/components/performance/PerfCoreCountUtilizationChart.tsx
@@ -65,7 +65,7 @@ function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCoun
         showLegend: true,
         xAxis: {
             title: { text: 'Operation' },
-            range: [0, getMaxArrayLength(datasets)],
+            range: [0, getMaxArrayLength(datasets, comparisonReport)],
         },
         yAxis: {
             title: { text: 'Core Count' },

--- a/src/components/performance/PerfOperationKernelUtilizationChart.tsx
+++ b/src/components/performance/PerfOperationKernelUtilizationChart.tsx
@@ -66,7 +66,7 @@ function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOp
         },
         showLegend: true,
         xAxis: {
-            range: [0, getMaxArrayLength(datasets)],
+            range: [0, getMaxArrayLength(datasets, comparisonReport)],
             title: {
                 text: 'Operation',
             },

--- a/src/components/performance/PerfOperationKernelUtilizationChart.tsx
+++ b/src/components/performance/PerfOperationKernelUtilizationChart.tsx
@@ -9,7 +9,7 @@ import { PerfTableRow } from '../../definitions/PerfTable';
 import getCoreUtilization from '../../functions/getCoreUtilization';
 import PerfChart from './PerfChart';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
-import getMaxArrayLength from '../../functions/getMaxArrayLength';
+import { getAxisUpperRange } from '../../functions/perfFunctions';
 import getPlotLabel from '../../functions/getPlotLabel';
 import { activePerformanceReportAtom, comparisonPerformanceReportAtom } from '../../store/app';
 import { getPrimaryDataColours, getSecondaryDataColours } from '../../definitions/PerformancePlotColours';
@@ -66,7 +66,7 @@ function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOp
         },
         showLegend: true,
         xAxis: {
-            range: [0, getMaxArrayLength(datasets, comparisonReport)],
+            range: [0, getAxisUpperRange(datasets, !!comparisonReport)],
             title: {
                 text: 'Operation',
             },

--- a/src/functions/getMaxArrayLength.ts
+++ b/src/functions/getMaxArrayLength.ts
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-//
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
-
-export default function getMaxArrayLength(arrays: Array<unknown[]>, comparisonReport: string | null): number {
-    // If a comparison report is provided, add 1 to the max length to avoid data being cut off when plotting the grouped bars
-    return Math.max(...arrays.map((arr) => arr.length), 0) + (comparisonReport ? 1 : 0);
-}

--- a/src/functions/getMaxArrayLength.ts
+++ b/src/functions/getMaxArrayLength.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-export default function getMaxArrayLength(arrays: Array<unknown[]>): number {
-    return Math.max(...arrays.map((arr) => arr.length), 0);
+export default function getMaxArrayLength(arrays: Array<unknown[]>, comparisonReport: string | null): number {
+    // If a comparison report is provided, add 1 to the max length to avoid data being cut off when plotting the grouped bars
+    return Math.max(...arrays.map((arr) => arr.length), 0) + (comparisonReport ? 1 : 0);
 }

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -361,3 +361,8 @@ export function getOperationDetails(operations: OperationDescription[], id: numb
 
     return matchingOp ? `${matchingOp.name} (${matchingOp.operationFileIdentifier})` : '';
 }
+
+export function getAxisUpperRange(arrays: Array<unknown[]>, hasComparisonReport: boolean): number {
+    // If a comparison report is provided, add 1 to the max length to avoid data being cut off when plotting the grouped bars
+    return Math.max(...arrays.map((arr) => arr.length), 0) + (hasComparisonReport ? 1 : 0);
+}


### PR DESCRIPTION
Due to the way plotly plots grouped data it's possible for some data to be cut off by the current logic determining x-axis length.

Added an offset to avoid data being cut off when needed.