### PR TITLE
Remove redundant error fields

### DIFF
--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -163,6 +163,16 @@ class ErrorRecord(SerializeableDataclass):
     stack_trace: str
     timestamp: str
 
+    def to_nested_dict(self) -> dict:
+        """
+        Returns a dictionary representation without operation_id and operation_name.
+        Use this when the error is nested under an operation to avoid redundancy.
+        """
+        result = self.to_dict()
+        result.pop("operation_id", None)
+        result.pop("operation_name", None)
+        return result
+
 
 # Non Data Models
 

--- a/backend/ttnn_visualizer/serializers.py
+++ b/backend/ttnn_visualizer/serializers.py
@@ -33,7 +33,7 @@ def serialize_operations(
     errors_dict = {}
     if error_records:
         for error in error_records:
-            errors_dict[error.operation_id] = error.to_dict()
+            errors_dict[error.operation_id] = error.to_nested_dict()
 
     arguments_dict = defaultdict(list)
     for argument in operation_arguments:
@@ -186,8 +186,8 @@ def serialize_operation(
             device_operations_data = do.captured_graph
             break
 
-    # Convert error record to dict if it exists
-    error_data = error_record.to_dict() if error_record else None
+    # Convert error record to nested dict if it exists (excludes operation_id and operation_name)
+    error_data = error_record.to_nested_dict() if error_record else None
 
     return {
         **operation_data,


### PR DESCRIPTION
This PR removes the `operation_id` and `operation_name` fields from the nested error object that is returned with operations. The fields remain when calling `/api/errors`.