### PR TITLE
Chore/Update setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,8 @@ dependencies = [
     "pydantic==2.7.3",
     "python-dotenv==1.0.1",
     "PyYAML==6.0.2",
-    "setuptools==78.1.1",
     "tt-perf-report==1.0.7",
     "uvicorn==0.30.1",
-    "wheel",
     "zstd==1.5.7.0"
 ]
 
@@ -47,7 +45,7 @@ package-dir = { "" = "backend" }
 where = ["backend"]
 
 [build-system]
-requires = ["setuptools>=7", "wheel"]
+requires = ["setuptools==78.1.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]


### PR DESCRIPTION
Didn't seem we used `setuptools-scm` so I removed it. Original PR doesn't target pyproject which we're exclusively using now.

Originally flagged by Dependabot: https://github.com/tenstorrent/ttnn-visualizer/pull/567