### PR TITLE
sticky header + fixed active transfer

### DIFF
--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -742,23 +742,23 @@ const NPEView: React.FC<NPEViewProps> = ({ npeData }) => {
                         );
                     })}
                 </div>
-
-                <ActiveTransferDetails
-                    groupedTransfersByNoCID={groupedTransfersByNoCID}
-                    selectedNode={selectedNode}
-                    congestionData={links?.link_demand.filter(
-                        (route) =>
-                            route[NPE_LINK.Y] === selectedNode?.coords[NPE_LINK.Y] &&
-                            route[NPE_LINK.X] === selectedNode?.coords[NPE_LINK.X],
-                    )}
-                    showActiveTransfers={showActiveTransfers}
-                    highlightedTransfer={highlightedTransfer}
-                    setHighlightedTransfer={setHighlightedTransfer}
-                    highlightedRoute={highlightedRoute}
-                    setHighlightedRoute={setHighlightedRoute}
-                    nocType={nocFilter}
-                />
+                {selectedNode && <div style={{ width: '380px' }}>&nbsp;</div>}
             </div>
+            <ActiveTransferDetails
+                groupedTransfersByNoCID={groupedTransfersByNoCID}
+                selectedNode={selectedNode}
+                congestionData={links?.link_demand.filter(
+                    (route) =>
+                        route[NPE_LINK.Y] === selectedNode?.coords[NPE_LINK.Y] &&
+                        route[NPE_LINK.X] === selectedNode?.coords[NPE_LINK.X],
+                )}
+                showActiveTransfers={showActiveTransfers}
+                highlightedTransfer={highlightedTransfer}
+                setHighlightedTransfer={setHighlightedTransfer}
+                highlightedRoute={highlightedRoute}
+                setHighlightedRoute={setHighlightedRoute}
+                nocType={nocFilter}
+            />
         </div>
     );
 };

--- a/src/scss/components/ActiveTransferDetails.scss
+++ b/src/scss/components/ActiveTransferDetails.scss
@@ -8,17 +8,18 @@
 $outer-padding: 10px;
 
 .side-data {
+    z-index: 10;
     display: flex;
     flex-direction: column;
     width: 380px;
     overflow-y: scroll;
     flex: 0 1 auto;
     background-color: $tt-grey-3;
-    position: sticky;
+    position: fixed;
     top: 0;
     right: 0;
-    left: 0;
     max-height: 100vh;
+    min-height: 100vh;
 
     &:empty {
         display: none;

--- a/src/scss/components/NPEComponent.scss
+++ b/src/scss/components/NPEComponent.scss
@@ -15,6 +15,13 @@
 .npe {
     position: relative;
 
+    .header {
+        position: sticky;
+        top: 0;
+        background-color: $tt-grey-2;
+        z-index: 5;
+    }
+
     .npe-controls {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Moved the ActiveTransferDetails component outside the main content flex row and updated its CSS to use fixed positioning with full viewport height. Also made the NPE header sticky for improved UI consistency.

<img width="1410" height="1016" alt="image" src="https://github.com/user-attachments/assets/60dfcb4f-d752-4696-98e3-53d0baff6133" />


closes #872 