### PR TITLE
Add option to load reports directly from TT_METAL_HOME directory

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -192,6 +192,9 @@ def parse_args():
     parser.add_argument(
         "--performance-path", help="Specify a performance path", default=None
     )
+    parser.add_argument(
+        "--tt-metal-home", help="Specify a TT-Metal home path", default=None
+    )
     return parser.parse_args()
 
 
@@ -219,6 +222,9 @@ def main():
             sys.exit("Invalid profiler path")
 
         instance_id = session.instance_id
+
+    if args.tt_metal_home:
+        config.TT_METAL_HOME = args.tt_metal_home
 
     # Check if DEBUG environment variable is set
     debug_mode = os.environ.get("DEBUG", "false").lower() == "true"

--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -42,6 +42,7 @@ class DefaultConfig(object):
     APPLICATION_DIR = os.path.abspath(os.path.join(__file__, "..", os.pardir))
     APP_DATA_DIRECTORY = os.getenv("APP_DATA_DIRECTORY", APPLICATION_DIR)
     STATIC_ASSETS_DIR = Path(APPLICATION_DIR).joinpath("ttnn_visualizer", "static")
+    TT_METAL_HOME = os.getenv("TT_METAL_HOME", None)
     SEND_FILE_MAX_AGE_DEFAULT = 0
 
     LAUNCH_BROWSER_ON_START = str_to_bool(os.getenv("LAUNCH_BROWSER_ON_START", "true"))

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -24,7 +24,7 @@ class PathResolver:
     def __init__(self, current_app):
         self.current_app = current_app
         self.tt_metal_home = current_app.config.get("TT_METAL_HOME")
-        self.is_tt_metal_mode = bool(self.tt_metal_home)
+        self.is_local_tt_metal = bool(self.tt_metal_home)
 
     def get_base_report_path(self, report_type: str, remote_connection=None):
         """
@@ -37,7 +37,7 @@ class PathResolver:
         Returns:
             Path object to the base directory for this report type
         """
-        if self.is_tt_metal_mode:
+        if self.is_local_tt_metal:
             tt_metal_base = Path(self.tt_metal_home) / "generated"
             if report_type == "profiler":
                 return tt_metal_base / "ttnn" / "reports"
@@ -69,7 +69,7 @@ class PathResolver:
 
         base_path = self.get_base_report_path("profiler", remote_connection)
 
-        if self.is_tt_metal_mode and not base_path.exists():
+        if self.is_local_tt_metal and not base_path.exists():
             logger.warning(f"TT-Metal profiler reports not found: {base_path}")
             return ""
 
@@ -82,7 +82,7 @@ class PathResolver:
         """Get the full path to a performance report directory."""
         base_path = self.get_base_report_path("performance", remote_connection)
 
-        if self.is_tt_metal_mode and not base_path.exists():
+        if self.is_local_tt_metal and not base_path.exists():
             logger.warning(f"TT-Metal performance reports not found: {base_path}")
             return ""
 
@@ -91,7 +91,7 @@ class PathResolver:
 
     def get_mode_info(self):
         """Get information about the current mode for debugging/display."""
