### PR TITLE
Add NPERootZone and related types to NPEModel

### DIFF
--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -15,6 +15,7 @@ import {
     FABRIC_EVENT_SCOPE_OPTIONS,
     FabricEventScopeColors,
     NPEData,
+    NPERootZone,
     NPE_COORDINATES,
     NPE_LINK,
     NoCFlowBase,
@@ -82,6 +83,12 @@ const NPEView: React.FC<NPEViewProps> = ({ npeData }) => {
     const [nocFilter, setNocFilter] = useState<NoCType | null>(null);
     const [fabricEventsFilter, setFabricEventsFilter] = useState<EVENT_TYPE_FILTER>(EVENT_TYPE_FILTER.ALL_EVENTS);
     const [timestepsScale, setTimestepsScale] = useState<boolean>(true);
+
+    const zones: NPERootZone[] = useMemo(() => {
+        return npeData.zones || [];
+    }, [npeData]);
+    // eslint-disable-next-line no-void
+    void zones;
 
     const isFabricTransfersFilteringEnabled = useMemo(() => {
         return npeData.noc_transfers.some((tr) => tr.fabric_event_type);

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -159,6 +159,7 @@ export interface NoCTransfer extends NoCFlowBase {
     start_cycle: number;
     end_cycle: number;
     route: NoCRoute[];
+    zones?: string;
 }
 
 export interface TimestepData {
@@ -180,15 +181,36 @@ export interface NPEData {
     common_info: CommonInfo;
     noc_transfers: NoCTransfer[];
     timestep_data: TimestepData[];
+    zones?: NPERootZone[];
     chips: {
         [key: device_id]: ClusterCoordinates;
     };
 }
 
-export enum NPE_LINK {
+export interface NPERootZone {
+    id: string;
+    zones: NPEZone[];
+    proc: KERNEL_PROCESS;
+    core: NPE_COORDINATES[];
+}
+
+export interface NPEZone {
+    id: string;
+    zones: NPEZone[];
+    start: number;
+    end: number;
+}
+
+export enum NPE_COORDINATE_INDEX {
     CHIP_ID,
     Y,
     X,
+}
+
+export enum NPE_LINK {
+    CHIP_ID = NPE_COORDINATE_INDEX.CHIP_ID,
+    Y = NPE_COORDINATE_INDEX.Y,
+    X = NPE_COORDINATE_INDEX.X,
     NOC_ID,
     DEMAND,
     FABRIC_EVENT_SCOPE,
@@ -197,4 +219,13 @@ export enum NPE_LINK {
 export interface NPEManifestEntry {
     global_call_count: number;
     file: string;
+}
+
+export enum KERNEL_PROCESS {
+    BRISC = 'BRISC',
+    TRISC_0 = 'TRISC_0',
+    TRISC_1 = 'TRISC_1',
+    NCRISC = 'NCRISC',
+    ERISC = 'ERISC',
+    CORE_AGG = 'CORE_AGG',
 }


### PR DESCRIPTION
Introduces NPERootZone, NPEZone, and KERNEL_PROCESS enums to the NPEModel. Updates NPEData and NoCTransfer interfaces to support zones, and adjusts NPEViewComponent to utilize the new zones property from npeData.

closes #884 

[UnknownOP_ID1.zones.npeviz.json.zip](https://github.com/user-attachments/files/22686800/UnknownOP_ID1.zones.npeviz.json.zip)
