### PR TITLE
Add plugin for tt-metal pytest

### DIFF
--- a/backend/ttnn_visualizer/pytest_plugin.py
+++ b/backend/ttnn_visualizer/pytest_plugin.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 import json
 import os
 import urllib


### PR DESCRIPTION
This PR adds a new pytest plugin that is intended to be run from TT-Metal. When the plugin is used, it will do a post to TTNN Visualizer's `/api/notify` endpoint after each test, with the report paths.

Example usage in TT-Metal:

`WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python -m tracy -r -v -m pytest -p ttnn_visualizer.pytest_plugin  --disable-warnings models/demos/wormhole/resnet50/demo/demo.py::test_demo_sample`

or without profiling:

`pytest -p ttnn_visualizer.pytest_plugin  --disable-warnings models/demos/wormhole/resnet50/demo/demo.py::test_demo_sample`

For this to work, you first need to setup and build TT-Metal. Once you're at the CLI with TT-Metal's python env activated, you could just run `pip install ttnn-visualizer`, and then be able to add the `-p ttnn_visualizer.pytest_plugin` option when you run the pytest commands for the models in TT-Metal.

[Closes #795]