-        if self.is_tt_metal_mode:
+        if self.is_local_tt_metal:
             return {
                 "mode": "tt_metal",
                 "tt_metal_home": self.tt_metal_home,
@@ -111,7 +111,7 @@ class PathResolver:
 
     def validate_tt_metal_setup(self):
         """Validate that TT-Metal directories exist and are accessible."""
-        if not self.is_tt_metal_mode:
+        if not self.is_local_tt_metal:
             return True, "Not in TT-Metal mode"
 
         tt_metal_base = Path(self.tt_metal_home)

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -54,16 +54,24 @@ def get_performance_path(performance_name, current_app, remote_connection=None):
 
     :return: Profiler path as a string.
     """
-    local_dir = Path(current_app.config["LOCAL_DATA_DIRECTORY"])
-    remote_dir = Path(current_app.config["REMOTE_DATA_DIRECTORY"])
-
-    if remote_connection:
-        base_dir = Path(remote_dir).joinpath(remote_connection.host)
+    if current_app.config["TT_METAL_HOME"]:
+        tt_metal_home = Path(current_app.config["TT_METAL_HOME"])
+        tt_metal_report_path = tt_metal_home / "generated" / "profiler" / "reports"
+        if not tt_metal_report_path.exists():
+            logger.warning(f"TT-Metal reports not found: {tt_metal_report_path}")
+            return None
+        performance_path = tt_metal_report_path / performance_name
     else:
-        base_dir = local_dir
+        local_dir = Path(current_app.config["LOCAL_DATA_DIRECTORY"])
+        remote_dir = Path(current_app.config["REMOTE_DATA_DIRECTORY"])
 
-    profiler_dir = base_dir / current_app.config["PERFORMANCE_DIRECTORY_NAME"]
-    performance_path = profiler_dir / performance_name
+        if remote_connection:
+            base_dir = Path(remote_dir).joinpath(remote_connection.host)
+        else:
+            base_dir = local_dir
+
+        profiler_dir = base_dir / current_app.config["PERFORMANCE_DIRECTORY_NAME"]
+        performance_path = profiler_dir / performance_name
 
     return str(performance_path)
 
@@ -82,14 +90,22 @@ def get_profiler_path(profiler_name, current_app, remote_connection=None):
     remote_dir = current_app.config["REMOTE_DATA_DIRECTORY"]
 
     if profiler_name:
-        if remote_connection:
-            base_dir = Path(remote_dir).joinpath(remote_connection.host)
+        if current_app.config["TT_METAL_HOME"]:
+            tt_metal_home = Path(current_app.config["TT_METAL_HOME"])
+            tt_metal_report_path = tt_metal_home / "generated" / "ttnn" / "reports"
+            if not tt_metal_report_path.exists():
+                logger.warning(f"TT-Metal reports not found: {tt_metal_report_path}")
+                return None
+            profiler_path = tt_metal_report_path / profiler_name
         else:
-            base_dir = local_dir
+            if remote_connection:
+                base_dir = Path(remote_dir).joinpath(remote_connection.host)
+            else:
+                base_dir = local_dir
 
-        profiler_path = (
-            base_dir / current_app.config["PROFILER_DIRECTORY_NAME"] / profiler_name
-        )
+            profiler_path = (
+                base_dir / current_app.config["PROFILER_DIRECTORY_NAME"] / profiler_name
+            )
         target_path = profiler_path / database_file_name
 
         return str(target_path)

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -24,7 +24,7 @@ class PathResolver:
     def __init__(self, current_app):
         self.current_app = current_app
         self.tt_metal_home = current_app.config.get("TT_METAL_HOME")
-        self.is_local_tt_metal = bool(self.tt_metal_home)
+        self.is_direct_report_mode = bool(self.tt_metal_home)
 
     def get_base_report_path(self, report_type: str, remote_connection=None):
         """
@@ -37,7 +37,7 @@ class PathResolver:
         Returns:
             Path object to the base directory for this report type
         """
-        if self.is_local_tt_metal:
+        if self.is_direct_report_mode:
             tt_metal_base = Path(self.tt_metal_home) / "generated"
             if report_type == "profiler":
                 return tt_metal_base / "ttnn" / "reports"
@@ -69,7 +69,7 @@ class PathResolver:
 
         base_path = self.get_base_report_path("profiler", remote_connection)
 
-        if self.is_local_tt_metal and not base_path.exists():
+        if self.is_direct_report_mode and not base_path.exists():
             logger.warning(f"TT-Metal profiler reports not found: {base_path}")
             return ""
 
@@ -82,7 +82,7 @@ class PathResolver:
         """Get the full path to a performance report directory."""
         base_path = self.get_base_report_path("performance", remote_connection)
 
-        if self.is_local_tt_metal and not base_path.exists():
+        if self.is_direct_report_mode and not base_path.exists():
             logger.warning(f"TT-Metal performance reports not found: {base_path}")
             return ""
 
@@ -91,7 +91,7 @@ class PathResolver:
 
     def get_mode_info(self):
         """Get information about the current mode for debugging/display."""
-        if self.is_local_tt_metal:
+        if self.is_direct_report_mode:
             return {
                 "mode": "tt_metal",
                 "tt_metal_home": self.tt_metal_home,
@@ -111,7 +111,7 @@ class PathResolver:
 
     def validate_tt_metal_setup(self):
         """Validate that TT-Metal directories exist and are accessible."""
-        if not self.is_local_tt_metal:
+        if not self.is_direct_report_mode:
             return True, "Not in TT-Metal mode"
 
         tt_metal_base = Path(self.tt_metal_home)

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -376,7 +376,7 @@ def get_profiler_data_list(instance: Instance):
     path = resolver.get_base_report_path("profiler", instance.remote_connection)
 
     if not path.exists():
-        if resolver.is_local_tt_metal:
+        if resolver.is_direct_report_mode:
             logger.warning(f"TT-Metal profiler reports not found: {path}")
             return jsonify([])
         else:
@@ -498,7 +498,7 @@ def get_performance_data_list(instance: Instance):
     is_remote = True if instance.remote_connection else False
 
     if not path.exists():
-        if resolver.is_local_tt_metal:
+        if resolver.is_direct_report_mode:
             logger.warning(f"TT-Metal performance reports not found: {path}")
             return jsonify([])
         elif not is_remote:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -376,7 +376,7 @@ def get_profiler_data_list(instance: Instance):
     path = resolver.get_base_report_path("profiler", instance.remote_connection)
 
     if not path.exists():
-        if resolver.is_tt_metal_mode:
+        if resolver.is_local_tt_metal:
             logger.warning(f"TT-Metal profiler reports not found: {path}")
             return jsonify([])
         else:
@@ -498,7 +498,7 @@ def get_performance_data_list(instance: Instance):
     is_remote = True if instance.remote_connection else False
 
     if not path.exists():
-        if resolver.is_tt_metal_mode:
+        if resolver.is_local_tt_metal:
             logger.warning(f"TT-Metal performance reports not found: {path}")
             return jsonify([])
         elif not is_remote:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,6 +119,7 @@ The `ttnn-visualizer` command supports two CLI arguments for passing custom data
 
 * `--profiler-path` - specify the local path to the folder containing the report
 * `--performance-path` - specify the local path to the folder containing the profiler data
+* `--tt-metal-home` - specify the path to the TT Metal repo when running directly on the machine where reports are being generated.
 
 These options allow you to pass the folders when starting the visualizer, instead of uploading the report and profiler
 data files from the browser after loading the site. This can be used for starting `ttnn-visualizer` from other tools
@@ -127,3 +128,18 @@ with the data preloaded, or for restarting the visualizer with the same data, wi
 ```bash
 ttnn-visualizer --report-path ~/Downloads/report/generated/ttnn/reports/17274205533343344897 --profiler-path ~/Downloads/report/generated/profiler/reports/2025_02_24_23_17_27
 ```
+
+### TT-Metal Home
+
+If reports are being generated on a machine which is accessible to your local workstation,
+the `ttnn-visualizer` command can be run directly on the remote machine and load reports
+directly from the directory specified by the `--tt-metal-home` CLI arg or the `TT_METAL_HOME`
+env var.
+
+When running this way, you must ensure that the HOST and PORT used by the Flask webserver
+on the remote machine or container are accessible to the browser on your local machine. When
+working directly with the TT-Metal home directory, the remote sync and upload features are
+disabled, and you can see the reports generated on that machine only.
+
+This feature is intended for custom tools and integrations only, that bypass the default ways
+of loading data into `ttnn-visualizer`.

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -19,6 +19,7 @@ import {
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 import FileStatusOverlay from '../FileStatusOverlay';
 import createToastNotification from '../../functions/createToastNotification';
+import getServerConfig from '../../functions/getServerConfig';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
 import {
     PERFORMANCE_FOLDER_QUERY_KEY,
@@ -229,6 +230,9 @@ const LocalFolderOptions: FC = () => {
         }
     };
 
+    // Check if TT_METAL_HOME is set to conditionally hide upload forms
+    const isTtMetalMode = !!getServerConfig()?.TT_METAL_HOME;
+
     return (
         <>
             <FormGroup
@@ -248,38 +252,41 @@ const LocalFolderOptions: FC = () => {
                 />
             </FormGroup>
 
-            <FormGroup subLabel='Upload a local memory report'>
-                <div className='buttons-container'>
-                    <FileInput
-                        id='local-upload'
-                        onInputChange={handleReportDirectoryOpen}
-                        text={profilerUploadLabel}
-                        inputProps={{
-                            // @ts-expect-error 'directory' (needed for Safari) and 'webkitdirectory' - TypeScript’s DOM types do not include non-standard attributes
-                            directory: '',
-                            webkitdirectory: '',
-                            multiple: true,
-                            'data-testid': 'local-profiler-upload',
-                        }}
-                    />
+            {!isTtMetalMode && (
+                <FormGroup subLabel='Upload a local memory report'>
+                    <div className='buttons-container'>
+                        <FileInput
+                            id='local-upload'
+                            onInputChange={handleReportDirectoryOpen}
+                            text={profilerUploadLabel}
+                            inputProps={{
+                                // @ts-expect-error 'directory' (needed for Safari) and 'webkitdirectory' - TypeScript’s DOM types do not include non-standard attributes
+                                directory: '',
+                                webkitdirectory: '',
+                                multiple: true,
+                                'data-testid': 'local-profiler-upload',
+                            }}
+                        />
 
-                    <FileStatusOverlay />
+                        <FileStatusOverlay />
 
-                    {profilerFolder && !isUploadingReport && (
-                        <div className={`verify-connection-item status-${ConnectionTestStates[profilerFolder.status]}`}>
-                            <Icon
-                                className='connection-status-icon'
-                                icon={ICON_MAP[profilerFolder.status]}
-                                size={20}
-                                intent={INTENT_MAP[profilerFolder.status]}
-                            />
+                        {profilerFolder && !isUploadingReport && (
+                            <div
+                                className={`verify-connection-item status-${ConnectionTestStates[profilerFolder.status]}`}
+                            >
+                                <Icon
+                                    className='connection-status-icon'
+                                    icon={ICON_MAP[profilerFolder.status]}
+                                    size={20}
+                                    intent={INTENT_MAP[profilerFolder.status]}
+                                />
 
-                            <span className='connection-status-text'>{profilerFolder.message}</span>
-                        </div>
-                    )}
-                </div>
-            </FormGroup>
-
+                                <span className='connection-status-text'>{profilerFolder.message}</span>
+                            </div>
+                        )}
+                    </div>
+                </FormGroup>
+            )}
             <FormGroup
                 className='form-group'
                 label={<h3 className='label'>Performance report</h3>}
@@ -299,37 +306,39 @@ const LocalFolderOptions: FC = () => {
                 />
             </FormGroup>
 
-            <FormGroup subLabel='Upload a local performance report'>
-                <div className='buttons-container'>
-                    <FileInput
-                        id='local-performance-upload'
-                        onInputChange={handlePerformanceDirectoryOpen}
-                        text={performanceDataUploadLabel}
-                        inputProps={{
-                            // @ts-expect-error 'directory' (needed for Safari) and 'webkitdirectory' - TypeScript’s DOM types do not include non-standard attributes
-                            directory: '',
-                            webkitdirectory: '',
-                            multiple: true,
-                            'data-testid': 'local-performance-upload',
-                        }}
-                    />
+            {!isTtMetalMode && (
+                <FormGroup subLabel='Upload a local performance report'>
+                    <div className='buttons-container'>
+                        <FileInput
+                            id='local-performance-upload'
+                            onInputChange={handlePerformanceDirectoryOpen}
+                            text={performanceDataUploadLabel}
+                            inputProps={{
+                                // @ts-expect-error 'directory' (needed for Safari) and 'webkitdirectory' - TypeScript’s DOM types do not include non-standard attributes
+                                directory: '',
+                                webkitdirectory: '',
+                                multiple: true,
+                                'data-testid': 'local-performance-upload',
+                            }}
+                        />
 
-                    {performanceFolder && !isUploadingPerformance && (
-                        <div
-                            className={`verify-connection-item status-${ConnectionTestStates[performanceFolder.status]}`}
-                        >
-                            <Icon
-                                className='connection-status-icon'
-                                icon={ICON_MAP[performanceFolder.status]}
-                                size={20}
-                                intent={INTENT_MAP[performanceFolder.status]}
-                            />
+                        {performanceFolder && !isUploadingPerformance && (
+                            <div
+                                className={`verify-connection-item status-${ConnectionTestStates[performanceFolder.status]}`}
+                            >
+                                <Icon
+                                    className='connection-status-icon'
+                                    icon={ICON_MAP[performanceFolder.status]}
+                                    size={20}
+                                    intent={INTENT_MAP[performanceFolder.status]}
+                                />
 
-                            <span className='connection-status-text'>{performanceFolder.message}</span>
-                        </div>
-                    )}
-                </div>
-            </FormGroup>
+                                <span className='connection-status-text'>{performanceFolder.message}</span>
+                            </div>
+                        )}
+                    </div>
+                </FormGroup>
+            )}
         </>
     );
 };

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -230,7 +230,7 @@ const LocalFolderOptions: FC = () => {
         }
     };
 
-    const isLocalTtMetal = !!getServerConfig()?.TT_METAL_HOME;
+    const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
 
     return (
         <>
@@ -251,7 +251,7 @@ const LocalFolderOptions: FC = () => {
                 />
             </FormGroup>
 
-            {!isLocalTtMetal && (
+            {!isDirectReportMode && (
                 <FormGroup subLabel='Upload a local memory report'>
                     <div className='buttons-container'>
                         <FileInput
@@ -305,7 +305,7 @@ const LocalFolderOptions: FC = () => {
                 />
             </FormGroup>
 
-            {!isLocalTtMetal && (
+            {!isDirectReportMode && (
                 <FormGroup subLabel='Upload a local performance report'>
                     <div className='buttons-container'>
                         <FileInput

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -230,8 +230,8 @@ const LocalFolderOptions: FC = () => {
         }
     };
 
-    // Check if TT_METAL_HOME is set to conditionally hide upload forms
-    const isTtMetalMode = !!getServerConfig()?.TT_METAL_HOME;
+    // Check if local TT-Metal is available to conditionally hide upload forms
+    const isLocalTtMetal = !!getServerConfig()?.TT_METAL_HOME;
 
     return (
         <>
@@ -252,7 +252,7 @@ const LocalFolderOptions: FC = () => {
                 />
             </FormGroup>
 
-            {!isTtMetalMode && (
+            {!isLocalTtMetal && (
                 <FormGroup subLabel='Upload a local memory report'>
                     <div className='buttons-container'>
                         <FileInput
@@ -306,7 +306,7 @@ const LocalFolderOptions: FC = () => {
                 />
             </FormGroup>
 
-            {!isTtMetalMode && (
+            {!isLocalTtMetal && (
                 <FormGroup subLabel='Upload a local performance report'>
                     <div className='buttons-container'>
                         <FileInput

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -230,7 +230,6 @@ const LocalFolderOptions: FC = () => {
         }
     };
 
-    // Check if local TT-Metal is available to conditionally hide upload forms
     const isLocalTtMetal = !!getServerConfig()?.TT_METAL_HOME;
 
     return (

--- a/src/functions/getServerConfig.ts
+++ b/src/functions/getServerConfig.ts
@@ -11,6 +11,7 @@ declare global {
 interface ServerConfig {
     SERVER_MODE?: boolean;
     BASE_PATH?: string;
+    TT_METAL_HOME?: string;
 }
 
 const getServerConfig = (): ServerConfig => {
@@ -19,12 +20,14 @@ const getServerConfig = (): ServerConfig => {
         return {
             BASE_PATH: '/',
             SERVER_MODE: !!import.meta.env.VITE_SERVER_MODE || false,
+            TT_METAL_HOME: import.meta.env.VITE_TT_METAL_HOME || undefined,
         };
     }
 
     return {
         BASE_PATH: window?.TTNN_VISUALIZER_CONFIG?.BASE_PATH || '/',
         SERVER_MODE: window?.TTNN_VISUALIZER_CONFIG?.SERVER_MODE || false,
+        TT_METAL_HOME: window?.TTNN_VISUALIZER_CONFIG?.TT_METAL_HOME || undefined,
     };
 };
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -15,6 +15,7 @@ function Home() {
     useClearSelectedBuffer();
 
     const isServerMode = !!getServerConfig()?.SERVER_MODE;
+    const isTtMetalMode = !!getServerConfig()?.TT_METAL_HOME;
 
     return (
         <div className='home'>
@@ -44,7 +45,7 @@ function Home() {
                         <RemoteSyncConfigurator />
                     </div>
 
-                    {isServerMode ? (
+                    {isServerMode || isTtMetalMode ? (
                         <div
                             className='feature-disabled'
                             data-testid='remote-sync-disabled'

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -15,7 +15,7 @@ function Home() {
     useClearSelectedBuffer();
 
     const isServerMode = !!getServerConfig()?.SERVER_MODE;
-    const isLocalTtMetal = !!getServerConfig()?.TT_METAL_HOME;
+    const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
 
     return (
         <div className='home'>
@@ -45,7 +45,7 @@ function Home() {
                         <RemoteSyncConfigurator />
                     </div>
 
-                    {isServerMode || isLocalTtMetal ? (
+                    {isServerMode || isDirectReportMode ? (
                         <div
                             className='feature-disabled'
                             data-testid='remote-sync-disabled'

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -15,7 +15,7 @@ function Home() {
     useClearSelectedBuffer();
 
     const isServerMode = !!getServerConfig()?.SERVER_MODE;
-    const isTtMetalMode = !!getServerConfig()?.TT_METAL_HOME;
+    const isLocalTtMetal = !!getServerConfig()?.TT_METAL_HOME;
 
     return (
         <div className='home'>
@@ -45,7 +45,7 @@ function Home() {
                         <RemoteSyncConfigurator />
                     </div>
 
-                    {isServerMode || isTtMetalMode ? (
+                    {isServerMode || isLocalTtMetal ? (
                         <div
                             className='feature-disabled'
                             data-testid='remote-sync-disabled'


### PR DESCRIPTION
This PR adds a new way of loading the report data into ttnn-visualizer, by loading the data directly from the TT-Metal `generated` directory.

The ordinary use case is for the Visualizer to run locally, say on a developer's laptop. The reports are typically being generated on remote machines or docker containers, that are running on Tenstorrent hardware. The main way of getting data into `ttnn-visualizer` has been to run `ttnn-visualizer` locally on the dev's local machine, and have them upload reports that they have downloaded from the remote machine/container, or to sync the reports from the remote machine/container using the remote sync feature, which downloads them to the machine where `ttnn-visualizer` is running.

This PR enables a new way of running `ttnn-visualizer`, which is directly on the remote machine/container TT-Metal is being used. If `--tt-metal-home` CLI arg is passed, or `TT_METAL_HOME` env var is set when `ttnn-visualizer` runs, then it switches to "TT Metal Mode", in which it loads the reports directly from the `$TT_METAL_HOME/generated/ttnn/reports` and `$TT_METAL_HOME/generated/profiler/reports` directories, as opposed to the Visualizer's own `data/local` and `data/remote` directories.

When "TT Metal Mode" is enabled, the upload report and remote sync features are disabled, and the Visualizer with only show the reports from `$TT_METAL_HOME`.

This is intended to be used when running the Visualizer on the Tenstorrent machines directly, and should not be used when running the Visualizer on local dev machines, such as Macbooks.

User's will need to make sure that they are able to access the Visualizer on the remote machine, such as by mapping ports from the dev containers to host ports and can access the remote machines from their local machine where they are running their browser.

[Closes #747]