### PR TITLE
Add --daemon CLI option

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -310,7 +310,7 @@ def main():
     if args.daemon:
         gunicorn_args.insert(1, "--daemon")
 
-    if config.LAUNCH_BROWSER_ON_START:
+    if config.LAUNCH_BROWSER_ON_START and not args.daemon:
         flask_env = os.getenv("FLASK_ENV", "development")
         port = config.PORT if flask_env == "production" else config.DEV_SERVER_PORT
         host = config.HOST if flask_env == "production" else config.DEV_SERVER_HOST


### PR DESCRIPTION
This PR adds a `--daemon` CLI arg when running the `ttnn-visualizer` command. The purpose is to make it possible to detach the process from the terminal where it was started, and have app continue running in the background, even if the user logs out.

The intention is make it easier to run TTNN Visualizer on remote Tenstorrent servers and Docker containers where TT-Metal is located.

This will facilitate us starting TTNN Visualizer on remote machines by running an ssh command from custom plugins and tools, without an active terminal session.

[Closes #1006]
