### PR TITLE
Chore/Rename function

### DIFF
--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -16,7 +16,7 @@ import ROUTES from '../definitions/Routes';
 import { ScrollLocations } from '../definitions/ScrollPositions';
 import { SortingOptions } from '../definitions/SortingOptions';
 import isValidNumber from '../functions/isValidNumber';
-import { convertBytes, toReadableShape, toReadableType } from '../functions/math';
+import { formatMemorySize, toReadableShape, toReadableType } from '../functions/math';
 import { useGetTensorDeallocationReportByOperation, useOperationsList, useTensors } from '../hooks/useAPI';
 import useRestoreScrollPosition from '../hooks/useRestoreScrollPosition';
 import useScrollShade from '../hooks/useScrollShade';
@@ -451,7 +451,9 @@ const TensorList = () => {
                                                     ) : null}
 
                                                     {isValidNumber(tensor.size) ? (
-                                                        <span className='tensor-size'>{convertBytes(tensor.size)}</span>
+                                                        <span className='tensor-size'>
+                                                            {formatMemorySize(tensor.size)}
+                                                        </span>
                                                     ) : null}
                                                 </ListItem>
                                             }

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { IconNames } from '@blueprintjs/icons';
 import { Buffer, Tensor } from '../../model/APIData';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
-import { convertBytes, toHex, toReadableShape, toReadableType } from '../../functions/math';
+import { formatMemorySize, toHex, toReadableShape, toReadableType } from '../../functions/math';
 import { selectedAddressAtom, selectedTensorAtom } from '../../store/app';
 import useBufferFocus from '../../hooks/useBufferFocus';
 import { getDimmedColour } from '../../functions/colour';
