### PR TITLE
Feature/Replace StackByIn0 with GroupBy

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -616,11 +616,12 @@ class OpsPerformanceReportQueries:
                             if index < len(row)
                         }
 
+                        # Map "OP Code Joined" to "op_code" for consistency with non-stacked report
                         if "OP Code Joined" in processed_row:
                             processed_row["op_code"] = processed_row["OP Code Joined"]
                             del processed_row["OP Code Joined"]
 
-                        if "OP Code op_code" in processed_row and any(
+                        if "op_code" in processed_row and any(
                             processed_row["op_code"] in signpost["op_code"]
                             for signpost in signposts
                         ):

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -489,10 +489,10 @@ class OpsPerformanceReportQueries:
         end_signpost = kwargs.get("end_signpost", cls.DEFAULT_END_SIGNPOST)
         ignore_signposts = cls.DEFAULT_IGNORE_SIGNPOSTS
         print_signposts = kwargs.get("print_signposts", cls.DEFAULT_PRINT_SIGNPOSTS)
-        stack_by_in0 = kwargs.get("stack_by_in0", cls.DEFAULT_NO_STACK_BY_IN0)
         no_host_ops = kwargs.get("hide_host_ops", cls.DEFAULT_NO_HOST_OPS)
         merge_devices = kwargs.get("merge_devices", cls.DEFAULT_MERGE_DEVICES)
         tracing_mode = kwargs.get("tracing_mode", cls.DEFAULT_TRACING_MODE)
+        group_by = kwargs.get("group_by", cls.DEFAULT_GROUP_BY)
 
         if start_signpost or end_signpost:
             ignore_signposts = False
@@ -513,11 +513,11 @@ class OpsPerformanceReportQueries:
                 cls.DEFAULT_RAW_OP_CODES,
                 no_host_ops,
                 cls.DEFAULT_NO_SUMMARY,
-                cls.DEFAULT_GROUP_BY,
+                group_by,
                 cls.DEFAULT_CLASSIC_COLORS,
                 csv_summary_file.name,
                 cls.DEFAULT_NO_STACKED_REPORT,
-                stack_by_in0,
+                cls.DEFAULT_NO_STACK_BY_IN0,
                 cls.DEFAULT_STACKED_CSV_FILE,
                 not merge_devices,
             )
@@ -616,9 +616,12 @@ class OpsPerformanceReportQueries:
                             if index < len(row)
                         }
 
