### PR TITLE
fix: support perf result file name without datetime suffix

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -482,6 +482,8 @@ class OpsPerformanceQueries:
 
         # Find the latest file with the correct prefix
         perf_files = list(
+            performance_path.glob(f"{OpsPerformanceQueries.PERF_RESULTS_PREFIX}.csv")
+        ) + list(
             performance_path.glob(f"{OpsPerformanceQueries.PERF_RESULTS_PREFIX}_*.csv")
         )
         if not perf_files:


### PR DESCRIPTION
The perf result file name was previously assumed to follow the format `ops_perf_results_[datetime].csv`. However, files generated by `ttrt perf` use the format `ops_perf_results.csv`, without the `_[datetime]` suffix, causing glob pattern matching to fail.

This commit adds support for the `ops_perf_results.csv` format by including an additional glob pattern, ensuring compatibility with both formats.