### PR TITLE
Feature/Update tt-perf-report dependency and support new version

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -463,7 +463,7 @@ class OpsPerformanceReportQueries:
 
         try:
             perf_report.generate_perf_report(
-                csv_file,
+                [csv_file],
                 signpost,
                 ignore_signposts,
                 cls.DEFAULT_MIN_PERCENTAGE,
@@ -497,7 +497,12 @@ class OpsPerformanceReportQueries:
                 op_id = index + 2  # Match IDs with row numbers in ops perf results csv
                 if not any(s["op_code"] == op_code for s in signposts):
                     captured_signposts.add(op_code)
-                    signposts.append({"id": op_id, "op_code": op_code})
+                    signposts.append(
+                        {
+                            "id": op_id,
+                            "op_code": op_code,
+                        }
+                    )
 
         report = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic==2.10.3",
     "python-dotenv==1.0.1",
     "PyYAML==6.0.2",
-    "tt-perf-report==1.1.8",
+    "tt-perf-report==1.1.9",
     "uvicorn==0.30.1",
     "zstd==1.5.7.0"
 ]


### PR DESCRIPTION
The breaking change is that reports are now passed as an array. I'm not sure we'll want to do this because it merges the data.