### PR TITLE
Fix L1 Small switch label logic

### DIFF
--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -228,7 +228,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                             />
 
                             <Switch
-                                label={!showCircularBuffer ? 'Show L1 Small' : 'Hide L1 Small'}
+                                label={!showL1Small ? 'Show L1 Small' : 'Hide L1 Small'}
                                 checked={showL1Small}
                                 disabled={l1Small.condensed.size === 0}
                                 onChange={() => {


### PR DESCRIPTION
Corrects the label logic for the L1 Small switch to use the showL1Small state instead of showCircularBuffer, ensuring the label accurately reflects the switch's state.

closes #964 