### PR TITLE
Reformat backend files with isort

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -7,20 +7,17 @@ import json
 import logging
 import os
 import subprocess
+import sys
 import threading
 import webbrowser
 from os import environ
 from pathlib import Path
-import sys
 from typing import cast
 
 import flask
 from dotenv import load_dotenv
 from flask import Flask, abort, jsonify
 from flask_cors import CORS
-from werkzeug.debug import DebuggedApplication
-from werkzeug.middleware.proxy_fix import ProxyFix
-
 from ttnn_visualizer.exceptions import (
     DatabaseFileNotFoundException,
     InvalidProfilerPath,
@@ -28,6 +25,8 @@ from ttnn_visualizer.exceptions import (
 )
 from ttnn_visualizer.instances import create_instance_from_local_paths
 from ttnn_visualizer.settings import Config, DefaultConfig
+from werkzeug.debug import DebuggedApplication
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +103,7 @@ def create_app(settings_override=None):
 
 
 def extensions(app: flask.Flask):
-    from ttnn_visualizer.extensions import flask_static_digest, db, socketio
+    from ttnn_visualizer.extensions import db, flask_static_digest, socketio
     from ttnn_visualizer.sockets import register_handlers
 
     """

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -8,17 +8,16 @@ import subprocess
 import tempfile
 from io import StringIO
 from pathlib import Path
-from typing import List, Dict, Union, Optional
+from typing import Dict, List, Optional, Union
 
 import pandas as pd
 import zstd
 from tt_perf_report import perf_report
-
-from ttnn_visualizer.exceptions import DataFormatError
 from ttnn_visualizer.exceptions import (
-    SSHException,
     AuthenticationException,
+    DataFormatError,
     NoValidConnectionsError,
+    SSHException,
 )
 from ttnn_visualizer.models import Instance, RemoteConnection
 from ttnn_visualizer.sftp_operations import read_remote_file

--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -4,19 +4,18 @@
 
 import logging
 import re
-from ttnn_visualizer.enums import ConnectionTestStates
-
-
 from functools import wraps
+
 from flask import abort, request, session
+from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
-    NoValidConnectionsError,
-    SSHException,
-    RemoteConnectionException,
     AuthenticationFailedException,
     NoProjectsException,
+    NoValidConnectionsError,
+    RemoteConnectionException,
     RemoteSqliteException,
+    SSHException,
 )
 from ttnn_visualizer.instances import get_or_create_instance
 

--- a/backend/ttnn_visualizer/extensions.py
+++ b/backend/ttnn_visualizer/extensions.py
@@ -3,9 +3,8 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 from flask_socketio import SocketIO
-from flask_static_digest import FlaskStaticDigest
 from flask_sqlalchemy import SQLAlchemy
-
+from flask_static_digest import FlaskStaticDigest
 
 flask_static_digest = FlaskStaticDigest()
 # Initialize Flask SQLAlchemy

--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -13,7 +13,6 @@ import time
 from pathlib import Path
 
 from flask import current_app
-
 from ttnn_visualizer.exceptions import DataFormatError
 
 logger = logging.getLogger(__name__)

--- a/backend/ttnn_visualizer/instances.py
+++ b/backend/ttnn_visualizer/instances.py
@@ -9,19 +9,15 @@ from logging import getLogger
 from pathlib import Path
 
 from flask import request
-
-from ttnn_visualizer.exceptions import InvalidReportPath, InvalidProfilerPath
-from ttnn_visualizer.utils import get_profiler_path, get_performance_path, get_npe_path
-from ttnn_visualizer.models import (
-    InstanceTable,
-)
+from ttnn_visualizer.exceptions import InvalidProfilerPath, InvalidReportPath
 from ttnn_visualizer.extensions import db
+from ttnn_visualizer.models import InstanceTable
+from ttnn_visualizer.utils import get_npe_path, get_performance_path, get_profiler_path
 
 logger = getLogger(__name__)
 
-from flask import jsonify, current_app
+from flask import current_app, jsonify
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-
 
 _sentinel = object()
 

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -6,17 +6,14 @@ import dataclasses
 import enum
 import json
 from json import JSONDecodeError
-from typing import Optional, Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
-from sqlalchemy import Integer, Column, String, JSON
+from sqlalchemy import JSON, Column, Integer, String
 from sqlalchemy.ext.mutable import MutableDict
-
-from ttnn_visualizer.utils import SerializeableDataclass
 from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.extensions import db
-
-from ttnn_visualizer.utils import parse_memory_config
+from ttnn_visualizer.utils import SerializeableDataclass, parse_memory_config
 
 
 class BufferType(enum.Enum):

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -2,29 +2,26 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-from typing import Generator, Dict, Any, Union
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Optional, Union
 
-from ttnn_visualizer.exceptions import (
-    DatabaseFileNotFoundException,
-)
+from ttnn_visualizer.exceptions import DatabaseFileNotFoundException
 from ttnn_visualizer.models import (
-    Operation,
-    DeviceOperation,
     Buffer,
     BufferPage,
-    Instance,
-    Tensor,
-    OperationArgument,
-    StackTrace,
-    InputTensor,
-    OutputTensor,
     Device,
+    DeviceOperation,
+    InputTensor,
+    Instance,
+    Operation,
+    OperationArgument,
+    OutputTensor,
     ProducersConsumers,
+    StackTrace,
+    Tensor,
     TensorComparisonRecord,
 )
-import sqlite3
-from typing import List, Optional
-from pathlib import Path
 
 
 class LocalQueryRunner:

--- a/backend/ttnn_visualizer/remote_sqlite_setup.py
+++ b/backend/ttnn_visualizer/remote_sqlite_setup.py
@@ -8,10 +8,10 @@ import subprocess
 from ttnn_visualizer.decorators import remote_exception_handler
 from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
-    RemoteSqliteException,
-    SSHException,
     AuthenticationException,
     NoValidConnectionsError,
+    RemoteSqliteException,
+    SSHException,
 )
 from ttnn_visualizer.models import RemoteConnection
 

--- a/backend/ttnn_visualizer/requirements.txt
+++ b/backend/ttnn_visualizer/requirements.txt
@@ -21,3 +21,4 @@ zstd==1.5.7.0
 # Dev dependencies
 mypy
 black==25.1.0
+isort==6.0.1

--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -4,8 +4,8 @@
 
 import os
 from pathlib import Path
-from dotenv import load_dotenv
 
+from dotenv import load_dotenv
 from ttnn_visualizer.utils import str_to_bool
 
 load_dotenv()

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -5,30 +5,25 @@
 import json
 import logging
 import re
-import time
 import subprocess
+import time
 from pathlib import Path
 from stat import S_ISDIR
 from threading import Thread
 from typing import List, Optional
 
 from flask import current_app
-
 from ttnn_visualizer.decorators import remote_exception_handler
 from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
+    AuthenticationException,
     NoProjectsException,
+    NoValidConnectionsError,
     RemoteConnectionException,
     SSHException,
-    AuthenticationException,
-    NoValidConnectionsError,
 )
 from ttnn_visualizer.models import RemoteConnection, RemoteReportFolder
-from ttnn_visualizer.sockets import (
-    FileProgress,
-    FileStatus,
-    emit_file_status,
-)
+from ttnn_visualizer.sockets import FileProgress, FileStatus, emit_file_status
 from ttnn_visualizer.utils import update_last_synced
 
 logger = logging.getLogger(__name__)

--- a/backend/ttnn_visualizer/sockets.py
+++ b/backend/ttnn_visualizer/sockets.py
@@ -9,10 +9,8 @@ from datetime import datetime
 from enum import Enum
 from logging import getLogger
 
-from flask_socketio import join_room, disconnect, leave_room
-
+from flask_socketio import disconnect, join_room, leave_room
 from ttnn_visualizer.utils import SerializeableDataclass
-
 
 logger = getLogger(__name__)
 

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -3,19 +3,13 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 
-import tempfile
 import sqlite3
 import tempfile
 import unittest
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from ttnn_visualizer.models import (
-    DeviceOperation,
-    TensorComparisonRecord,
-)
-from ttnn_visualizer.queries import DatabaseQueries
-from ttnn_visualizer.queries import LocalQueryRunner
+from ttnn_visualizer.models import DeviceOperation, TensorComparisonRecord
+from ttnn_visualizer.queries import DatabaseQueries, LocalQueryRunner
 
 
 class TestQueryTable(unittest.TestCase):

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -5,28 +5,28 @@
 import unittest
 
 from ttnn_visualizer.models import (
+    Buffer,
+    BufferPage,
+    BufferType,
+    Device,
+    DeviceOperation,
+    InputTensor,
     Operation,
     OperationArgument,
-    Tensor,
-    Device,
-    InputTensor,
     OutputTensor,
     ProducersConsumers,
     StackTrace,
-    DeviceOperation,
-    Buffer,
-    BufferType,
-    BufferPage,
+    Tensor,
 )
 from ttnn_visualizer.serializers import (
-    serialize_operations,
+    serialize_buffer_pages,
+    serialize_devices,
     serialize_inputs_outputs,
     serialize_operation,
-    serialize_tensors,
-    serialize_buffer_pages,
     serialize_operation_buffers,
+    serialize_operations,
     serialize_operations_buffers,
-    serialize_devices,
+    serialize_tensors,
 )
 
 

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -6,13 +6,12 @@ import dataclasses
 import enum
 import json
 import logging
+import re
+import time
 from functools import wraps
 from pathlib import Path
-import time
-import re
 from timeit import default_timer
-from typing import Callable, Optional, Dict, Any
-
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 import shutil
+import subprocess
 import time
 from http import HTTPStatus
 from pathlib import Path
@@ -14,70 +15,58 @@ from typing import List
 
 import yaml
 import zstd
-from flask import (
-    Blueprint,
-    Response,
-    current_app,
-    jsonify,
-    session,
-    request,
-)
-
+from flask import Blueprint, Response, current_app, jsonify, request, session
 from ttnn_visualizer.csv_queries import (
     DeviceLogProfilerQueries,
+    NPEQueries,
     OpsPerformanceQueries,
     OpsPerformanceReportQueries,
-    NPEQueries,
 )
-from ttnn_visualizer.decorators import with_instance, local_only
+from ttnn_visualizer.decorators import local_only, with_instance
 from ttnn_visualizer.enums import ConnectionTestStates
-from ttnn_visualizer.exceptions import DataFormatError
-from ttnn_visualizer.exceptions import RemoteConnectionException
+from ttnn_visualizer.exceptions import (
+    AuthenticationException,
+    AuthenticationFailedException,
+    DataFormatError,
+    NoValidConnectionsError,
+    RemoteConnectionException,
+    SSHException,
+)
 from ttnn_visualizer.file_uploads import (
     extract_folder_name_from_files,
     extract_npe_name,
     save_uploaded_files,
     validate_files,
 )
-from ttnn_visualizer.instances import (
-    get_instances,
-    update_instance,
-)
+from ttnn_visualizer.instances import get_instances, update_instance
 from ttnn_visualizer.models import (
-    RemoteReportFolder,
-    RemoteConnection,
-    StatusMessage,
     Instance,
+    RemoteConnection,
+    RemoteReportFolder,
+    StatusMessage,
 )
 from ttnn_visualizer.queries import DatabaseQueries
-from ttnn_visualizer.remote_sqlite_setup import get_sqlite_path, check_sqlite_path
+from ttnn_visualizer.remote_sqlite_setup import check_sqlite_path, get_sqlite_path
 from ttnn_visualizer.serializers import (
-    serialize_operations,
-    serialize_tensors,
-    serialize_operation,
-    serialize_buffer_pages,
-    serialize_operation_buffers,
-    serialize_operations_buffers,
-    serialize_devices,
     serialize_buffer,
+    serialize_buffer_pages,
+    serialize_devices,
+    serialize_operation,
+    serialize_operation_buffers,
+    serialize_operations,
+    serialize_operations_buffers,
+    serialize_tensors,
 )
 from ttnn_visualizer.sftp_operations import (
-    sync_remote_profiler_folders,
-    read_remote_file,
-    check_remote_path_for_reports,
-    get_remote_profiler_folders,
     check_remote_path_exists,
-    get_remote_performance_folders,
-    sync_remote_performance_folders,
+    check_remote_path_for_reports,
     get_cluster_desc,
+    get_remote_performance_folders,
+    get_remote_profiler_folders,
+    read_remote_file,
+    sync_remote_performance_folders,
+    sync_remote_profiler_folders,
 )
-from ttnn_visualizer.exceptions import (
-    SSHException,
-    AuthenticationException,
-    NoValidConnectionsError,
-    AuthenticationFailedException,
-)
-import subprocess
 from ttnn_visualizer.utils import (
     get_cluster_descriptor_path,
     read_last_synced_file,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,scss,css,json,md}\"",
-    "flask:lint": "black --check backend/ttnn_visualizer",
+    "flask:lint": "isort --check-only backend/ttnn_visualizer && black --check backend/ttnn_visualizer",
     "flask:start": "PYTHONPATH=backend python -m ttnn_visualizer.app",
     "flask:start-debug": "DEBUG=true PYTHONPATH=backend python -m ttnn_visualizer.app",
     "flask:test": "PYTHONPATH=backend pytest backend/ttnn_visualizer/tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "black==25.1.0",
+    "isort==6.0.1",
     "mypy",
     "pytest==8.4.1",
 ]
@@ -72,3 +73,6 @@ exclude = '''
 )/
 '''
 
+[tool.isort]
+profile = "black"
+line_length = 88


### PR DESCRIPTION
This PR adds isort to the dev dependencies, runs isort on all of the Python files, and adds it to the `pnpm run flask:lint` command. That command is run from the husky pre-commit hook, and from the GitHub workflow for PRs - it will be required for all Python files to have their imports sorted correctly going forward.