### PR TITLE
Set transfer opacity to 0 when transfer is highlighted

### DIFF
--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -190,7 +190,7 @@ const NPEView: React.FC<NPEViewProps> = ({ npeData }) => {
             return 1;
         }
         if (highlightedTransfer !== null) {
-            return 0.15;
+            return 0;
         }
         if (selectedTransferList.length === 0) {
             return 0; // 0.45;


### PR DESCRIPTION
closes #646 
Changed the opacity value from 0.15 to 0 when a transfer is highlighted in NPEViewComponent. This ensures that non-highlighted items are fully hidden instead of partially visible.