### PR TITLE
Add event type filter for fabric and local events in NPE view

### DIFF
--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -94,6 +94,12 @@ export enum NoCType {
     NOC1 = 'NOC1',
 }
 
+export enum EVENT_TYPE_FILTER {
+    ALL_EVENTS,
+    FABRIC_EVENTS,
+    LOCAL_EVENTS,
+}
+
 export enum NoCID {
     NOC1_NORTH = 'NOC1_NORTH',
     NOC0_SOUTH = 'NOC0_SOUTH',


### PR DESCRIPTION
Introduces EVENT_TYPE_FILTER enum and replaces the boolean fabricEventsOnlyFilter with a more flexible filter supporting all, fabric, and local events. Updates UI switches and filtering logic in NPEViewComponent to allow toggling between event types for transfers and link demand display.

closes #751 