### PR TITLE
Feature/Add scroll shade to legend

### DIFF
--- a/src/scss/components/OperationDetailsComponent.scss
+++ b/src/scss/components/OperationDetailsComponent.scss
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 @use '../definitions/colours' as *;
+@use '../mixins/scrollShade' as scrollShade;
 
 .operation-details-component {
     .core-view-buttons {
@@ -58,6 +59,8 @@
         margin-bottom: 20px;
         margin-top: 20px;
         padding-right: 15px;
+
+        @include scrollShade.scroll-shade(10px);
 
         &.nested-legend {
             padding-left: 18px;


### PR DESCRIPTION
Applies scroll shade to list when it is "lengthy".

**Before**
<img width="1240" height="252" alt="Screenshot 2026-01-19 at 10 54 49" src="https://github.com/user-attachments/assets/f091629d-e7c0-40cc-9993-1e7e66606556" />

**After**
<img width="1240" height="252" alt="Screenshot 2026-01-19 at 10 14 56" src="https://github.com/user-attachments/assets/a986acdf-0792-48a0-8282-156ba8b540bf" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1139.