### PR TITLE
Chore/tt-perf-report dependency (Fix signposts filtering in the stacked report)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic==2.10.3",
     "python-dotenv==1.0.1",
     "PyYAML==6.0.2",
-    "tt-perf-report==1.1.6",
+    "tt-perf-report==1.1.7",
     "uvicorn==0.30.1",
     "zstd==1.5.7.0"
 ]


### PR DESCRIPTION
`v1.1.6 -> v1.1.7`
- Fix signposts filtering in the stacked report