### PR TITLE
Move route list rendering outside inner div

### DIFF
--- a/src/components/npe/ActiveTransferDetails.tsx
+++ b/src/components/npe/ActiveTransferDetails.tsx
@@ -132,35 +132,35 @@ const ActiveTransferDetails = ({
                                                         Fabric
                                                     </Tag>
                                                 )}
-                                                {showRoutes && (
-                                                    <ul className='routes'>
-                                                        {transfer.route.map((route, index) => (
-                                                            <li
-                                                                key={`${transfer.id}-${route.src}-${route.dst.join('-')}`}
-                                                                // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-                                                                onMouseOver={() => setHighlightedRoute(index)}
-                                                                // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-                                                                onMouseOut={() => setHighlightedRoute(null)}
-                                                                style={{
-                                                                    opacity:
-                                                                        highlightedRoute === null ||
-                                                                        highlightedRoute === index
-                                                                            ? 1
-                                                                            : 0.5,
-                                                                }}
-                                                            >
-                                                                <Icon icon={IconNames.FLOW_LINEAR} />
-                                                                {route.src.join('-')}
-                                                                <Icon
-                                                                    size={11}
-                                                                    icon={IconNames.ArrowRight}
-                                                                />{' '}
-                                                                {route.dst.map((el) => el.join('-')).join('-')}
-                                                            </li>
-                                                        ))}
-                                                    </ul>
-                                                )}
                                             </div>
+                                            {showRoutes && (
+                                                <ul className='routes'>
+                                                    {transfer.route.map((route, index) => (
+                                                        <li
+                                                            key={`${transfer.id}-${route.src}-${route.dst.join('-')}`}
+                                                            // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+                                                            onMouseOver={() => setHighlightedRoute(index)}
+                                                            // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+                                                            onMouseOut={() => setHighlightedRoute(null)}
+                                                            style={{
+                                                                opacity:
+                                                                    highlightedRoute === null ||
+                                                                    highlightedRoute === index
+                                                                        ? 1
+                                                                        : 0.5,
+                                                            }}
+                                                        >
+                                                            <Icon icon={IconNames.FLOW_LINEAR} />
+                                                            {route.src.join('-')}
+                                                            <Icon
+                                                                size={11}
+                                                                icon={IconNames.ArrowRight}
+                                                            />{' '}
+                                                            {route.dst.map((el) => el.join('-')).join('-')}
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            )}
                                         </div>
                                     ))}
                                 </div>


### PR DESCRIPTION
Relocated the rendering of the routes list from inside the transfer details inner div to outside, ensuring proper structure and visibility of route information when 'showRoutes' is true.