### PR TITLE
Remove placeholder remote mesh descriptor code

### DIFF
--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -208,12 +208,6 @@ def get_cluster_desc(remote_connection: RemoteConnection):
         return None
 
 
-@remote_exception_handler
-def get_mesh_desc(remote_connection: RemoteConnection):
-    # this needs an actual implementation
-    return None
-
-
 def is_excluded(file_path, exclude_patterns):
     """Check if a file path should be excluded based on patterns."""
     for pattern in exclude_patterns:

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -428,13 +428,9 @@ def get_mesh_descriptor_paths(instance):
         return []
 
     parent = Path(instance.profiler_path).parent
-    pattern = re.compile(r"physical_chip_mesh_coordinate_mapping_[1-8]_of_[1-8]\.yaml")
+    glob_pattern = "physical_chip_mesh_coordinate_mapping_[0-9]_of_[0-9].yaml"
 
-    return sorted(
-        str(path)
-        for path in parent.iterdir()
-        if path.is_file() and pattern.fullmatch(path.name)
-    )
+    return sorted(str(path) for path in parent.glob(glob_pattern) if path.is_file())
 
 
 def read_last_synced_file(directory: str) -> Optional[int]:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -58,7 +58,6 @@ from ttnn_visualizer.sftp_operations import (
     check_remote_path_exists,
     check_remote_path_for_reports,
     get_cluster_desc,
-    get_mesh_desc,
     get_remote_performance_folders,
     get_remote_profiler_folders,
     read_remote_file,
@@ -1165,50 +1164,25 @@ def get_cluster_descriptor(instance: Instance):
 @api.route("/mesh-descriptor", methods=["GET"])
 @with_instance
 def get_mesh_descriptor(instance: Instance):
-    if instance.remote_connection:
-        try:
-            mesh_desc_file = get_mesh_desc(instance.remote_connection)
-            if not mesh_desc_file:
-                return jsonify({"error": "mesh.yaml not found"}), HTTPStatus.NOT_FOUND
+    paths = get_mesh_descriptor_paths(instance)
 
-            yaml_data = yaml.safe_load(mesh_desc_file.decode("utf-8"))
-            return jsonify(yaml_data), HTTPStatus.OK
+    if not paths:
+        return (
+            jsonify(
+                {"error": "physical_chip_mesh_coordinate_mapping_1_of_1.yaml not found"}
+            ),
+            HTTPStatus.NOT_FOUND,
+        )
 
-        except yaml.YAMLError as e:
-            return (
-                jsonify({"error": f"Failed to parse YAML: {str(e)}"}),
-                HTTPStatus.BAD_REQUEST,
-            )
-
-        except RemoteConnectionException as e:
-            return jsonify({"error": e.message}), e.http_status
-
-        except Exception as e:
-            return (
-                jsonify({"error": f"An unexpected error occurred: {str(e)}"}),
-                HTTPStatus.BAD_REQUEST,
-            )
-    else:
-        paths = get_mesh_descriptor_paths(instance)
-        if not paths:
-            return jsonify({"error": "mesh.yaml not found"}), HTTPStatus.NOT_FOUND
-
-        local_path = paths[0]
-
-        if not local_path:
-            return jsonify({"error": "mesh.yaml not found"}), HTTPStatus.NOT_FOUND
-
-        try:
-            with open(local_path) as mesh_descriptor_path:
-                yaml_data = yaml.safe_load(mesh_descriptor_path)
-                return jsonify(yaml_data)  # yaml_data is not compatible with orjson
-        except yaml.YAMLError as e:
-            return (
-                jsonify({"error": f"Failed to parse YAML: {str(e)}"}),
-                HTTPStatus.BAD_REQUEST,
-            )
-
-    return jsonify({"error": "Mesh descriptor not found"}), HTTPStatus.NOT_FOUND
+    try:
+        with open(paths[0]) as mesh_descriptor_path:
+            yaml_data = yaml.safe_load(mesh_descriptor_path)
+            return jsonify(yaml_data)  # yaml_data is not compatible with orjson
+    except yaml.YAMLError as e:
+        return (
+            jsonify({"error": f"Failed to parse YAML: {str(e)}"}),
+            HTTPStatus.BAD_REQUEST,
+        )
 
 
 @api.route("/remote/test", methods=["POST"])


### PR DESCRIPTION
This PR tweaks the code to return mesh descriptors. There was placeholder code to fetch remote mesh descriptor files, but it is not necessary. The mesh descriptor files will be downloaded with the other files when the report is synched.

[Closes #1159]