### PR TITLE
Add headers to prevent caching when serving the frontend index.html page

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -78,7 +78,15 @@ def create_app(settings_override=None):
                     js,
                 )
 
-            return flask.Response(html_with_config, mimetype="text/html")
+            return flask.Response(
+                html_with_config,
+                mimetype="text/html",
+                headers={
+                    "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+                    "Pragma": "no-cache",
+                    "Expires": "0",
+                },
+            )
 
     return app
 


### PR DESCRIPTION
Adds caching to ensure the index.html file is not cached when it is served by Flask.

<img width="570" alt="Screenshot 2025-06-26 at 1 54 50 PM" src="https://github.com/user-attachments/assets/1e8218c3-4161-4ebd-be6f-25ff706a0d65" />
