### PR TITLE
Fix setting report paths when switching instances

### DIFF
--- a/backend/ttnn_visualizer/instances.py
+++ b/backend/ttnn_visualizer/instances.py
@@ -71,17 +71,32 @@ def update_existing_instance(
 
     if profiler_path is not _sentinel:
         instance_data.profiler_path = profiler_path
+    else:
+        if active_report.get("profiler_name"):
+            instance_data.profiler_path = get_profiler_path(
+                profiler_name=active_report["profiler_name"],
+                current_app=current_app,
+                remote_connection=remote_connection,
+            )
 
     if performance_path is not _sentinel:
         instance_data.performance_path = performance_path
+    else:
+        if active_report.get("performance_name"):
+            instance_data.performance_path = get_performance_path(
+                performance_name=active_report["performance_name"],
+                current_app=current_app,
+                remote_connection=remote_connection,
+            )
 
     if npe_path is not _sentinel:
         instance_data.npe_path = npe_path
-
-    if remote_connection and not clear_remote:
-        update_paths(
-            instance_data, active_report, remote_connection
-        )
+    else:
+        if active_report.get("npe_name"):
+            instance_data.npe_path = get_npe_path(
+                npe_name=active_report["npe_name"],
+                current_app=current_app
+            )
 
 
 def clear_remote_data(instance_data):
@@ -102,30 +117,6 @@ def commit_and_log_session(instance_data, instance_id):
     current_app.logger.info(
         f"Data for instance {instance_id}: {json.dumps(instance_data.to_dict(), indent=4)}"
     )
-
-
-def update_paths(
-    instance_data, active_report, remote_connection
-):
-    if active_report.get("performance_name"):
-        instance_data.performance_path = get_performance_path(
-            performance_name=active_report["performance_name"],
-            current_app=current_app,
-            remote_connection=remote_connection,
-        )
-
-    if active_report.get("profiler_name"):
-        instance_data.profiler_path = get_profiler_path(
-            profiler_name=active_report["profiler_name"],
-            current_app=current_app,
-            remote_connection=remote_connection,
-        )
-
-    if active_report.get("npe_name"):
-        instance_data.npe_path = get_npe_path(
-            npe_name=active_report["npe_name"],
-            current_app=current_app
-        )
 
 
 def create_new_instance(

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -413,7 +413,7 @@ def get_profiler_data_list(instance: Instance):
         demo_pattern = re.compile(r"^demo", re.IGNORECASE)
         for report in path.glob("*"):
             if demo_pattern.match(report.name):
-                demo_directory_names.append(str(report))
+                demo_directory_names.append(report.name)
         directory_names = list(set(db_directory_names + session_directory_names + demo_directory_names))
     else:
         directory_names = [directory.name for directory in path.iterdir() if directory.is_dir()]
@@ -504,7 +504,7 @@ def get_performance_data_list(instance: Instance):
         demo_pattern = re.compile(r"^demo", re.IGNORECASE)
         for report in path.glob("*"):
             if demo_pattern.match(report.name):
-                demo_directory_names.append(str(report))
+                demo_directory_names.append(report.name)
         directory_names = list(set(db_directory_names + session_directory_names + demo_directory_names))
     else:
         if is_remote:


### PR DESCRIPTION
This PR fixes a bug that was recently introduced with the changes to support running the app on the server, where the report paths did not get updated correctly in the DB when updating the reports with the dropdowns.