### PR TITLE
Feature/Disable Merge Multi Device Conditionally

### DIFF
--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -52,14 +52,10 @@ function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: Buffe
         >,
     );
 
-    const isMultiDevice = useMemo(
-        () =>
-            buffersByOperation.some((op) => {
-                const deviceIds = new Set(op.buffers.map((buffer) => buffer.device_id));
-                return deviceIds.size > 1;
-            }),
-        [buffersByOperation],
-    );
+    const isMultiDevice = useMemo(() => {
+        const allDeviceIds = new Set(buffersByOperation.flatMap((op) => op.buffers.map((buffer) => buffer.device_id)));
+        return allDeviceIds.size > 1;
+    }, [buffersByOperation]);
 
     // TODO: move this to a hook. eventually
     const uniqueBuffersByOperationList = useMemo(() => {


### PR DESCRIPTION
Checks if data contains multiple device IDs and disables the merge checkbox if not.

With multiple device IDs (and default current behaviour)
<img width="1009" height="403" alt="Screenshot 2025-12-17 at 10 15 18 AM" src="https://github.com/user-attachments/assets/e718f726-4100-4d55-8231-9af447f79fe6" />

Only one device ID (now disables checkbox)
<img width="1009" height="403" alt="Screenshot 2025-12-17 at 10 16 00 AM" src="https://github.com/user-attachments/assets/d9b94fa0-eced-401f-bae9-69762eb0988a" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1080.
