### PR TITLE
Add late deallocated tensor highlighting and filtering

### DIFF
--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -12,7 +12,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import { MultiSelect } from '@blueprintjs/select';
 import SearchField from './SearchField';
 import LoadingSpinner from './LoadingSpinner';
-import { useOperationsList, useTensors } from '../hooks/useAPI';
+import { useGetTensorDeallocationReportByOperation, useOperationsList, useTensors } from '../hooks/useAPI';
 import ROUTES from '../definitions/Routes';
 import { Tensor } from '../model/APIData';
 import { BufferTypeLabel } from '../model/BufferType';
@@ -43,6 +43,7 @@ const TensorList = () => {
     const [hasScrolledFromTop, setHasScrolledFromTop] = useState(false);
     const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
     const [showHighConsumerTensors, setShowHighConsumerTensors] = useState(false);
+    const [showLateDeallocatedTensors, setShowLateDeallocatedTensors] = useState(false);
     const [expandedTensors, setExpandedTensors] = useAtom(expandedTensorsAtom);
     const selectedOperationRange = useAtomValue(selectedOperationRangeAtom);
 
@@ -62,6 +63,8 @@ const TensorList = () => {
 
         return fetchedTensors;
     }, [fetchedTensors, selectedOperationRange]);
+
+    const { nonDeallocatedTensorList } = useGetTensorDeallocationReportByOperation();
 
     const { getFilterOptions, updateFilters, activeFilters, FilterItem } = useTableFilter(
         'buffer_type',
@@ -106,29 +109,37 @@ const TensorList = () => {
         );
     };
 
