### PR TITLE
Feature/support buffer memory layout

### DIFF
--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -30,13 +30,13 @@ export default function getChartData(
             color = tensorColor !== undefined ? tensorColor : getBufferColor(address + (overrides?.colorVariance || 0));
         }
 
-        const tensorMemoryLayout = tensor?.memory_config?.memory_layout;
+        const stringTensorMemoryLayout = tensor?.memory_config?.memory_layout;
 
         let pattern = {};
 
         if (options?.renderPattern) {
             //  shape options "" | "/" | "\\" | "x" | "-" | "|" | "+" | ".";
-            if (tensorMemoryLayout === TensorMemoryLayout.INTERLEAVED) {
+            if (stringTensorMemoryLayout === TensorMemoryLayout.INTERLEAVED) {
                 pattern = {
                     shape: '.',
                     fillmode: 'overlay',
@@ -45,7 +45,7 @@ export default function getChartData(
                     fgopacity: 0.3,
                 };
             }
-            if (tensorMemoryLayout === TensorMemoryLayout.BLOCK_SHARDED) {
+            if (stringTensorMemoryLayout === TensorMemoryLayout.BLOCK_SHARDED) {
                 pattern = {
                     shape: '+',
                     fillmode: 'overlay',
@@ -54,7 +54,7 @@ export default function getChartData(
                     fgopacity: 0.2,
                 };
             }
-            if (tensorMemoryLayout === TensorMemoryLayout.HEIGHT_SHARDED) {
+            if (stringTensorMemoryLayout === TensorMemoryLayout.HEIGHT_SHARDED) {
                 pattern = {
                     shape: '|',
                     fillmode: 'overlay',
@@ -63,7 +63,7 @@ export default function getChartData(
                     fgopacity: 0.2,
                 };
             }
-            if (tensorMemoryLayout === TensorMemoryLayout.WIDTH_SHARDED) {
+            if (stringTensorMemoryLayout === TensorMemoryLayout.WIDTH_SHARDED) {
                 pattern = {
                     shape: '-',
                     fillmode: 'overlay',
@@ -100,7 +100,7 @@ export default function getChartData(
                     : `
 <span style="color:${color};font-size:20px;">&#9632;</span>
 ${address} (${toHex(address)}) <br>Size: ${formatSize(size)}
-${tensor ? `<br>${toReadableShape(tensor.shape)} ${toReadableType(tensor.dtype)} Tensor${tensor.id}<br>${tensorMemoryLayout || ''}` : ''}
+${tensor ? `<br>${toReadableShape(tensor.shape)} ${toReadableType(tensor.dtype)} Tensor${tensor.id}<br>${stringTensorMemoryLayout || ''}` : ''}
 <extra></extra>`,
 
             hoverlabel: {

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -30,13 +30,13 @@ export default function getChartData(
             color = tensorColor !== undefined ? tensorColor : getBufferColor(address + (overrides?.colorVariance || 0));
         }
 
-        const stringTensorMemoryLayout = tensor?.memory_config?.memory_layout;
+        const tensorMemoryLayout = tensor?.memory_config?.memory_layout;
 
         let pattern = {};
 
         if (options?.renderPattern) {
             //  shape options "" | "/" | "\\" | "x" | "-" | "|" | "+" | ".";
-            if (stringTensorMemoryLayout === TensorMemoryLayout.INTERLEAVED) {
+            if (tensorMemoryLayout === TensorMemoryLayout.INTERLEAVED) {
                 pattern = {
                     shape: '.',
                     fillmode: 'overlay',
@@ -45,7 +45,7 @@ export default function getChartData(
                     fgopacity: 0.3,
                 };
             }
-            if (stringTensorMemoryLayout === TensorMemoryLayout.BLOCK_SHARDED) {
+            if (tensorMemoryLayout === TensorMemoryLayout.BLOCK_SHARDED) {
                 pattern = {
                     shape: '+',
                     fillmode: 'overlay',
@@ -54,7 +54,7 @@ export default function getChartData(
                     fgopacity: 0.2,
                 };
             }
-            if (stringTensorMemoryLayout === TensorMemoryLayout.HEIGHT_SHARDED) {
+            if (tensorMemoryLayout === TensorMemoryLayout.HEIGHT_SHARDED) {
                 pattern = {
                     shape: '|',
                     fillmode: 'overlay',
@@ -63,7 +63,7 @@ export default function getChartData(
                     fgopacity: 0.2,
                 };
             }
-            if (stringTensorMemoryLayout === TensorMemoryLayout.WIDTH_SHARDED) {
+            if (tensorMemoryLayout === TensorMemoryLayout.WIDTH_SHARDED) {
                 pattern = {
                     shape: '-',
                     fillmode: 'overlay',
@@ -100,7 +100,7 @@ export default function getChartData(
                     : `
 <span style="color:${color};font-size:20px;">&#9632;</span>
 ${address} (${toHex(address)}) <br>Size: ${formatSize(size)}
-${tensor ? `<br>${toReadableShape(tensor.shape)} ${toReadableType(tensor.dtype)} Tensor${tensor.id}<br>${stringTensorMemoryLayout || ''}` : ''}
+${tensor ? `<br>${toReadableShape(tensor.shape)} ${toReadableType(tensor.dtype)} Tensor${tensor.id}<br>${tensorMemoryLayout || ''}` : ''}
 <extra></extra>`,
 
             hoverlabel: {

--- a/src/functions/parseMemoryConfig.ts
+++ b/src/functions/parseMemoryConfig.ts
@@ -23,6 +23,13 @@ export enum TensorMemoryLayout {
     'WIDTH_SHARDED' = 'TensorMemoryLayout::WIDTH_SHARDED',
 }
 
+export enum BufferMemoryLayout {
+    INTERLEAVED = 0,
+    HEIGHT_SHARDED = 2,
+    WIDTH_SHARDED = 3,
+    BLOCK_SHARDED = 4,
+}
+
 export type MemoryKeys =
     | 'shard_spec'
     | 'memory_layout'

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { RemoteConnection, RemoteFolder } from '../definitions/RemoteConnection';
-import { MemoryConfig } from '../functions/parseMemoryConfig';
+import { BufferMemoryLayout, MemoryConfig } from '../functions/parseMemoryConfig';
 import { BufferType } from './BufferType';
 
 export interface Operation {
@@ -64,6 +64,7 @@ export interface Buffer {
     buffer_type: number;
     device_id: number;
     size: number;
+    buffer_layout?: BufferMemoryLayout | null;
 }
 
 export interface OperationDetailsData extends Operation {


### PR DESCRIPTION
This pull request introduces support for a new `BufferMemoryLayout` enum, allowing for more explicit specification of buffer memory layouts in the codebase. The main changes include defining the new enum, updating imports, and extending the `Buffer` interface to optionally include this new property.

**Buffer memory layout enhancements:**

* Added a new `BufferMemoryLayout` enum to `parseMemoryConfig.ts` to represent different buffer memory layouts such as `INTERLEAVED`, `HEIGHT_SHARDED`, `WIDTH_SHARDED`, and `BLOCK_SHARDED`.
* Updated the import statements in `APIData.ts` to include the new `BufferMemoryLayout` enum.
* Extended the `Buffer` interface in `APIData.ts` to optionally include a `buffer_layout` property of type `BufferMemoryLayout` or `null`.