### PR TITLE
Refactor to use global_call_count in performance table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ttnn-visualizer",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.43.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ttnn_visualizer"
 authors = []
-version = "0.43.0"
+version = "0.43.1"
 description = "TT-NN Visualizer"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -143,9 +143,8 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
             // TODO: this is an imefficient way of doing things but its also temporary. will update next iteration
             const value = parseInt(String(row[key]), 10) || 0;
             const manifestRecord = npeManifest?.find((el) => {
-                return el.id === value;
+                return el.global_call_count === value;
             });
-
             if (manifestRecord) {
                 return (
                     npeManifest &&
@@ -287,11 +286,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                     colSpan={visibleHeaders.length}
                                     className='cell advice'
                                 >
-                                    <ul>
-                                        {row?.advice.map((advice, j) => (
-                                            <li key={`advice-${j}`}>{advice}</li>
-                                        ))}
-                                    </ul>
+                                    <ul>{row?.advice.map((advice, j) => <li key={`advice-${j}`}>{advice}</li>)}</ul>
                                 </td>
                             </tr>
                         )}

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -286,7 +286,11 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                     colSpan={visibleHeaders.length}
                                     className='cell advice'
                                 >
-                                    <ul>{row?.advice.map((advice, j) => <li key={`advice-${j}`}>{advice}</li>)}</ul>
+                                    <ul>
+                                        {row?.advice.map((advice, j) => (
+                                            <li key={`advice-${j}`}>{advice}</li>
+                                        ))}
+                                    </ul>
                                 </td>
                             </tr>
                         )}

--- a/src/functions/normalisePerformanceData.ts
+++ b/src/functions/normalisePerformanceData.ts
@@ -30,6 +30,7 @@ const PLACEHOLDER: TypedPerfTableRow = {
     output_subblock_h: '',
     output_subblock_w: '',
     pm_ideal_ns: '',
+    global_call_count: 0,
 };
 
 const MISSING_PREFIX = 'MISSING -';

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -166,7 +166,6 @@ export enum NPE_LINK {
 }
 
 export interface NPEManifestEntry {
-    id: number; // @deprecated use `global_call_count` instead unless we will augment this in the future
     global_call_count: number;
     file: string;
 }


### PR DESCRIPTION
Updated PerfTable to match manifest records using global_call_count instead of the deprecated id field. Removed id from NPEManifestEntry interface and added global_call_count to the PLACEHOLDER in normalisePerformanceData.