### PR TITLE
Fix/Row Attributes Not Extracting

### DIFF
--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -264,7 +264,7 @@ const getBufferType = (type?: string): BufferType | null => {
 };
 
 const getRowAttributes = (row: PerfTableRow): RowAttributes => {
-    const regex = /DEV_(\d)_(DRAM|L1)_(\w*)/m;
+    const regex = /DEV_(\d+)_(DRAM|L1)_(\w*)/m;
     const matchIn0 = regex.exec(row.input_0_memory);
 
     return {


### PR DESCRIPTION
Regex was missing anything which had more than one digit, e.g. `DEV_11_INTERLEAVED`.

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1063.