### PR TITLE
Handle L1 buffer fragmentation edge case, improve op details performance

### DIFF
--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -363,11 +363,11 @@ export class OperationDetails implements Partial<OperationDetailsData> {
                                 empty: true,
                             });
                         } else if (prevChunk.address === 0 && prevChunk.size === 0) {
-                            const startAddress = Math.max(this.memoryConfig.l1start, 0);
-                            const size = chunk.address - startAddress;
+                            const address = this.memoryConfig.l1start ?? 0;
+                            const size = chunk.address - address;
                             if (size > 0) {
                                 fragmentation.push({
-                                    address: startAddress,
+                                    address,
                                     size,
                                     empty: true,
                                 });


### PR DESCRIPTION
Adds logic to detect and record fragmentation when the previous chunk in L1 buffer has address and size zero, ensuring empty regions at the start of L1 memory are properly tracked. Limit to L1 only
before:
<img width="1549" height="765" alt="image" src="https://github.com/user-attachments/assets/9c7437c0-a678-430a-8e82-800d2496bf37" />
after:
<img width="1424" height="800" alt="image" src="https://github.com/user-attachments/assets/e2ae7058-9186-43d5-9098-a8fcef86cf4e" />

closes #945 