### PR TITLE
Chore/Remove Memoisation From Perf Fetch

### DIFF
--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -833,13 +833,10 @@ export const usePerformanceReport = (name: string | null) => {
         ],
         enabled: name !== null,
         retry: false, // TODO: Added to force not retrying on 4xx errors, might need to handle differently
+        staleTime: Infinity,
     });
 
-    return useMemo(
-        () => response,
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [response.data, response.error],
-    );
+    return response;
 };
 
 export const usePerformanceComparisonReport = () => {


### PR DESCRIPTION
Does nothing here and keeps the UI in an unhelpful state whilst loading is still on going.