### PR TITLE
Fix node selection logic in NPEViewComponent

### DIFF
--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -409,6 +409,8 @@ const NPEView: React.FC<NPEViewProps> = ({ npeData }) => {
                                                         <div
                                                             key={`selected-transfer-${rowIndex}-${colIndex}`}
                                                             className={
+                                                                selectedNode?.coords[NPE_LINK.CHIP_ID] ===
+                                                                    clusterChip.id &&
                                                                 selectedNode?.coords[NPE_LINK.Y] === rowIndex &&
                                                                 selectedNode?.coords[NPE_LINK.X] === colIndex
                                                                     ? 'selected tensix no-click'


### PR DESCRIPTION
Added a check to ensure the selected node's CHIP_ID matches the current cluster chip before applying the 'selected' class.

closes #653 