### PR TITLE
Feature/Indicate tensor tooltip exists

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -106,8 +106,11 @@ const renderTensorLabel = (node: Node, details: OperationDetails, buffers: JSX.E
             }
             position={PopoverPosition.TOP}
         >
-            <span className={classNames(Classes.TOOLTIP_INDICATOR, 'standard-flex-layout', 'has-tooltip')}>
-                {square} Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
+            <span className='standard-flex-layout'>
+                {square}{' '}
+                <span className={classNames(Classes.TOOLTIP_INDICATOR, 'has-tooltip')}>
+                    Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
+                </span>
             </span>
         </Tooltip>
     ) : (

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -106,7 +106,7 @@ const renderTensorLabel = (node: Node, details: OperationDetails, buffers: JSX.E
             }
             position={PopoverPosition.TOP}
         >
-            <span className='standard-flex-layout'>
+            <span className='standard-flex-layout has-tooltip'>
                 {square} Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
             </span>
         </Tooltip>

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import React, { Fragment, JSX, useCallback } from 'react';
-import { Icon, Intent, PopoverPosition, Tooltip } from '@blueprintjs/core';
+import { Classes, Icon, Intent, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
@@ -106,7 +106,7 @@ const renderTensorLabel = (node: Node, details: OperationDetails, buffers: JSX.E
             }
             position={PopoverPosition.TOP}
         >
-            <span className='standard-flex-layout has-tooltip'>
+            <span className={classNames(Classes.TOOLTIP_INDICATOR, 'standard-flex-layout', 'has-tooltip')}>
                 {square} Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
             </span>
         </Tooltip>

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -123,7 +123,7 @@ const DeviceOperationsFullRender: React.FC<{
                         }
                         position={PopoverPosition.TOP}
                     >
-                        <span className='standard-flex-layout'>
+                        <span className='standard-flex-layout has-tooltip'>
                             {square} Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
                         </span>
                     </Tooltip>

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -106,7 +106,7 @@ const renderTensorLabel = (node: Node, details: OperationDetails, buffers: JSX.E
             }
             position={PopoverPosition.TOP}
         >
-            <span className='standard-flex-layout'>
+            <span className='tensor-details-layout'>
                 {square}{' '}
                 <span className={classNames(Classes.TOOLTIP_INDICATOR, 'has-tooltip')}>
                     Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
@@ -114,7 +114,7 @@ const renderTensorLabel = (node: Node, details: OperationDetails, buffers: JSX.E
             </span>
         </Tooltip>
     ) : (
-        <span className='standard-flex-layout'>
+        <span className='tensor-details-layout'>
             {square} Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
         </span>
     );

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -18,6 +18,11 @@
     justify-content: space-between;
     align-items: center;
     gap: 5px;
+
+    &.has-tooltip {
+        cursor: help;
+        text-decoration: underline dotted;
+    }
 }
 
 .arg-tensor-tooltip {

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -13,15 +13,18 @@
     }
 }
 
-.standard-flex-layout {
+.tensor-details-layout {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 5px;
+    position: relative;
+    top: 1px;
 
     .has-tooltip {
         border-bottom-color: $tt-teal;
         border-bottom-width: 2px;
+        margin-top: 3px;
         padding-bottom: 2px;
     }
 }

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -21,7 +21,7 @@
 
     &.has-tooltip {
         cursor: help;
-        text-decoration: underline dotted;
+        text-decoration: underline dotted $tt-teal 2px;
     }
 }
 

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -19,7 +19,7 @@
     align-items: center;
     gap: 5px;
 
-    &.has-tooltip {
+    .has-tooltip {
         border-bottom-color: $tt-teal;
         border-bottom-width: 2px;
         padding-bottom: 2px;

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -20,8 +20,9 @@
     gap: 5px;
 
     &.has-tooltip {
-        cursor: help;
-        text-decoration: underline dotted $tt-teal 2px;
+        border-bottom-color: $tt-teal;
+        border-bottom-width: 2px;
+        padding-bottom: 2px;
     }
 }
 


### PR DESCRIPTION
Adds a dotted underline when there's a tooltip.

**Before**
<img width="1212" height="729" alt="Screenshot 2026-01-29 at 11 44 28" src="https://github.com/user-attachments/assets/8bc760ea-cab4-4c1a-a9aa-88649f4df0ad" />

**After**
<img width="1346" height="840" alt="Screenshot 2026-02-11 at 12 14 35" src="https://github.com/user-attachments/assets/fab6a708-b09b-44c4-a5d8-ca42aaa28077" />


Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1170.