### PR TITLE
Fix device operations graph rendering condition

### DIFF
--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -358,13 +358,15 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                         {details.device_operations && (
                             <>
                                 <h3>Device operations</h3>
-                                <Button
-                                    icon={IconNames.Graph}
-                                    intent={Intent.PRIMARY}
-                                    onClick={() => setDeviceOperationsGraphOpen(true)}
-                                >
-                                    Device operations graph view
-                                </Button>
+                                {details.device_operations && details.device_operations.length && (
+                                    <Button
+                                        icon={IconNames.Graph}
+                                        intent={Intent.PRIMARY}
+                                        onClick={() => setDeviceOperationsGraphOpen(true)}
+                                    >
+                                        Device operations graph view
+                                    </Button>
+                                )}
                                 <DeviceOperationsFullRender
                                     deviceOperations={details.device_operations}
                                     details={details}


### PR DESCRIPTION
Update the condition to render GraphComponent only when device_operations is non-empty, preventing the graph from rendering with empty data.

closes #791 