### PR TITLE
Allow syncing a remote performance report without a profiler report

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -229,8 +229,6 @@ def main():
 
     gunicorn_args = [
         "gunicorn",
-        "-t",
-        "300",
         "-k",
         config.GUNICORN_WORKER_CLASS,
         "-w",

--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -229,6 +229,8 @@ def main():
 
     gunicorn_args = [
         "gunicorn",
+        "-t",
+        "300",
         "-k",
         config.GUNICORN_WORKER_CLASS,
         "-w",

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -902,11 +902,11 @@ def sync_remote_profiler_folders(
 def sync_remote_performance_folders(
     remote_connection: RemoteConnection,
     path_prefix: str,
-    profile: RemoteReportFolder,
+    performance: RemoteReportFolder,
     exclude_patterns: Optional[List[str]] = None,
     sid=None,
 ):
-    remote_folder_path = profile.remotePath
+    remote_folder_path = performance.remotePath
     profile_folder = Path(remote_folder_path).name
     destination_dir = Path(
         REPORT_DATA_DIRECTORY,

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -643,9 +643,11 @@ def get_performance_data_list(instance: Instance):
                 / connection.host
                 / current_app.config["PERFORMANCE_DIRECTORY_NAME"]
             )
-        directory_names = [
-            directory.name for directory in path.iterdir() if directory.is_dir()
-        ]
+        directory_names = (
+            [directory.name for directory in path.iterdir() if directory.is_dir()]
+            if path.exists()
+            else []
+        )
 
     valid_dirs = []
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -763,7 +763,10 @@ def get_performance_results_data_raw(instance: Instance):
 @with_instance
 def get_performance_results_report(instance: Instance):
     if not instance.performance_path:
-        return Response(status=HTTPStatus.NOT_FOUND)
+        return Response(
+            status=HTTPStatus.BAD_REQUEST,
+            response="No performance data found for instance.",
+        )
 
     name = request.args.get("name", None)
 

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -55,7 +55,7 @@ const remoteFolderRenderer =
         }
 
         const { lastSynced, lastModified, reportName } = folder;
-        const lastSyncedDate = lastSynced ? formatter.format(new Date(lastSynced)) : 'Never';
+        const lastSyncedDate = lastSynced ? formatter.format(getUTC(lastSynced)) : 'Never';
 
         let statusIcon = (
             <Tooltip content={`Fetching folder status, last sync: ${lastSyncedDate}`}>
@@ -166,5 +166,12 @@ const RemoteFolderSelector: FC<PropsWithChildren<RemoteFolderSelectorProps>> = (
         </div>
     );
 };
+
+function getUTC(epoch: number) {
+    const date = new Date(0);
+    date.setUTCSeconds(epoch);
+
+    return date;
+}
 
 export default RemoteFolderSelector;

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -4,7 +4,7 @@
 
 import { FC, useState } from 'react';
 
-import { AnchorButton, FormGroup, Tooltip } from '@blueprintjs/core';
+import { Button, FormGroup, Tooltip } from '@blueprintjs/core';
 
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom, useSetAtom } from 'jotai';
@@ -158,6 +158,7 @@ const RemoteSyncConfigurator: FC = () => {
                     }}
                 />
             </FormGroup>
+
             <FormGroup
                 className='form-group'
                 label={<h3 className='label'>Use remote sync server</h3>}
@@ -280,7 +281,7 @@ const RemoteSyncConfigurator: FC = () => {
                     type='profiler'
                 >
                     <Tooltip content='Sync remote folder'>
-                        <AnchorButton
+                        <Button
                             icon={IconNames.REFRESH}
                             loading={isSyncingReportFolder}
                             disabled={isDisabled || !selectedReportFolder || reportFolderList?.length === 0}
@@ -325,13 +326,7 @@ const RemoteSyncConfigurator: FC = () => {
                                         );
 
                                         if (response.status === 200) {
-                                            const performanceFileName = selectedPerformanceFolder?.reportName;
-
                                             updateReportSelection(selectedReportFolder);
-
-                                            if (performanceFileName) {
-                                                updatePerformanceSelection(performanceFileName);
-                                            }
                                         }
                                     }
                                 }
