### PR TITLE
Fix appending instance ids to session instances

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -42,7 +42,8 @@ def with_instance(func):
             session['instances'] = []
 
         if instance.instance_id not in session['instances']:
-            session['instances'].append(instance.instance_id)
+            session['instances'] = session.get('instances', []) + [instance.instance_id]
+
 
         return func(*args, **kwargs)
 


### PR DESCRIPTION
This PR has a fix for how instance ids are appending to the list of instance ids in the Flask session. It was using `session['instances'].append(instance.instance_id)` which normally makes sense as a way to append to a Python list, but Flask was not recognizing the change. For Flask to detect the update, it's necessary to set the value for the dictionary key. Flask doesn't detect when the list gets updated by appending a new element to it.