### PR TITLE
Allow npeviz.zst files to be uploaded

### DIFF
--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -47,8 +47,16 @@ def extract_npe_name(files):
     if not files:
         return None
 
-    file_path = Path(files[0].filename)
-    return file_path.stem
+    filename = files[0].filename
+
+    if filename.endswith('.json'):
+        npe_name = filename.rstrip('.json')
+    elif filename.endswith('.npeviz.zst'):
+        npe_name = filename.rstrip('.npeviz.zst')
+    else:
+        raise ValueError(f"Unsupported file type: {filename}")
+
+    return npe_name
 
 
 def save_uploaded_files(

--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -4,6 +4,7 @@
 
 from pathlib import Path
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -43,20 +44,12 @@ def extract_profiler_name(files):
     unsplit_profiler_name = str(files[0].filename)
     return unsplit_profiler_name.split("/")[0]
 
+
 def extract_npe_name(files):
     if not files:
         return None
 
-    filename = files[0].filename
-
-    if filename.endswith('.json'):
-        npe_name = filename.rstrip('.json')
-    elif filename.endswith('.npeviz.zst'):
-        npe_name = filename.rstrip('.npeviz.zst')
-    else:
-        raise ValueError(f"Unsupported file type: {filename}")
-
-    return npe_name
+    return re.sub(r"\.(json|npeviz\.zst)$", "", files[0].filename)
 
 
 def save_uploaded_files(

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -18,6 +18,7 @@ build
 PyYAML==6.0.2
 python-dotenv==1.0.1
 tt-perf-report==1.0.6
+zstd==1.5.7.0
 
 # Dev dependencies
 mypy

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1029,7 +1029,7 @@ def get_npe_data(session: Instance):
 
     if compressed_path.exists():
        with open(compressed_path, "rb") as file:
-            compressed_data= file.read()
+            compressed_data = file.read()
             uncompressed_data = zstd.uncompress(compressed_data)
             npe_data = json.loads(uncompressed_data)
     else:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import List
 import shutil
 
+import zstd
 from flask import Blueprint
 from flask import request, current_app
 
@@ -672,10 +673,10 @@ def create_npe_files():
     data_directory = current_app.config["LOCAL_DATA_DIRECTORY"]
 
     for file in files:
-        if not file.filename.endswith(".json"):
+        if not file.filename.endswith(".json") and not file.filename.endswith('.npeviz.zst'):
             return StatusMessage(
                 status=ConnectionTestStates.FAILED,
-                message="NPE requires a valid JSON file",
+                message="NPE requires a valid .json or .npeviz.zst file",
             ).model_dump()
 
     npe_name = extract_npe_name(files)
@@ -1019,13 +1020,20 @@ def get_npe_data(session: Instance):
         logger.error("NPE path is not set in the session.")
         return Response(status=HTTPStatus.NOT_FOUND)
 
-    npe_file = Path(f"{session.npe_path}/{session.active_report.npe_name}.json")
+    compressed_path = Path(f"{session.npe_path}/{session.active_report.npe_name}.npeviz.zst")
+    uncompressed_path = Path(f"{session.npe_path}/{session.active_report.npe_name}.json")
 
-    if not npe_file.exists():
-        logger.error(f"NPE file does not exist: {npe_file}")
+    if not compressed_path.exists() and not uncompressed_path.exists():
+        logger.error(f"NPE file does not exist: {compressed_path} / {uncompressed_path}")
         return Response(status=HTTPStatus.NOT_FOUND)
 
-    with open(npe_file, "r") as file:
-        npe_data = json.load(file)
+    if compressed_path.exists():
+       with open(compressed_path, "rb") as file:
+            compressed_data= file.read()
+            uncompressed_data = zstd.uncompress(compressed_data)
+            npe_data = json.loads(uncompressed_data)
+    else:
+        with open(uncompressed_path, "r") as file:
+            npe_data = json.load(file)
 
     return jsonify(npe_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "sqlalchemy==2.0.34",
     "PyYAML==6.0.2",
     "python-dotenv==1.0.1",
-    "tt-perf-report==1.0.6"
+    "tt-perf-report==1.0.6",
+    "zstd==1.5.7.0"
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR modifies the visualizer backend to allow .npeviz.zst files to be uploaded on the NPE tab. These will be the same as the current timeline JSON files that get uploaded, except the file extension is .npeviz.zst instead of .json, and compressed with zstandard.

The approach taken here is the quickest and easiest way to add support for the compressed files, but it will likely breakdown with very large (gigabyte) timeline files. In the future it may be need to be changed to not load the full file contents into memory.

See: #483