### PR TITLE
Make allowed origins a configurable setting

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -127,7 +127,7 @@ def middleware(app: flask.Flask):
         app.wsgi_app = ProxyFix(app.wsgi_app)
 
     # CORS configuration
-    origins = ["http://localhost:5173", "http://localhost:8000"]
+    origins = app.config["ALLOWED_ORIGINS"]
 
     CORS(
         app,

--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -18,6 +18,10 @@ class DefaultConfig(object):
     PRINT_ENV = True
     SERVER_MODE = str_to_bool(os.getenv("SERVER_MODE", "false"))
     MALWARE_SCANNER = os.getenv("MALWARE_SCANNER")
+    ALLOWED_ORIGINS = [
+        o for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:5173,http://localhost:8000").split(",")
+        if o
+    ]
 
     # Path Settings
     DB_VERSION = "0.29.0"  # App version when DB schema last changed


### PR DESCRIPTION
This PR adds a new `ALLOWED_ORIGINS` setting, which can be configured by an environment variable.

Prior to this PR, the CORS origins were hard coded to be http://localhost:5173 and http://localhost:8000. Those are fine in local, but in server mode it needs to be configurable to match the URL the app is deployed to.