### PR TITLE
Fix/NPE calls API multiple times

### DIFF
--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -85,8 +85,6 @@ const NPEFileLoader: React.FC = () => {
 };
 
 // Remove file extension from the file name
-const sanitiseFileName = (fileName: string) => {
-    return fileName.split('.').slice(0, -1).join('.');
-};
+const sanitiseFileName = (fileName: string) => fileName.split('.').slice(0, -1).join('.');
 
 export default NPEFileLoader;

--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -51,7 +51,7 @@ const NPEFileLoader: React.FC = () => {
             setErrorMessage(response?.data?.message);
         } else {
             const fileName = file.name;
-            setActiveNpe(fileName);
+            setActiveNpe(sanitiseFileName(fileName));
             createToastNotification('Active NPE', fileName);
             setUploadStatus(ConnectionTestStates.OK);
             setErrorMessage(`${fileName} uploaded successfully`);
@@ -82,6 +82,11 @@ const NPEFileLoader: React.FC = () => {
             </div>
         </div>
     );
+};
+
+// Remove file extension from the file name
+const sanitiseFileName = (fileName: string) => {
+    return fileName.split('.').slice(0, -1).join('.');
 };
 
 export default NPEFileLoader;


### PR DESCRIPTION
Active NPE was being set as `whatever.json` but then is set as whatever` on the instance which then causes the app to think the active NPE has changed and therefore it refetches the data. 

Closes [769.](https://github.com/tenstorrent/ttnn-visualizer/issues/769).