### PR TITLE
Feature/Change browser launch approach

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -189,7 +189,7 @@ def open_browser(host, port, instance_id=None):
             time.sleep(0.5)
 
     if not server_ready:
-        print(f"Warning: Server not ready after {max_attempts} attempts.")
+        print(f"❌ Server not ready after {max_attempts} attempts.")
     else:
         print(f"Launching browser with url: {url}")
 


### PR DESCRIPTION
Instead of waiting for 2s before opening the browser, wait for the server to be ready.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1070.