-    useMemo(() => {
-        if (tensorsWithRange && operations) {
-            let tensors = [...tensorsWithRange];
+    useMemo(
+        () => {
+            if (tensorsWithRange && operations) {
+                let tensors = [...tensorsWithRange];
 
-            if (filterQuery) {
-                tensors = tensorsWithRange?.filter((tensor) =>
-                    getTensorFilterName(tensor).toLowerCase().includes(filterQuery.toLowerCase()),
-                );
+                if (filterQuery) {
+                    tensors = tensorsWithRange?.filter((tensor) =>
+                        getTensorFilterName(tensor).toLowerCase().includes(filterQuery.toLowerCase()),
+                    );
+                }
+
+                if (activeFilters?.length > 0) {
+                    tensors = tensors.filter(
+                        (tensor) => tensor?.buffer_type !== null && activeFilters.includes(tensor.buffer_type),
+                    );
+                }
+
+                if (showHighConsumerTensors) {
+                    tensors = tensors.filter((tensor) => tensor.consumers.length > MAX_NUM_CONSUMERS);
+                }
+
+                if (showLateDeallocatedTensors) {
+                    tensors = tensors.filter((tensor) => nonDeallocatedTensorList.get(tensor.id));
+                }
+
+                setFilteredTensorList(tensors);
             }
-
-            if (activeFilters?.length > 0) {
-                tensors = tensors.filter(
-                    (tensor) => tensor?.buffer_type !== null && activeFilters.includes(tensor.buffer_type),
-                );
-            }
-
-            if (showHighConsumerTensors) {
-                tensors = tensors.filter((tensor) => tensor.consumers.length > MAX_NUM_CONSUMERS);
-            }
-
-            setFilteredTensorList(tensors);
-        }
-    }, [operations, tensorsWithRange, filterQuery, activeFilters, showHighConsumerTensors]);
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [tensorsWithRange, operations, filterQuery, activeFilters, showHighConsumerTensors, showLateDeallocatedTensors],
+    );
 
     useEffect(() => {
         const initialTensorId = location.state?.previousOperationId;
@@ -184,6 +195,21 @@ const TensorList = () => {
                     </Tooltip>
 
                     <Tooltip
+                        content='Show late deallocated tensors'
+                        placement={PopoverPosition.TOP}
+                    >
+                        <Button
+                            onClick={() => setShowLateDeallocatedTensors(!showLateDeallocatedTensors)}
+                            endIcon={IconNames.OUTDATED}
+                            intent={Intent.WARNING}
+                            disabled={nonDeallocatedTensorList.size === 0}
+                            variant={showLateDeallocatedTensors ? 'outlined' : undefined}
+                            aria-label='Toggle high consumer tensors'
+                        >
+                            {filteredTensorList?.filter((tensor) => nonDeallocatedTensorList.get(tensor.id)).length}
+                        </Button>
+                    </Tooltip>
+                    <Tooltip
                         content={shouldCollapseAll ? 'Collapse all' : 'Expand all'}
                         placement={PopoverPosition.TOP}
                     >
@@ -193,7 +219,6 @@ const TensorList = () => {
                             aria-label={shouldCollapseAll ? 'Collapse all' : 'Expand all'}
                         />
                     </Tooltip>
-
                     <Tooltip
                         content='Scroll to top'
                         placement={PopoverPosition.TOP}
@@ -206,7 +231,6 @@ const TensorList = () => {
                             aria-label='Scroll to top'
                         />
                     </Tooltip>
-
                     <Tooltip
                         content='Scroll to bottom'
                         placement={PopoverPosition.TOP}
@@ -219,7 +243,6 @@ const TensorList = () => {
                             aria-label='Scroll to bottom'
                         />
                     </Tooltip>
-
                     <MultiSelect
                         items={tensorsWithRange ? (getFilterOptions() as number[]) : []}
                         placeholder='Buffer type filter...'
@@ -282,6 +305,8 @@ const TensorList = () => {
                             virtualItems.map((virtualRow) => {
                                 const tensor = filteredTensorList[virtualRow.index];
 
+                                const isLateDeallocated = nonDeallocatedTensorList.get(tensor.id);
+
                                 return (
                                     <li
                                         className='list-item-container'
@@ -320,6 +345,20 @@ const TensorList = () => {
                                                                 icon={IconNames.ISSUE}
                                                                 intent={HIGH_CONSUMER_INTENT}
                                                                 title='Unusually high number of consumers'
+                                                            />
+                                                        </Tooltip>
+                                                    ) : null}
+
+                                                    {isLateDeallocated ? (
+                                                        <Tooltip
+                                                            content='Tensor has an opportunity for earlier deallocation'
+                                                            position={PopoverPosition.TOP}
+                                                            className='high-number-consumers'
+                                                        >
+                                                            <Icon
+                                                                icon={IconNames.OUTDATED}
+                                                                intent={Intent.WARNING}
+                                                                title='Tensor has an opportunity for earlier deallocation'
                                                             />
                                                         </Tooltip>
                                                     ) : null}

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -249,7 +249,9 @@ function BufferSummaryPlotRenderer({
                                         memoryPadding={memoryPadding}
                                         tensorList={tensorListByOperation.get(operation.id)!}
                                         tensorDeallocationReport={
-                                            nondeallocatedTensorsByOperationId.get(operation.id) || []
+                                            showDeallocationReport
+                                                ? nondeallocatedTensorsByOperationId.get(operation.id) || []
+                                                : []
                                         }
                                         showMemoryLayout={renderMemoryLayout}
                                     />

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -43,12 +43,12 @@ const CHART_DATA: Partial<PlotData>[][] = [
 ];
 
 interface BufferSummaryPlotRendererDRAMProps {
-    buffersByOperation: BuffersByOperationData[];
+    uniqueBuffersByOperationList: BuffersByOperationData[];
     tensorListByOperation: TensorsByOperationByAddress;
 }
 
 function BufferSummaryPlotRendererDRAM({
-    buffersByOperation,
+    uniqueBuffersByOperationList,
     tensorListByOperation,
 }: BufferSummaryPlotRendererDRAMProps) {
     const [hasScrolledFromTop, setHasScrolledFromTop] = useState(false);
@@ -60,17 +60,19 @@ function BufferSummaryPlotRendererDRAM({
 
     const numberOfOperations = useMemo(
         () =>
-            buffersByOperation && buffersByOperation.length >= 0 ? buffersByOperation.length : PLACEHOLDER_ARRAY_SIZE,
-        [buffersByOperation],
+            uniqueBuffersByOperationList && uniqueBuffersByOperationList.length >= 0
+                ? uniqueBuffersByOperationList.length
+                : PLACEHOLDER_ARRAY_SIZE,
+        [uniqueBuffersByOperationList],
     );
 
     const segmentedChartData: BuffersByOperationData[][] = useMemo(() => {
         if (isZoomedIn) {
-            return getSplitBuffers(buffersByOperation);
+            return getSplitBuffers(uniqueBuffersByOperationList);
         }
 
-        return [buffersByOperation];
-    }, [buffersByOperation, isZoomedIn]);
+        return [uniqueBuffersByOperationList];
+    }, [uniqueBuffersByOperationList, isZoomedIn]);
 
     const zoomedMemoryOptions = useMemo(
         () =>
@@ -89,7 +91,7 @@ function BufferSummaryPlotRendererDRAM({
     );
 
     const virtualizer = useVirtualizer({
-        count: buffersByOperation?.length || PLACEHOLDER_ARRAY_SIZE,
+        count: uniqueBuffersByOperationList?.length || PLACEHOLDER_ARRAY_SIZE,
         getScrollElement: () => scrollElementRef.current,
         estimateSize: () => OPERATION_EL_HEIGHT,
         overscan: 20,
@@ -103,7 +105,7 @@ function BufferSummaryPlotRendererDRAM({
         setHasScrolledToBottom(el.scrollTop + el.offsetHeight >= el.scrollHeight);
     };
 
-    return buffersByOperation && tensorListByOperation ? (
+    return uniqueBuffersByOperationList && tensorListByOperation ? (
         <div className='buffer-summary-chart'>
             <div className='controls'>
                 <Switch

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -54,12 +54,12 @@ function BufferSummaryTab({
             >
                 {isDram ? (
                     <BufferSummaryPlotRendererDRAM
-                        buffersByOperation={uniqueBuffersByOperationList}
+                        uniqueBuffersByOperationList={uniqueBuffersByOperationList}
                         tensorListByOperation={tensorListByOperation}
                     />
                 ) : (
                     <BufferSummaryPlotRenderer
-                        buffersByOperation={uniqueBuffersByOperationList}
+                        uniqueBuffersByOperationList={uniqueBuffersByOperationList}
                         tensorListByOperation={tensorListByOperation}
                     />
                 )}

--- a/src/routes/BufferSummary.tsx
+++ b/src/routes/BufferSummary.tsx
@@ -7,11 +7,9 @@ import { Helmet } from 'react-helmet-async';
 import { AnchorButton, ButtonGroup, Callout, Intent, Tab, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom, useAtomValue } from 'jotai';
-import { BuffersByOperationData, useBuffers, useOperationsList } from '../hooks/useAPI';
+import { useBuffers, useCreateTensorsByOperationByIdList, useOperationsList } from '../hooks/useAPI';
 import useBufferFocus from '../hooks/useBufferFocus';
 import { BufferType } from '../model/BufferType';
-import { TensorsByOperationByAddress } from '../model/BufferSummary';
-import { Operation, Tensor } from '../model/APIData';
 import ROUTES from '../definitions/Routes';
 import BufferSummaryTab from '../components/buffer-summary/BufferSummaryTab';
 import LoadingSpinner from '../components/LoadingSpinner';
@@ -25,6 +23,7 @@ function BufferSummary() {
     const [activeSection, setActiveSection] = useState<SECTION_IDS>(SECTION_IDS.PLOT);
     const [selectedTabId, setSelectedTabId] = useAtom(selectedBufferSummaryTabAtom);
     const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
+    // TODO: this requires further optimization
     const { data: buffersByOperation, error: buffersError } = useBuffers(
         selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
         true,
@@ -55,8 +54,9 @@ function BufferSummary() {
         return () => window.removeEventListener('scroll', navHighlighter);
     }, []);
 
-    const tensorListByOperation = createTensorsByOperationByIdList(operationsList, buffersByOperation);
-
+    const tensorListByOperation = useCreateTensorsByOperationByIdList(
+        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
+    );
     return (
         <div className='buffer-summary data-padding'>
             <Helmet title='Buffer summary' />
@@ -103,6 +103,7 @@ function BufferSummary() {
                     title='L1'
                     icon={IconNames.PAGE_LAYOUT}
                     panel={
+                        // TODO: excessive prop passing
                         // eslint-disable-next-line no-nested-ternary
                         buffersByOperation && operationsList && tensorListByOperation ? (
                             <BufferSummaryTab
@@ -130,6 +131,7 @@ function BufferSummary() {
                     title='DRAM'
                     icon={IconNames.PAGE_LAYOUT}
                     panel={
+                        // TODO: excessive prop passing
                         // eslint-disable-next-line no-nested-ternary
                         buffersByOperation && operationsList && tensorListByOperation ? (
                             <BufferSummaryTab
@@ -155,52 +157,6 @@ function BufferSummary() {
             </Tabs>
         </div>
     );
-}
-
-// TODO: Refactor to optimise historical tensor lookup
-function createTensorsByOperationByIdList(operations?: Operation[], buffersByOperation?: BuffersByOperationData[]) {
-    const tensorsByOperationByAddress: TensorsByOperationByAddress = new Map();
-
-    if (!operations || !buffersByOperation) {
-        return tensorsByOperationByAddress;
-    }
-
-    buffersByOperation.forEach((operation) => {
-        const tensorsByBufferAddress: Map<number, Tensor> = new Map();
-        const currentOperation = operations.find((op) => op.id === operation.id);
-
-        for (const buffer of operation.buffers) {
-            const bufferAddress = buffer.address;
-            const bufferType = buffer.buffer_type;
-            let tensor: Tensor | undefined;
-
-            for (let i = operations.indexOf(currentOperation!); i >= 0; i--) {
-                const op = operations[i];
-                tensor = op.inputs.find((input) => input.address === bufferAddress);
-
-                if (tensor !== undefined) {
-                    break;
-                }
-
-                tensor = op.outputs.find((output) => output.address === bufferAddress);
-
-                if (tensor !== undefined) {
-                    break;
-                }
-            }
-
-            if (tensor !== undefined) {
-                tensorsByBufferAddress.set(bufferAddress, {
-                    ...tensor,
-                    buffer_type: bufferType,
-                });
-            }
-        }
-
-        tensorsByOperationByAddress.set(operation.id, tensorsByBufferAddress);
-    });
-
-    return tensorsByOperationByAddress;
 }
 
 export default BufferSummary;


### PR DESCRIPTION
Introduces logic and UI to identify and filter tensors that could be deallocated earlier. Refactors tensor deallocation report generation into a reusable hook, updates BufferSummary and related components to use this logic, and adds visual indicators and filter controls for late deallocated tensors in the TensorList.