### PR TITLE
Support torch.Size in toReadableShape function

### DIFF
--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -102,7 +102,7 @@ export const isEqual = <T>(value: T, other: T): boolean => {
     });
 };
 export const toReadableShape = (input: string) => {
-    const match = input.match(/Shape\((\[.*\])\)/);
+    const match = input.match(/(?:Shape|torch\.Size)\((\[.*\])\)/);
     if (!match) {
         return input;
     }


### PR DESCRIPTION
Updated the toReadableShape function to recognize both 'Shape' and 'torch.Size' patterns in input strings
before
<img width="642" height="616" alt="image" src="https://github.com/user-attachments/assets/1f4316a7-0b7d-4525-8c33-cf76cf02d9bd" />
after
<img width="650" height="615" alt="image" src="https://github.com/user-attachments/assets/41eeab69-2957-461a-bc69-a5650c9db969" />

closes #1076 