### PR TITLE
Improve NPE error handling and query logic

### DIFF
--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -97,7 +97,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
 
         if (key === ColumnHeaders.global_call_count) {
             // TODO: this is an inefficient way of doing things but its also temporary. will update next iteration
-            const value = parseInt(String(row[key]), 10) || 0;
+            const value = parseInt(String(row[key]), 10) || -1; // apparently npe is using 0 as a default value as opposed to no value.
             const manifestRecord = npeManifest?.find((el) => {
                 return el.global_call_count === value;
             });

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -431,13 +431,15 @@ const fetchNpeOpTrace = async () => {
     return response?.data;
 };
 
-export const useNpe = (fileName: string | null) =>
-    useQuery<NPEData, AxiosError>({
+export const useNpe = (fileName: string | null) => {
+    return useQuery<NPEData, AxiosError>({
         queryFn: () => fetchNpeOpTrace(),
         queryKey: ['fetch-npe', fileName],
         retry: false,
         staleTime: 30000,
+        enabled: fileName !== null,
     });
+};
 
 export const useOperationDetails = (operationId: number | null) => {
     const { data: operations } = useOperationsList();


### PR DESCRIPTION
Refactored NPE route to handle timeline file errors and distinguish between invalid JSON and other HTTP errors. Updated useNpe hook to enable queries only when a filename is provided, and adjusted PerfTable to use -1 as a default for missing global_call_count values.

this addresses NPE attempts to always load an npe file instead of the timeline if one is provided

closes #1065 