@@ -373,7 +368,7 @@ const RemoteSyncConfigurator: FC = () => {
                         type='performance'
                     >
                         <Tooltip content='Sync remote folder'>
-                            <AnchorButton
+                            <Button
                                 icon={IconNames.REFRESH}
                                 loading={isSyncingPerformanceFolder}
                                 disabled={

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -322,7 +322,6 @@ const RemoteSyncConfigurator: FC = () => {
                                         const response = await remote.mountRemoteFolder(
                                             remote.persistentState.selectedConnection,
                                             selectedReportFolder,
-                                            selectedPerformanceFolder,
                                         );
 
                                         if (response.status === 200) {
@@ -418,7 +417,7 @@ const RemoteSyncConfigurator: FC = () => {
                                             ) {
                                                 const response = await remote.mountRemoteFolder(
                                                     remote.persistentState.selectedConnection,
-                                                    selectedReportFolder,
+                                                    undefined,
                                                     selectedPerformanceFolder,
                                                 );
 

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -65,6 +65,7 @@ const useRemoteConnection = () => {
         if (!profilerRemoteFolder && !performanceRemoteFolder) {
             throw new Error('No remote folder provided');
         }
+
         return axiosInstance.post<RemoteFolder>('/api/remote/sync', {
             connection,
             profiler: profilerRemoteFolder,

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -55,32 +55,32 @@ const useRemoteConnection = () => {
 
     const syncRemoteFolder = async (
         connection?: RemoteConnection,
-        remoteFolder?: RemoteFolder,
-        remoteProfile?: RemoteFolder,
+        profilerRemoteFolder?: RemoteFolder,
+        performanceRemoteFolder?: RemoteFolder,
     ) => {
         if (!connection || !connection.host || !connection.port || !connection.profilerPath) {
             throw new Error('No connection provided');
         }
 
-        if (!remoteFolder && !remoteProfile) {
+        if (!profilerRemoteFolder && !performanceRemoteFolder) {
             throw new Error('No remote folder provided');
         }
         return axiosInstance.post<RemoteFolder>('/api/remote/sync', {
             connection,
-            folder: remoteFolder,
-            profile: remoteProfile,
+            profiler: profilerRemoteFolder,
+            performance: performanceRemoteFolder,
         });
     };
 
     const mountRemoteFolder = async (
         connection: RemoteConnection,
-        remoteFolder?: RemoteFolder,
-        remoteProfile?: RemoteFolder,
+        profilerRemoteFolder?: RemoteFolder,
+        performanceRemoteFolder?: RemoteFolder,
     ) => {
         return axiosInstance.post<MountRemoteFolder>('/api/remote/use', {
             connection,
-            folder: remoteFolder,
-            profile: remoteProfile,
+            profiler: profilerRemoteFolder,
+            performance: performanceRemoteFolder,
         });
     };
 


### PR DESCRIPTION
This PR resolves an issue where 500 errors were being returned when you put in the details for a report SSH connection, but tried to sync the performance report before the profiler report.

The remote sync wasn't set up to allow syncing performance report independent of profiler report. After fetching the remote folder list, if you pressed sync for the performance report, it would download the remote files for just the performance report, but the post to `/api/remote/use` didn't handle this scenario right. First of all the frontend was sending the profiler path in the post to `/api/remote/use` even though only the performance path had been synced by the user. The frontend is being updated to not do that anymore.

With the frontend sending the profiler path even though it hadn't been synced, the `/api/remote/use` code would save the path to the `instance` record in the db, and this would activate the corresponding tabs in the UI, but since the report had not been synced and saved locally to the path in the `instance.profiler_path` field in the db, all of the other APIs would return 500 errors, since the path did not exist locally.

I have updated the backend for `/api/remote/use` to independently save the profiler fields and the performance fields. They are only saved if they were sent in the request, and made it not required in the backend to have the profiler data sent.

Additionally, we are renaming the fields sent in the post to `/api/remote/use` and `/api/remote/sync`. The field names it was using, `folder` to refer to what is otherwise called the "profiler report", and `profile` to refer to what is otherwise called the performance report, was super confusing.

I am also removing code in the view for `/api/remote/use` that made a `connection_directory` var, had error handling to check that it existed, then constructed a `report_path` var, because all it was used for was a log statement. Way to much code for a not meaningfully useful log statement.

Closes [#628](https://github.com/tenstorrent/ttnn-visualizer/issues/628)
