### PR TITLE
Add footerSpan to handle footer widths

### DIFF
--- a/src/components/OperationListPerfData.tsx
+++ b/src/components/OperationListPerfData.tsx
@@ -43,7 +43,7 @@ const OperationListPerfData = ({ operation }: OperationListPerfDataProps) => {
                                             <span
                                                 className={classNames(
                                                     'monospace',
-                                                    getOpToOpGapColour(perf.perfData.op_to_op_gap),
+                                                    getOpToOpGapColour(parseFloat(perf.perfData.op_to_op_gap)),
                                                 )}
                                             >
                                                 {formatSize(parseFloat(perf.perfData.op_to_op_gap))} µs

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -11,9 +11,9 @@ import { useAtomValue } from 'jotai';
 import {
     ColumnHeaders,
     ComparisonKeys,
+    TableColumn,
+    TableColumns,
     TableFilter,
-    TableHeader,
-    TableHeaders,
     TypedPerfTableRow,
 } from '../../definitions/PerfTable';
 import 'styles/components/PerfReport.scss';
@@ -78,22 +78,22 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
         [comparisonData, sortTableFields],
     );
 
-    const visibleHeaders = [
-        ...TableHeaders.slice(0, OP_ID_INSERTION_POINT),
+    const visibleColumns = [
+        ...TableColumns.slice(0, OP_ID_INSERTION_POINT),
         ...(opIdsMap.length > 0 ? [{ label: 'OP', key: ColumnHeaders.OP, sortable: true }] : []),
-        ...TableHeaders.slice(OP_ID_INSERTION_POINT, HIGH_DISPATCH_INSERTION_POINT),
+        ...TableColumns.slice(OP_ID_INSERTION_POINT, HIGH_DISPATCH_INSERTION_POINT),
         ...(hiliteHighDispatch ? [{ label: 'Slow', key: ColumnHeaders.high_dispatch }] : []),
-        ...TableHeaders.slice(HIGH_DISPATCH_INSERTION_POINT),
+        ...TableColumns.slice(HIGH_DISPATCH_INSERTION_POINT),
         ...(npeManifest && npeManifest.length > 0 ? [{ label: 'NPE', key: ColumnHeaders.global_call_count }] : []),
-    ] as TableHeader[];
+    ] as TableColumn[];
 
     const cellFormattingProxy = (
         row: TypedPerfTableRow,
-        header: TableHeader,
+        column: TableColumn,
         operations?: OperationDescription[],
         highlight?: string | null,
     ) => {
-        const { key } = header;
+        const { key } = column;
 
         if (key === ColumnHeaders.global_call_count) {
             // TODO: this is an inefficient way of doing things but its also temporary. will update next iteration
@@ -121,7 +121,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
             return null;
         }
 
-        return formatCell(row, header, operations, highlight);
+        return formatCell(row, column, operations, highlight);
     };
 
     if (!data) {
@@ -150,7 +150,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                 <table className='perf-table monospace'>
                     <thead className='table-header'>
                         <tr>
-                            {visibleHeaders.map((h) => {
+                            {visibleColumns.map((h) => {
                                 const targetSortDirection =
                                     // eslint-disable-next-line no-nested-ternary
                                     sortingColumn === h.key
@@ -224,7 +224,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                         'signpost-op': row.op_type === OpType.SIGNPOST,
                                     })}
                                 >
-                                    {visibleHeaders.map((h) => (
+                                    {visibleColumns.map((h) => (
                                         <td
                                             key={h.key}
                                             className={classNames('cell', {
@@ -251,7 +251,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                                 `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
                                             )}
                                         >
-                                            {visibleHeaders.map((h) => (
+                                            {visibleColumns.map((h) => (
                                                 <td
                                                     key={h.key}
                                                     className={classNames('cell', {
@@ -269,7 +269,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
                                 {provideMatmulAdvice && row.op_code.includes('Matmul') && (
                                     <tr>
                                         <td
-                                            colSpan={visibleHeaders.length}
+                                            colSpan={visibleColumns.length}
                                             className='cell advice'
                                         >
                                             <ul>
@@ -286,9 +286,9 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
 
                     <tfoot className='table-footer'>
                         <tr>
-                            {visibleHeaders.length > 0 &&
+                            {visibleColumns.length > 0 &&
                                 data?.length > 0 &&
-                                visibleHeaders
+                                visibleColumns
                                     .filter((header) => header?.footerSpan !== 0)
                                     .map((header) => (
                                         <td
@@ -313,19 +313,19 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
     );
 };
 
-const getTotalsForFooter = (header: TableHeader, data: TypedPerfTableRow[], hideHostOps: boolean): string => {
-    if (header.key === ColumnHeaders.total_percent) {
+const getTotalsForFooter = (column: TableColumn, data: TypedPerfTableRow[], hideHostOps: boolean): string => {
+    if (column.key === ColumnHeaders.total_percent) {
         return `100 %`;
     }
 
-    if (header.key === ColumnHeaders.device_time) {
+    if (column.key === ColumnHeaders.device_time) {
         return `${formatSize(
             data?.reduce((acc, curr) => acc + (curr.device_time || 0), 0),
             2,
         )} µs`;
     }
 
-    if (header.key === ColumnHeaders.op_code) {
+    if (column.key === ColumnHeaders.op_code) {
         const hostOpsCount = data.filter((row) => isHostOp(row.bound)).length;
         const deviceOpsCount = data.length - hostOpsCount;
 
@@ -334,7 +334,7 @@ const getTotalsForFooter = (header: TableHeader, data: TypedPerfTableRow[], hide
             : `${data.length} ops\n(${deviceOpsCount} device ops + ${hostOpsCount} host ops)`;
     }
 
-    if (header.key === ColumnHeaders.op_to_op_gap) {
+    if (column.key === ColumnHeaders.op_to_op_gap) {
         return `${formatSize(
             data?.reduce((acc, curr) => acc + (curr.op_to_op_gap || 0), 0),
             2,

--- a/src/components/performance/StackedPerfTable.tsx
+++ b/src/components/performance/StackedPerfTable.tsx
@@ -8,8 +8,8 @@ import { Button, ButtonVariant, Icon, Intent, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import {
     StackedColumnHeaders,
-    StackedTableHeader,
-    TableHeaders,
+    StackedTableColumn,
+    StackedTableColumns,
     TypedStackedPerfRow,
 } from '../../definitions/StackedPerfTable';
 import 'styles/components/PerfReport.scss';
@@ -70,10 +70,10 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
                 <table className='perf-table monospace'>
                     <thead className='table-header'>
                         <tr>
-                            {TableHeaders.map((h) => {
+                            {StackedTableColumns.map((column) => {
                                 const targetSortDirection =
                                     // eslint-disable-next-line no-nested-ternary
-                                    sortingColumn === h.key
+                                    sortingColumn === column.key
                                         ? sortDirection === SortingDirection.ASC
                                             ? SortingDirection.DESC
                                             : SortingDirection.ASC
@@ -81,22 +81,21 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
 
                                 return (
                                     <th
-                                        key={h.key}
+                                        key={column.key}
                                         className='cell-header'
                                     >
-                                        {h.sortable ? (
+                                        {column.sortable ? (
                                             <Button
-                                                onClick={() => changeSorting(h.key)(targetSortDirection)}
+                                                onClick={() => changeSorting(column.key)(targetSortDirection)}
                                                 variant={ButtonVariant.MINIMAL}
                                                 size={Size.SMALL}
                                             >
-                                                <span className='header-label'>{h.label}</span>
-
-                                                {sortingColumn === h.key ? (
+                                                <span className='header-label'>{column.label}</span>
+                                                {sortingColumn === column.key ? (
                                                     <Icon
                                                         className={classNames(
                                                             {
-                                                                'is-active': sortingColumn === h.key,
+                                                                'is-active': sortingColumn === column.key,
                                                             },
                                                             'sort-icon',
                                                         )}
@@ -114,7 +113,7 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
                                                 )}
                                             </Button>
                                         ) : (
-                                            <span className='header-label no-button'>{h.label}</span>
+                                            <span className='header-label no-button'>{column.label}</span>
                                         )}
                                     </th>
                                 );
@@ -126,12 +125,12 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
                         {tableFields?.map((row, i) => (
                             <Fragment key={`row-${i}`}>
                                 <tr>
-                                    {TableHeaders.map((h: StackedTableHeader) => (
+                                    {StackedTableColumns.map((column: StackedTableColumn) => (
                                         <td
-                                            key={h.key}
+                                            key={column.key}
                                             className={classNames('cell')}
                                         >
-                                            {formatStackedCell(row, h, filters?.[h.key])}
+                                            {formatStackedCell(row, column, filters?.[column.key])}
                                         </td>
                                     ))}
                                 </tr>
@@ -149,13 +148,13 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
                                                 `pattern-${datasetIndex >= PATTERN_COUNT ? datasetIndex - PATTERN_COUNT : datasetIndex}`,
                                             )}
                                         >
-                                            {TableHeaders.map((h: StackedTableHeader) => (
+                                            {StackedTableColumns.map((column: StackedTableColumn) => (
                                                 <td
-                                                    key={`comparison-${h.key}`}
+                                                    key={`comparison-${column.key}`}
                                                     className='cell'
                                                 >
                                                     {matchingRow
-                                                        ? formatStackedCell(matchingRow, h, filters?.[h.key])
+                                                        ? formatStackedCell(matchingRow, column, filters?.[column.key])
                                                         : ''}
                                                 </td>
                                             ))}
@@ -170,14 +169,14 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
                         <tr>
                             {stackedData &&
                                 stackedData?.length > 0 &&
-                                TableHeaders.map((header) => (
+                                StackedTableColumns.map((column) => (
                                     <td
-                                        key={`footer-${header.key}`}
+                                        key={`footer-${column.key}`}
                                         className={classNames({
-                                            'no-wrap': header.key === StackedColumnHeaders.OpCodeJoined,
+                                            'no-wrap': column.key === StackedColumnHeaders.OpCodeJoined,
                                         })}
                                     >
-                                        {getTotalsForFooter(header, stackedData)}
+                                        {getTotalsForFooter(column, stackedData)}
                                     </td>
                                 ))}
                         </tr>
@@ -192,23 +191,23 @@ const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
     );
 };
 
-const getTotalsForFooter = (header: StackedTableHeader, data: TypedStackedPerfRow[]): string => {
-    if (header.key === StackedColumnHeaders.Percent) {
+const getTotalsForFooter = (column: StackedTableColumn, data: TypedStackedPerfRow[]): string => {
+    if (column.key === StackedColumnHeaders.Percent) {
         return `100 %`;
     }
 
-    if (header.key === StackedColumnHeaders.DeviceTimeSumUs) {
+    if (column.key === StackedColumnHeaders.DeviceTimeSumUs) {
         return `${formatSize(
             data?.reduce((acc, curr) => acc + (curr.device_time_sum_us || 0), 0),
             2,
         )} µs`;
     }
 
-    if (header.key === StackedColumnHeaders.OpCodeJoined) {
+    if (column.key === StackedColumnHeaders.OpCodeJoined) {
         return `${data.length} op types`;
     }
 
-    if (header.key === StackedColumnHeaders.OpsCount) {
+    if (column.key === StackedColumnHeaders.OpsCount) {
         return `${data?.reduce((acc, curr) => acc + (curr.ops_count || 0), 0)}`;
     }
 

--- a/src/definitions/PerfTable.ts
+++ b/src/definitions/PerfTable.ts
@@ -9,7 +9,7 @@ import { OpType } from './Performance';
 export type TableKeys = keyof TypedPerfTableRow;
 export type TableFilter = Partial<Record<TableKeys, string>> | null;
 
-export interface TableHeader {
+export interface TableColumn {
     label: string;
     key: TableKeys;
     colour?: string;
@@ -162,7 +162,7 @@ export enum ColumnHeaders {
     global_call_count = 'global_call_count',
 }
 
-export const TableHeaders: TableHeader[] = [
+export const TableColumns: TableColumn[] = [
     { label: 'ID', key: ColumnHeaders.id, sortable: true },
     { label: 'Total %', key: ColumnHeaders.total_percent, unit: '%', decimals: 1, sortable: true },
     { label: 'Bound', key: ColumnHeaders.bound, colour: 'yellow' },
@@ -180,7 +180,7 @@ export const TableHeaders: TableHeader[] = [
     { label: 'Math Fidelity', key: ColumnHeaders.math_fidelity, colour: 'cyan' },
 ];
 
-export const FilterableColumnKeys = TableHeaders.filter((column) => column.filterable).map((column) => column.key);
+export const FilterableColumnKeys = TableColumns.filter((column) => column.filterable).map((column) => column.key);
 
 export const ComparisonKeys: TableKeys[] = [
     ColumnHeaders.op_code,

--- a/src/definitions/StackedPerfTable.ts
+++ b/src/definitions/StackedPerfTable.ts
@@ -8,7 +8,7 @@ export type StackedTableKeys = Partial<keyof StackedPerfRow>;
 
 export type StackedTableFilter = Record<StackedTableKeys, string> | null;
 
-export interface StackedTableHeader {
+export interface StackedTableColumn {
     label: string;
     key: StackedTableKeys;
     colour?: string;
@@ -55,7 +55,7 @@ export enum StackedColumnHeaders {
     FlopsStd = 'flops_std',
 }
 
-export const TableHeaders: StackedTableHeader[] = [
+export const StackedTableColumns: StackedTableColumn[] = [
     { label: 'Percent', key: StackedColumnHeaders.Percent, unit: '%', decimals: 2, sortable: true },
     { label: 'Op Code', key: StackedColumnHeaders.OpCodeJoined, sortable: true, filterable: true },
     { label: 'Device Time', key: StackedColumnHeaders.DeviceTimeSumUs, unit: 'µs', decimals: 2, sortable: true },
@@ -66,6 +66,6 @@ export const TableHeaders: StackedTableHeader[] = [
     { label: 'Std FLOPS', key: StackedColumnHeaders.FlopsStd, unit: '%', decimals: 2, sortable: true },
 ];
 
-export const FilterableStackedColumnKeys = TableHeaders.filter((column) => column.filterable).map(
+export const FilterableStackedColumnKeys = StackedTableColumns.filter((column) => column.filterable).map(
     (column) => column.key,
 );

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -10,7 +10,7 @@ import {
     BoundType,
     ColumnHeaders,
     MathFidelity,
-    TableHeader,
+    TableColumn,
     TableKeys,
     TypedPerfTableRow,
 } from '../definitions/PerfTable';
@@ -64,11 +64,11 @@ const MIN_PERCENTAGE = 0.5;
 // TODO: Check if we still need this formatting step because we're using typed data
 export const formatCell = (
     row: TypedPerfTableRow,
-    header: TableHeader,
+    column: TableColumn,
     operations?: OperationDescription[],
     highlight?: string | null,
 ): React.JSX.Element | string => {
-    const { key, unit, decimals } = header;
+    const { key, unit, decimals } = column;
     const isSignpost = row.op_type === OpType.SIGNPOST;
     const isHost = isHostOp(row.bound);
     let formatted: string | boolean | string[];
@@ -128,7 +128,7 @@ export const formatCell = (
     if (typeof value === 'number') {
         formatted = formatSize(value, decimals);
     } else {
-        formatted = value.toString();
+        formatted = value?.toString() || '';
     }
 
     if (unit) {

--- a/src/functions/stackedPerfFunctions.tsx
+++ b/src/functions/stackedPerfFunctions.tsx
@@ -7,7 +7,7 @@ import HighlightedText from '../components/HighlightedText';
 import { formatSize } from './math';
 import {
     StackedColumnHeaders,
-    StackedTableHeader,
+    StackedTableColumn,
     StackedTableKeys,
     TypedStackedPerfRow,
 } from '../definitions/StackedPerfTable';
@@ -44,10 +44,10 @@ const FALLBACK_COLOUR = CellColour.Grey;
 
 export const formatStackedCell = (
     row: TypedStackedPerfRow,
-    header: StackedTableHeader,
+    column: StackedTableColumn,
     highlight?: string | null,
 ): React.JSX.Element | string => {
-    const { key, unit, decimals } = header;
+    const { key, unit, decimals } = column;
     let formatted: string | boolean | string[];
     const value = row[key];
 


### PR DESCRIPTION
Adds a footerSpan key to TableHeader to control the width of elements in the footer.

<img width="1254" height="884" alt="Screenshot 2025-12-05 at 4 37 00 PM" src="https://github.com/user-attachments/assets/9f838554-1c22-4748-b95f-004b14467b79" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1040.
