### PR TITLE
Feat/Improve responsive styles

### DIFF
--- a/src/components/TensorArgument.tsx
+++ b/src/components/TensorArgument.tsx
@@ -51,7 +51,7 @@ function TensorArgument({ argument, onCollapse }: TensorArgumentProps) {
     }
 
     return (
-        <div className='expandable-argument'>
+        <div className='tensor-argument'>
             <Switch
                 label={isExpanded ? 'Hide full tensor' : 'Show full tensor'}
                 onChange={() => handleExpandToggle()}
@@ -60,9 +60,7 @@ function TensorArgument({ argument, onCollapse }: TensorArgumentProps) {
 
             {isExpanded ? (
                 <>
-                    {typeof argument.value === 'string' && (
-                        <pre className='full-tensor'>{argument.value as string}</pre>
-                    )}
+                    {typeof argument.value === 'string' && <pre>{argument.value as string}</pre>}
 
                     {onCollapse && (
                         <Switch
@@ -75,9 +73,9 @@ function TensorArgument({ argument, onCollapse }: TensorArgumentProps) {
             ) : (
                 Array.isArray(splitArgument) && (
                     <>
-                        <p className='collapsed-tensor monospace'>{splitArgument[0]}</p>
-                        <p className='collapsed-tensor monospace'>.........</p>
-                        <p className='collapsed-tensor monospace'>{splitArgument[splitArgument.length - 1]}</p>
+                        <p className='monospace'>{splitArgument[0]}</p>
+                        <p className='monospace'>.........</p>
+                        <p className='monospace'>{splitArgument[splitArgument.length - 1]}</p>
                     </>
                 )
             )}

--- a/src/components/performance/ComparisonReportSelector.tsx
+++ b/src/components/performance/ComparisonReportSelector.tsx
@@ -6,6 +6,7 @@ import { Button, ButtonVariant, FormGroup } from '@blueprintjs/core';
 import { useAtom, useAtomValue } from 'jotai';
 import React, { FC } from 'react';
 import { IconNames } from '@blueprintjs/icons';
+import classNames from 'classnames';
 import LocalFolderPicker from '../report-selection/LocalFolderPicker';
 import { ReportFolder } from '../../definitions/Reports';
 import { activePerformanceReportAtom, comparisonPerformanceReportAtom } from '../../store/app';
@@ -15,15 +16,22 @@ interface ComparisonReportSelectorProps {
     reportIndex: number;
     label?: React.ReactNode;
     subLabel?: string;
+    className?: string;
 }
 
-const ComparisonReportSelector: FC<ComparisonReportSelectorProps> = ({ folderList, reportIndex, label, subLabel }) => {
+const ComparisonReportSelector: FC<ComparisonReportSelectorProps> = ({
+    folderList,
+    reportIndex,
+    label,
+    subLabel,
+    className,
+}) => {
     const [comparisonReports, setComparisonReports] = useAtom(comparisonPerformanceReportAtom);
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
 
     return (
         <FormGroup
-            className='form-group'
+            className={classNames('form-group', className)}
             label={label}
             subLabel={subLabel}
             data-testid='comparison-report-selector'

--- a/src/components/report-selection/RemoteConnectionSelector.tsx
+++ b/src/components/report-selection/RemoteConnectionSelector.tsx
@@ -37,59 +37,61 @@ const RemoteConnectionSelector: FC<RemoteConnectionSelectorProps> = ({
     const selectedConnection = connection ?? connectionList[0];
 
     return (
-        <div className='buttons-container'>
-            <Select
-                className='remote-connection-select'
-                items={connectionList}
-                itemRenderer={(item, itemProps) => renderRemoteConnection(item, itemProps, selectedConnection)}
-                disabled={disabled}
-                filterable
-                itemPredicate={filterRemoteConnections}
-                noResults={
-                    <MenuItem
-                        disabled
-                        text='No results'
-                        roleStructure='listoption'
-                    />
-                }
-                onItemSelect={onSelectConnection}
-            >
-                <Button
-                    icon={offline ? IconNames.BAN_CIRCLE : IconNames.CLOUD}
-                    endIcon={IconNames.CARET_DOWN}
+        <>
+            <div className='buttons-container'>
+                <Select
+                    className='remote-connection-select'
+                    items={connectionList}
+                    itemRenderer={(item, itemProps) => renderRemoteConnection(item, itemProps, selectedConnection)}
                     disabled={disabled}
-                    text={formatConnectionString(selectedConnection)}
-                />
-            </Select>
-            <Tooltip content='Edit selected connection'>
-                <AnchorButton
-                    icon={IconNames.EDIT}
-                    disabled={disabled || !selectedConnection}
-                    onClick={() => setIsEditDialogOpen(true)}
-                />
-            </Tooltip>
-            <Tooltip content='Remove selected connection'>
-                <AnchorButton
-                    icon={IconNames.TRASH}
-                    disabled={disabled || !selectedConnection}
-                    onClick={() => onRemoveConnection(selectedConnection)}
-                />
-            </Tooltip>
+                    filterable
+                    itemPredicate={filterRemoteConnections}
+                    noResults={
+                        <MenuItem
+                            disabled
+                            text='No results'
+                            roleStructure='listoption'
+                        />
+                    }
+                    onItemSelect={onSelectConnection}
+                >
+                    <Button
+                        icon={offline ? IconNames.BAN_CIRCLE : IconNames.CLOUD}
+                        endIcon={IconNames.CARET_DOWN}
+                        disabled={disabled}
+                        text={formatConnectionString(selectedConnection)}
+                    />
+                </Select>
+                <Tooltip content='Edit selected connection'>
+                    <AnchorButton
+                        icon={IconNames.EDIT}
+                        disabled={disabled || !selectedConnection}
+                        onClick={() => setIsEditDialogOpen(true)}
+                    />
+                </Tooltip>
+                <Tooltip content='Remove selected connection'>
+                    <AnchorButton
+                        icon={IconNames.TRASH}
+                        disabled={disabled || !selectedConnection}
+                        onClick={() => onRemoveConnection(selectedConnection)}
+                    />
+                </Tooltip>
 
-            <RemoteConnectionDialog
-                key={`${selectedConnection?.name}${selectedConnection?.host}${selectedConnection?.port}${selectedConnection?.profilerPath}`}
-                open={isEditdialogOpen}
-                onAddConnection={(updatedConnection) => {
-                    setIsEditDialogOpen(false);
-                    onEditConnection(updatedConnection, connection);
-                }}
-                onClose={() => {
-                    setIsEditDialogOpen(false);
-                }}
-                title='Edit remote connection'
-                buttonLabel='Save connection'
-                remoteConnection={selectedConnection}
-            />
+                <RemoteConnectionDialog
+                    key={`${selectedConnection?.name}${selectedConnection?.host}${selectedConnection?.port}${selectedConnection?.profilerPath}`}
+                    open={isEditdialogOpen}
+                    onAddConnection={(updatedConnection) => {
+                        setIsEditDialogOpen(false);
+                        onEditConnection(updatedConnection, connection);
+                    }}
+                    onClose={() => {
+                        setIsEditDialogOpen(false);
+                    }}
+                    title='Edit remote connection'
+                    buttonLabel='Save connection'
+                    remoteConnection={selectedConnection}
+                />
+            </div>
 
             <Button
                 icon={IconNames.LOCATE}
@@ -98,7 +100,7 @@ const RemoteConnectionSelector: FC<RemoteConnectionSelectorProps> = ({
                 text='Fetch remote folders list'
                 onClick={() => onSyncRemoteFolderList(selectedConnection)}
             />
-        </div>
+        </>
     );
 };
 

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -148,6 +148,7 @@ export default function Performance() {
                         {folderList &&
                             reportSelectors?.map((_, index) => (
                                 <ComparisonReportSelector
+                                    className='report-selector'
                                     key={`${index}-comparison-report-selector`}
                                     folderList={folderList}
                                     reportIndex={index}

--- a/src/scss/components/BufferSummaryTable.scss
+++ b/src/scss/components/BufferSummaryTable.scss
@@ -12,6 +12,8 @@
     display: inline-flex;
     height: 600px;
     flex-direction: column;
+    overflow: auto;
+    max-width: 100%;
 
     .aside-container {
         display: flex;

--- a/src/scss/components/MainNavigation.scss
+++ b/src/scss/components/MainNavigation.scss
@@ -4,8 +4,8 @@
 
 @use 'styles/definitions/colours' as *;
 
-$breakpoint-medium: 1300px;
-$breakpoint-small: 1100px;
+$bp-nav-large: 1300px;
+$bp-nav-medium: 1100px;
 
 @mixin button-styles($color, $colorActive, $icon) {
     color: $color;
@@ -118,7 +118,7 @@ $breakpoint-small: 1100px;
         gap: 7px;
     }
 
-    @media screen and (width <= $breakpoint-medium) {
+    @media screen and (width <= $bp-nav-large) {
         .bp5-button-text {
             font-size: 13px;
         }
@@ -133,7 +133,7 @@ $breakpoint-small: 1100px;
         }
     }
 
-    @media screen and (width <= $breakpoint-small) {
+    @media screen and (width <= $bp-nav-medium) {
         .bp5-button-text {
             display: none;
         }

--- a/src/scss/components/MainNavigation.scss
+++ b/src/scss/components/MainNavigation.scss
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 @use 'styles/definitions/colours' as *;
+@use 'styles/definitions/variables' as variables;
 
 $bp-nav-large: 1300px;
 $bp-nav-medium: 1100px;
@@ -118,7 +119,7 @@ $bp-nav-medium: 1100px;
         gap: 7px;
     }
 
-    @media screen and (width <= $bp-nav-large) {
+    @media screen and (width <= #{variables.$bp-large}) {
         .bp5-button-text {
             font-size: 13px;
         }
@@ -133,7 +134,7 @@ $bp-nav-medium: 1100px;
         }
     }
 
-    @media screen and (width <= $bp-nav-medium) {
+    @media screen and (width <= #{variables.$bp-medium}) {
         .bp5-button-text {
             display: none;
         }

--- a/src/scss/components/MainNavigation.scss
+++ b/src/scss/components/MainNavigation.scss
@@ -5,9 +5,6 @@
 @use 'styles/definitions/colours' as *;
 @use 'styles/definitions/variables' as variables;
 
-$bp-nav-large: 1300px;
-$bp-nav-medium: 1100px;
-
 @mixin button-styles($color, $colorActive, $icon) {
     color: $color;
 

--- a/src/scss/components/OldFolderPicker.scss
+++ b/src/scss/components/OldFolderPicker.scss
@@ -29,7 +29,7 @@
         justify-content: stretch;
         min-height: fit-content;
         flex-basis: 45%;
-        flex-grow: 0;
+        flex-grow: 1;
         max-width: 550px;
 
         & > .bp5-icon {
@@ -44,7 +44,7 @@
 
         .buttons-container {
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             gap: 5px;
         }
 

--- a/src/scss/components/OperationDetailsComponent.scss
+++ b/src/scss/components/OperationDetailsComponent.scss
@@ -113,7 +113,6 @@
         display: flex;
         flex-wrap: wrap;
         gap: 20px;
-        overflow-x: hidden;
     }
 
     .no-buffer-type-selected {

--- a/src/scss/components/OperationGraphComponent.scss
+++ b/src/scss/components/OperationGraphComponent.scss
@@ -2,7 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-@use '../definitions/colours' as *;
+@use 'styles/definitions/colours' as *;
+@use 'styles/definitions/variables' as variables;
 
 .operation-graph-component {
     .operation-graph-container {
@@ -85,6 +86,22 @@
 
                 > div {
                     margin-left: 15px;
+                }
+            }
+        }
+
+        @media screen and (width <= #{variables.$bp-large}) {
+            width: 350px;
+
+            .tensors {
+                .tensor-details {
+                    > table {
+                        tr {
+                            display: flex;
+                            flex-direction: column;
+                            align-items: flex-start;
+                        }
+                    }
                 }
             }
         }

--- a/src/scss/components/PerfChart.scss
+++ b/src/scss/components/PerfChart.scss
@@ -6,8 +6,7 @@
 
 .chart-container {
     margin-bottom: 60px;
-    height: 500px; // TEMP: Stops charts from collapsing on occasion
-    min-width: 800px;
+    height: 500px; // Stops charts from collapsing on occasion
 
     .chart {
         width: 100%;

--- a/src/scss/components/PerfChart.scss
+++ b/src/scss/components/PerfChart.scss
@@ -7,6 +7,7 @@
 .chart-container {
     margin-bottom: 60px;
     height: 500px; // TEMP: Stops charts from collapsing on occasion
+    min-width: 800px;
 
     .chart {
         width: 100%;

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -9,7 +9,7 @@
     gap: 30px;
 
     .charts {
-        min-width: 800px;
+        min-width: 800px; // Ensures charts are wide enough to display properly and allows overflow
         overflow: auto;
     }
 }

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -7,6 +7,11 @@
     grid-template-columns: 250px 1fr;
     position: relative;
     gap: 30px;
+
+    .charts {
+        min-width: 800px;
+        overflow: auto;
+    }
 }
 
 .folder-selection {

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -13,6 +13,7 @@ $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%
     color: #fff;
     padding: 1rem;
     min-width: 1240px;
+    overflow: auto;
 
     .table-header {
         display: flex;

--- a/src/scss/components/TensorArgument.scss
+++ b/src/scss/components/TensorArgument.scss
@@ -1,17 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-.tensor-argument {
-    .collapsed-tensor {
-        white-space: preserve-breaks;
-        margin-top: 20px;
-        margin-bottom: 20px;
-        font-size: 1em;
-    }
 
-    .full-tensor {
-        margin-top: 20px;
-        margin-bottom: 20px;
-        white-space: preserve-breaks;
-    }
+.tensor-argument {
+    overflow: auto;
 }

--- a/src/scss/definitions/_variables.scss
+++ b/src/scss/definitions/_variables.scss
@@ -2,5 +2,10 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+// Fonts
 $base-font: 'Arial Nova', arial, sans-serif;
 $monospace-font: monospace;
+
+// Breakpoints
+$bp-large: 1300px;
+$bp-medium: 1100px;

--- a/src/scss/routes/Performance.scss
+++ b/src/scss/routes/Performance.scss
@@ -7,6 +7,11 @@
     align-items: flex-end;
     flex-wrap: wrap;
     gap: 10px;
+    margin-bottom: 15px;
+
+    .report-selector {
+        margin-bottom: 0;
+    }
 }
 
 .switch-label-with-icon {


### PR DESCRIPTION
Tweaks various styles (adding overflow, change wrapping behaviour, sizing etc) to improve responsiveness of our views.

Where we use the Blueprint table, I just overflowed it because it would need more work to make it truly responsive. Similarly with the perf charts I put a min-width because the smaller they get the less readable they get.

Example of overflowing table and improved input wrapping in Performance
<img width="882" height="870" alt="Screenshot 2025-07-21 at 1 09 20 PM" src="https://github.com/user-attachments/assets/13e396cd-eaf8-4731-ab60-c6f686590061" />


More narrow sidebar in Graph at a specific breakpoint
<img width="1316" height="706" alt="Screenshot 2025-07-21 at 1 02 02 PM" src="https://github.com/user-attachments/assets/b0181b3a-1f7d-4f31-84d7-2eedaa8cb2c3" />
<img width="1262" height="706" alt="Screenshot 2025-07-21 at 1 01 53 PM" src="https://github.com/user-attachments/assets/c54d4585-fe18-407f-90dc-ef67239f414a" />

https://github.com/tenstorrent/ttnn-visualizer/issues/663