### PR TITLE
Remove remote querying

### DIFF
--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -169,7 +169,6 @@ class RemoteConnection(SerializeableModel):
     profilerPath: str
     performancePath: Optional[str] = None
     sqliteBinaryPath: Optional[str] = None
-    useRemoteQuerying: bool = False
 
 
 class StatusMessage(SerializeableModel):

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -72,11 +72,7 @@ class DatabaseQueries:
                 raise ValueError(
                     "Must provide either an existing connection or instance"
                 )
-            remote_connection = instance.remote_connection if instance else None
-            if remote_connection and remote_connection.useRemoteQuerying:
-                raise NotImplementedError("Remote querying is not implemented yet")
-            else:
-                self.query_runner = LocalQueryRunner(instance=instance)
+            self.query_runner = LocalQueryRunner(instance=instance)
 
     def _check_table_exists(self, table_name: str) -> bool:
         """

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Button, ButtonGroup, Dialog, DialogBody, DialogFooter, FormGroup, InputGroup } from '@blueprintjs/core';
+import { Button, Dialog, DialogBody, DialogFooter, FormGroup, InputGroup } from '@blueprintjs/core';
 import { FC, useState } from 'react';
 import 'styles/components/RemoteConnectionDialog.scss';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
@@ -40,23 +40,11 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
     ];
     const [connection, setConnection] = useState<Partial<RemoteConnection>>(defaultConnection);
     const [connectionTests, setConnectionTests] = useState<ConnectionStatus[]>(defaultConnectionTests);
-    const { testConnection, fetchSqlitePath } = useRemoteConnection();
+    const { testConnection } = useRemoteConnection();
     const [isTestingConnection, setIsTestingconnection] = useState(false);
-    const [isDetectingBinaryPath, setIsDetectingBinaryPath] = useState(false);
+    const [isDetectingBinaryPath] = useState(false);
 
     const isValidConnection = connectionTests.every((status) => status.status === ConnectionTestStates.OK);
-
-    const getSqlitePath = async () => {
-        setIsDetectingBinaryPath(true);
-        const status = await fetchSqlitePath(connection);
-        if (status.status === ConnectionTestStates.OK) {
-            setConnection({ ...connection, sqliteBinaryPath: status.message });
-        }
-        if (status.status === ConnectionTestStates.FAILED) {
-            setConnection({ ...connection, sqliteBinaryPath: 'Path Not Found' });
-        }
-        setIsDetectingBinaryPath(false);
-    };
 
     const testConnectionStatus = async () => {
         setIsTestingconnection(true);
@@ -176,40 +164,6 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
                         onChange={(e) => setConnection({ ...connection, performancePath: e.target.value })}
                     />
                 </FormGroup>
-
-                {/* TODO: Disabled for now until we have a solution for out of date sqlite versions */}
-                {/* <FormGroup>
-                    <Checkbox
-                        checked={connection.useRemoteQuerying}
-                        label='Use Remote Querying'
-                        onChange={(e) => setConnection({ ...connection, useRemoteQuerying: e.target.checked })}
-                    />
-                </FormGroup> */}
-                {connection.useRemoteQuerying && (
-                    <fieldset className='remote-querying-fieldset'>
-                        <legend>Remote Querying Configuration</legend>
-
-                        <FormGroup
-                            label='Remote SQLite Binary Location'
-                            subLabel='SQLite Binary Location'
-                        >
-                            <InputGroup
-                                key='sqliteBinaryPath'
-                                value={connection.sqliteBinaryPath}
-                                onChange={(e) => setConnection({ ...connection, sqliteBinaryPath: e.target.value })}
-                            />
-                        </FormGroup>
-
-                        <ButtonGroup className='remote-sql-test-buttons'>
-                            <Button
-                                text='Detect Path'
-                                disabled={isDetectingBinaryPath}
-                                loading={isDetectingBinaryPath}
-                                onClick={getSqlitePath}
-                            />
-                        </ButtonGroup>
-                    </fieldset>
-                )}
 
                 <fieldset>
                     <legend>Test Connection</legend>

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -50,9 +50,6 @@ const remoteFolderRenderer =
         connection?: RemoteConnection,
     ): ItemRenderer<RemoteFolder> =>
     (folder, { handleClick, modifiers }) => {
-        const { persistentState } = useRemoteConnection();
-        const isUsingRemoteQuerying = persistentState.selectedConnection?.useRemoteQuerying;
-
         if (!modifiers.matchesPredicate) {
             return null;
         }
@@ -91,7 +88,7 @@ const remoteFolderRenderer =
         const getLabelElement = () => (
             <>
                 <span>{reportName}</span>
-                <span className='status-icon'>{!isUsingRemoteQuerying && statusIcon}</span>
+                <span className='status-icon'>{statusIcon}</span>
             </>
         );
 

--- a/src/definitions/RemoteConnection.ts
+++ b/src/definitions/RemoteConnection.ts
@@ -13,7 +13,6 @@ export interface RemoteConnection {
     profilerPath: string;
     performancePath?: string;
     sqliteBinaryPath?: string;
-    useRemoteQuerying: boolean;
 }
 
 export interface RemoteFolder {


### PR DESCRIPTION
This PR fully removes the code for the legacy remote querying feature, which had been disabled for a while. This is distinct from the remote sync feature, which remains in place. Remote querying executed SQL queries in the sqlite3 db on the server, rather than downloading the the db and executing the queries locally.

Closes #660