### PR TITLE
Chore/Cleanup CSS

### DIFF
--- a/src/components/report-selection/ConnectionTestMessage.tsx
+++ b/src/components/report-selection/ConnectionTestMessage.tsx
@@ -4,13 +4,9 @@
 
 import { Icon, Intent } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
-import { ConnectionTestStates } from '../../definitions/ConnectionStatus';
+import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 
-interface ConnectionTestMessageProps {
-    status: ConnectionTestStates;
-    message: string;
-    detail?: string;
-}
+type ConnectionTestMessageProps = ConnectionStatus;
 
 const ICON_MAP: Record<ConnectionTestStates, IconName> = {
     [ConnectionTestStates.IDLE]: IconNames.DOT,
@@ -37,7 +33,7 @@ function ConnectionTestMessage({ status, message, detail }: ConnectionTestMessag
             />
             <div className='connection-status-content'>
                 <span className='connection-status-text'>{message}</span>
-                {detail && <pre className='connection-status-detail'>{detail}</pre>}
+                {detail && <code className='connection-status-detail'>{detail}</code>}
             </div>
         </div>
     );

--- a/src/scss/components/RemoteConnectionDialog.scss
+++ b/src/scss/components/RemoteConnectionDialog.scss
@@ -4,8 +4,6 @@
 
 @use '../definitions/colours' as *;
 
-$tt-pending: $tt-yellow;
-
 .bp5-dialog.remote-connection-dialog {
     background-color: $tt-grey-3;
 
@@ -57,18 +55,11 @@ $tt-pending: $tt-yellow;
     }
 
     .connection-status-detail {
-        font-family: 'Courier New', Consolas, 'Lucida Console', monospace;
         font-size: 12px;
         color: $tt-grey-6;
         background-color: $tt-grey-2;
-        border: 1px solid $tt-grey-4;
         border-radius: 4px;
         padding: 8px;
-        margin: 0;
-        white-space: pre-wrap;
-        word-break: break-all;
-        max-width: 400px;
-        overflow-x: auto;
     }
 
     &.status-idle .connection-status-icon {


### PR DESCRIPTION
Uses `<code>` tag in place of `<pre>` which lets us simplify the CSS required.

Also uses previously defined interface for component instead of duplicating it.

<img width="583" height="255" alt="Screenshot 2025-07-31 at 10 35 58 AM" src="https://github.com/user-attachments/assets/fa376cf0-42fd-4511-8da9-68d7d7b98060" />
