### PR TITLE
Feature/Allow scroll restoration on filtered lists

### DIFF
--- a/src/components/OperationList.tsx
+++ b/src/components/OperationList.tsx
@@ -16,7 +16,12 @@ import LoadingSpinner from './LoadingSpinner';
 import 'styles/components/ListView.scss';
 import { useOperationsList } from '../hooks/useAPI';
 import ROUTES from '../definitions/Routes';
-import { activePerformanceReportAtom, selectedOperationRangeAtom, shouldCollapseAllOperationsAtom } from '../store/app';
+import {
+    activePerformanceReportAtom,
+    operationListFilterAtom,
+    selectedOperationRangeAtom,
+    shouldCollapseAllOperationsAtom,
+} from '../store/app';
 import { OperationDescription } from '../model/APIData';
 import ListItem from './ListItem';
 import { formatSize } from '../functions/math';
@@ -42,7 +47,7 @@ const OperationList = () => {
     const selectedOperationRange = useAtomValue(selectedOperationRangeAtom);
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
 
-    const [filterQuery, setFilterQuery] = useState('');
+    const [filterQuery, setFilterQuery] = useAtom(operationListFilterAtom);
     const [shouldSortByID, setShouldSortByID] = useState<SortingOptions>(SortingOptions.ASCENDING);
     const [shouldSortDuration, setShouldSortDuration] = useState<SortingOptions>(SortingOptions.OFF);
     const [focusedRow, setFocusedRow] = useState<number | null>(null);
@@ -194,7 +199,7 @@ const OperationList = () => {
 
         if (initialOperationId) {
             const operationIndex =
-                fetchedOperations?.findIndex(
+                filteredOperationsList?.findIndex(
                     (operation: OperationDescription) => operation.id === parseInt(initialOperationId, 10),
                 ) || 0;
 
@@ -203,7 +208,7 @@ const OperationList = () => {
             // Navigating to the same page replaces the entry in the browser history
             navigate(ROUTES.OPERATIONS, { replace: true });
         }
-    }, [fetchedOperations, location.state?.previousOperationId, navigate]);
+    }, [filteredOperationsList, location.state?.previousOperationId, navigate]);
 
     useEffect(() => {
         if (virtualHeight <= 0 && scrollElementRef.current) {

--- a/src/hooks/useRestoreScrollPosition.tsx
+++ b/src/hooks/useRestoreScrollPosition.tsx
@@ -2,13 +2,14 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useCallback } from 'react';
-import { scrollPositionsAtom } from '../store/app';
+import { operationListFilterAtom, scrollPositionsAtom } from '../store/app';
 import { ScrollLocations, ScrollPosition, VirtualListState } from '../definitions/ScrollPositions';
 
 const useRestoreScrollPosition = (key?: ScrollLocations) => {
     const [scrollPositions, setScrollPositions] = useAtom(scrollPositionsAtom);
+    const setOperationListFilter = useSetAtom(operationListFilterAtom);
 
     const updateListState = useCallback(
         (state: Partial<VirtualListState>) => {
@@ -45,7 +46,8 @@ const useRestoreScrollPosition = (key?: ScrollLocations) => {
 
     const resetListStates = useCallback(() => {
         setScrollPositions(null);
-    }, [setScrollPositions]);
+        setOperationListFilter('');
+    }, [setScrollPositions, setOperationListFilter]);
 
     return {
         getListState,

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -47,6 +47,7 @@ export const fileTransferProgressAtom = atom<FileProgress>({
 
 // Operations route
 export const shouldCollapseAllOperationsAtom = atom(false);
+export const operationListFilterAtom = atom('');
 
 // Operation details route
 export const isFullStackTraceAtom = atom(false);


### PR DESCRIPTION
Changes scroll restoration to work with a filtered list instead of the full data set and moves operation list filter value to an atom.

<img width="1009" height="403" alt="Screenshot 2025-12-18 at 10 38 09 AM" src="https://github.com/user-attachments/assets/697bc40e-b52f-4a08-9b1c-cd0e56de781c" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1095.