### PR TITLE
Update error handling for NPE data processing

### DIFF
--- a/src/definitions/NPEData.ts
+++ b/src/definitions/NPEData.ts
@@ -36,7 +36,7 @@ export const getNpeDataErrorType = (
     dataVersion: string | null,
     httpStatus?: HttpStatusCode,
     isValidData?: boolean,
-): ErrorCodes => {
+): ErrorCodes | null => {
     const parsedVersion = dataVersion ? semverParse(dataVersion) : null;
 
     if (httpStatus === HttpStatusCode.UnprocessableEntity) {
@@ -51,7 +51,7 @@ export const getNpeDataErrorType = (
         return ErrorCodes.INVALID_NPE_VERSION;
     }
 
-    return ErrorCodes.DEFAULT;
+    return null;
 };
 
 export const isValidNpeData = (data: NPEData): boolean => {

--- a/src/routes/NPE.tsx
+++ b/src/routes/NPE.tsx
@@ -30,6 +30,7 @@ const NPE: FC = () => {
 
         return npeData ? getNpeDataErrorType(dataVersion, processingError?.status, isValidNpeData(npeData)) : null;
     }, [npeData, processingError]);
+
     const isDemoEnabled = getServerConfig()?.SERVER_MODE;
     const isLoading = isLoadingNPE || isLoadingTimeline;
     const hasUploadedFile = !!npeFileName || !!filepath;


### PR DESCRIPTION
Changed getNpeDataErrorType to return null instead of a default error code when no error is present. Minor formatting update in NPE route.

closes #1019 