### PR TITLE
Feature/Support stacked perf reports

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -525,4 +525,4 @@ class OpsPerformanceReportQueries:
             if os.path.exists(stacked_png_file):
                 os.unlink(stacked_png_file)
 
-        return report, stacked_report
+        return {"report": report, "stacked_report": stacked_report}

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -100,7 +100,6 @@ class NPEQueries:
 
     @staticmethod
     def get_npe_manifest(instance: Instance):
-
         file_path = Path(
             instance.performance_path,
             NPEQueries.NPE_FOLDER,
@@ -418,14 +417,14 @@ class OpsPerformanceReportQueries:
     ]
 
     STACKED_REPORT_COLUMNS = [
-        "%",
-        "OP Code Joined",
-        "Device_Time_Sum_us",
-        "Ops_Count",
-        "Flops_min",
-        "Flops_max",
-        "Flops_mean",
-        "Flops_std",
+        "percent",
+        "op_code",
+        "device_time_sum_us",
+        "ops_count",
+        "flops_min",
+        "flops_max",
+        "flops_mean",
+        "flops_std",
     ]
 
     PASSTHROUGH_COLUMNS = {

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -444,7 +444,7 @@ class OpsPerformanceReportQueries:
         csv_file = StringIO(raw_csv)
         csv_output_file = tempfile.mktemp(suffix=".csv")
         csv_stacked_output_file = tempfile.mktemp(suffix=".csv")
-        # perf_report currently generates a PNG alongside the CSV using the same temp name
+        # perf_report currently generates a PNG alongside the CSV using the same temp name - we'll just delete it afterwards
         stacked_png_file = os.path.splitext(csv_output_file)[0] + ".png"
 
         try:

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -417,6 +417,17 @@ class OpsPerformanceReportQueries:
         "raw_op_code",
     ]
 
+    STACKED_REPORT_COLUMNS = [
+        "%",
+        "OP Code Joined",
+        "Device_Time_Sum_us",
+        "Ops_Count",
+        "Flops_min",
+        "Flops_max",
+        "Flops_mean",
+        "Flops_std",
+    ]
+
     PASSTHROUGH_COLUMNS = {
         "pm_ideal_ns": "PM IDEAL [ns]",
     }
@@ -433,6 +444,9 @@ class OpsPerformanceReportQueries:
         raw_csv = OpsPerformanceQueries.get_raw_csv(instance)
         csv_file = StringIO(raw_csv)
         csv_output_file = tempfile.mktemp(suffix=".csv")
+        csv_stacked_output_file = tempfile.mktemp(suffix=".csv")
+        # perf_report currently generates a PNG alongside the CSV using the same temp name
+        stacked_png_file = os.path.splitext(csv_output_file)[0] + ".png"
 
         try:
             perf_report.generate_perf_report(
@@ -446,9 +460,9 @@ class OpsPerformanceReportQueries:
                 cls.DEFAULT_TRACING_MODE,
                 True,
                 True,
-                True,
-                True,
                 False,
+                True,  # no_stack_by_in0 - need to ask what this is
+                csv_stacked_output_file,
             )
         except Exception as e:
             raise DataFormatError(f"Error generating performance report: {e}") from e
@@ -489,4 +503,26 @@ class OpsPerformanceReportQueries:
         finally:
             os.unlink(csv_output_file)
 
