### PR TITLE
Fix bug creating folders when malware scanning is enabled

### DIFF
--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -76,10 +76,11 @@ def save_uploaded_files(
         scanned_files = scan_uploaded_files(files, base_directory, parent_folder_name)
 
         for temp_path, dest_path in scanned_files:
-            if dest_path.parent.exists():
+            if not dest_path.parent.exists():
                 dest_path.parent.mkdir(exist_ok=True, parents=True)
 
             logger.info(f"Saving uploaded file (clean): {dest_path}")
+
             shutil.move(temp_path, dest_path)
     else:
         for file in files:


### PR DESCRIPTION
There was a bug in the code that was recently merged in #517 , which caused directory creation to fail. The problem is self-evident looking at the diff, but it wasn't noticed due to uploading the same reports repeatedly during testing.