-                        if "OP Code Joined" in processed_row and any(
-                            processed_row["OP Code Joined"]
-                            in signpost["OP Code Joined"]
+                        if "OP Code Joined" in processed_row:
+                            processed_row["op_code"] = processed_row["OP Code Joined"]
+                            del processed_row["OP Code Joined"]
+
+                        if "OP Code op_code" in processed_row and any(
+                            processed_row["op_code"] in signpost["op_code"]
                             for signpost in signposts
                         ):
                             processed_row["op_type"] = "signpost"

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -732,10 +732,10 @@ def get_performance_results_report(instance: Instance):
     start_signpost = request.args.get("start_signpost", None)
     end_signpost = request.args.get("end_signpost", None)
     print_signposts = str_to_bool(request.args.get("print_signposts", "true"))
-    stack_by_in0 = str_to_bool(request.args.get("stack_by_in0", "true"))
     hide_host_ops = str_to_bool(request.args.get("hide_host_ops", "true"))
     merge_devices = str_to_bool(request.args.get("merge_devices", "true"))
     tracing_mode = str_to_bool(request.args.get("tracing_mode", "false"))
+    group_by = request.args.get("group_by", None)
 
     if name and not current_app.config["SERVER_MODE"]:
         performance_path = Path(instance.performance_path).parent / name
@@ -745,13 +745,13 @@ def get_performance_results_report(instance: Instance):
     try:
         report = OpsPerformanceReportQueries.generate_report(
             instance,
-            stack_by_in0=stack_by_in0,
             start_signpost=start_signpost,
             print_signposts=print_signposts,
             end_signpost=end_signpost,
             hide_host_ops=hide_host_ops,
             merge_devices=merge_devices,
             tracing_mode=tracing_mode,
+            group_by=group_by,
         )
     except DataFormatError:
         return Response(status=HTTPStatus.UNPROCESSABLE_ENTITY)

--- a/src/definitions/StackedPerfTable.ts
+++ b/src/definitions/StackedPerfTable.ts
@@ -25,9 +25,9 @@ export enum StackedColumnHeaders {
 }
 
 export enum StackedGroupBy {
-    OP = 'operation',
-    MEMORY = 'memory',
     CATEGORY = 'category',
+    MEMORY = 'memory',
+    OP = 'operation',
 }
 
 export type StackedTableKeys = Partial<keyof StackedPerfRow>;

--- a/src/definitions/StackedPerfTable.ts
+++ b/src/definitions/StackedPerfTable.ts
@@ -12,7 +12,7 @@ enum OperationCategories {
 
 export enum StackedColumnHeaders {
     Percent = '%',
-    OpCode = 'OP Code Joined',
+    OpCode = 'op_code',
     Device = 'Device',
     DeviceTimeSumUs = 'Device_Time_Sum_us',
     OpsCount = 'Ops_count',
@@ -22,6 +22,12 @@ export enum StackedColumnHeaders {
     FlopsMean = 'Flops_mean',
     FlopsStd = 'Flops_std',
     FlopsWeightedMean = 'Flops_weighted_mean',
+}
+
+export enum StackedGroupBy {
+    OP = 'operation',
+    MEMORY = 'memory',
+    CATEGORY = 'category',
 }
 
 export type StackedTableKeys = Partial<keyof StackedPerfRow>;

--- a/src/functions/formatting.ts
+++ b/src/functions/formatting.ts
@@ -19,3 +19,7 @@ export const toReadableType = (input: string) => {
 export const toReadableLayout = (input: TensorMemoryLayout) => {
     return input.replace(/^TensorMemoryLayout::/, '');
 };
+
+export const capitalizeString = (input: string) => {
+    return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
+};

--- a/src/functions/sortAndFilterStackedPerfTableData.ts
+++ b/src/functions/sortAndFilterStackedPerfTableData.ts
@@ -23,7 +23,7 @@ const sortAndFilterStackedPerfTableData = (
     data: TypedStackedPerfRow[],
     filters: StackedTableFilter,
     rawOpCodeFilter: string[],
-    stackByIn0: boolean,
+    isGroupedByMemory: boolean,
 ): TypedStackedPerfRow[] => {
     if (data?.length === 0) {
         return data;
@@ -67,7 +67,7 @@ const sortAndFilterStackedPerfTableData = (
             (row) =>
                 row?.[StackedColumnHeaders.OpCode] !== null &&
                 rawOpCodeFilter.some((filterValue) =>
-                    stackByIn0
+                    isGroupedByMemory
                         ? filterValue.toLowerCase() === row[StackedColumnHeaders.OpCode].toLowerCase()
                         : // TODO: This split is currently needed but we should store the data differently
                           filterValue.toLowerCase() === row[StackedColumnHeaders.OpCode].split(' ')[0].toLowerCase(),

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -15,6 +15,7 @@ import { PerfTabIds } from '../definitions/Performance';
 import { ReportFolder, ReportLocation } from '../definitions/Reports';
 import { TableFilter, TypedPerfTableRow } from '../definitions/PerfTable';
 import { BufferType } from '../model/BufferType';
+import { StackedGroupBy } from '../definitions/StackedPerfTable';
 
 // Unsorted
 export const profilerReportLocationAtom = atom<ReportLocation | null>(null);
@@ -68,7 +69,6 @@ export const comparisonPerformanceReportListAtom = atom<string[] | null>(null);
 export const perfSelectedTabAtom = atom<TabId>(PerfTabIds.TABLE);
 export const perfTableFiltersAtom = atom<TableFilter | null>(null);
 export const isStackedViewAtom = atom(false);
-export const stackByIn0Atom = atom(true);
 export const filterBySignpostAtom = atom<(Signpost | null)[]>([null, null]);
 export const selectedDeviceAtom = atom<number | null>(DEFAULT_DEVICE_ID); // Assumes device_id always uses a zero based index (NOT REALLY USED AT THE MOMENT)
 export const renderMemoryLayoutAtom = atom<boolean>(false);
@@ -78,6 +78,7 @@ export const rawOpCodeFilterListAtom = atom<TypedPerfTableRow['raw_op_code'][]>(
 export const bufferTypeFilterListAtom = atom<TypedPerfTableRow['buffer_type'][]>([]);
 export const mergeDevicesAtom = atom<boolean>(true);
 export const tracingModeAtom = atom<boolean>(false);
+export const stackedGroupByAtom = atom<StackedGroupBy>(StackedGroupBy.OP);
 
 // NPE
 export const altCongestionColorsAtom = atomWithStorage<boolean>('altCongestionColorsAtom', false);


### PR DESCRIPTION
StackByIn0 has been deprecated in tt-perf-report and GroupBy is the new way forward. 

**Grouped by Op**
<img width="1292" height="888" alt="Screenshot 2026-02-04 at 12 27 00" src="https://github.com/user-attachments/assets/4e708e83-49f5-4c85-95cb-59f4284eb89d" />

**Grouped by Memory (same as StackByIn0)**
<img width="1292" height="888" alt="Screenshot 2026-02-04 at 12 26 56" src="https://github.com/user-attachments/assets/2b979631-dbe3-44ae-988b-280f4d6ec46d" />

**Group by Category**
<img width="1292" height="888" alt="Screenshot 2026-02-04 at 12 26 51" src="https://github.com/user-attachments/assets/f9df940b-f815-4ddf-8690-835d9f50b21c" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1165.