### PR TITLE
Fix/Hide Host Ops In Charts

### DIFF
--- a/src/components/performance/PerfChartFilter.tsx
+++ b/src/components/performance/PerfChartFilter.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '@blueprintjs/core';
 import { useEffect, useState } from 'react';
 import 'styles/components/PerfChartFilter.scss';
 import { Marker } from '../../definitions/PerfTable';
+import { isHostOp } from '../../functions/perfFunctions';
 
 const MAX_OPTION_LENGTH = 25; // Brittle
 
@@ -95,6 +96,7 @@ function PerfChartFilter({ opCodeOptions, selectedOpCodes, updateOpCodes }: Perf
                 </div>
 
                 {opCodeOptions
+                    .filter((option) => !isHostOp(option.opCode))
                     .sort((a, b) => a.opCode.localeCompare(b.opCode))
                     .map((option) => (
                         <div


### PR DESCRIPTION
Had fixed previously, but snuck back in after some refactoring. 

Hides host op codes from charts.