### PR TITLE
Fix colon rendering in MemoryLegendElement

### DIFF
--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -117,7 +117,8 @@ export const MemoryLegendElement: React.FC<{
             <div>
                 {!isMultiDeviceBuffer && !chunk.empty && derivedTensor && (
                     <>
-                        {derivedTensor.operationIdentifier} : Tensor {derivedTensor.id}
+                        {derivedTensor.operationIdentifier} {derivedTensor.operationIdentifier && ':'} Tensor{' '}
+                        {derivedTensor.id}
                     </>
                 )}
                 {!isMultiDeviceBuffer && chunk.empty && emptyChunkLabel}


### PR DESCRIPTION
Adjusts the display logic to only show a colon after operationIdentifier if it exists, improving the clarity of tensor information in the legend.