### PR TITLE
Docs/Update Logo Link

### DIFF
--- a/docs/MakeFile
+++ b/docs/MakeFile
@@ -1,7 +1,0 @@
-.PHONY: build clean
-
-build:
-	sphinx-build . output
-
-clean:
-	rm -rf output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,11 +89,8 @@ html_favicon = "shared/images/favicon.png"
 html_static_path = ["shared/_static"]
 templates_path = ["shared/_templates"]
 html_last_updated_fmt = "%b %d, %Y"
-
-
 html_baseurl = f"https://docs.tenstorrent.com/{project}"
-
-html_context = {"logo_link_url": os.environ.get("homepage")}
+html_context = {"logo_link_url": "https://docs.tenstorrent.com/"}
 
 
 def setup(app):

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -48,7 +48,7 @@ Network-on-chip performance estimator data can be loaded separately on the `/npe
 
 To generate this data for your model, refer to the [tt-npe documentation](https://github.com/tenstorrent/tt-npe/blob/main/docs/src/getting_started.md).
 
-{#installing-from-pypi}
+(installing-from-pypi)=
 ## Installing from PyPI
 
 TT-NN Visualizer can be installed from [PyPI](https://pypi.org/project/ttnn-visualizer/):

--- a/docs/src/running-from-source.md
+++ b/docs/src/running-from-source.md
@@ -1,6 +1,6 @@
 # Running from source
 
-**NOTE:** If you're just looking to run the app, [installing via PyPI](./installing.md#installing-from-pypi) or using the [hosted version](https://ttnn-visualizer.tenstorrent.com/) is highly recommended.
+**NOTE:** If you're just looking to run the app, try {ref}`installing from pypi <installing-from-pypi>` or using the [hosted version](https://ttnn-visualizer.tenstorrent.com/) is highly recommended.
 
 ## Front end
 
@@ -14,7 +14,7 @@ pnpm install
 pnpm run dev
 ```
 
-{#back-end}
+(back-end)=
 ## Back end
 
 create env

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -23,7 +23,7 @@ deactivate
 rm -rf myenv
 ```
 
-Then [follow the steps](./running-from-source.md#back-end) for creating virtual environment and reinstalling dependencies
+Then {ref}`follow the steps <back-end>` for creating virtual environment and reinstalling dependencies
 
 ## Fix for missing distutils package
 

--- a/docs/src/what-is-ttnn-visualizer.md
+++ b/docs/src/what-is-ttnn-visualizer.md
@@ -2,7 +2,7 @@
 
 The visualiser is a diagnostic tool for visualizing the Tenstorrent Neural Network model ([TT-NN](https://docs.tenstorrent.com/tt-metal/latest/ttnn/index.html)). 
 
-The app is available to [install via PyPI](./installing.md#installing-from-pypi) or [hosted online](https://ttnn-visualizer.tenstorrent.com/). You may also [build and run from source](./running-from-source.md).
+The app is available to {ref}`install via PyPi <installing-from-pypi>` or [hosted online](https://ttnn-visualizer.tenstorrent.com/). You may also [build and run from source](./running-from-source.md).
 
 ## Features
 


### PR DESCRIPTION
Sets the appropriate logo link as noted in the screenshot. Also removes an unused MakeFile and cleans up warnings related to anchor link syntax.

<img width="1406" height="1014" alt="Screenshot 2025-12-05 at 10 36 04 AM" src="https://github.com/user-attachments/assets/98900d7f-d488-4546-b58f-38a85de35e08" />
