### PR TITLE
Feature/Redo hover template

### DIFF
--- a/src/components/performance/PerfCoreCountUtilizationChart.tsx
+++ b/src/components/performance/PerfCoreCountUtilizationChart.tsx
@@ -29,7 +29,7 @@ function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCoun
                 x: data?.map((_row, index) => index + 1),
                 y: data?.map((row) => row.cores),
                 type: 'bar',
-                hovertemplate: `Operation: %{x}<br />Cores: %{y}`,
+                hovertemplate: `<b>%{data.name}</b><br />Operation: %{x}<br />Cores: %{y}<extra></extra>`,
                 name: getPlotLabel(dataIndex, perfReport, comparisonReport),
                 legendgroup: `group${dataIndex}`,
                 marker: {
@@ -45,7 +45,7 @@ function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCoun
                 x: data?.map((_row, index) => index + 1),
                 y: data?.map((row) => getCoreUtilization(row, maxCores)).filter((value) => value !== -1),
                 yaxis: 'y2',
-                hovertemplate: `Operation: %{x}<br />Utilization: %{y}`,
+                hovertemplate: `<b>%{data.name}</b><br />Operation: %{x}<br />Utilization: %{y}<extra></extra>`,
                 name: getPlotLabel(dataIndex, perfReport, comparisonReport),
                 legendgroup: `group${dataIndex}`,
                 marker: {

--- a/src/components/performance/PerfOperationKernelUtilizationChart.tsx
+++ b/src/components/performance/PerfOperationKernelUtilizationChart.tsx
@@ -29,7 +29,7 @@ function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOp
                 x: data?.map((_row, index) => index + 1),
                 y: data?.map((row) => row.device_time),
                 type: 'bar',
-                hovertemplate: `Operation: %{x}<br />Duration: %{y} ns`,
+                hovertemplate: `<b>%{data.name}</b><br />Operation: %{x}<br />Duration: %{y} ns<extra></extra>`,
                 name: getPlotLabel(dataIndex, perfReport, comparisonReport),
                 legendgroup: `group${dataIndex}`,
                 marker: {
@@ -45,7 +45,7 @@ function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOp
                 x: data?.map((_row, index) => index + 1),
                 y: data?.map((row) => getCoreUtilization(row, maxCores)).filter((value) => value !== -1) ?? [],
                 yaxis: 'y2',
-                hovertemplate: `Operation: %{x}<br />Utilization: %{y}`,
+                hovertemplate: `<b>%{data.name}</b><br />Operation: %{x}<br />Utilization: %{y}<extra></extra>`,
                 name: getPlotLabel(dataIndex, perfReport, comparisonReport),
                 legendgroup: `group${dataIndex}`,
                 marker: {


### PR DESCRIPTION
Moved dataset label into the main hovertemplate area instead of within `<extra></extra>` as it's easier to style.
**Before**
<img width="809" alt="Screenshot 2025-05-06 at 9 19 47 AM" src="https://github.com/user-attachments/assets/e470ff02-3e08-4c43-857f-e202c9991e01" />

**After**
<img width="1038" alt="Screenshot 2025-05-05 at 4 09 03 PM" src="https://github.com/user-attachments/assets/50e2b96b-2c39-4b5f-832f-cfc4260e2d66" />
