### PR TITLE
Update flask:lint script to use black --fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "vite build",
     "dev:server": "VITE_SERVER_MODE=1 vite",
     "dev": "vite",
-    "flask:lint": "isort --check-only backend/ttnn_visualizer && black --fix backend/ttnn_visualizer",
+    "flask:lint": "isort --check-only backend/ttnn_visualizer && black backend/ttnn_visualizer",
     "flask:mypy": "PYTHONPATH=backend mypy backend/ttnn_visualizer",
     "flask:start-debug": "DEBUG=true PYTHONPATH=backend python -m ttnn_visualizer.app",
     "flask:start": "PYTHONPATH=backend python -m ttnn_visualizer.app",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build": "vite build",
     "dev:server": "VITE_SERVER_MODE=1 vite",
     "dev": "vite",
-    "flask:lint": "isort --check-only backend/ttnn_visualizer && black backend/ttnn_visualizer",
+    "flask:lint": "isort --check-only backend/ttnn_visualizer && black --check backend/ttnn_visualizer",
+    "flask:format": "isort backend/ttnn_visualizer && black backend/ttnn_visualizer",
     "flask:mypy": "PYTHONPATH=backend mypy backend/ttnn_visualizer",
     "flask:start-debug": "DEBUG=true PYTHONPATH=backend python -m ttnn_visualizer.app",
     "flask:start": "PYTHONPATH=backend python -m ttnn_visualizer.app",
@@ -138,6 +139,6 @@
     ],
     "**/*.scss": "npx stylelint --fix",
     "**/*.{js,jsx,ts,tsx,css,scss}": "pnpm run format",
-    "backend/ttnn_visualizer/**/*.py": "pnpm run flask:lint"
+    "backend/ttnn_visualizer/**/*.py": "pnpm run flask:format"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "vite build",
     "dev:server": "VITE_SERVER_MODE=1 vite",
     "dev": "vite",
-    "flask:lint": "isort --check-only backend/ttnn_visualizer && black --check backend/ttnn_visualizer",
+    "flask:lint": "isort --check-only backend/ttnn_visualizer && black --fix backend/ttnn_visualizer",
     "flask:mypy": "PYTHONPATH=backend mypy backend/ttnn_visualizer",
     "flask:start-debug": "DEBUG=true PYTHONPATH=backend python -m ttnn_visualizer.app",
     "flask:start": "PYTHONPATH=backend python -m ttnn_visualizer.app",


### PR DESCRIPTION
Changed the flask:lint npm script to use 'black --fix' instead of 'black --check' for automatic code formatting in the backend/ttnn_visualizer directory.