### PR TITLE
Feature/Multiple all operations charts 

### DIFF
--- a/src/components/performance/NonFilterablePerfCharts.tsx
+++ b/src/components/performance/NonFilterablePerfCharts.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import { FC, useMemo } from 'react';
+import { useAtomValue } from 'jotai';
 import PerfCoreCountUtilizationChart from './PerfCoreCountUtilizationChart';
 import { Marker, PerfTableRow } from '../../definitions/PerfTable';
 import PerfOperationTypesChart from './PerfOperationTypesChart';
@@ -10,6 +11,7 @@ import SkeletalChart from './SkeletalChart';
 import PerfOperationKernelUtilizationChart from './PerfOperationKernelUtilizationChart';
 import PerfKernelDurationUtilizationChart from './PerfKernelDurationUtilizationChart';
 import 'styles/components/PerfCharts.scss';
+import { activePerformanceReportAtom, comparisonPerformanceReportAtom } from '../../store/app';
 
 interface NonFilterablePerfChartsProps {
     chartData: PerfTableRow[];
@@ -24,6 +26,9 @@ const NonFilterablePerfCharts: FC<NonFilterablePerfChartsProps> = ({
     maxCores,
     opCodeOptions,
 }) => {
+    const performanceReport = useAtomValue(activePerformanceReportAtom);
+    const comparisonReport = useAtomValue(comparisonPerformanceReportAtom);
+
     const datasets = [chartData, ...(secondaryData || [])].filter((set) => set.length > 0);
 
     const matmulData = useMemo(
@@ -85,10 +90,25 @@ const NonFilterablePerfCharts: FC<NonFilterablePerfChartsProps> = ({
             )}
 
             <h2>All operations</h2>
-            <PerfOperationTypesChart
-                data={chartData}
-                opCodes={opCodeOptions}
-            />
+            <div className='operation-types-charts'>
+                {performanceReport && (
+                    <PerfOperationTypesChart
+                        className='flex-chart'
+                        reportTitle={comparisonReport ? performanceReport : ''}
+                        data={chartData}
+                        opCodes={opCodeOptions}
+                    />
+                )}
+
+                {comparisonReport && (
+                    <PerfOperationTypesChart
+                        className='flex-chart'
+                        reportTitle={performanceReport ? comparisonReport : ''}
+                        data={secondaryData[0]}
+                        opCodes={opCodeOptions}
+                    />
+                )}
+            </div>
         </div>
     );
 };

--- a/src/components/performance/PerfCoreCountUtilizationChart.tsx
+++ b/src/components/performance/PerfCoreCountUtilizationChart.tsx
@@ -65,7 +65,7 @@ function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCoun
         showLegend: true,
         xAxis: {
             title: { text: 'Operation' },
-            range: [0, getAxisUpperRange(datasets, !!comparisonReport)],
+            range: [0, getAxisUpperRange(datasets)],
         },
         yAxis: {
             title: { text: 'Core Count' },

--- a/src/components/performance/PerfOperationKernelUtilizationChart.tsx
+++ b/src/components/performance/PerfOperationKernelUtilizationChart.tsx
@@ -66,7 +66,7 @@ function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOp
         },
         showLegend: true,
         xAxis: {
-            range: [0, getAxisUpperRange(datasets, !!comparisonReport)],
+            range: [0, getAxisUpperRange(datasets)],
             title: {
                 text: 'Operation',
             },

--- a/src/components/performance/PerfOperationTypesChart.tsx
+++ b/src/components/performance/PerfOperationTypesChart.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import Plot from 'react-plotly.js';
+import classNames from 'classnames';
 import { Layout, PlotData } from 'plotly.js';
 import { useMemo } from 'react';
 import { Marker, PerfTableRow } from '../../definitions/PerfTable';
@@ -10,23 +11,25 @@ import 'styles/components/PerformanceOperationTypesChart.scss';
 import { PerfChartConfig } from '../../definitions/PlotConfigurations';
 
 interface PerfOperationTypesChartProps {
+    reportTitle: string;
     opCodes: Marker[];
     data?: PerfTableRow[];
+    className?: string;
 }
 
 const LAYOUT: Partial<Layout> = {
     autosize: true,
     paper_bgcolor: 'transparent',
     margin: {
-        l: 0,
-        r: 0,
-        b: 0,
-        t: 0,
+        l: 50,
+        r: 50,
+        b: 50,
+        t: 50,
     },
     showlegend: false,
 };
 
-function PerfOperationTypesChart({ data = [], opCodes }: PerfOperationTypesChartProps) {
+function PerfOperationTypesChart({ reportTitle, data = [], opCodes, className = '' }: PerfOperationTypesChartProps) {
     const filteredOpCodes = useMemo(
         () => [...new Set(data?.filter((row) => row.raw_op_code !== undefined).map((row) => row.raw_op_code))],
         [data],
@@ -45,13 +48,17 @@ function PerfOperationTypesChart({ data = [], opCodes }: PerfOperationTypesChart
                         (opCode) => opCodes.find((selected) => selected.opCode === opCode)?.colour,
                     ),
                 },
+                outsidetextfont: {
+                    color: 'white',
+                },
             }) as Partial<PlotData>,
         [data, opCodes, filteredOpCodes],
     );
 
     return (
-        <div className='operation-types-chart'>
+        <div className={classNames('operation-types-chart', className)}>
             <h3>Operation Types</h3>
+            <p>{reportTitle}</p>
 
             <Plot
                 className='chart'

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -362,7 +362,7 @@ export function getOperationDetails(operations: OperationDescription[], id: numb
     return matchingOp ? `${matchingOp.name} (${matchingOp.operationFileIdentifier})` : '';
 }
 
-export function getAxisUpperRange(arrays: Array<unknown[]>, hasComparisonReport: boolean): number {
-    // If a comparison report is provided, add 1 to the max length to avoid data being cut off when plotting the grouped bars
-    return Math.max(...arrays.map((arr) => arr.length), 0) + (hasComparisonReport ? 1 : 0);
+export function getAxisUpperRange(arrays: Array<unknown[]>): number {
+    // Adds + 1 to avoid cutting off the last plotted element in some cases and to create some space on the right side of the chart data
+    return Math.max(...arrays.map((arr) => arr.length), 0) + 1;
 }

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -23,3 +23,13 @@
         flex: 0 0 30px;
     }
 }
+
+.operation-types-charts {
+    display: flex;
+    gap: 10px;
+
+    .flex-chart {
+        flex-basis: 50%;
+        flex-grow: 1;
+    }
+}


### PR DESCRIPTION
Restored multiple "all operations" pie charts with improved layout/style. In some cases the text outside the chart can get a little compressed, but Plotly isn't very elegant with how you can reserve space for this.

**Before**
<img width="809" alt="Screenshot 2025-05-06 at 9 21 45 AM" src="https://github.com/user-attachments/assets/badea1e1-23f6-4c8a-8b68-4d168693c77b" />

**After**
<img width="1038" alt="Screenshot 2025-05-05 at 3 27 02 PM" src="https://github.com/user-attachments/assets/cc0d9bd7-5064-4db4-a73f-e79be7ba9509" />
