### PR TITLE
Prevent duplicate transfers in grouping

### DIFF
--- a/src/components/npe/useNPEHandlers.tsx
+++ b/src/components/npe/useNPEHandlers.tsx
@@ -132,7 +132,9 @@ export function useSelectedTransferGrouping(
                         if (!groups[nocId]) {
                             groups[nocId] = [];
                         }
-                        groups[nocId].push(transfer);
+                        if (!groups[nocId].some((t) => t.id === transfer.id)) {
+                            groups[nocId].push(transfer);
+                        }
                     }
                 });
             });


### PR DESCRIPTION
before
<img width="804" height="556" alt="image" src="https://github.com/user-attachments/assets/20d6894f-9d0c-4b9d-ad20-a16a7c57742d" />

after
<img width="860" height="553" alt="image" src="https://github.com/user-attachments/assets/845c45eb-9888-43a0-bba9-6acfd8113958" />