### PR TITLE
Feature/Support Safari directory uploads

### DIFF
--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -8,7 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def validate_files(files, required_files, pattern=None):
+def validate_files(files, required_files, pattern=None, folder_name=None):
     """Validate uploaded files against required file names and an optional pattern."""
     found_files = set()
 
@@ -19,7 +19,7 @@ def validate_files(files, required_files, pattern=None):
             pattern and file_path.name.startswith(pattern)
         ):
             found_files.add(file_path.name)
-            if len(file_path.parents) != 2:
+            if not folder_name and len(file_path.parents) != 2:
                 logger.warning(
                     f"File {file.filename} is not under a single parent folder."
                 )
@@ -54,14 +54,14 @@ def extract_npe_name(files):
 def save_uploaded_files(
     files,
     target_directory,
-    profiler_name=None,
+    folder_name=None,
 ):
     """
     Save uploaded files to the target directory.
 
     :param files: List of files to be saved.
     :param target_directory: The base directory for saving the files.
-    :param profiler_name: The report name to use for the directory.
+    :param folder_name: The name to use for the directory.
     """
     for file in files:
         current_file_name = str(file.filename)
@@ -69,7 +69,10 @@ def save_uploaded_files(
 
         file_path = Path(current_file_name)
 
-        destination_file = Path(target_directory).joinpath(str(file_path))
+        if folder_name:
+            destination_file = Path(target_directory) / folder_name / str(file_path)
+        else:
+            destination_file = Path(target_directory) / str(file_path)
 
         logger.info(f"Writing file to {destination_file}")
 

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -96,12 +96,6 @@ const LocalFolderOptions: FC = () => {
     const [performanceFolder, setPerformanceFolder] = useState<ConnectionStatus | undefined>();
     const [performanceDataUploadLabel, setPerformanceDataUploadLabel] = useState('Choose directory...');
 
-    /**
-     * This is a temporrary solution until we support Safari
-     */
-    const ua = navigator.userAgent.toLowerCase();
-    const isSafari = ua.includes('safari') && !ua.includes('chrome') && !ua.includes('android');
-
     const handleReportDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
         if (!e.target.files) {
             return;
@@ -235,125 +229,105 @@ const LocalFolderOptions: FC = () => {
     };
 
     return (
-        <>
-            {isSafari && (
-                <>
-                    <h3>
-                        <Icon
-                            icon={IconNames.WARNING_SIGN}
-                            size={20}
-                            intent={Intent.WARNING}
-                        />{' '}
-                        This functionality is not supported in safari browser
-                    </h3>
-                    <p>Please use Chrome or Firefox to upload a local report </p>
-                </>
-            )}
+        <div>
+            <FormGroup
+                className='form-group'
+                label={<h3 className='label'>Memory report</h3>}
+                subLabel='Select a memory report'
+            >
+                <LocalFolderPicker
+                    items={reportFolderList}
+                    value={reportFolderList?.includes(activeProfilerReport) ? activeProfilerReport : null}
+                    handleSelect={handleSelectProfiler}
+                    handleDelete={handleDeleteProfiler}
+                />
+            </FormGroup>
 
-            <div>
-                <FormGroup
-                    className='form-group'
-                    label={<h3 className='label'>Memory report</h3>}
-                    subLabel='Select a memory report'
-                >
-                    <LocalFolderPicker
-                        items={reportFolderList}
-                        value={reportFolderList?.includes(activeProfilerReport) ? activeProfilerReport : null}
-                        handleSelect={handleSelectProfiler}
-                        handleDelete={handleDeleteProfiler}
-                    />
-                </FormGroup>
+            <FormGroup subLabel='Upload a local memory report'>
+                <div className='buttons-container'>
+                    <label
+                        className='bp5-file-input'
+                        htmlFor='local-upload'
+                    >
+                        <input
+                            id='local-upload'
+                            type='file'
+                            multiple
+                            /* @ts-expect-error 'directory' does not exist on native HTMLInputElement */
+                            // eslint-disable-next-line react/no-unknown-property
+                            directory=''
+                            webkitdirectory=''
+                            onChange={handleReportDirectoryOpen}
+                        />
+                        <span className='bp5-file-upload-input'>{profilerUploadLabel}</span>
+                    </label>
 
-                <FormGroup subLabel='Upload a local memory report'>
-                    <div className='buttons-container'>
-                        <label
-                            className='bp5-file-input'
-                            htmlFor='local-upload'
-                        >
-                            <input
-                                id='local-upload'
-                                type='file'
-                                multiple
-                                /* @ts-expect-error 'directory' does not exist on native HTMLInputElement */
-                                // eslint-disable-next-line react/no-unknown-property
-                                directory=''
-                                webkitdirectory=''
-                                disabled={isSafari}
-                                onChange={handleReportDirectoryOpen}
+                    <FileStatusOverlay />
+
+                    {profilerFolder && !isUploadingReport && (
+                        <div className={`verify-connection-item status-${ConnectionTestStates[profilerFolder.status]}`}>
+                            <Icon
+                                className='connection-status-icon'
+                                icon={ICON_MAP[profilerFolder.status]}
+                                size={20}
+                                intent={INTENT_MAP[profilerFolder.status]}
                             />
-                            <span className='bp5-file-upload-input'>{profilerUploadLabel}</span>
-                        </label>
 
-                        <FileStatusOverlay />
+                            <span className='connection-status-text'>{profilerFolder.message}</span>
+                        </div>
+                    )}
+                </div>
+            </FormGroup>
 
-                        {profilerFolder && !isUploadingReport && (
-                            <div
-                                className={`verify-connection-item status-${ConnectionTestStates[profilerFolder.status]}`}
-                            >
-                                <Icon
-                                    className='connection-status-icon'
-                                    icon={ICON_MAP[profilerFolder.status]}
-                                    size={20}
-                                    intent={INTENT_MAP[profilerFolder.status]}
-                                />
+            <FormGroup
+                className='form-group'
+                label={<h3 className='label'>Performance report</h3>}
+                subLabel='Select a performance report'
+            >
+                <LocalFolderPicker
+                    items={perfFolderList}
+                    value={perfFolderList?.includes(activePerformanceReport) ? activePerformanceReport : null}
+                    handleSelect={handleSelectPerformance}
+                    handleDelete={handleDeletePerformance}
+                />
+            </FormGroup>
 
-                                <span className='connection-status-text'>{profilerFolder.message}</span>
-                            </div>
-                        )}
-                    </div>
-                </FormGroup>
+            <FormGroup subLabel='Upload a local performance report'>
+                <div className='buttons-container'>
+                    <label
+                        className='bp5-file-input'
+                        htmlFor='local-performance-upload'
+                    >
+                        <input
+                            id='local-performance-upload'
+                            type='file'
+                            multiple
+                            /* @ts-expect-error 'directory' does not exist on native HTMLInputElement */
+                            // eslint-disable-next-line react/no-unknown-property
+                            directory=''
+                            webkitdirectory=''
+                            onChange={handlePerformanceDirectoryOpen}
+                        />
+                        <span className='bp5-file-upload-input'>{performanceDataUploadLabel}</span>
+                    </label>
 
-                <FormGroup
-                    className='form-group'
-                    label={<h3 className='label'>Performance report</h3>}
-                    subLabel='Select a performance report'
-                >
-                    <LocalFolderPicker
-                        items={perfFolderList}
-                        value={perfFolderList?.includes(activePerformanceReport) ? activePerformanceReport : null}
-                        handleSelect={handleSelectPerformance}
-                        handleDelete={handleDeletePerformance}
-                    />
-                </FormGroup>
-
-                <FormGroup subLabel='Upload a local performance report'>
-                    <div className='buttons-container'>
-                        <label
-                            className='bp5-file-input'
-                            htmlFor='local-performance-upload'
+                    {performanceFolder && !isUploadingPerformance && (
+                        <div
+                            className={`verify-connection-item status-${ConnectionTestStates[performanceFolder.status]}`}
                         >
-                            <input
-                                id='local-performance-upload'
-                                type='file'
-                                multiple
-                                /* @ts-expect-error 'directory' does not exist on native HTMLInputElement */
-                                // eslint-disable-next-line react/no-unknown-property
-                                directory=''
-                                webkitdirectory=''
-                                disabled={isSafari}
-                                onChange={handlePerformanceDirectoryOpen}
+                            <Icon
+                                className='connection-status-icon'
+                                icon={ICON_MAP[performanceFolder.status]}
+                                size={20}
+                                intent={INTENT_MAP[performanceFolder.status]}
                             />
-                            <span className='bp5-file-upload-input'>{performanceDataUploadLabel}</span>
-                        </label>
 
-                        {performanceFolder && !isUploadingPerformance && (
-                            <div
-                                className={`verify-connection-item status-${ConnectionTestStates[performanceFolder.status]}`}
-                            >
-                                <Icon
-                                    className='connection-status-icon'
-                                    icon={ICON_MAP[performanceFolder.status]}
-                                    size={20}
-                                    intent={INTENT_MAP[performanceFolder.status]}
-                                />
-
-                                <span className='connection-status-text'>{performanceFolder.message}</span>
-                            </div>
-                        )}
-                    </div>
-                </FormGroup>
-            </div>
-        </>
+                            <span className='connection-status-text'>{performanceFolder.message}</span>
+                        </div>
+                    )}
+                </div>
+            </FormGroup>
+        </div>
     );
 };
 

--- a/src/hooks/useLocal.tsx
+++ b/src/hooks/useLocal.tsx
@@ -15,6 +15,9 @@ export interface UploadProgress {
 
 type FileWithRelativePath = File & { webkitRelativePath?: string };
 
+const ua = navigator.userAgent.toLowerCase();
+const IS_SAFARI = ua.includes('safari') && !ua.includes('chrome') && !ua.includes('android');
+
 const useLocalConnection = () => {
     /**
      * Retrieves the top level folder name from an array of uploaded files
@@ -100,6 +103,11 @@ const useLocalConnection = () => {
             formData.append('files', f);
         });
 
+        // In the POST request Safari seems to remove the parent folder name so we're adding it specifically here
+        if (IS_SAFARI) {
+            formData.append('folderName', files[0].webkitRelativePath.split('/')[0]);
+        }
+
         return axiosInstance
             .post(`${import.meta.env.VITE_API_ROOT}/local/upload/profiler`, formData, {
                 headers: {
@@ -138,6 +146,11 @@ const useLocalConnection = () => {
         Array.from(files).forEach((f) => {
             formData.append('files', f);
         });
+
+        // In the POST request Safari seems to remove the parent folder name so we're adding it specifically here
+        if (IS_SAFARI) {
+            formData.append('folderName', files[0].webkitRelativePath.split('/')[0]);
+        }
 
         return axiosInstance
             .post(`${import.meta.env.VITE_API_ROOT}/local/upload/performance`, formData, {

--- a/ttnn-visualizer.code-workspace
+++ b/ttnn-visualizer.code-workspace
@@ -18,6 +18,7 @@
         "cSpell.words": [
             "blueprintjs",
             "esbenp",
+            "jsonify",
             "matmul",
             "Metalium",
             "pipx",


### PR DESCRIPTION
Longstanding issue with Safari and uploading directories.

Upload endpoints now support an optional `folder_name` value which I am passing only when `IS_SAFARI`.

Doesn't affect NPE because that is a single file upload.
