### PR TITLE
Enforce Node.js engine version and strict engine check

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 node-linker=hoisted
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "private": true,
   "version": "0.44.0",
   "type": "module",
-  "scripts": {
+    "engines": {
+        "node": "22.1.0"
+    },
+    "scripts": {
     "dev": "vite",
     "dev:server": "VITE_SERVER_MODE=1 vite",
     "build": "vite build",


### PR DESCRIPTION
Added an 'engines' field to package.json to require Node.js version 22.1.0 and set 'engine-strict=true' in .npmrc to enforce this requirement during installs.