### PR TITLE
Add fabric event filtering to NPE view

### DIFF
--- a/src/components/npe/ActiveTransferDetails.tsx
+++ b/src/components/npe/ActiveTransferDetails.tsx
@@ -91,6 +91,7 @@ const ActiveTransferDetails = ({
                                         </div>
                                         <div>{formatSize(transfer.total_bytes)}B</div>
                                         <div>{transfer.noc_event_type}</div>
+                                        <div>Fabric event: {transfer.fabric_event_type ? 'TRUE' : 'FALSE'}</div>
 
                                         <div>
                                             <div className='route'>

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -59,7 +59,7 @@ const NPEView: React.FC<NPEViewProps> = ({ npeData }) => {
         const timestepData = npeData.timestep_data[selectedTimestep];
         timestepData.active_transfers.forEach((id) => {
             const transfer = npeData.noc_transfers.find((tr) => tr.id === id);
-            // TODO: this functionality should likely move to BE.
+            // TODO: this functionality should move to BE. https://github.com/orgs/tenstorrent/projects/178/views/1?pane=issue&itemId=124188622&issue=tenstorrent%7Cttnn-visualizer%7C745
             if (transfer && transfer.fabric_event_type && fabricEventsOnlyFilter) {
                 transfer.route.forEach((route) => {
                     route.links.forEach((link) => {

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -105,7 +105,14 @@ export enum NoCID {
     NOC1_OUT = 'NOC1_OUT',
 }
 
-export type LinkUtilization = [device_id: number, row: number, col: number, noc_id: NoCID, demand: number];
+export type LinkUtilization = [
+    device_id: number,
+    row: number,
+    col: number,
+    noc_id: NoCID,
+    demand: number,
+    fabric_event_type: boolean,
+];
 export type NoCLink = [device_id: number, row: number, col: number, noc_id: NoCID];
 export type NPE_COORDINATES = [device_id: number, row: number, col: number];
 
@@ -128,6 +135,7 @@ export interface NoCTransfer {
     dst: [[device_id, row, col]];
     total_bytes: number;
     noc_event_type: '';
+    fabric_event_type: boolean;
     start_cycle: number;
     end_cycle: number;
     route: NoCRoute[];
@@ -158,11 +166,12 @@ export interface NPEData {
 }
 
 export enum NPE_LINK {
-    CHIP_ID, // future iteration
+    CHIP_ID,
     Y,
     X,
     NOC_ID,
     DEMAND,
+    FABRIC_EVENT_TYPE,
 }
 
 export interface NPEManifestEntry {


### PR DESCRIPTION
Introduces a 'Fabric events only' filter in the NPEViewComponent, allowing users to display only transfers and link utilizations associated with fabric events. Updates the NPEModel types to include 'fabric_event_type' in LinkUtilization and NoCTransfer, and adjusts UI and logic to support the new filter.

<img width="944" height="716" alt="image" src="https://github.com/user-attachments/assets/1cb5ce5b-f044-4f5f-9efe-48a7eec2f0e2" />

closes #657 
