### PR TITLE
Feature/Include paths when report preload paths fail

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -359,9 +359,9 @@ def main():
                 )
                 instance_id = session.instance_id
             except InvalidReportPath:
-                sys.exit("Invalid report path")
+                sys.exit(f"❌ Invalid profiler path: {args.profiler_path}")
             except InvalidProfilerPath:
-                sys.exit("Invalid profiler path")
+                sys.exit(f"❌ Invalid performance path: {args.performance_path}")
 
         # Clean up this temporary app - workers will create their own
         del app


### PR DESCRIPTION
Adds the failing path to the error message.

<img width="941" height="148" alt="Screenshot 2026-01-19 at 16 24 51" src="https://github.com/user-attachments/assets/4862aa34-b235-4316-9162-e50fd05bb263" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1003.