### PR TITLE
Use L1 default memory size as fallback in useGetL1SmallMarker

### DIFF
--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -52,6 +52,7 @@ import createToastNotification from '../functions/createToastNotification';
 import { normaliseReportFolder } from '../functions/validateReportFolder';
 import { Signpost } from '../functions/perfFunctions';
 import { TensorDeallocationReport, TensorsByOperationByAddress } from '../model/BufferSummary';
+import { L1_DEFAULT_MEMORY_SIZE } from '../definitions/L1MemorySize';
 
 const EMPTY_PERF_RETURN = { report: [], stacked_report: [], signposts: [] };
 
@@ -251,7 +252,7 @@ export const useGetL1SmallMarker = (): number => {
     return useMemo(() => {
         const addresses = buffers?.map((buffer) => {
             return buffer.address;
-        }) || [0];
+        }) || [L1_DEFAULT_MEMORY_SIZE];
 
         let min = Infinity;
         for (let i = 0; i < addresses.length; i++) {
@@ -259,7 +260,7 @@ export const useGetL1SmallMarker = (): number => {
                 min = addresses[i];
             }
         }
-        return min === Infinity ? 0 : min;
+        return min === Infinity ? L1_DEFAULT_MEMORY_SIZE : min;
     }, [buffers]);
 };
 


### PR DESCRIPTION
Replaces hardcoded fallback values with L1_DEFAULT_MEMORY_SIZE in useGetL1SmallMarker hook to ensure consistent default behavior when buffers are undefined or empty.
<img width="1622" height="355" alt="image" src="https://github.com/user-attachments/assets/ba485d62-8bfd-4afb-bc10-bf382e84c251" />

fixes #1102 