### PR TITLE
Improve destination display in ActiveTransferDetails

### DIFF
--- a/src/components/npe/ActiveTransferDetails.tsx
+++ b/src/components/npe/ActiveTransferDetails.tsx
@@ -159,7 +159,9 @@ const ActiveTransferDetails = ({
                                                                         size={11}
                                                                         icon={IconNames.ArrowRight}
                                                                     />{' '}
-                                                                    {route.dst.map((el) => el.join('-')).join('-')}
+                                                                    {route.dst.length === 1
+                                                                        ? route.dst[0].join('-')
+                                                                        : `${route.dst[0].join('-')} - ${route.dst[route.dst.length - 1].join('-')}`}
                                                                 </li>
                                                             ))}
                                                         </ul>


### PR DESCRIPTION
Updated the rendering logic for route destinations to show a concise format: if there is only one destination, display it directly; for multicast renders a range

<img width="345" height="350" alt="image" src="https://github.com/user-attachments/assets/09b19889-3cce-4323-8375-b5667469ccb6" />

closes #887 