### PR TITLE
fixes disabled overlay color

### DIFF
--- a/src/scss/components/OldFolderPicker.scss
+++ b/src/scss/components/OldFolderPicker.scss
@@ -64,7 +64,7 @@
             position: absolute;
             inset: -10px;
             top: -40px;
-            background: rgb(62 62 62 / 90%);
+            background: rgb(52 52 52 / 90%);
             display: flex;
             flex-direction: column;
             justify-content: center;


### PR DESCRIPTION
before:
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/eac3e50e-454e-4670-8499-426b4d21dafd" />

after:
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/fa65c551-17f7-4f4f-822b-cd50c3c43f2e" />
