### PR TITLE
Revert back to using jsonify for cluster descriptor

### DIFF
--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1026,10 +1026,7 @@ def get_cluster_descriptor(instance: Instance):
         try:
             with open(local_path) as cluster_desc_file:
                 yaml_data = yaml.safe_load(cluster_desc_file)
-                return Response(
-                    orjson.dumps(yaml_data),
-                    mimetype="application/json",
-                )
+                return jsonify(yaml_data)  # yaml_data is not compatible with orjson
         except yaml.YAMLError as e:
             return jsonify({"error": f"Failed to parse YAML: {str(e)}"}), 400
 


### PR DESCRIPTION
This PR modifies the `/api/cluster_descriptor` endpoint to revert back to using Flask's `jsonify` to encode the response, instead of orjson. In #804 we changed most of the views to use orjson for performance reasons, but it turns out it is not a drop-in replacement, and has some subtle differences from `jsonify`. In particular, this view is loading the data to return with a YAML library, and for numeric values, it's using integers as dict keys, instead of strings. It turns out that the `json.dumps` silently casts numbers to strings is the keys, but orjson considers this an error and desired behaviour and not a bug.

To illustrate the problem:

```
(Pdb) json.dumps({"foo": "bar", 0: "10"})
'{"foo": "bar", "0": "10"}'
(Pdb) orjson.dumps({"foo": "bar", 0: "10"})
*** TypeError: Dict key must be str
```

We could have a utility method that casts the dict keys to str, but the cluster descriptor data is relatively small and doesn't really need an "optimization". It was changed just for consistency to use orjson everywhere, but it doesn't work with the cluster descriptor data, as returned from the YAML library, and it's fine to (indirectly) use Python's `json.dumps` for it.

[Closes #831]