### PR TITLE
Handle unsupported cluster topologies in ClusterRenderer

### DIFF
--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -71,9 +71,14 @@ function ClusterRenderer() {
             );
         } else {
             return (
-                <div className='cluster-view-wrap'>
+                <div className='cluster-view-renderer'>
                     {header}
-                    <p>Topology is not supported for your current setup. This will be supported in future releases</p>
+                    <div className='cluster-view-wrap'>
+                        <p>
+                            Topology rendering is not supported for your current setup. This will be supported in future
+                            releases
+                        </p>
+                    </div>
                 </div>
             );
         }


### PR DESCRIPTION
prevents rendering unsupported configurations and informs users about future support.

<img width="1460" height="1044" alt="image" src="https://github.com/user-attachments/assets/7324fce2-a55a-431f-bf8e-badf1732ed09" />
