### PR TITLE
Add compact view toggle to OperationGraph

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -48,6 +48,7 @@ const OperationGraph: React.FC<{
     const [filterOutDeallocate, setFilterOutDeallocate] = useState<boolean>(true);
     const networkRef = useRef<Network | null>(null);
     const currentOpIdRef = useRef<number>(currentOperationId);
+    const [compactView, setCompactView] = useState<boolean>(false);
 
     const edges = useMemo(
         () =>
@@ -318,7 +319,7 @@ const OperationGraph: React.FC<{
                                 nodeSpacing: 700,
                                 treeSpacing: 700,
                                 blockShifting: true,
-                                edgeMinimization: true,
+                                edgeMinimization: !compactView,
                                 direction: 'UD',
                                 sortMethod: 'directed',
                                 shakeTowards: 'leaves',
@@ -389,7 +390,7 @@ const OperationGraph: React.FC<{
             networkRef.current = null;
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [edges, nodes, data]);
+    }, [edges, nodes, data, compactView]);
 
     const getNextOperationId = (currentId: number | null) => {
         if (nodes === null || currentId === null) {
@@ -504,6 +505,12 @@ const OperationGraph: React.FC<{
                         checked={filterOutDeallocate}
                         onChange={() => setFilterOutDeallocate(!filterOutDeallocate)}
                         label='Hide deallocate ops'
+                        disabled={isLoading}
+                    />
+                    <Switch
+                        checked={compactView}
+                        onChange={() => setCompactView(!compactView)}
+                        label='Compact view'
                         disabled={isLoading}
                     />
                 </div>


### PR DESCRIPTION
Introduced a 'Compact view' switch to the OperationGraph component, allowing users to toggle edge minimization for a more condensed graph layout.

closes #1160 
<img width="1402" height="841" alt="image" src="https://github.com/user-attachments/assets/8625b70d-3732-4e3f-b108-f43cce3d5837" />
