### PR TITLE
Feat/Improve tensor visualisation responsiveness

### DIFF
--- a/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
+++ b/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
@@ -7,7 +7,6 @@ import { BufferPage } from '../../model/APIData';
 import { pageDataToChunkArray } from '../../functions/getChartData';
 
 interface SVGBufferRendererProps {
-    width: number;
     height: number;
     data: BufferPage[];
     memorySize: number;
@@ -15,28 +14,27 @@ interface SVGBufferRendererProps {
 }
 
 const SVGBufferRenderer: React.FC<SVGBufferRendererProps> = ({
-    width,
     height,
     data,
     memorySize,
     memoryStart,
 }: SVGBufferRendererProps) => {
-    const ratio = width / (memorySize - memoryStart);
+    const memoryRange = memorySize - memoryStart;
     const mergedRange = pageDataToChunkArray(data);
 
     return (
-        <svg
-            width={width}
-            height={height}
-        >
+        <svg height={height}>
             <g>
                 {mergedRange.map((range) => {
+                    const xPercent = ((range.address - memoryStart) / memoryRange) * 100;
+                    const widthPercent = (range.size / memoryRange) * 100;
+
                     return (
                         <rect
                             key={range.address}
-                            x={ratio * (range.address - memoryStart)}
+                            x={`${xPercent}%`}
                             y={0}
-                            width={ratio * range.size}
+                            width={`${widthPercent}%`}
                             height={height}
                             fill={range.color || 'red'}
                         />

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -139,66 +139,68 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
                         />
                     </h3>
                 </div>
+
                 <div className='chip'>
-                    <div
-                        className='tensix-grid empty'
-                        style={{
-                            gridTemplateColumns: `repeat(${width || 0}, ${tensixSize}px)`,
-                            gridTemplateRows: `repeat(${height || 0}, ${tensixHeight}px)`,
-                        }}
-                    >
-                        {Array.from({ length: width * height }).map((_, index) => (
-                            <div
-                                key={index}
-                                className='tensix empty-tensix'
-                                style={{
-                                    width: `${tensixSize}px`,
-                                    height: `${tensixHeight}px`,
-                                    gridColumn: (index % width) + 1,
-                                    gridRow: Math.floor(index / width) + 1,
-                                }}
-                            />
-                        ))}
-                    </div>
                     <div
                         className='tensix-grid'
                         style={{
-                            gridTemplateColumns: `repeat(${width || 0}, ${tensixSize}px)`,
+                            gridTemplateColumns: `repeat(${width || 0}, 1fr)`,
                             gridTemplateRows: `repeat(${height || 0}, ${tensixHeight}px)`,
                         }}
                     >
-                        {coordsByBankId.map((coords, index) => (
-                            <button
-                                type='button'
-                                key={index}
-                                className={classNames('tensix', { active: selectedTensix === index })}
-                                style={{
-                                    width: `${tensixSize}px`,
-                                    height: `${tensixHeight}px`,
-                                    gridColumn: coords.x + 1,
-                                    gridRow: coords.y + 1,
-                                }}
-                                onClick={() => {
-                                    setSelectedTensix(index);
-                                    setChartData(
-                                        getChartData(
-                                            pageDataToChunkArray(buffersByBankId[index]),
-                                            (id) => tensorByAddress?.get(id) || null,
-                                        ),
-                                    );
-                                }}
-                            >
-                                <SVGBufferRenderer
-                                    width={tensixSize - 2}
-                                    height={tensixHeight}
-                                    data={buffersByBankId[index]}
-                                    memorySize={memSize}
-                                    memoryStart={memStart}
+                        {Array.from({ length: width * height }).map((_, index) => {
+                            const x = index % width;
+                            const y = Math.floor(index / width);
+                            const matchIndex = coordsByBankId.findIndex((coord) => coord?.x === x && coord?.y === y);
+                            const match = coordsByBankId[matchIndex];
+
+                            return match ? (
+                                <button
+                                    type='button'
+                                    key={index}
+                                    className={classNames('tensix', {
+                                        active:
+                                            selectedTensix ===
+                                            coordsByBankId.findIndex((coord) => coord?.x === x && coord?.y === y),
+                                    })}
+                                    style={{
+                                        gridColumn: match.x + 1,
+                                        gridRow: match.y + 1,
+                                    }}
+                                    onClick={() => {
+                                        const tensixIndex = coordsByBankId.findIndex(
+                                            (coord) => coord?.x === x && coord?.y === y,
+                                        );
+                                        setSelectedTensix(tensixIndex);
+                                        setChartData(
+                                            getChartData(
+                                                pageDataToChunkArray(buffersByBankId[tensixIndex]),
+                                                (id) => tensorByAddress?.get(id) || null,
+                                            ),
+                                        );
+                                    }}
+                                >
+                                    <SVGBufferRenderer
+                                        height={tensixHeight}
+                                        data={buffersByBankId[matchIndex]}
+                                        memorySize={memSize}
+                                        memoryStart={memStart}
+                                    />
+                                </button>
+                            ) : (
+                                <div
+                                    key={index}
+                                    className='tensix empty-tensix'
+                                    style={{
+                                        gridColumn: x + 1,
+                                        gridRow: y + 1,
+                                    }}
                                 />
-                            </button>
-                        ))}
+                            );
+                        })}
                     </div>
                 </div>
+
                 {selectedTensix !== null && (
                     <div className='tensix-details'>
                         <div className='tensix-details-header'>

--- a/src/scss/components/TensorVisualizationComponent.scss
+++ b/src/scss/components/TensorVisualizationComponent.scss
@@ -30,11 +30,6 @@
         }
 
         .tensix-grid {
-            &.empty {
-                position: absolute;
-                z-index: -1;
-            }
-
             display: grid;
             gap: 10px;
 
@@ -43,6 +38,7 @@
                 flex-direction: column;
                 border: 1px solid $tt-black;
                 background-color: $tt-grey-2;
+                max-width: 120px;
 
                 &:hover {
                     transition: border-color 100ms linear;


### PR DESCRIPTION
Previous approach to rendering this used two grids, I've combined them and set a max size for each tensix to 120px (default size before). It'll scale as the screen gets smaller.

<img width="1152" height="870" alt="Screenshot 2025-07-21 at 1 31 48 PM" src="https://github.com/user-attachments/assets/98deacfc-8c02-4705-9e88-6afd0cf36f79" />


The major visual change is that if there is no tensix information each cell is about 50px.
<img width="1033" height="870" alt="Screenshot 2025-07-21 at 1 32 19 PM" src="https://github.com/user-attachments/assets/c7fa2a4a-c051-497b-a212-6790a12f506d" />


https://github.com/tenstorrent/ttnn-visualizer/issues/662