### PR TITLE
Set staleTime to 0 in useNpe query

### DIFF
--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -434,7 +434,7 @@ export const useNpe = (fileName: string | null) =>
         queryFn: () => fetchNpeOpTrace(),
         queryKey: ['fetch-npe', fileName],
         retry: false,
-        staleTime: Infinity,
+        staleTime: 0,
     });
 
 export const useOperationDetails = (operationId: number | null) => {


### PR DESCRIPTION
Changed the staleTime option in the useNpe hook's query to ensure data is not cached and is always refetched.

closes #633