@@ -194,7 +194,7 @@ const BufferSummaryRow = ({
                             {/* {showHex
                                 ? toHex(interactiveBuffer.buffer.address + interactiveBuffer.buffer.size)
                                 : interactiveBuffer.buffer.address + interactiveBuffer.buffer.size} */}
-                            {convertBytes(interactiveBuffer.buffer.size, 2)}
+                            {formatMemorySize(interactiveBuffer.buffer.size, 2)}
                             <br />
                             {interactiveBuffer.tensor?.shape
                                 ? toReadableShape(interactiveBuffer.tensor.shape)

--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -15,7 +15,7 @@ import 'styles/components/BufferSummaryTable.scss';
 import HighlightedText from '../HighlightedText';
 import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
 import { TensorsByOperationByAddress } from '../../model/BufferSummary';
-import { convertBytes, toHex } from '../../functions/math';
+import { formatMemorySize, toHex } from '../../functions/math';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { Buffer, BufferData, BuffersByOperation } from '../../model/APIData';
 import { selectedTensorAtom } from '../../store/app';
@@ -311,7 +311,7 @@ const getCellContent = (key: ColumnKeys, rowIndex: number, rows: SummaryTableBuf
     // TODO: Format address but also allow easy filtering
 
     if (key === 'size') {
-        return convertBytes(buffer.size, 2);
+        return formatMemorySize(buffer.size, 2);
     }
 
     if (key === 'tensor_id') {

--- a/src/components/npe/ActiveTransferDetails.tsx
+++ b/src/components/npe/ActiveTransferDetails.tsx
@@ -9,7 +9,7 @@ import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { LinkUtilization, NPE_LINK, NoCID, NoCTransfer, NoCType, SelectedNode } from '../../model/NPEModel';
 import { calculateLinkCongestionColor, getRouteColor } from './drawingApi';
-import { convertBytes, formatPercentage } from '../../functions/math';
+import { formatMemorySize, formatPercentage } from '../../functions/math';
 import 'styles/components/ActiveTransferDetails.scss';
 import { altCongestionColorsAtom } from '../../store/app';
 
@@ -132,7 +132,7 @@ const ActiveTransferDetails = ({
                                                             : `${transfer.dst[0].join('-')} - ${transfer.dst[transfer.dst.length - 1].join('-')}`}
                                                     </span>
                                                 </div>
-                                                <div>{convertBytes(transfer.total_bytes, 2)}</div>
+                                                <div>{formatMemorySize(transfer.total_bytes, 2)}</div>
                                                 <div>{transfer.noc_event_type}</div>
                                                 {transfer.route[0].injection_rate.toFixed(2)} b/cycle
                                                 <div className='transfer-properties'>

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -14,7 +14,7 @@ import { OperationDetails } from '../../model/OperationDetails';
 import { selectedAddressAtom } from '../../store/app';
 import Collapsible, { COLLAPSIBLE_EMPTY_CLASS } from '../Collapsible';
 import { AllocationDetails, processMemoryAllocations } from '../../functions/processMemoryAllocations';
-import { convertBytes, prettyPrintAddress, toReadableShape } from '../../functions/math';
+import { formatMemorySize, prettyPrintAddress, toReadableShape } from '../../functions/math';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
 import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1MemorySize';
@@ -71,7 +71,7 @@ const DeviceOperationsFullRender: React.FC<{
                         <span className='address'>
                             {tensorSquare} {address !== undefined && `${prettyPrintAddress(address, 0)}`}
                         </span>
-                        <span> {convertBytes(parseInt(buffer.params.size, 10), 2)}</span>
+                        <span> {formatMemorySize(parseInt(buffer.params.size, 10), 2)}</span>
                         <span>
                             <MemoryTag memory={buffer.params.type} />
                         </span>
@@ -157,9 +157,9 @@ const DeviceOperationsFullRender: React.FC<{
                             peak: memoryDetails.total_memory === peakMemoryLoad,
                         })}
                     >
-                        <span className='format-numbers'>{convertBytes(memoryDetails.total_cb, 2)}</span>
-                        <span className='format-numbers'>{convertBytes(memoryDetails.total_buffer, 2)}</span>
-                        <span className='format-numbers'>{convertBytes(memoryDetails.total_memory, 2)}</span>
+                        <span className='format-numbers'>{formatMemorySize(memoryDetails.total_cb, 2)}</span>
+                        <span className='format-numbers'>{formatMemorySize(memoryDetails.total_buffer, 2)}</span>
+                        <span className='format-numbers'>{formatMemorySize(memoryDetails.total_memory, 2)}</span>
                     </span>
                 ) : undefined;
                 if (nodeType === NodeType.function_start) {
@@ -291,7 +291,7 @@ const DeviceOperationsFullRender: React.FC<{
                                 _node={node}
                                 memoryInfo={(buffer.type === DeviceOperationTypes.L1 && memoryInfo) || undefined}
                                 key={index}
-                                title={`Buffer deallocate ${convertBytes(bufferSize)} ${buffer.type} x ${cores} cores`}
+                                title={`Buffer deallocate ${formatMemorySize(bufferSize)} ${buffer.type} x ${cores} cores`}
                             />
                         );
                     } else if (nodeType === NodeType.circular_buffer_deallocate_all) {
@@ -364,7 +364,8 @@ const DeviceOperationsFullRender: React.FC<{
     return (
         <div className='device-operations-full-render-wrap'>
             <h3 className='peak-load monospace'>
-                Peak L1 memory load per core: <span className='format-numbers'>{convertBytes(peakMemoryLoad, 2)}</span>
+                Peak L1 memory load per core:{' '}
+                <span className='format-numbers'>{formatMemorySize(peakMemoryLoad, 2)}</span>
             </h3>
             <div className='device-operations-full-render'>
                 <span className='memory-info monospace'>
@@ -378,7 +379,7 @@ const DeviceOperationsFullRender: React.FC<{
             {deviceOperations.length > 20 && (
                 <h3 className='peak-load monospace'>
                     Peak L1 memory load per core:{' '}
-                    <span className='format-numbers'>{convertBytes(peakMemoryLoad, 2)}</span>
+                    <span className='format-numbers'>{formatMemorySize(peakMemoryLoad, 2)}</span>
                 </h3>
             )}
         </div>

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -9,7 +9,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { DeviceOperationLayoutTypes, DeviceOperationTypes, FragmentationEntry } from '../../model/APIData';
 import { OperationDetails } from '../../model/OperationDetails';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
-import { convertBytes, prettyPrintAddress, toHex, toReadableShape, toReadableType } from '../../functions/math';
+import { formatMemorySize, prettyPrintAddress, toHex, toReadableShape, toReadableType } from '../../functions/math';
 import 'styles/components/MemoryLegendElement.scss';
 import { L1_SMALL_MARKER_COLOR, L1_START_MARKER_COLOR } from '../../definitions/PlotConfigurations';
 
@@ -109,7 +109,7 @@ export const MemoryLegendElement: React.FC<{
                     'L1 START'
                 ) : (
                     <>
-                        {convertBytes(chunk.size, 2)}
+                        {formatMemorySize(chunk.size, 2)}
                         {numCoresLabel}
                     </>
                 )}

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { getBufferColor, getTensorColor } from './colorGenerator';
-import { convertBytes, toHex, toReadableShape, toReadableType } from './math';
+import { formatMemorySize, toHex, toReadableShape, toReadableType } from './math';
 import { BufferPage, Chunk, ColoredChunk, Tensor } from '../model/APIData';
 import { PlotDataCustom } from '../definitions/PlotConfigurations';
 import { TensorMemoryLayout } from './parseMemoryConfig';
@@ -101,7 +101,7 @@ export default function getChartData(
                     ? overrides?.hovertemplate
                     : `
 <span style="color:${color};font-size:20px;">&#9632;</span>
-${address} (${toHex(address)}) <br />${convertBytes(size, 2)}
+${address} (${toHex(address)}) <br />${formatMemorySize(size, 2)}
 ${tensor ? `<br>${toReadableShape(tensor.shape)} ${toReadableType(tensor.dtype)} Tensor${tensor.id}<br>${tensorMemoryLayout || ''}` : ''}
 ${
     options?.lateDeallocation && chunk.lateDeallocation

--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -13,7 +13,11 @@ export const formatSize = (number: number, decimals?: number): string => {
     return new Intl.NumberFormat(LOCALE, { maximumFractionDigits: decimals }).format(number);
 };
 
-export const formatUnit = (value: number, unit: string, unitDisplay: 'long' | 'short' | 'narrow' = 'long'): string => {
+export const formatUnit = (
+    value: number,
+    unit: string,
+    unitDisplay: Intl.NumberFormatOptions['unitDisplay'] = 'long',
+): string => {
     return new Intl.NumberFormat(LOCALE, {
         style: 'unit',
         unit,
@@ -101,6 +105,7 @@ export const isEqual = <T>(value: T, other: T): boolean => {
         return isEqual(valueObj[key], otherObj[key]);
     });
 };
+
 export const toReadableShape = (input: string) => {
     const match = input.match(/(?:Shape|torch\.Size)\((\[.*\])\)/);
     if (!match) {
@@ -108,6 +113,7 @@ export const toReadableShape = (input: string) => {
     }
     return match[1];
 };
+
 export const toReadableType = (input: string) => {
     return input.replace(/^DataType\./, '');
 };
@@ -140,7 +146,7 @@ export const getCoresInRange = (rangeString: string): number => {
  * @example convertBytes(163840) // "160 KiB"
  * @example convertBytes(22370304) // "21.33 MiB"
  */
-export const convertBytes = (bytes: number, decimals = 0): string => {
+export const formatMemorySize = (bytes: number, decimals = 0): string => {
     const sizes = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
 
     if (bytes === 0) {

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { PlotData } from 'plotly.js';
-import { convertBytes, getCoresInRange, toHex } from '../functions/math';
+import { formatMemorySize, getCoresInRange, toHex } from '../functions/math';
 import {
     BufferData,
     Chunk,
@@ -415,7 +415,7 @@ export class OperationDetails implements Partial<OperationDetailsData> {
         const cbColor = '#e2defc';
         const cbHoverTemplate = `
 <span style="color:${cbColor};font-size:20px;">&#9632;</span>
-${cbCondensed.address} (${toHex(cbCondensed.address)}) <br />${convertBytes(cbCondensed.size, 2)}
+${cbCondensed.address} (${toHex(cbCondensed.address)}) <br />${formatMemorySize(cbCondensed.size, 2)}
 <br><br>CBs Summary
 <extra></extra>`;
 
@@ -436,7 +436,7 @@ ${cbCondensed.address} (${toHex(cbCondensed.address)}) <br />${convertBytes(cbCo
         const bufferColor = '#fcdefa';
         const bufferHoverTemplate = `
 <span style="color:${bufferColor};font-size:20px;">&#9632;</span>
-${bufferCondensed.address} (${toHex(bufferCondensed.address)}) <br /> ${convertBytes(bufferCondensed.size, 2)}
+${bufferCondensed.address} (${toHex(bufferCondensed.address)}) <br /> ${formatMemorySize(bufferCondensed.size, 2)}
 <br><br>Buffers Summary
 <extra></extra>`;
         const bufferChartData = this.getChartData([bufferCondensed], {


### PR DESCRIPTION
Renamed `convertBytes` to `formatMemorySize` and changed imports where required.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1150.