### PR TITLE
Chore/Improve SPDX check

### DIFF
--- a/scripts/check-spdx.mjs
+++ b/scripts/check-spdx.mjs
@@ -50,17 +50,12 @@ const isFileType = (filePath, extensions) => extensions.includes(path.extname(fi
 const checkLicenseString = (filePath, licenseType) => {
     const content = fs.readFileSync(filePath, 'utf8');
 
-    if (licenseType instanceof RegExp) {
-        if (licenseType.test(content)) {
-            return;
-        }
-    } else {
-        if (content.includes(licenseType)) {
-            return;
-        }
-    }
+    const isCompliant =
+        licenseType instanceof RegExp ? licenseType.test(content) : content.includes(licenseType);
 
-    NON_COMPLIANT_FILES.push(filePath);
+    if (!isCompliant) {
+        NON_COMPLIANT_FILES.push(filePath);
+    }
 };
 
 const checkLicenseObject = (filePath, licenseType) => {


### PR DESCRIPTION
Updates previous fix in https://github.com/tenstorrent/ttnn-visualizer/pull/1114 to look for a four digit number rather than anything related to specific years. Will need updating before we reach five digit years.