### PR TITLE
Feature/Upgrade perf UI

### DIFF
--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -678,7 +678,16 @@ def get_performance_results_report(instance: Instance):
 def get_performance_data_raw(instance: Instance):
     if not instance.performance_path:
         return Response(status=HTTPStatus.NOT_FOUND)
+
+    name = request.args.get("name", None)
+
+    if name and not current_app.config["SERVER_MODE"]:
+        performance_path = Path(instance.performance_path).parent / name
+        instance.performance_path = str(performance_path)
+        logger.info(f"************ Performance path set to {instance.performance_path}")
+
     content = DeviceLogProfilerQueries.get_raw_csv(instance)
+
     return Response(
         content,
         mimetype="text/csv",

--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -30,6 +30,7 @@ import useTableFilter from '../hooks/useTableFilter';
 const PLACEHOLDER_ARRAY_SIZE = 10;
 const OPERATION_EL_HEIGHT = 39; // Height in px of each list item
 const TOTAL_SHADE_HEIGHT = 100; // Height in px of 'scroll-shade' pseudo elements
+const HIGH_CONSUMER_INTENT = Intent.DANGER;
 
 const TensorList = () => {
     const location = useLocation();
@@ -174,7 +175,7 @@ const TensorList = () => {
                             onClick={() => setShowHighConsumerTensors(!showHighConsumerTensors)}
                             endIcon={IconNames.ISSUE}
                             disabled={!tensorsWithRange?.some((tensor) => tensor.consumers.length > MAX_NUM_CONSUMERS)}
-                            intent={Intent.DANGER}
+                            intent={HIGH_CONSUMER_INTENT}
                             variant={showHighConsumerTensors ? 'outlined' : undefined}
                             aria-label='Toggle high consumer tensors'
                         >
@@ -317,7 +318,7 @@ const TensorList = () => {
                                                         >
                                                             <Icon
                                                                 icon={IconNames.ISSUE}
-                                                                intent={Intent.DANGER}
+                                                                intent={HIGH_CONSUMER_INTENT}
                                                                 title='Unusually high number of consumers'
                                                             />
                                                         </Tooltip>

--- a/src/components/performance/NonFilterablePerfCharts.tsx
+++ b/src/components/performance/NonFilterablePerfCharts.tsx
@@ -13,24 +13,29 @@ import PerfKernelDurationUtilizationChart from './PerfKernelDurationUtilizationC
 import 'styles/components/PerfCharts.scss';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import PerfDeviceTimeChart from './PerfDeviceTimeChart';
+import getCoreCount from '../../functions/getCoreCount';
+import { DeviceArchitecture } from '../../definitions/DeviceArchitecture';
+import { useDeviceLog } from '../../hooks/useAPI';
 
 interface NonFilterablePerfChartsProps {
     chartData: PerfTableRow[];
     secondaryData?: PerfTableRow[][];
-    maxCores: number;
     opCodeOptions: Marker[];
 }
 
 const NonFilterablePerfCharts: FC<NonFilterablePerfChartsProps> = ({
     chartData,
     secondaryData = [],
-    maxCores,
     opCodeOptions,
 }) => {
+    const { data: deviceLog } = useDeviceLog();
+
     const performanceReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
 
     const datasets = [chartData, ...(secondaryData || [])].filter((set) => set.length > 0);
+    const architecture = (deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE) as DeviceArchitecture;
+    const maxCores = getCoreCount(architecture, datasets[0]);
 
     const matmulData = useMemo(
         () => datasets.map((set) => set.filter((row) => row.raw_op_code.toLowerCase().includes('matmul'))),

--- a/src/components/performance/NonFilterablePerfCharts.tsx
+++ b/src/components/performance/NonFilterablePerfCharts.tsx
@@ -35,7 +35,7 @@ const NonFilterablePerfCharts: FC<NonFilterablePerfChartsProps> = ({
 
     const datasets = [chartData, ...(secondaryData || [])].filter((set) => set.length > 0);
     const architecture = (deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE) as DeviceArchitecture;
-    const maxCores = getCoreCount(architecture, datasets[0]);
+    const maxCores = getCoreCount(architecture, datasets[0] ?? []);
 
     const matmulData = useMemo(
         () => datasets.map((set) => set.filter((row) => row.raw_op_code.toLowerCase().includes('matmul'))),

--- a/src/components/performance/PerfCharts.tsx
+++ b/src/components/performance/PerfCharts.tsx
@@ -12,11 +12,10 @@ import 'styles/components/PerfCharts.scss';
 interface PerfChartsProps {
     filteredPerfData: PerfTableRow[];
     comparisonData?: PerfTableRow[][];
-    maxCores: number;
     selectedOpCodes: Marker[];
 }
 
-const PerfCharts: FC<PerfChartsProps> = ({ filteredPerfData, comparisonData, maxCores, selectedOpCodes }) => {
+const PerfCharts: FC<PerfChartsProps> = ({ filteredPerfData, comparisonData, selectedOpCodes }) => {
     const data = [filteredPerfData, ...(comparisonData || [])].filter((set) => set.length > 0);
 
     return (
@@ -26,10 +25,7 @@ const PerfCharts: FC<PerfChartsProps> = ({ filteredPerfData, comparisonData, max
                 selectedOpCodes={selectedOpCodes}
             />
 
-            <PerfDeviceKernelRuntimeChart
-                datasets={data}
-                maxCores={maxCores}
-            />
+            <PerfDeviceKernelRuntimeChart datasets={data} />
 
             <PerfDeviceKernelDurationChart datasets={data} />
         </div>

--- a/src/components/performance/PerfDeviceKernelRuntimeChart.tsx
+++ b/src/components/performance/PerfDeviceKernelRuntimeChart.tsx
@@ -11,16 +11,21 @@ import { PlotConfiguration } from '../../definitions/PlotConfigurations';
 import getPlotLabel from '../../functions/getPlotLabel';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import { getPrimaryDataColours, getSecondaryDataColours } from '../../definitions/PerformancePlotColours';
+import { useDeviceLog } from '../../hooks/useAPI';
+import { DeviceArchitecture } from '../../definitions/DeviceArchitecture';
+import getCoreCount from '../../functions/getCoreCount';
 
 interface PerfDeviceKernelRuntimeChartProps {
-    maxCores: number;
     datasets?: PerfTableRow[][];
 }
 
-function PerfDeviceKernelRuntimeChart({ maxCores, datasets = [] }: PerfDeviceKernelRuntimeChartProps) {
+function PerfDeviceKernelRuntimeChart({ datasets = [] }: PerfDeviceKernelRuntimeChartProps) {
+    const { data: deviceLog } = useDeviceLog();
     const perfReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const maxDataSize = datasets.reduce((max, data) => Math.max(max, data?.length || 0), 0);
+    const architecture = (deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE) as DeviceArchitecture;
+    const maxCores = getCoreCount(architecture, datasets[0]);
 
     const chartDataCoreCount = useMemo(
         () =>

--- a/src/components/performance/PerfDeviceKernelRuntimeChart.tsx
+++ b/src/components/performance/PerfDeviceKernelRuntimeChart.tsx
@@ -25,7 +25,7 @@ function PerfDeviceKernelRuntimeChart({ datasets = [] }: PerfDeviceKernelRuntime
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const maxDataSize = datasets.reduce((max, data) => Math.max(max, data?.length || 0), 0);
     const architecture = (deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE) as DeviceArchitecture;
-    const maxCores = getCoreCount(architecture, datasets[0]);
+    const maxCores = getCoreCount(architecture, datasets[0] ?? []);
 
     const chartDataCoreCount = useMemo(
         () =>

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -4,11 +4,21 @@
 
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import { Icon, MenuItem, PopoverPosition, Size, Switch, Tab, TabId, Tabs, Tooltip } from '@blueprintjs/core';
+import {
+    Button,
+    Intent,
+    MenuItem,
+    PopoverPosition,
+    Position,
+    Size,
+    Tab,
+    TabId,
+    Tabs,
+    Tooltip,
+} from '@blueprintjs/core';
 import { MultiSelect } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { PerfTableRow, TableFilter, TableHeader, TableKeys } from '../../definitions/PerfTable';
-import 'styles/components/PerfReport.scss';
 import { useOpToPerfIdFiltered } from '../../hooks/useAPI';
 import { calcHighDispatchOps } from '../../functions/perfFunctions';
 import SearchField from '../SearchField';
@@ -17,6 +27,7 @@ import PerfTable from './PerfTable';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import alignByOpCode from '../../functions/normalisePerformanceData';
 import sortAndFilterPerfTableData, { TypedPerfTableRow } from '../../functions/sortAndFilterPerfTableData';
+import 'styles/components/PerfReport.scss';
 
 interface PerformanceReportProps {
     data?: PerfTableRow[];
@@ -169,46 +180,6 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                 disabled={!isMultiDevice}
             /> */}
 
-            <Switch
-                label='Show Matmul optimization analysis'
-                onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
-                checked={provideMatmulAdvice}
-            />
-
-            <Switch
-                label='Highlight high dispatch ops'
-                onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
-                checked={hiliteHighDispatch}
-            />
-
-            <Switch
-                labelElement={
-                    <Tooltip content='Tries to match up operations between the performance reports'>
-                        <span className='switch-label-with-icon'>
-                            <span>Normalise performance data</span>
-                            <Icon icon={IconNames.SMALL_INFO_SIGN} />
-                        </span>
-                    </Tooltip>
-                }
-                onChange={() => setUseNormalisedData(!useNormalisedData)}
-                checked={useNormalisedData}
-                disabled={!activeComparisonReportList}
-            />
-
-            <Switch
-                labelElement={
-                    <Tooltip content='Highlights rows where ops have been added or are missing after normalising the data'>
-                        <span className='switch-label-with-icon'>
-                            <span>Highlight row difference</span>
-                            <Icon icon={IconNames.SMALL_INFO_SIGN} />
-                        </span>
-                    </Tooltip>
-                }
-                onChange={() => setHighlightRows(!highlightRows)}
-                checked={highlightRows}
-                disabled={!activeComparisonReportList || !useNormalisedData}
-            />
-
             <div className='perf-report'>
                 <div className='table-header'>
                     <h3 className='title'>Performance report</h3>
@@ -218,6 +189,10 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                             {filteredDataLength !== totalDataLength
                                 ? `Showing ${filteredDataLength} of ${totalDataLength} rows`
                                 : `Showing ${filteredDataLength} rows`}
+
+                            {useNormalisedData && normalisedData.missingRows.length > 0
+                                ? ` (${normalisedData.missingRows.length} rows with missing ops)`
+                                : ''}
                         </p>
                     </div>
                 </div>
@@ -253,15 +228,52 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                         }
                         resetOnSelect
                     />
+                </div>
 
-                    {/* Need to refactor to have the reset working */}
-                    {/* <Button
-                        onClick={() => changeSorting(null)(null)}
-                        variant={ButtonVariant.OUTLINED}
-                        disabled={sortingColumn === null}
+                <div className='data-options'>
+                    <Button
+                        icon={IconNames.PREDICTIVE_ANALYSIS}
+                        text='Matmul optimization analysis'
+                        aria-label='Matmul optimization analysis'
+                        intent={provideMatmulAdvice ? Intent.PRIMARY : Intent.NONE}
+                        onClick={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
+                    />
+
+                    <Button
+                        icon={IconNames.WARNING_SIGN}
+                        text='Highlight high dispatch ops'
+                        aria-label='Highlight high dispatch ops'
+                        intent={hiliteHighDispatch ? Intent.WARNING : Intent.NONE}
+                        onClick={() => setHiliteHighDispatch(!hiliteHighDispatch)}
+                    />
+
+                    <Tooltip
+                        content='Tries to match up operations between the performance reports'
+                        position={Position.TOP}
                     >
-                        Reset sort
-                    </Button> */}
+                        <Button
+                            icon={IconNames.MANY_TO_ONE}
+                            text='Normalise data'
+                            aria-label='Normalise data'
+                            intent={useNormalisedData ? Intent.PRIMARY : Intent.NONE}
+                            disabled={!activeComparisonReportList}
+                            onClick={() => setUseNormalisedData(!useNormalisedData)}
+                        />
+                    </Tooltip>
+
+                    <Tooltip
+                        content='Highlights rows where ops have been added or are missing after normalising the data'
+                        position={Position.TOP}
+                    >
+                        <Button
+                            icon={IconNames.SMALL_INFO_SIGN}
+                            text='Highlight row differences'
+                            aria-label='Highlight row differences'
+                            onClick={() => setHighlightRows(!highlightRows)}
+                            intent={useNormalisedData && highlightRows ? Intent.DANGER : Intent.NONE}
+                            disabled={!activeComparisonReportList || !useNormalisedData}
+                        />
+                    </Tooltip>
                 </div>
 
                 <Tabs

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -148,6 +148,28 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
         comparisonData?.[comparisonIndex],
     );
     const filteredDataLength = getFilteredDataLength(selectedTabId, filteredRows, filteredComparisonRows);
+    const rowDelta = useMemo(() => {
+        if (!useNormalisedData) {
+            return 0;
+        }
+
+        if (selectedTabId === INITIAL_TAB_ID) {
+            return processedRows.length - (normalisedData.data?.[0]?.length || 0);
+        }
+
+        if (processedComparisonRows?.[comparisonIndex] && normalisedData.data?.[comparisonIndex + 1]) {
+            return processedComparisonRows[comparisonIndex].length - normalisedData.data[comparisonIndex + 1].length;
+        }
+
+        return 0;
+    }, [
+        useNormalisedData,
+        selectedTabId,
+        processedRows,
+        normalisedData.data,
+        comparisonIndex,
+        processedComparisonRows,
+    ]);
 
     // Resets various state if we remove all comparison reports
     useEffect(() => {
@@ -190,9 +212,9 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                                 ? `Showing ${filteredDataLength} of ${totalDataLength} rows`
                                 : `Showing ${filteredDataLength} rows`}
 
-                            {useNormalisedData && normalisedData.missingRows.length > 0
-                                ? ` (${normalisedData.missingRows.length} rows with missing ops)`
-                                : ''}
+                            {useNormalisedData && rowDelta
+                                ? ` (${rowDelta > 0 ? `${rowDelta} ops removed` : `${rowDelta * -1} ops added`})`
+                                : null}
                         </p>
                     </div>
                 </div>

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -4,18 +4,7 @@
 
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import {
-    Button,
-    Intent,
-    MenuItem,
-    PopoverPosition,
-    Position,
-    Size,
-    Tab,
-    TabId,
-    Tabs,
-    Tooltip,
-} from '@blueprintjs/core';
+import { MenuItem, PopoverPosition, Position, Size, Switch, Tab, TabId, Tabs, Tooltip } from '@blueprintjs/core';
 import { MultiSelect } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { PerfTableRow, TableFilter, TableHeader, TableKeys } from '../../definitions/PerfTable';
@@ -84,7 +73,6 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
     const [selectedTabId, setSelectedTabId] = useState<TabId>(INITIAL_TAB_ID);
     const [useNormalisedData, setUseNormalisedData] = useState(true);
     const [highlightRows, setHighlightRows] = useState<boolean>(true);
-
     const [filters, setFilters] = useState<TableFilter>(
         Object.fromEntries(FILTERABLE_COLUMN_KEYS.map((key) => [key, ''] as [TableKeys, string])) as Record<
             TableKeys,
@@ -253,49 +241,43 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                 </div>
 
                 <div className='data-options'>
-                    <Button
-                        icon={IconNames.PREDICTIVE_ANALYSIS}
-                        text='Matmul optimization analysis'
-                        aria-label='Matmul optimization analysis'
-                        intent={provideMatmulAdvice ? Intent.PRIMARY : Intent.NONE}
-                        onClick={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
+                    <Switch
+                        label='Matmul optimization analysis'
+                        onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
+                        checked={provideMatmulAdvice}
                     />
 
-                    <Button
-                        icon={IconNames.WARNING_SIGN}
-                        text='Highlight high dispatch ops'
-                        aria-label='Highlight high dispatch ops'
-                        intent={hiliteHighDispatch ? Intent.WARNING : Intent.NONE}
-                        onClick={() => setHiliteHighDispatch(!hiliteHighDispatch)}
+                    <Switch
+                        label='Highlight high dispatch ops'
+                        onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
+                        checked={hiliteHighDispatch}
                     />
 
                     <Tooltip
                         content='Tries to match up operations between the performance reports'
                         position={Position.TOP}
                     >
-                        <Button
-                            icon={IconNames.MANY_TO_ONE}
-                            text='Normalise data'
-                            aria-label='Normalise data'
-                            intent={useNormalisedData ? Intent.PRIMARY : Intent.NONE}
+                        <Switch
+                            label='Normalise data'
                             disabled={!activeComparisonReportList}
-                            onClick={() => setUseNormalisedData(!useNormalisedData)}
+                            onChange={() => setUseNormalisedData(!useNormalisedData)}
+                            checked={useNormalisedData}
                         />
                     </Tooltip>
 
-                    <Tooltip
-                        content='Highlights rows where ops have been added or are missing after normalising the data'
-                        position={Position.TOP}
-                    >
-                        <Button
-                            icon={IconNames.SMALL_INFO_SIGN}
-                            text='Highlight row differences'
-                            aria-label='Highlight row differences'
-                            onClick={() => setHighlightRows(!highlightRows)}
-                            intent={useNormalisedData && highlightRows ? Intent.DANGER : Intent.NONE}
-                            disabled={!activeComparisonReportList || !useNormalisedData}
-                        />
-                    </Tooltip>
+                    {activeComparisonReportList && useNormalisedData && (
+                        <Tooltip
+                            content='Highlights rows where ops have been added or are missing after normalising the data'
+                            position={Position.TOP}
+                        >
+                            <Switch
+                                label='Highlight row differences'
+                                onChange={() => setHighlightRows(!highlightRows)}
+                                disabled={!activeComparisonReportList || !useNormalisedData}
+                                checked={highlightRows}
+                            />
+                        </Tooltip>
+                    )}
                 </div>
 
                 <Tabs
@@ -303,11 +285,13 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                     onChange={setSelectedTabId}
                     renderActiveTabPanelOnly
                     size={Size.LARGE}
+                    id='performance-tabs'
                 >
                     <Tab
                         id={INITIAL_TAB_ID}
                         title={activePerformanceReport}
                         icon={IconNames.TH_LIST}
+                        className='tab-panel'
                         panel={
                             <PerfTable
                                 data={useNormalisedData ? normalisedData.data[0] : filteredRows}
@@ -330,6 +314,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                             id={report}
                             key={index}
                             icon={IconNames.TH_LIST}
+                            className='tab-panel'
                             disabled={useNormalisedData && normalisedComparisonData?.[index]?.length === 0}
                             title={
                                 normalisedData?.data?.slice(1)?.[index]?.length === 0 ? (
@@ -360,6 +345,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, comparisonData })
                                     provideMatmulAdvice={provideMatmulAdvice}
                                     hiliteHighDispatch={hiliteHighDispatch}
                                     shouldHighlightRows={highlightRows && useNormalisedData}
+                                    reportName={report}
                                 />
                             }
                         />

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -82,8 +82,8 @@ const COMPARISON_KEYS: TableKeys[] = [
 
 const OP_ID_INSERTION_POINT = 1;
 const HIGH_DISPATCH_INSERTION_POINT = 5;
-
 const NO_META_DATA = 'n/a';
+const PATTERN_COUNT = 3; // Number of row patterns defined in PerfReport.scss
 
 const PerformanceTable: FC<PerformanceTableProps> = ({
     data,
@@ -307,6 +307,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                                     shouldHighlightRows && dataset[i]?.raw_op_code.includes('MISSING'),
                                             },
                                             'comparison-row',
+                                            `report-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
                                         )}
                                     >
                                         {visibleHeaders.map((h) => (

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -9,12 +9,16 @@ import { IconNames } from '@blueprintjs/icons';
 import { useNavigate } from 'react-router';
 import { TableHeader, TableKeys } from '../../definitions/PerfTable';
 import 'styles/components/PerfReport.scss';
-import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList } from '../../hooks/useAPI';
+import { useDeviceLog, useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList } from '../../hooks/useAPI';
 import { formatCell } from '../../functions/perfFunctions';
 import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
 import sortAndFilterPerfTableData, { TypedPerfTableRow } from '../../functions/sortAndFilterPerfTableData';
 import { OperationDescription } from '../../model/APIData';
 import ROUTES from '../../definitions/Routes';
+import { DeviceArchitecture } from '../../definitions/DeviceArchitecture';
+import getCoreCount from '../../functions/getCoreCount';
+import LoadingSpinner from '../LoadingSpinner';
+import { LoadingSpinnerSizes } from '../../definitions/LoadingSpinner';
 
 interface PerformanceTableProps {
     data: TypedPerfTableRow[];
@@ -24,6 +28,7 @@ interface PerformanceTableProps {
     provideMatmulAdvice: boolean;
     hiliteHighDispatch: boolean;
     shouldHighlightRows: boolean;
+    reportName?: string;
 }
 
 enum COLUMN_HEADERS {
@@ -78,6 +83,8 @@ const COMPARISON_KEYS: TableKeys[] = [
 const OP_ID_INSERTION_POINT = 1;
 const HIGH_DISPATCH_INSERTION_POINT = 5;
 
+const NO_META_DATA = 'n/a';
+
 const PerformanceTable: FC<PerformanceTableProps> = ({
     data,
     comparisonData,
@@ -86,12 +93,17 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
     provideMatmulAdvice,
     hiliteHighDispatch,
     shouldHighlightRows,
+    reportName = null,
 }) => {
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(null);
     const opIdsMap = useOpToPerfIdFiltered();
     const { data: operations } = useOperationsList();
     const { data: npeManifest, error: npeManifestError } = useGetNPEManifest();
     const navigate = useNavigate();
+    const { data: deviceLog, isLoading: isLoadingDeviceLog } = useDeviceLog(reportName);
+
+    const architecture = deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE;
+    const maxCores = data ? getCoreCount(architecture, data) : 0;
 
     const filterableColumnKeys = useMemo(
         () => TABLE_HEADERS.filter((column) => column.filterable).map((column) => column.key),
@@ -179,6 +191,23 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                     <p>Invalid NPE manifest: {npeManifestError.message}</p>
                 </div>
             )}
+
+            <div className='meta-data'>
+                {isLoadingDeviceLog ? (
+                    <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />
+                ) : (
+                    <>
+                        <p>
+                            <strong>Arch: </strong>
+                            {architecture || NO_META_DATA}
+                        </p>
+                        <p>
+                            <strong>Cores: </strong>
+                            {maxCores || NO_META_DATA}
+                        </p>
+                    </>
+                )}
+            </div>
 
             <table className='perf-table monospace'>
                 <thead>

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -307,7 +307,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                                     shouldHighlightRows && dataset[i]?.raw_op_code.includes('MISSING'),
                                             },
                                             'comparison-row',
-                                            `report-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
+                                            `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
                                         )}
                                     >
                                         {visibleHeaders.map((h) => (

--- a/src/functions/getCoreCount.ts
+++ b/src/functions/getCoreCount.ts
@@ -2,16 +2,29 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { PerfTableRow } from '../definitions/PerfTable';
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
+import { PerfTableRow } from '../definitions/PerfTable';
+import { TypedPerfTableRow } from './sortAndFilterPerfTableData';
 
 const CORE_COUNT = {
     grayskull: 108,
     wormhole_b0: 64,
 };
 
-function getCoreCount(architecture: DeviceArchitecture, data: PerfTableRow[]): number {
-    const highestCoreCount = Math.max(...data.filter((row) => row.cores).map((row) => parseInt(row.cores ?? '0', 10)));
+function getCoreCount(architecture: DeviceArchitecture, data: PerfTableRow[] | TypedPerfTableRow[]): number {
+    const highestCoreCount = Math.max(
+        ...data
+            .filter((row) => row.cores)
+            .map((row) => {
+                const { cores } = row;
+
+                if (typeof cores === 'string') {
+                    const parsed = parseInt(cores, 10);
+                    return Number.isNaN(parsed) ? 0 : parsed;
+                }
+                return cores ?? 0;
+            }),
+    );
 
     // @ts-expect-error no blackhole yet
     return highestCoreCount > CORE_COUNT[architecture] ? highestCoreCount : CORE_COUNT[architecture];

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -349,7 +349,7 @@ export const useNPETimelineFile = (fileName: string | undefined) => {
 };
 
 interface MetaData {
-    architecture: string | null;
+    architecture: DeviceArchitecture | null;
     frequency: number | null;
 }
 
@@ -358,13 +358,15 @@ interface FetchDeviceLogRawResult {
     deviceLog: ParseResult<Record<string, string>[]>;
 }
 
-const fetchDeviceLogRaw = async (): Promise<FetchDeviceLogRawResult> => {
-    const { data } = await axiosInstance.get<string>('/api/performance/device-log/raw');
+const fetchDeviceLogRaw = async (name: string | null): Promise<FetchDeviceLogRawResult> => {
+    const { data } = await axiosInstance.get<string>('/api/performance/device-log/raw', {
+        params: { name },
+    });
 
     function parseArchAndFreq(input: string): MetaData {
         const archMatch = input.match(/ARCH:\s*([\w\d_]+)/);
         const freqMatch = input.match(/CHIP_FREQ\[MHz\]:\s*(\d+)/);
-        const architecture = archMatch ? archMatch[1] : null;
+        const architecture = archMatch ? (archMatch[1] as DeviceArchitecture) : null;
         const frequency = freqMatch ? parseInt(freqMatch[1], 10) : null;
 
         return { architecture, frequency };
@@ -781,12 +783,12 @@ export const useBuffers = (bufferType: BufferType, useRange?: boolean) => {
     }, [range, response.data, useRange]);
 };
 
-export const useDeviceLog = () => {
-    const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
+export const useDeviceLog = (name?: string | null) => {
+    const key = name || null;
 
     return useQuery({
-        queryFn: () => fetchDeviceLogRaw(),
-        queryKey: ['get-device-log-raw', activePerformanceReport],
+        queryFn: () => fetchDeviceLogRaw(key),
+        queryKey: ['get-device-log-raw', key],
         staleTime: Infinity,
     });
 };

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -8,7 +8,6 @@ import { Size, Tab, TabId, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom, useAtomValue } from 'jotai';
 import {
-    useDeviceLog,
     usePerfFolderList,
     usePerformanceComparisonReport,
     usePerformanceRange,
@@ -17,8 +16,6 @@ import {
 import useClearSelectedBuffer from '../functions/clearSelectedBuffer';
 import LoadingSpinner from '../components/LoadingSpinner';
 import PerformanceReport from '../components/performance/PerfReport';
-import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
-import getCoreCount from '../functions/getCoreCount';
 import {
     activePerformanceReportAtom,
     comparisonPerformanceReportListAtom,
@@ -39,7 +36,6 @@ export default function Performance() {
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const [selectedRange, setSelectedRange] = useAtom(selectedPerformanceRangeAtom);
 
-    const { data: deviceLog, isLoading: isLoadingDeviceLog } = useDeviceLog();
     const { data: perfData, isLoading: isLoadingPerformance } = usePerformanceReport(activePerformanceReport);
     const { data: comparisonData } = usePerformanceComparisonReport();
     const { data: folderList } = usePerfFolderList();
@@ -129,14 +125,10 @@ export default function Performance() {
         [selectedRange, filteredPerfData, comparisonReportList],
     );
 
-    if (isLoadingPerformance || isLoadingDeviceLog) {
+    if (isLoadingPerformance) {
         return <LoadingSpinner />;
     }
 
-    const activeData =
-        comparisonReportList && filteredComparisonData.length > 0 ? filteredComparisonData[0] : rangedData;
-    const architecture = (deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE) as DeviceArchitecture;
-    const maxCores = activeData ? getCoreCount(architecture, activeData) : 0;
     const reportSelectors =
         comparisonReportList && comparisonReportList?.length > 0 ? [...comparisonReportList, null] : [null];
 
@@ -204,7 +196,6 @@ export default function Performance() {
                                         <PerfCharts
                                             filteredPerfData={rangedData}
                                             comparisonData={filteredComparisonData}
-                                            maxCores={maxCores}
                                             selectedOpCodes={selectedOpCodes}
                                         />
                                     </div>
@@ -216,7 +207,6 @@ export default function Performance() {
                                             <NonFilterablePerfCharts
                                                 chartData={rangedData}
                                                 secondaryData={comparisonData || []}
-                                                maxCores={maxCores}
                                                 opCodeOptions={opCodeOptions}
                                             />
                                         </div>

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -133,8 +133,10 @@ export default function Performance() {
         return <LoadingSpinner />;
     }
 
+    const activeData =
+        comparisonReportList && filteredComparisonData.length > 0 ? filteredComparisonData[0] : rangedData;
     const architecture = (deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE) as DeviceArchitecture;
-    const maxCores = perfData ? getCoreCount(architecture, perfData) : 0;
+    const maxCores = activeData ? getCoreCount(architecture, activeData) : 0;
     const reportSelectors =
         comparisonReportList && comparisonReportList?.length > 0 ? [...comparisonReportList, null] : [null];
 
@@ -143,13 +145,6 @@ export default function Performance() {
             <Helmet title='Performance' />
 
             <h1 className='page-title'>Performance analysis</h1>
-
-            <p>
-                <strong>Arch:</strong> {architecture}
-            </p>
-            <p>
-                <strong>Cores:</strong> {maxCores}
-            </p>
 
             {!shouldDisableComparison &&
                 (folderList ? (

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -144,6 +144,13 @@ export default function Performance() {
 
             <h1 className='page-title'>Performance analysis</h1>
 
+            <p>
+                <strong>Arch:</strong> {architecture}
+            </p>
+            <p>
+                <strong>Cores:</strong> {maxCores}
+            </p>
+
             {!shouldDisableComparison &&
                 (folderList ? (
                     <div className='comparison-selectors'>
@@ -188,12 +195,7 @@ export default function Performance() {
                     icon={IconNames.TIMELINE_AREA_CHART}
                     panel={
                         <div className='chart-tab'>
-                            <p>
-                                <strong>Arch:</strong> {architecture}
-                            </p>
-                            <p>
-                                <strong>Cores:</strong> {maxCores}
-                            </p>
+                            <h3 className='title'>Performance charts</h3>
 
                             {perfData ? (
                                 <>

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -9,9 +9,7 @@
 $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%) 50%);
 
 .perf-report {
-    background: #222;
     color: #fff;
-    padding: 1rem;
     min-width: 1240px;
     overflow: auto;
 
@@ -28,10 +26,6 @@ $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%
     .perf-table {
         border-collapse: collapse;
         width: 100%;
-    }
-
-    .title {
-        margin-top: 0;
     }
 
     .header-aside {
@@ -55,7 +49,7 @@ $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%
     .data-options {
         display: flex;
         flex-wrap: nowrap;
-        gap: 5px;
+        gap: 10px;
         margin-bottom: 15px;
     }
 

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -50,7 +50,17 @@ $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%
         display: flex;
         flex-wrap: nowrap;
         gap: 10px;
-        margin-bottom: 15px;
+    }
+
+    .tab-panel {
+        margin-top: 10px;
+    }
+
+    .meta-data {
+        display: flex;
+        flex-direction: column;
+        height: 46px;
+        margin-bottom: 20px;
     }
 
     .cell-header {

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -112,15 +112,15 @@ $row-pattern-2: linear-gradient(45deg, transparent 50%, rgb(255 255 255 / 5%) 50
                 border-bottom: 1px solid colours.$tt-sand-accent;
                 background-size: 5px 5px;
 
-                &.report-0 {
+                &.pattern-0 {
                     background-image: $row-pattern-0;
                 }
 
-                &.report-1 {
+                &.pattern-1 {
                     background-image: $row-pattern-1;
                 }
 
-                &.report-2 {
+                &.pattern-2 {
                     background-image: $row-pattern-2;
                 }
             }

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -52,6 +52,13 @@ $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%
         margin-bottom: 15px;
     }
 
+    .data-options {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 5px;
+        margin-bottom: 15px;
+    }
+
     .cell-header {
         text-align: left;
         vertical-align: initial;

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -6,7 +6,9 @@
 @use '../definitions/colours' as colours;
 @use '../mixins/perfReportColours' as perf;
 
-$group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%) 50%);
+$row-pattern-0: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%) 50%);
+$row-pattern-1: linear-gradient(0deg, transparent 50%, rgb(255 255 255 / 5%) 50%);
+$row-pattern-2: linear-gradient(45deg, transparent 50%, rgb(255 255 255 / 5%) 50%);
 
 .perf-report {
     color: #fff;
@@ -104,8 +106,19 @@ $group-row-pattern: linear-gradient(90deg, transparent 50%, rgb(255 255 255 / 5%
         tr {
             &.comparison-row {
                 border-bottom: 1px solid colours.$tt-sand-accent;
-                background-image: $group-row-pattern;
                 background-size: 5px 5px;
+
+                &.report-0 {
+                    background-image: $row-pattern-0;
+                }
+
+                &.report-1 {
+                    background-image: $row-pattern-1;
+                }
+
+                &.report-2 {
+                    background-image: $row-pattern-2;
+                }
             }
         }
     }

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -104,6 +104,10 @@ $row-pattern-2: linear-gradient(45deg, transparent 50%, rgb(255 255 255 / 5%) 50
 
     tbody {
         tr {
+            &:hover {
+                background-color: rgb(255 255 255 / 5%);
+            }
+
             &.comparison-row {
                 border-bottom: 1px solid colours.$tt-sand-accent;
                 background-size: 5px 5px;

--- a/src/scss/routes/Performance.scss
+++ b/src/scss/routes/Performance.scss
@@ -2,6 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+@use '../definitions/colours' as *;
+
 .comparison-selectors {
     display: flex;
     align-items: flex-end;
@@ -18,4 +20,14 @@
     display: flex;
     align-items: center;
     gap: 5px;
+}
+
+.perf-report,
+.chart-tab {
+    background: $tt-black;
+    padding: 1rem;
+
+    .title {
+        margin-top: 0;
+    }
 }


### PR DESCRIPTION
Made various UI changes to the Performance UI.

- Moved table controls into PerfReport
- Highlight Row Differences control now hides when normalised data is disabled
- Displaying the delta of the op count if rows are added/removed after normalisation
- Now computing Arch/Cores per report and moved the display into PerfTable and PerfCharts
- Adds a small hover effect when user interacts with a normalised table row

**Previous UI**
<img width="1240" height="870" alt="Screenshot 2025-09-02 at 3 44 20 PM" src="https://github.com/user-attachments/assets/18a4bf86-806f-4ab0-bb82-01e0e12be4bc" />

**Fetching device log loading state**
<img width="1241" height="870" alt="Screenshot 2025-09-02 at 3 38 59 PM" src="https://github.com/user-attachments/assets/cba5e92f-9387-4832-a7ee-982feda41154" />

**Showing normalised data difference and Highlight Row Differences control**
<img width="1241" height="870" alt="Screenshot 2025-09-02 at 3 38 47 PM" src="https://github.com/user-attachments/assets/4ed1a2ba-4a58-4e1f-9bb4-c085c0f27822" />

Related to https://github.com/tenstorrent/ttnn-visualizer/issues/808.