-        return report
+        stacked_report = []
+
+        try:
+            with open(csv_stacked_output_file, newline="") as csvfile:
+                reader = csv.reader(csvfile, delimiter=",")
+                next(reader, None)
+
+                for row in reader:
+                    processed_row = {
+                        column: row[index]
+                        for index, column in enumerate(cls.STACKED_REPORT_COLUMNS)
+                        if index < len(row)
+                    }
+
+                    stacked_report.append(processed_row)
+        except csv.Error as e:
+            raise DataFormatError() from e
+        finally:
+            os.unlink(csv_stacked_output_file)
+            if os.path.exists(stacked_png_file):
+                os.unlink(stacked_png_file)
+
+        return report, stacked_report

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -217,7 +217,7 @@ function Range() {
                                 labelStepSize={getStepSize(perfMax)}
                                 disabled={!isPerformanceRoute || !!comparisonReportList}
                                 labelRenderer={(id, options) =>
-                                    getPerformanceLabel(id, perfData, options?.isHandleTooltip)
+                                    getPerformanceLabel(id, perfData?.report, options?.isHandleTooltip)
                                 }
                                 handleHtmlProps={{
                                     start: { 'aria-label': 'Performance min range handle' },

--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -227,7 +227,7 @@ function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: Buffe
             filteredTableFields = listOfBuffers.filter((buffer) => buffer.tensor_id === selectedTensor);
         }
 
-        if (areFiltersActive(filters) && filterableColumnKeys) {
+        if (isFiltersActive(filters) && filterableColumnKeys) {
             filteredTableFields = filteredTableFields.filter((buffer) => {
                 const isFilteredOut = Object.entries(filters)
                     .filter(([_key, filterValue]) => String(filterValue).length)
@@ -393,7 +393,7 @@ const getCellContent = (
     );
 };
 
-function areFiltersActive(filters: Record<COLUMN_KEYS, string>) {
+function isFiltersActive(filters: Record<COLUMN_KEYS, string>) {
     return Object.values(filters).some((filter) => filter.length > 0);
 }
 

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -253,7 +253,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                         size={Size.SMALL}
                     >
                         <Button
-                            text='All'
+                            text='Standard'
                             icon={IconNames.LIST}
                             active={!isStackedView}
                             onClick={() => setIsStackedView(false)}
@@ -273,6 +273,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                         onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
                         checked={provideMatmulAdvice}
                         className='option-switch'
+                        disabled={isStackedView}
                     />
 
                     <Switch
@@ -280,6 +281,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                         onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
                         checked={hiliteHighDispatch}
                         className='option-switch'
+                        disabled={isStackedView}
                     />
 
                     <Tooltip

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -257,14 +257,14 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                             icon={IconNames.LIST}
                             active={!isStackedView}
                             onClick={() => setIsStackedView(false)}
-                            intent={Intent.PRIMARY}
+                            intent={!isStackedView ? Intent.PRIMARY : Intent.NONE}
                         />
                         <Button
                             text='Stacked'
                             icon={IconNames.LAYOUT_TWO_ROWS}
                             active={isStackedView}
                             onClick={() => setIsStackedView(true)}
-                            intent={Intent.PRIMARY}
+                            intent={isStackedView ? Intent.PRIMARY : Intent.NONE}
                         />
                     </ButtonGroup>
 

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -4,7 +4,21 @@
 
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import { MenuItem, PopoverPosition, Position, Size, Switch, Tab, TabId, Tabs, Tooltip } from '@blueprintjs/core';
+import {
+    Button,
+    ButtonGroup,
+    ButtonVariant,
+    Intent,
+    MenuItem,
+    PopoverPosition,
+    Position,
+    Size,
+    Switch,
+    Tab,
+    TabId,
+    Tabs,
+    Tooltip,
+} from '@blueprintjs/core';
 import { MultiSelect } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import {
@@ -224,22 +238,38 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, stackedData, comp
                 </div>
 
                 <div className='data-options'>
-                    <Switch
-                        label='Stacked display'
-                        onChange={() => setIsStackedView(!isStackedView)}
-                        checked={isStackedView}
-                    />
+                    <ButtonGroup
+                        variant={ButtonVariant.OUTLINED}
+                        size={Size.SMALL}
+                    >
+                        <Button
+                            text='All'
+                            icon={IconNames.LIST}
+                            active={!isStackedView}
+                            onClick={() => setIsStackedView(false)}
+                            intent={Intent.PRIMARY}
+                        />
+                        <Button
+                            text='Stacked'
+                            icon={IconNames.LAYOUT_TWO_ROWS}
+                            active={isStackedView}
+                            onClick={() => setIsStackedView(true)}
+                            intent={Intent.PRIMARY}
+                        />
+                    </ButtonGroup>
 
                     <Switch
                         label='Matmul optimization analysis'
                         onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
                         checked={provideMatmulAdvice}
+                        className='no-margin'
                     />
 
                     <Switch
                         label='Highlight high dispatch ops'
                         onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
                         checked={hiliteHighDispatch}
+                        className='no-margin'
                     />
 
                     <Tooltip
@@ -251,6 +281,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({ data, stackedData, comp
                             disabled={!activeComparisonReportList}
                             onChange={() => setUseNormalisedData(!useNormalisedData)}
                             checked={useNormalisedData}
+                            className='no-margin'
                         />
                     </Tooltip>
 

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -272,14 +272,14 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                         label='Matmul optimization analysis'
                         onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
                         checked={provideMatmulAdvice}
-                        className='no-margin'
+                        className='option-switch'
                     />
 
                     <Switch
                         label='Highlight high dispatch ops'
                         onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
                         checked={hiliteHighDispatch}
-                        className='no-margin'
+                        className='option-switch'
                     />
 
                     <Tooltip
@@ -291,7 +291,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                             disabled={!activeComparisonReportList || isStackedView}
                             onChange={() => setUseNormalisedData(!useNormalisedData)}
                             checked={useNormalisedData}
-                            className='no-margin'
+                            className='option-switch'
                         />
                     </Tooltip>
 
@@ -305,7 +305,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                                 onChange={() => setHighlightRows(!highlightRows)}
                                 disabled={!activeComparisonReportList || !useNormalisedData || isStackedView}
                                 checked={highlightRows}
-                                className='no-margin'
+                                className='option-switch'
                             />
                         </Tooltip>
                     )}

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -205,8 +205,8 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                                     )}
                                                     icon={
                                                         sortDirection === SortingDirection.ASC
-                                                            ? IconNames.CARET_DOWN
-                                                            : IconNames.CARET_UP
+                                                            ? IconNames.CARET_UP
+                                                            : IconNames.CARET_DOWN
                                                     }
                                                 />
                                             ) : (

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -117,6 +117,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
             const manifestRecord = npeManifest?.find((el) => {
                 return el.global_call_count === value;
             });
+
             if (manifestRecord) {
                 return (
                     npeManifest &&
@@ -132,8 +133,10 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                     )
                 );
             }
+
             return null;
         }
+
         return formatCell(row, header, operations, highlight);
     };
 

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -45,8 +45,8 @@ enum COLUMN_HEADERS {
     flops_percent = 'flops_percent',
     math_fidelity = 'math_fidelity',
     OP = 'op',
-    HIGH_DISPATCH = 'high_dispatch',
-    GLOBAL_CALL_COUNT = 'global_call_count',
+    high_dispatch = 'high_dispatch',
+    global_call_count = 'global_call_count',
 }
 
 const TABLE_HEADERS: TableHeader[] = [
@@ -76,8 +76,8 @@ const COMPARISON_KEYS: TableKeys[] = [
     COLUMN_HEADERS.flops,
     COLUMN_HEADERS.flops_percent,
     COLUMN_HEADERS.math_fidelity,
-    COLUMN_HEADERS.HIGH_DISPATCH,
-    COLUMN_HEADERS.GLOBAL_CALL_COUNT,
+    COLUMN_HEADERS.high_dispatch,
+    COLUMN_HEADERS.global_call_count,
 ];
 
 const OP_ID_INSERTION_POINT = 1;
@@ -139,9 +139,9 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
         ...TABLE_HEADERS.slice(0, OP_ID_INSERTION_POINT),
         ...(opIdsMap.length > 0 ? [{ label: 'OP', key: COLUMN_HEADERS.OP, sortable: true }] : []),
         ...TABLE_HEADERS.slice(OP_ID_INSERTION_POINT, HIGH_DISPATCH_INSERTION_POINT),
-        ...(hiliteHighDispatch ? [{ label: 'Slow', key: COLUMN_HEADERS.HIGH_DISPATCH }] : []),
+        ...(hiliteHighDispatch ? [{ label: 'Slow', key: COLUMN_HEADERS.high_dispatch }] : []),
         ...TABLE_HEADERS.slice(HIGH_DISPATCH_INSERTION_POINT),
-        ...(npeManifest && npeManifest.length > 0 ? [{ label: 'NPE', key: COLUMN_HEADERS.GLOBAL_CALL_COUNT }] : []),
+        ...(npeManifest && npeManifest.length > 0 ? [{ label: 'NPE', key: COLUMN_HEADERS.global_call_count }] : []),
     ] as TableHeader[];
 
     const cellFormattingProxy = (

--- a/src/components/performance/StackedPerfTable.tsx
+++ b/src/components/performance/StackedPerfTable.tsx
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { FC, useMemo } from 'react';
+import classNames from 'classnames';
+import { Button, ButtonVariant, Icon, Intent, Size } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { StackedTableHeader } from '../../definitions/PerfTable';
+import 'styles/components/PerfReport.scss';
+import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
+import { TypedPerfTableRow } from '../../functions/sortAndFilterPerfTableData';
+import { useDeviceLog, useGetNPEManifest } from '../../hooks/useAPI';
+import LoadingSpinner from '../LoadingSpinner';
+import { LoadingSpinnerSizes } from '../../definitions/LoadingSpinner';
+import { DeviceArchitecture } from '../../definitions/DeviceArchitecture';
+import getCoreCount from '../../functions/getCoreCount';
+import sortAndFilterStackedPerfTableData, {
+    TypedStackedPerfRow,
+} from '../../functions/sortAndFilterStackedPerfTableData';
+import { formatStackedCell } from '../../functions/stackedPerfFunctions';
+
+interface StackedPerformanceTableProps {
+    data: TypedPerfTableRow[];
+    filters: Record<string, string> | null;
+    stackedData?: TypedStackedPerfRow[];
+    reportName?: string;
+}
+
+enum COLUMN_HEADERS {
+    Percent = 'percent',
+    OpCodeJoined = 'op_code',
+    DeviceTimeSumUs = 'device_time_sum_us',
+    OpsCount = 'ops_count',
+    FlopsMin = 'flops_min',
+    FlopsMax = 'flops_max',
+    FlopsMean = 'flops_mean',
+    FlopsStd = 'flops_std',
+}
+
+const TABLE_HEADERS: StackedTableHeader[] = [
+    { label: 'Percent', key: COLUMN_HEADERS.Percent, unit: '%', decimals: 1, sortable: true },
+    { label: 'Op Code', key: COLUMN_HEADERS.OpCodeJoined, sortable: true, filterable: true },
+    { label: 'Device Time', key: COLUMN_HEADERS.DeviceTimeSumUs, unit: 'µs', decimals: 1, sortable: true },
+    { label: 'Ops Count', key: COLUMN_HEADERS.OpsCount, sortable: true },
+    { label: 'Min FLOPS', key: COLUMN_HEADERS.FlopsMin, unit: '%', decimals: 1, sortable: true },
+    { label: 'Max FLOPS', key: COLUMN_HEADERS.FlopsMax, unit: '%', decimals: 1, sortable: true },
+    { label: 'Mean FLOPS', key: COLUMN_HEADERS.FlopsMean, unit: '%', decimals: 1, sortable: true },
+    { label: 'Std FLOPS', key: COLUMN_HEADERS.FlopsStd, unit: '%', decimals: 1, sortable: true },
+];
+
+const FILTERABLE_COLUMN_KEYS = TABLE_HEADERS.filter((column) => column.filterable).map((column) => column.key);
+
+const NO_META_DATA = 'n/a';
+
+const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({ data, stackedData, filters, reportName }) => {
+    const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(null);
+    const { error: npeManifestError } = useGetNPEManifest();
+    const { data: deviceLog, isLoading: isLoadingDeviceLog } = useDeviceLog(reportName);
+
+    const architecture = deviceLog?.deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE;
+    const maxCores = data ? getCoreCount(architecture, data) : 0;
+
+    const tableFields = useMemo<TypedStackedPerfRow[]>(() => {
+        const parsedRows = stackedData
+            ? sortAndFilterStackedPerfTableData(stackedData, filters, FILTERABLE_COLUMN_KEYS)
+            : [];
+
+        // Still some awkward casting here
+        return [...sortTableFields(parsedRows as [])];
+    }, [stackedData, sortTableFields, filters]);
+
+    return (
+        <>
+            {npeManifestError && (
+                <div className='error-message'>
+                    <Icon
+                        icon={IconNames.ERROR}
+                        size={20}
+                        intent={Intent.WARNING}
+                    />
+                    <p>Invalid NPE manifest: {npeManifestError.message}</p>
+                </div>
+            )}
+
+            <div className='meta-data'>
+                {isLoadingDeviceLog ? (
+                    <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />
+                ) : (
+                    <>
+                        <p>
+                            <strong>Arch: </strong>
+                            {architecture || NO_META_DATA}
+                        </p>
+                        <p>
+                            <strong>Cores: </strong>
+                            {maxCores || NO_META_DATA}
+                        </p>
+                    </>
+                )}
+            </div>
+
+            <table className='perf-table monospace'>
+                <thead>
+                    <tr>
+                        {TABLE_HEADERS.map((h) => {
+                            const targetSortDirection =
+                                // eslint-disable-next-line no-nested-ternary
+                                sortingColumn === h.key
+                                    ? sortDirection === SortingDirection.ASC
+                                        ? SortingDirection.DESC
+                                        : SortingDirection.ASC
+                                    : sortDirection;
+
+                            return (
+                                <th
+                                    key={h.key}
+                                    className='cell-header'
+                                >
+                                    {h.sortable ? (
+                                        <Button
+                                            onClick={() => changeSorting(h.key)(targetSortDirection)}
+                                            variant={ButtonVariant.MINIMAL}
+                                            size={Size.SMALL}
+                                        >
+                                            <span className='header-label'>{h.label}</span>
+
+                                            {sortingColumn === h.key ? (
+                                                <Icon
+                                                    className={classNames(
+                                                        {
+                                                            'is-active': sortingColumn === h.key,
+                                                        },
+                                                        'sort-icon',
+                                                    )}
+                                                    icon={
+                                                        sortDirection === SortingDirection.ASC
+                                                            ? IconNames.CARET_DOWN
+                                                            : IconNames.CARET_UP
+                                                    }
+                                                />
+                                            ) : (
+                                                <Icon
+                                                    className={classNames('sort-icon')}
+                                                    icon={IconNames.CARET_DOWN}
+                                                />
+                                            )}
+                                        </Button>
+                                    ) : (
+                                        <span className='header-label no-button'>{h.label}</span>
+                                    )}
+
+                                    {/* TODO: May want this in the near future */}
+                                    {/* {h?.filterable && (
+                                            <div className='column-filter'>
+                                                <InputGroup
+                                                    asyncControl
+                                                    size='small'
+                                                    onValueChange={(value) => updateColumnFilter(h.key, value)}
+                                                    placeholder='Filter...'
+                                                    value={filters?.[h.key]}
+                                                />
+                                            </div>
+                                        )} */}
+                                </th>
+                            );
+                        })}
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {tableFields?.map((row, i) => (
+                        <tr key={i}>
+                            {TABLE_HEADERS.map((h: StackedTableHeader) => (
+                                <td
+                                    key={h.key}
+                                    className={classNames('cell')}
+                                >
+                                    {formatStackedCell(row, h, filters?.[h.key])}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </>
+    );
+};
+
+export default StackedPerformanceTable;

--- a/src/components/performance/StackedPerfTable.tsx
+++ b/src/components/performance/StackedPerfTable.tsx
@@ -6,19 +6,22 @@ import { FC, useMemo } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonVariant, Icon, Intent, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { StackedTableHeader } from '../../definitions/PerfTable';
+import {
+    FilterableColumnKeys,
+    StackedTableHeader,
+    TableHeaders,
+    TypedStackedPerfRow,
+} from '../../definitions/StackedPerfTable';
 import 'styles/components/PerfReport.scss';
 import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
-import { TypedPerfTableRow } from '../../functions/sortAndFilterPerfTableData';
 import { useDeviceLog, useGetNPEManifest } from '../../hooks/useAPI';
 import LoadingSpinner from '../LoadingSpinner';
 import { LoadingSpinnerSizes } from '../../definitions/LoadingSpinner';
 import { DeviceArchitecture } from '../../definitions/DeviceArchitecture';
 import getCoreCount from '../../functions/getCoreCount';
-import sortAndFilterStackedPerfTableData, {
-    TypedStackedPerfRow,
-} from '../../functions/sortAndFilterStackedPerfTableData';
+import sortAndFilterStackedPerfTableData from '../../functions/sortAndFilterStackedPerfTableData';
 import { formatStackedCell } from '../../functions/stackedPerfFunctions';
+import { TypedPerfTableRow } from '../../definitions/PerfTable';
 
 interface StackedPerformanceTableProps {
     data: TypedPerfTableRow[];
@@ -26,30 +29,6 @@ interface StackedPerformanceTableProps {
     stackedData?: TypedStackedPerfRow[];
     reportName?: string;
 }
-
-enum COLUMN_HEADERS {
-    Percent = 'percent',
-    OpCodeJoined = 'op_code',
-    DeviceTimeSumUs = 'device_time_sum_us',
-    OpsCount = 'ops_count',
-    FlopsMin = 'flops_min',
-    FlopsMax = 'flops_max',
-    FlopsMean = 'flops_mean',
-    FlopsStd = 'flops_std',
-}
-
-const TABLE_HEADERS: StackedTableHeader[] = [
-    { label: 'Percent', key: COLUMN_HEADERS.Percent, unit: '%', decimals: 1, sortable: true },
-    { label: 'Op Code', key: COLUMN_HEADERS.OpCodeJoined, sortable: true, filterable: true },
-    { label: 'Device Time', key: COLUMN_HEADERS.DeviceTimeSumUs, unit: 'µs', decimals: 1, sortable: true },
-    { label: 'Ops Count', key: COLUMN_HEADERS.OpsCount, sortable: true },
-    { label: 'Min FLOPS', key: COLUMN_HEADERS.FlopsMin, unit: '%', decimals: 1, sortable: true },
-    { label: 'Max FLOPS', key: COLUMN_HEADERS.FlopsMax, unit: '%', decimals: 1, sortable: true },
-    { label: 'Mean FLOPS', key: COLUMN_HEADERS.FlopsMean, unit: '%', decimals: 1, sortable: true },
-    { label: 'Std FLOPS', key: COLUMN_HEADERS.FlopsStd, unit: '%', decimals: 1, sortable: true },
-];
-
-const FILTERABLE_COLUMN_KEYS = TABLE_HEADERS.filter((column) => column.filterable).map((column) => column.key);
 
 const NO_META_DATA = 'n/a';
 
@@ -63,7 +42,7 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({ data, stack
 
     const tableFields = useMemo<TypedStackedPerfRow[]>(() => {
         const parsedRows = stackedData
-            ? sortAndFilterStackedPerfTableData(stackedData, filters, FILTERABLE_COLUMN_KEYS)
+            ? sortAndFilterStackedPerfTableData(stackedData, filters, FilterableColumnKeys)
             : [];
 
         // Still some awkward casting here
@@ -103,7 +82,7 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({ data, stack
             <table className='perf-table monospace'>
                 <thead>
                     <tr>
-                        {TABLE_HEADERS.map((h) => {
+                        {TableHeaders.map((h) => {
                             const targetSortDirection =
                                 // eslint-disable-next-line no-nested-ternary
                                 sortingColumn === h.key
@@ -171,7 +150,7 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({ data, stack
                 <tbody>
                     {tableFields?.map((row, i) => (
                         <tr key={i}>
-                            {TABLE_HEADERS.map((h: StackedTableHeader) => (
+                            {TableHeaders.map((h: StackedTableHeader) => (
                                 <td
                                     key={h.key}
                                     className={classNames('cell')}

--- a/src/components/performance/StackedPerfTable.tsx
+++ b/src/components/performance/StackedPerfTable.tsx
@@ -114,8 +114,8 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({ data, stack
                                                     )}
                                                     icon={
                                                         sortDirection === SortingDirection.ASC
-                                                            ? IconNames.CARET_DOWN
-                                                            : IconNames.CARET_UP
+                                                            ? IconNames.CARET_UP
+                                                            : IconNames.CARET_DOWN
                                                     }
                                                 />
                                             ) : (

--- a/src/definitions/PerfTable.ts
+++ b/src/definitions/PerfTable.ts
@@ -3,24 +3,12 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 export type TableKeys = Partial<keyof PerfTableRow>;
-export type StackedTableKeys = Partial<keyof StackedPerfRow>;
 
 export type TableFilter = Record<TableKeys, string> | null;
-export type StackedTableFilter = Record<StackedTableKeys, string> | null;
 
 export interface TableHeader {
     label: string;
     key: TableKeys;
-    colour?: string;
-    unit?: string;
-    decimals?: number;
-    sortable?: boolean;
-    filterable?: boolean;
-}
-
-export interface StackedTableHeader {
-    label: string;
-    key: StackedTableKeys;
     colour?: string;
     unit?: string;
     decimals?: number;
@@ -60,15 +48,30 @@ export interface PerfTableRow {
     missing?: boolean;
 }
 
-export interface StackedPerfRow {
-    percent: string;
-    op_code: string;
-    device_time_sum_us: string;
-    ops_count: string;
-    flops_min: string;
-    flops_max: string;
-    flops_mean: string;
-    flops_std: string;
+export interface TypedPerfTableRow
+    extends Omit<
+        PerfTableRow,
+        | 'id'
+        | 'global_call_count'
+        | 'total_percent'
+        | 'device_time'
+        | 'op_to_op_gap'
+        | 'cores'
+        | 'dram'
+        | 'dram_percent'
+        | 'flops'
+        | 'flops_percent'
+    > {
+    id: number | null;
+    global_call_count: number | null;
+    total_percent: number | null;
+    device_time: number | null;
+    op_to_op_gap: number | null;
+    cores: number | null;
+    dram: number | null;
+    dram_percent: number | null;
+    flops: number | null;
+    flops_percent: number | null;
 }
 
 export type MathFidelity = 'HiFi4' | 'HiFi2' | 'LoFi';
@@ -103,3 +106,54 @@ export interface Marker {
     opCode: string;
     colour: (typeof MARKER_COLOURS)[number];
 }
+
+export enum ColumnHeaders {
+    id = 'id',
+    total_percent = 'total_percent',
+    bound = 'bound',
+    op_code = 'op_code',
+    device_time = 'device_time',
+    op_to_op_gap = 'op_to_op_gap',
+    cores = 'cores',
+    dram = 'dram',
+    dram_percent = 'dram_percent',
+    flops = 'flops',
+    flops_percent = 'flops_percent',
+    math_fidelity = 'math_fidelity',
+    OP = 'op',
+    high_dispatch = 'high_dispatch',
+    global_call_count = 'global_call_count',
+}
+
+export const TableHeaders: TableHeader[] = [
+    { label: 'ID', key: ColumnHeaders.id, sortable: true },
+    { label: 'Total %', key: ColumnHeaders.total_percent, unit: '%', decimals: 1, sortable: true },
+    { label: 'Bound', key: ColumnHeaders.bound, colour: 'yellow' },
+    { label: 'OP Code', key: ColumnHeaders.op_code, colour: 'blue', sortable: true, filterable: true },
+    { label: 'Device Time', key: ColumnHeaders.device_time, unit: 'µs', decimals: 0, sortable: true },
+    { label: 'Op-to-Op Gap', key: ColumnHeaders.op_to_op_gap, colour: 'red', unit: 'µs', decimals: 0, sortable: true },
+    { label: 'Cores', key: ColumnHeaders.cores, colour: 'green', sortable: true },
+    { label: 'DRAM', key: ColumnHeaders.dram, colour: 'yellow', unit: 'GB/s', sortable: true },
+    { label: 'DRAM %', key: ColumnHeaders.dram_percent, colour: 'yellow', unit: '%', sortable: true },
+    { label: 'FLOPs', key: ColumnHeaders.flops, unit: 'TFLOPs', sortable: true },
+    { label: 'FLOPs %', key: ColumnHeaders.flops_percent, unit: '%', sortable: true },
+    { label: 'Math Fidelity', key: ColumnHeaders.math_fidelity, colour: 'cyan' },
+];
+
+export const FilterableColumnKeys = TableHeaders.filter((column) => column.filterable).map((column) => column.key);
+
+export const ComparisonKeys: TableKeys[] = [
+    ColumnHeaders.op_code,
+    ColumnHeaders.bound,
+    ColumnHeaders.total_percent,
+    ColumnHeaders.device_time,
+    ColumnHeaders.op_to_op_gap,
+    ColumnHeaders.cores,
+    ColumnHeaders.dram,
+    ColumnHeaders.dram_percent,
+    ColumnHeaders.flops,
+    ColumnHeaders.flops_percent,
+    ColumnHeaders.math_fidelity,
+    ColumnHeaders.high_dispatch,
+    ColumnHeaders.global_call_count,
+];

--- a/src/definitions/PerfTable.ts
+++ b/src/definitions/PerfTable.ts
@@ -3,12 +3,24 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 export type TableKeys = Partial<keyof PerfTableRow>;
+export type StackedTableKeys = Partial<keyof StackedPerfRow>;
 
 export type TableFilter = Record<TableKeys, string> | null;
+export type StackedTableFilter = Record<StackedTableKeys, string> | null;
 
 export interface TableHeader {
     label: string;
     key: TableKeys;
+    colour?: string;
+    unit?: string;
+    decimals?: number;
+    sortable?: boolean;
+    filterable?: boolean;
+}
+
+export interface StackedTableHeader {
+    label: string;
+    key: StackedTableKeys;
     colour?: string;
     unit?: string;
     decimals?: number;
@@ -49,14 +61,14 @@ export interface PerfTableRow {
 }
 
 export interface StackedPerfRow {
-    '%': string;
-    'OP Code Joined': string;
-    Device_Time_Sum_us: string;
-    Ops_Count: string;
-    Flops_min: string;
-    Flops_max: string;
-    Flops_mean: string;
-    Flops_std: string;
+    percent: string;
+    op_code: string;
+    device_time_sum_us: string;
+    ops_count: string;
+    flops_min: string;
+    flops_max: string;
+    flops_mean: string;
+    flops_std: string;
 }
 
 export type MathFidelity = 'HiFi4' | 'HiFi2' | 'LoFi';

--- a/src/definitions/PerfTable.ts
+++ b/src/definitions/PerfTable.ts
@@ -48,6 +48,17 @@ export interface PerfTableRow {
     missing?: boolean;
 }
 
+export interface StackedPerfRow {
+    '%': string;
+    'OP Code Joined': string;
+    Device_Time_Sum_us: string;
+    Ops_Count: string;
+    Flops_min: string;
+    Flops_max: string;
+    Flops_mean: string;
+    Flops_std: string;
+}
+
 export type MathFidelity = 'HiFi4' | 'HiFi2' | 'LoFi';
 
 export const MARKER_COLOURS = [

--- a/src/definitions/StackedPerfTable.ts
+++ b/src/definitions/StackedPerfTable.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+export type StackedTableKeys = Partial<keyof StackedPerfRow>;
+
+export type StackedTableFilter = Record<StackedTableKeys, string> | null;
+
+export interface StackedTableHeader {
+    label: string;
+    key: StackedTableKeys;
+    colour?: string;
+    unit?: string;
+    decimals?: number;
+    sortable?: boolean;
+    filterable?: boolean;
+}
+
+export interface StackedPerfRow {
+    percent: string;
+    op_code: string;
+    device_time_sum_us: string;
+    ops_count: string;
+    flops_min: string;
+    flops_max: string;
+    flops_mean: string;
+    flops_std: string;
+}
+
+export interface TypedStackedPerfRow
+    extends Omit<
+        StackedPerfRow,
+        'percent' | 'device_time_sum_us' | 'ops_count' | 'flops_min' | 'flops_max' | 'flops_mean' | 'flops_std'
+    > {
+    percent: number | null;
+    device_time_sum_us: number | null;
+    ops_count: number | null;
+    flops_min: number | null;
+    flops_max: number | null;
+    flops_mean: number | null;
+    flops_std: number | null;
+}
+
+export enum ColumnHeaders {
+    Percent = 'percent',
+    OpCodeJoined = 'op_code',
+    DeviceTimeSumUs = 'device_time_sum_us',
+    OpsCount = 'ops_count',
+    FlopsMin = 'flops_min',
+    FlopsMax = 'flops_max',
+    FlopsMean = 'flops_mean',
+    FlopsStd = 'flops_std',
+}
+
+export const TableHeaders: StackedTableHeader[] = [
+    { label: 'Percent', key: ColumnHeaders.Percent, unit: '%', decimals: 1, sortable: true },
+    { label: 'Op Code', key: ColumnHeaders.OpCodeJoined, sortable: true, filterable: true },
+    { label: 'Device Time', key: ColumnHeaders.DeviceTimeSumUs, unit: 'µs', decimals: 1, sortable: true },
+    { label: 'Ops Count', key: ColumnHeaders.OpsCount, sortable: true },
+    { label: 'Min FLOPS', key: ColumnHeaders.FlopsMin, unit: '%', decimals: 1, sortable: true },
+    { label: 'Max FLOPS', key: ColumnHeaders.FlopsMax, unit: '%', decimals: 1, sortable: true },
+    { label: 'Mean FLOPS', key: ColumnHeaders.FlopsMean, unit: '%', decimals: 1, sortable: true },
+    { label: 'Std FLOPS', key: ColumnHeaders.FlopsStd, unit: '%', decimals: 1, sortable: true },
+];
+
+export const FilterableColumnKeys = TableHeaders.filter((column) => column.filterable).map((column) => column.key);

--- a/src/functions/getCoreCount.ts
+++ b/src/functions/getCoreCount.ts
@@ -3,8 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
-import { PerfTableRow } from '../definitions/PerfTable';
-import { TypedPerfTableRow } from './sortAndFilterPerfTableData';
+import { PerfTableRow, TypedPerfTableRow } from '../definitions/PerfTable';
 
 const CORE_COUNT = {
     grayskull: 108,

--- a/src/functions/normalisePerformanceData.ts
+++ b/src/functions/normalisePerformanceData.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { TypedPerfTableRow } from './sortAndFilterPerfTableData';
+import { TypedPerfTableRow } from '../definitions/PerfTable';
 
 const MISSING_OP_STRING = 'MISSING';
 const PLACEHOLDER: TypedPerfTableRow = {

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -38,6 +38,9 @@ const OPERATION_COLOURS: { [key: string]: CellColour } = {
     OptimizedConvNew: CellColour.Orange,
 };
 
+const DEFAULT_COLOUR = CellColour.White;
+const FALLBACK_COLOUR = CellColour.Grey;
+
 const MIN_PERCENTAGE = 0.5;
 
 const NUMBER_KEYS_TO_PARSE = [
@@ -139,11 +142,11 @@ export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColou
     const percentage = row.total_percent;
 
     if (percentage != null && percentage < MIN_PERCENTAGE) {
-        return CellColour.Grey;
+        return FALLBACK_COLOUR;
     }
 
     if (key === 'id' || key === 'total_percent' || key === 'device_time') {
-        return CellColour.White;
+        return DEFAULT_COLOUR;
     }
 
     if (key === 'bound') {
@@ -178,7 +181,7 @@ export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColou
             return CellColour.Red;
         }
 
-        return CellColour.White;
+        return DEFAULT_COLOUR;
     }
 
     if (key === 'cores' && keyValue != null) {
@@ -188,7 +191,7 @@ export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColou
     if (key === 'op_code') {
         const match = Object.keys(OPERATION_COLOURS).find((opCodeKey) => row.raw_op_code.includes(opCodeKey));
 
-        return match ? OPERATION_COLOURS[match] : CellColour.White;
+        return match ? OPERATION_COLOURS[match] : DEFAULT_COLOUR;
     }
 
     if (key === 'math_fidelity' && typeof keyValue === 'string') {
@@ -211,7 +214,7 @@ export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColou
             return CellColour.Cyan;
         }
 
-        return CellColour.White;
+        return DEFAULT_COLOUR;
     }
 
     if (key === 'op_to_op_gap' && typeof keyValue === 'string') {
@@ -219,7 +222,7 @@ export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColou
     }
 
     // Shouldn't get to this point but need to return something
-    return CellColour.Grey;
+    return FALLBACK_COLOUR;
 };
 
 export const getCoreColour = (value: string | string[] | boolean | number): CellColour | '' => {
@@ -237,13 +240,13 @@ export const getCoreColour = (value: string | string[] | boolean | number): Cell
         return '';
     }
 
-    return CellColour.White;
+    return DEFAULT_COLOUR;
 };
 
 export const getOpToOpGapColour = (value: string): CellColour => {
     const parsedValue = parseFloat(value) || 0;
 
-    return parsedValue > 6.5 ? CellColour.Red : CellColour.Grey;
+    return parsedValue > 6.5 ? CellColour.Red : FALLBACK_COLOUR;
 };
 
 export const calcHighDispatchOps = (rows: TypedPerfTableRow[]) => {

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -6,12 +6,11 @@ import React from 'react';
 import { Icon, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Link } from 'react-router-dom';
-import { MathFidelity, TableHeader, TableKeys } from '../definitions/PerfTable';
+import { MathFidelity, TableHeader, TableKeys, TypedPerfTableRow } from '../definitions/PerfTable';
 import { OperationDescription } from '../model/APIData';
 import { formatSize, toSecondsPretty } from './math';
 import ROUTES from '../definitions/Routes';
 import HighlightedText from '../components/HighlightedText';
-import { TypedPerfTableRow } from './sortAndFilterPerfTableData';
 
 type CellColour = 'white' | 'green' | 'red' | 'blue' | 'magenta' | 'cyan' | 'yellow' | 'orange' | 'grey';
 

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -101,7 +101,7 @@ export const formatCell = (
     return getCellMarkup(formatted, getCellColour(row, key), highlight);
 };
 
-export const getCellMarkup = (text: string, colour?: string, highlight?: string | null) => {
+export const getCellMarkup = (text: string, colour?: CellColour, highlight?: string | null) => {
     if (!text) {
         return '';
     }
@@ -123,7 +123,7 @@ export const getCellMarkup = (text: string, colour?: string, highlight?: string 
     return <span>{text}</span>;
 };
 
-export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColour | '' => {
+export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColour => {
     const keyValue = row[key];
     const percentage = row.total_percent;
 

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -225,7 +225,7 @@ export const getCellColour = (row: TypedPerfTableRow, key: TableKeys): CellColou
     return FALLBACK_COLOUR;
 };
 
-export const getCoreColour = (value: string | string[] | boolean | number): CellColour | '' => {
+export const getCoreColour = (value: string | string[] | boolean | number): CellColour => {
     const cores = (typeof value === 'string' ? parseInt(value, 10) : value) as number;
 
     if (cores != null) {
@@ -236,8 +236,6 @@ export const getCoreColour = (value: string | string[] | boolean | number): Cell
         if (cores === 64) {
             return CellColour.Green;
         }
-    } else {
-        return '';
     }
 
     return DEFAULT_COLOUR;

--- a/src/functions/sortAndFilterPerfTableData.ts
+++ b/src/functions/sortAndFilterPerfTableData.ts
@@ -4,7 +4,7 @@
 
 import { TableFilter, TableKeys, TypedPerfTableRow } from '../definitions/PerfTable';
 
-const areFiltersActive = (filters: Record<TableKeys, string> | null) =>
+const isFiltersActive = (filters: Record<TableKeys, string> | null) =>
     filters ? Object.values(filters).some((filter) => filter.length > 0) : false;
 
 const getCellText = (buffer: TypedPerfTableRow, key: TableKeys) => {
@@ -25,7 +25,7 @@ const sortAndFilterPerfTableData = (
 
     let filteredRows = data || [];
 
-    if (areFiltersActive(filters) && filterableColumnKeys) {
+    if (isFiltersActive(filters) && filterableColumnKeys) {
         filteredRows = filteredRows.filter((row) => {
             const isFilteredOut =
                 filters &&

--- a/src/functions/sortAndFilterPerfTableData.ts
+++ b/src/functions/sortAndFilterPerfTableData.ts
@@ -2,33 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { PerfTableRow, TableFilter, TableKeys } from '../definitions/PerfTable';
-
-export interface TypedPerfTableRow
-    extends Omit<
-        PerfTableRow,
-        | 'id'
-        | 'global_call_count'
-        | 'total_percent'
-        | 'device_time'
-        | 'op_to_op_gap'
-        | 'cores'
-        | 'dram'
-        | 'dram_percent'
-        | 'flops'
-        | 'flops_percent'
-    > {
-    id: number | null;
-    global_call_count: number | null;
-    total_percent: number | null;
-    device_time: number | null;
-    op_to_op_gap: number | null;
-    cores: number | null;
-    dram: number | null;
-    dram_percent: number | null;
-    flops: number | null;
-    flops_percent: number | null;
-}
+import { TableFilter, TableKeys, TypedPerfTableRow } from '../definitions/PerfTable';
 
 const areFiltersActive = (filters: Record<TableKeys, string> | null) =>
     filters ? Object.values(filters).some((filter) => filter.length > 0) : false;

--- a/src/functions/sortAndFilterStackedPerfTableData.ts
+++ b/src/functions/sortAndFilterStackedPerfTableData.ts
@@ -4,7 +4,7 @@
 
 import { StackedTableFilter, StackedTableKeys, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
 
-const areFiltersActive = (filters: Record<StackedTableKeys, string> | null) =>
+const isFiltersActive = (filters: Record<StackedTableKeys, string> | null) =>
     filters ? Object.values(filters).some((filter) => filter.length > 0) : false;
 
 const getCellText = (buffer: TypedStackedPerfRow, key: StackedTableKeys) => {
@@ -24,7 +24,7 @@ const sortAndFilterStackedPerfTableData = (
 
     let filteredRows = data || [];
 
-    if (areFiltersActive(filters) && filterableColumnKeys) {
+    if (isFiltersActive(filters) && filterableColumnKeys) {
         filteredRows = filteredRows.filter((row) => {
             const isFilteredOut =
                 filters &&

--- a/src/functions/sortAndFilterStackedPerfTableData.ts
+++ b/src/functions/sortAndFilterStackedPerfTableData.ts
@@ -2,21 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { StackedPerfRow, StackedTableFilter, StackedTableKeys } from '../definitions/PerfTable';
-
-export interface TypedStackedPerfRow
-    extends Omit<
-        StackedPerfRow,
-        'percent' | 'device_time_sum_us' | 'ops_count' | 'flops_min' | 'flops_max' | 'flops_mean' | 'flops_std'
-    > {
-    percent: number | null;
-    device_time_sum_us: number | null;
-    ops_count: number | null;
-    flops_min: number | null;
-    flops_max: number | null;
-    flops_mean: number | null;
-    flops_std: number | null;
-}
+import { StackedTableFilter, StackedTableKeys, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
 
 const areFiltersActive = (filters: Record<StackedTableKeys, string> | null) =>
     filters ? Object.values(filters).some((filter) => filter.length > 0) : false;

--- a/src/functions/sortAndFilterStackedPerfTableData.ts
+++ b/src/functions/sortAndFilterStackedPerfTableData.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { StackedPerfRow, StackedTableFilter, StackedTableKeys } from '../definitions/PerfTable';
+
+export interface TypedStackedPerfRow
+    extends Omit<
+        StackedPerfRow,
+        'percent' | 'device_time_sum_us' | 'ops_count' | 'flops_min' | 'flops_max' | 'flops_mean' | 'flops_std'
+    > {
+    percent: number | null;
+    device_time_sum_us: number | null;
+    ops_count: number | null;
+    flops_min: number | null;
+    flops_max: number | null;
+    flops_mean: number | null;
+    flops_std: number | null;
+}
+
+const areFiltersActive = (filters: Record<StackedTableKeys, string> | null) =>
+    filters ? Object.values(filters).some((filter) => filter.length > 0) : false;
+
+const getCellText = (buffer: TypedStackedPerfRow, key: StackedTableKeys) => {
+    const textValue = buffer[key]?.toString() || '';
+
+    return textValue;
+};
+
+const sortAndFilterStackedPerfTableData = (
+    data: TypedStackedPerfRow[],
+    filters: StackedTableFilter,
+    filterableColumnKeys: StackedTableKeys[],
+): TypedStackedPerfRow[] => {
+    if (data?.length === 0) {
+        return data;
+    }
+
+    let filteredRows = data || [];
+
+    if (areFiltersActive(filters) && filterableColumnKeys) {
+        filteredRows = filteredRows.filter((row) => {
+            const isFilteredOut =
+                filters &&
+                Object.entries(filters)
+                    .filter(([_key, filterValue]) => String(filterValue).length)
+                    .some(([key, filterValue]) => {
+                        const bufferValue = getCellText(row, key as StackedTableKeys);
+
+                        return !bufferValue.toLowerCase().includes(filterValue.toLowerCase());
+                    });
+
+            return !isFilteredOut;
+        });
+    }
+
+    return filteredRows;
+};
+
+export default sortAndFilterStackedPerfTableData;

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -34,6 +34,9 @@ const OPERATION_COLOURS: { [key: string]: CellColour } = {
     OptimizedConvNew: CellColour.Orange,
 };
 
+const DEFAULT_COLOUR = CellColour.White;
+const FALLBACK_COLOUR = CellColour.Grey;
+
 export const formatStackedCell = (
     row: TypedStackedPerfRow,
     header: StackedTableHeader,
@@ -82,19 +85,19 @@ export const getCellMarkup = (text: string, colour?: CellColour, highlight?: str
 
 export const getCellColour = (row: TypedStackedPerfRow, key: StackedTableKeys): CellColour => {
     if (PERCENTAGE_KEYS.includes(key)) {
-        return typeof row[key] === 'number' && row[key]! > 0 ? CellColour.White : CellColour.Grey;
+        return typeof row[key] === 'number' && row[key]! > 0 ? DEFAULT_COLOUR : FALLBACK_COLOUR;
     }
 
     if (key === 'op_code') {
         const match = Object.keys(OPERATION_COLOURS).find((opCodeKey) => row.op_code.includes(opCodeKey));
 
-        return match ? OPERATION_COLOURS[match] : CellColour.Grey;
+        return match ? OPERATION_COLOURS[match] : FALLBACK_COLOUR;
     }
 
     if (key === 'ops_count' || key === 'device_time_sum_us') {
-        return CellColour.White;
+        return DEFAULT_COLOUR;
     }
 
     // Shouldn't get to this point but need to return something
-    return CellColour.Grey;
+    return FALLBACK_COLOUR;
 };

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -22,12 +22,10 @@ export const formatStackedCell = (
         return '';
     }
 
-    if (typeof value === 'number' && PERCENTAGE_KEYS.includes(key)) {
-        formatted = formatPercentage(value, decimals ?? 0);
-    }
-
     if (typeof value === 'number') {
-        formatted = formatSize(Number(value.toFixed(decimals ?? 0)));
+        formatted = PERCENTAGE_KEYS.includes(key)
+            ? formatPercentage(value, decimals ?? 0)
+            : formatSize(Number(value.toFixed(decimals ?? 0)));
     } else {
         formatted = value.toString();
     }

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -7,21 +7,31 @@ import HighlightedText from '../components/HighlightedText';
 import { formatPercentage, formatSize } from './math';
 import { StackedTableHeader, StackedTableKeys, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
 
-type CellColour = 'white' | 'green' | 'red' | 'blue' | 'magenta' | 'cyan' | 'yellow' | 'orange' | 'grey';
+export enum CellColour {
+    White = 'white',
+    Green = 'green',
+    Red = 'red',
+    Blue = 'blue',
+    Magenta = 'magenta',
+    Cyan = 'cyan',
+    Yellow = 'yellow',
+    Orange = 'orange',
+    Grey = 'grey',
+}
 
 const PERCENTAGE_KEYS = ['percent', 'flops_min', 'flops_max', 'flops_mean', 'flops_std'];
 const OPERATION_COLOURS: { [key: string]: CellColour } = {
-    '(torch)': 'red',
-    Matmul: 'magenta',
-    LayerNorm: 'cyan',
-    AllGather: 'cyan',
-    AllReduce: 'cyan',
-    ScaledDotProductAttentionDecode: 'blue',
-    ScaledDotProductAttentionGQADecode: 'blue',
-    NlpCreateHeadsDeviceOperation: 'blue',
-    NLPConcatHeadsDecodeDeviceOperation: 'blue',
-    UpdateCache: 'blue',
-    OptimizedConvNew: 'orange',
+    '(torch)': CellColour.Red,
+    Matmul: CellColour.Magenta,
+    LayerNorm: CellColour.Cyan,
+    AllGather: CellColour.Cyan,
+    AllReduce: CellColour.Cyan,
+    ScaledDotProductAttentionDecode: CellColour.Blue,
+    ScaledDotProductAttentionGQADecode: CellColour.Blue,
+    NlpCreateHeadsDeviceOperation: CellColour.Blue,
+    NLPConcatHeadsDecodeDeviceOperation: CellColour.Blue,
+    UpdateCache: CellColour.Blue,
+    OptimizedConvNew: CellColour.Orange,
 };
 
 export const formatStackedCell = (
@@ -72,19 +82,19 @@ export const getCellMarkup = (text: string, colour?: CellColour, highlight?: str
 
 export const getCellColour = (row: TypedStackedPerfRow, key: StackedTableKeys): CellColour => {
     if (PERCENTAGE_KEYS.includes(key)) {
-        return typeof row[key] === 'number' && row[key]! > 0 ? 'white' : 'grey';
+        return typeof row[key] === 'number' && row[key]! > 0 ? CellColour.White : CellColour.Grey;
     }
 
     if (key === 'op_code') {
         const match = Object.keys(OPERATION_COLOURS).find((opCodeKey) => row.op_code.includes(opCodeKey));
 
-        return match ? OPERATION_COLOURS[match] : 'grey';
+        return match ? OPERATION_COLOURS[match] : CellColour.Grey;
     }
 
     if (key === 'ops_count' || key === 'device_time_sum_us') {
-        return 'white';
+        return CellColour.White;
     }
 
     // Shouldn't get to this point but need to return something
-    return 'grey';
+    return CellColour.Grey;
 };

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
 import React from 'react';
 import HighlightedText from '../components/HighlightedText';
 import { formatPercentage, formatSize } from './math';

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -84,8 +84,10 @@ export const getCellMarkup = (text: string, colour?: CellColour, highlight?: str
 };
 
 export const getCellColour = (row: TypedStackedPerfRow, key: StackedTableKeys): CellColour => {
-    if (PERCENTAGE_KEYS.includes(key)) {
-        return typeof row[key] === 'number' && row[key]! > 0 ? DEFAULT_COLOUR : FALLBACK_COLOUR;
+    const value = row[key];
+
+    if (PERCENTAGE_KEYS.includes(key) && typeof value === 'number') {
+        return value > 0 ? DEFAULT_COLOUR : FALLBACK_COLOUR;
     }
 
     if (key === 'op_code') {

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { StackedTableHeader } from '../definitions/PerfTable';
 import HighlightedText from '../components/HighlightedText';
 import { formatPercentage, formatSize } from './math';
-import { TypedStackedPerfRow } from './sortAndFilterStackedPerfTableData';
+import { StackedTableHeader, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
 
 const PERCENTAGE_KEYS = ['percent', 'flops_min', 'flops_max', 'flops_mean', 'flops_std'];
 

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { StackedTableHeader } from '../definitions/PerfTable';
+import HighlightedText from '../components/HighlightedText';
+import { formatPercentage, formatSize } from './math';
+import { TypedStackedPerfRow } from './sortAndFilterStackedPerfTableData';
+
+const PERCENTAGE_KEYS = ['percent', 'flops_min', 'flops_max', 'flops_mean', 'flops_std'];
+
+export const formatStackedCell = (
+    row: TypedStackedPerfRow,
+    header: StackedTableHeader,
+    highlight?: string | null,
+): React.JSX.Element | string => {
+    const { key, unit, decimals } = header;
+    let formatted: string | boolean | string[];
+    const value = row[key];
+
+    if (value == null || value === '') {
+        return '';
+    }
+
+    if (typeof value === 'number' && PERCENTAGE_KEYS.includes(key)) {
+        formatted = formatPercentage(value, decimals ?? 0);
+    }
+
+    if (typeof value === 'number') {
+        formatted = formatSize(Number(value.toFixed(decimals ?? 0)));
+    } else {
+        formatted = value.toString();
+    }
+
+    if (unit) {
+        formatted += ` ${unit}`;
+    }
+
+    return getCellMarkup(formatted, highlight);
+};
+
+export const getCellMarkup = (text: string, highlight?: string | null) => {
+    if (!text) {
+        return '';
+    }
+
+    if (highlight) {
+        return (
+            <HighlightedText
+                text={text}
+                filter={highlight || ''}
+            />
+        );
+    }
+
+    return <span>{text}</span>;
+};

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -318,7 +318,7 @@ const fetchDevices = async (reportName: string) => {
 //     });
 // };
 
-interface PerformanceReportResponse {
+export interface PerformanceReportResponse {
     report: PerfTableRow[];
     stacked_report: StackedPerfRow[];
 }
@@ -849,7 +849,7 @@ export const usePerformanceComparisonReport = () => {
         return Array.isArray(rawReportNames) ? [...rawReportNames] : rawReportNames;
     }, [rawReportNames]);
 
-    const response = useQuery({
+    const response = useQuery<PerformanceReportResponse[], AxiosError>({
         queryFn: async () => {
             if (!reportNames || !Array.isArray(reportNames) || reportNames.length === 0) {
                 return [];
@@ -866,10 +866,15 @@ export const usePerformanceComparisonReport = () => {
 
     const filteredData = useMemo(() => {
         if (response.data) {
-            return response.data.map((perfReport: PerformanceReportResponse) =>
-                perfReport.report.slice().filter((r) => !r.op_code?.includes('(torch)') && !(r.op_code === '')),
-            );
+            return response.data.map((perfReport: PerformanceReportResponse) => {
+                perfReport.report = perfReport.report
+                    .slice()
+                    .filter((r) => !r.op_code?.includes('(torch)') && !(r.op_code === ''));
+
+                return perfReport;
+            });
         }
+
         return response.data;
     }, [response.data]);
 

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -26,7 +26,8 @@ import {
 } from '../model/APIData';
 import { BufferType } from '../model/BufferType';
 import parseMemoryConfig, { MemoryConfig, memoryConfigPattern } from '../functions/parseMemoryConfig';
-import { PerfTableRow, StackedPerfRow } from '../definitions/PerfTable';
+import { PerfTableRow } from '../definitions/PerfTable';
+import { StackedPerfRow } from '../definitions/StackedPerfTable';
 import { isDeviceOperation } from '../functions/filterOperations';
 import {
     activeNpeOpTraceAtom,

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -53,7 +53,7 @@ export default function Performance() {
     const opCodeOptions = useMemo(() => {
         const opCodes = Array.from(
             new Set([
-                ...(perfData
+                ...(perfData?.report
                     ?.map((row) => row.raw_op_code)
                     .filter((opCode): opCode is string => opCode !== undefined) || []),
                 ...(comparisonData
@@ -107,7 +107,7 @@ export default function Performance() {
 
     useEffect(() => {
         setFilteredPerfData(
-            perfData?.filter((row) =>
+            perfData?.report?.filter((row) =>
                 selectedOpCodes.length
                     ? selectedOpCodes.map((selected) => selected.opCode).includes(row.raw_op_code ?? '')
                     : false,

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -50,6 +50,9 @@ export default function Performance() {
     const perfData = data?.report;
     const stackedData = data?.stacked_report;
 
+    const comparisonPerfData = useMemo(() => comparisonData?.map((d) => d.report) || [], [comparisonData]);
+    const comparisonStackedData = useMemo(() => comparisonData?.map((d) => d.stacked_report) || [], [comparisonData]);
+
     // useClearSelectedBuffer();
 
     const opCodeOptions = useMemo(() => {
@@ -58,8 +61,8 @@ export default function Performance() {
                 ...(perfData
                     ?.map((row) => row.raw_op_code)
                     .filter((opCode): opCode is string => opCode !== undefined) || []),
-                ...(comparisonData
-                    ? comparisonData.flatMap((report) =>
+                ...(comparisonPerfData
+                    ? comparisonPerfData.flatMap((report) =>
                           report
                               .map((row) => row.raw_op_code)
                               .filter((opCode): opCode is string => opCode !== undefined),
@@ -72,7 +75,7 @@ export default function Performance() {
             opCode,
             colour: MARKER_COLOURS[index],
         }));
-    }, [perfData, comparisonData]);
+    }, [perfData, comparisonPerfData]);
 
     const [selectedTabId, setSelectedTabId] = useState<TabId>(INITIAL_TAB_ID);
     const [filteredPerfData, setFilteredPerfData] = useState<PerfTableRow[]>([]);
@@ -97,7 +100,7 @@ export default function Performance() {
 
     useEffect(() => {
         setFilteredComparisonData(
-            comparisonData?.map((dataset) =>
+            comparisonPerfData?.map((dataset) =>
                 dataset.filter((row) =>
                     selectedOpCodes.length
                         ? selectedOpCodes.map((selected) => selected.opCode).includes(row.raw_op_code ?? '')
@@ -105,7 +108,7 @@ export default function Performance() {
                 ),
             ) || [],
         );
-    }, [selectedOpCodes, comparisonData]);
+    }, [selectedOpCodes, comparisonPerfData]);
 
     useEffect(() => {
         setFilteredPerfData(
@@ -194,8 +197,9 @@ export default function Performance() {
                     panel={
                         <PerformanceReport
                             data={rangedData}
-                            stackedData={stackedData}
                             comparisonData={filteredComparisonData}
+                            stackedData={stackedData}
+                            comparisonStackedData={comparisonStackedData}
                         />
                     }
                 />
@@ -230,7 +234,7 @@ export default function Performance() {
                                         <div>
                                             <NonFilterablePerfCharts
                                                 chartData={rangedData}
-                                                secondaryData={comparisonData || []}
+                                                secondaryData={comparisonPerfData || []}
                                                 opCodeOptions={opCodeOptions}
                                             />
                                         </div>

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -14,7 +14,6 @@ import {
     usePerformanceRange,
     usePerformanceReport,
 } from '../hooks/useAPI';
-import useClearSelectedBuffer from '../functions/clearSelectedBuffer';
 import LoadingSpinner from '../components/LoadingSpinner';
 import PerformanceReport from '../components/performance/PerfReport';
 import {
@@ -38,7 +37,7 @@ export default function Performance() {
     const [selectedRange, setSelectedRange] = useAtom(selectedPerformanceRangeAtom);
 
     const {
-        data: perfData,
+        data,
         isLoading: isLoadingPerformance,
         error: perfDataError,
     } = usePerformanceReport(activePerformanceReport);
@@ -48,12 +47,15 @@ export default function Performance() {
 
     const shouldDisableComparison = getServerConfig()?.SERVER_MODE;
 
-    useClearSelectedBuffer();
+    const perfData = data?.report;
+    const stackedData = data?.stacked_report;
+
+    // useClearSelectedBuffer();
 
     const opCodeOptions = useMemo(() => {
         const opCodes = Array.from(
             new Set([
-                ...(perfData?.report
+                ...(perfData
                     ?.map((row) => row.raw_op_code)
                     .filter((opCode): opCode is string => opCode !== undefined) || []),
                 ...(comparisonData
@@ -107,7 +109,7 @@ export default function Performance() {
 
     useEffect(() => {
         setFilteredPerfData(
-            perfData?.report?.filter((row) =>
+            perfData?.filter((row) =>
                 selectedOpCodes.length
                     ? selectedOpCodes.map((selected) => selected.opCode).includes(row.raw_op_code ?? '')
                     : false,
@@ -192,6 +194,7 @@ export default function Performance() {
                     panel={
                         <PerformanceReport
                             data={rangedData}
+                            stackedData={stackedData}
                             comparisonData={filteredComparisonData}
                         />
                     }

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -54,7 +54,7 @@ $row-pattern-2: linear-gradient(45deg, transparent 50%, rgb(255 255 255 / 5%) 50
         gap: 10px;
         align-items: center;
 
-        .no-margin {
+        .option-switch {
             margin-bottom: 0;
         }
     }

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -52,6 +52,11 @@ $row-pattern-2: linear-gradient(45deg, transparent 50%, rgb(255 255 255 / 5%) 50
         display: flex;
         flex-wrap: nowrap;
         gap: 10px;
+        align-items: center;
+
+        .no-margin {
+            margin-bottom: 0;
+        }
     }
 
     .tab-panel {

--- a/ttnn-visualizer.code-workspace
+++ b/ttnn-visualizer.code-workspace
@@ -68,6 +68,7 @@
         "recommendations": [
             "dbaeumer.vscode-eslint",
             "esbenp.prettier-vscode",
+            "freakypie.code-python-isort",
             "Gruntfuggly.todo-tree",
             "ms-python.black-formatter",
             "ms-python.python",

--- a/ttnn-visualizer.code-workspace
+++ b/ttnn-visualizer.code-workspace
@@ -68,9 +68,9 @@
         "recommendations": [
             "dbaeumer.vscode-eslint",
             "esbenp.prettier-vscode",
-            "freakypie.code-python-isort",
             "Gruntfuggly.todo-tree",
             "ms-python.black-formatter",
+            "ms-python.isort",
             "ms-python.python",
             "streetsidesoftware.code-spell-checker",
             "stylelint.vscode-stylelint"


### PR DESCRIPTION
Adds support for tt-perf-report stacked reports.

- Includes a new option to switch the view to "stacked"
- Stacked view is a new table with new data. Follows a similar pattern to the current perf table and has similar functionality
- Moved a lot of consts to other files to organise the components better

<img width="1424" height="832" alt="Screenshot 2025-09-09 at 12 13 17 PM" src="https://github.com/user-attachments/assets/112063b3-4bc7-4f4a-8793-ee574992b84a" />
