### PR TITLE
Return raw JSON file contents in NPE view

### DIFF
--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1300,16 +1300,15 @@ def get_npe_data(instance: Instance):
         if compressed_path and compressed_path.exists():
             with open(compressed_path, "rb") as file:
                 compressed_data = file.read()
-                uncompressed_data = zstd.uncompress(compressed_data)
-                npe_data = json.loads(uncompressed_data)
+                npe_data = zstd.uncompress(compressed_data)
         else:
             with open(uncompressed_path, "r") as file:
-                npe_data = json.load(file)
-    except json.JSONDecodeError as e:
-        logger.error(f"Invalid JSON in NPE file: {e}")
+                npe_data = file.read()
+    except Exception as e:
+        logger.error(f"Error reading NPE file: {e}")
         return Response(status=HTTPStatus.UNPROCESSABLE_ENTITY)
 
-    return Response(orjson.dumps(npe_data), mimetype="application/json")
+    return Response(npe_data, mimetype="application/json")
 
 
 @api.route("/notify", methods=["POST"])


### PR DESCRIPTION
This PR modifies the `/api/npe` endpoint to return the raw JSON file the uploaded data file, without loading it into a Python dict first.

It previously uncompressed the zstandard file, then read the JSON file contents into a Python dict, then used orjson to generate the JSON response. This was nice in theory, ensured the JSON was valid and had consistent formatting when output. But some of the `.npeviz.zst` are very big. A 75 MB `.npeviz.zst` file is uncompressing to an 885 MB JSON file. Loading a 885 MB JSON file into a Python dict, and then re-encoding it to JSON, is unacceptably slow.

Returning the raw JSON is much quicker with these very large files.