### PR TITLE
Change static assets to be nested under /static/

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,12 +12,13 @@ import { legacySassSvgInlinerFactory } from './src/libs/blueprintjs/legacySassSv
 import { version } from './package.json';
 
 // https://vitejs.dev/config/
-export default defineConfig(() => {
+export default defineConfig(({ command }) => {
     return {
         build: {
             outDir: './backend/ttnn_visualizer/static/',
             emptyOutDir: true,
         },
+        base: command === 'serve' ? '/' : '/static/',
         define: {
             'import.meta.env.APP_VERSION': JSON.stringify(version),
         },


### PR DESCRIPTION
This PR changes the static assets to be served from `/static/` in production env, and keeps them at `/` for local dev.

The reason for doing this is to fix the 404 errors when reloading pages when running from the wheel or on the server. Reloading pages when accessing the site through the node dev server worked, because all of the routing was being taken care of in the React SPA. When running in production mode and accessing the site via Flask, only the index page was being matched by the "catch_all" route, and everything else was going to the static files handler, to due clashing route patterns.

If you were to go to a URL like /operations, instead of the `catch_all` route in `app.py` matching it and returning the index.html file for the React SPA, it was instead looking for a static file called `operations` in the `backend/ttnn_visualizer/static` directory, which of course was not found and it would return a 404.

This moves the static assets under `/static/` in the URL, so that the static files handler in Flask only matches files under that path, and the rest go to the "catch all" view, which serves the index.html file for the React SPA and React Router handles loading the right page.