### PR TITLE
Change black to use lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npx lint-staged
-

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 npx lint-staged
-pnpm run flask:lint
+

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
       "eslint ./src --fix --ext ts,tsx --report-unused-disable-directives --max-warnings 0 --no-ignore"
     ],
     "**/*.scss": "npx stylelint --fix",
-    "**/*.{js,jsx,ts,tsx,css,scss}": "pnpm run format"
+    "**/*.{js,jsx,ts,tsx,css,scss}": "pnpm run format",
+    "backend/ttnn_visualizer/**/*.py": "pnpm run flask:lint"
   },
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
Instead of running `pnpm run flask:lint` from the `pre-commit` file, it changes it to run from `lint-staged`. This makes it so that black only runs if Python files have been staged for commit, and the venv does not need to be activated to run black if only frontend files are being committed.