### PR TITLE
Allow HOST env var to be used with Flask

### DIFF
--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -53,7 +53,7 @@ class DefaultConfig(object):
     GUNICORN_WORKER_CLASS = os.getenv("GUNICORN_WORKER_CLASS", "gevent")
     GUNICORN_WORKERS = os.getenv("GUNICORN_WORKERS", "1")
     PORT = os.getenv("PORT", "8000")
-    HOST = "localhost"
+    HOST = os.getenv("HOST", "localhost")
     DEV_SERVER_PORT = "5173"
     DEV_SERVER_HOST = "localhost"
 


### PR DESCRIPTION
This PR modifies the backend settings to allow using a `HOST` env var to override the default `localhost` that is passed to gunicorn.

This facilities using the app in server environments.
