### PR TITLE
Add max content length setting

### DIFF
--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -23,6 +23,9 @@ class DefaultConfig(object):
         if o
     ]
     BASE_PATH = os.getenv("BASE_PATH", "/")
+    MAX_CONTENT_LENGTH = (
+        None if not (v := os.getenv("MAX_CONTENT_LENGTH")) else int(v)
+    )
 
     # Path Settings
     DB_VERSION = "0.29.0"  # App version when DB schema last changed


### PR DESCRIPTION
This PR adds a `MAX_CONTENT_LENGTH` setting. This is a Flask setting, and the value is read from an env var. If the env var is not set, it default to `None`, in which case no maximum upload file size is set. In local use the setting is not needed, but it can be used when running the app on a server.