### PR TITLE
Fix/Host Ops Toggle Disabled

### DIFF
--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -365,7 +365,7 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                         checked={hideHostOps}
                         className='option-switch'
                         // TODO: Host Ops don't get sent in non-stacked-by-in0
-                        disabled={!stackByIn0}
+                        disabled={!stackByIn0 && isStackedView}
                     />
 
                     {!isStackedView && (


### PR DESCRIPTION
Host ops toggle should only be disabled in stacked view if noStackByIn0 is disabled.