### PR TITLE
Change default paths for app db and reports

### DIFF
--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from sqlalchemy.pool import NullPool
 from ttnn_visualizer.utils import (
     get_app_data_directory,
+    get_report_data_directory,
     is_running_in_container,
     str_to_bool,
 )
@@ -36,20 +37,21 @@ class DefaultConfig(object):
 
     # Path Settings
     DB_VERSION = "0.29.0"  # App version when DB schema last changed
-    REPORT_DATA_DIRECTORY = os.getenv(
-        "REPORT_DATA_DIRECTORY", Path(__file__).parent.absolute().joinpath("data")
-    )
-    LOCAL_DATA_DIRECTORY = Path(REPORT_DATA_DIRECTORY).joinpath("local")
-    REMOTE_DATA_DIRECTORY = Path(REPORT_DATA_DIRECTORY).joinpath("remote")
-    PROFILER_DIRECTORY_NAME = "profiler-reports"
-    PERFORMANCE_DIRECTORY_NAME = "performance-reports"
-    NPE_DIRECTORY_NAME = "npe-reports"
     APPLICATION_DIR = os.path.abspath(os.path.join(__file__, "..", os.pardir))
     TT_METAL_HOME = os.getenv("TT_METAL_HOME", None)
     APP_DATA_DIRECTORY = os.getenv(
         "APP_DATA_DIRECTORY",
         get_app_data_directory(TT_METAL_HOME, APPLICATION_DIR),
     )
+    REPORT_DATA_DIRECTORY = os.getenv(
+        "REPORT_DATA_DIRECTORY",
+        get_report_data_directory(TT_METAL_HOME, APPLICATION_DIR),
+    )
+    LOCAL_DATA_DIRECTORY = Path(REPORT_DATA_DIRECTORY).joinpath("local")
+    REMOTE_DATA_DIRECTORY = Path(REPORT_DATA_DIRECTORY).joinpath("remote")
+    PROFILER_DIRECTORY_NAME = "profiler-reports"
+    PERFORMANCE_DIRECTORY_NAME = "performance-reports"
+    NPE_DIRECTORY_NAME = "npe-reports"
 
     STATIC_ASSETS_DIR = Path(APPLICATION_DIR).joinpath("ttnn_visualizer", "static")
     SEND_FILE_MAX_AGE_DEFAULT = 0

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 TEST_CONFIG_FILE = "config.json"
 TEST_PROFILER_FILE = "profile_log_device.csv"
-# REPORT_DATA_DIRECTORY is now obtained from app.config, not hardcoded
 
 
 def start_background_task(task, *args):

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 TEST_CONFIG_FILE = "config.json"
 TEST_PROFILER_FILE = "profile_log_device.csv"
-REPORT_DATA_DIRECTORY = Path(__file__).parent.absolute().joinpath("data")
+# REPORT_DATA_DIRECTORY is now obtained from app.config, not hardcoded
 
 
 def start_background_task(task, *args):
@@ -853,7 +853,7 @@ def sync_remote_profiler_folders(
     """Main function to sync test folders, handles both compressed and individual syncs."""
     profiler_folder = Path(remote_folder_path).name
     destination_dir = Path(
-        REPORT_DATA_DIRECTORY,
+        current_app.config["REPORT_DATA_DIRECTORY"],
         path_prefix,
         remote_connection.host,
         current_app.config["PROFILER_DIRECTORY_NAME"],
@@ -877,7 +877,7 @@ def sync_remote_performance_folders(
     remote_folder_path = performance.remotePath
     profile_folder = Path(remote_folder_path).name
     destination_dir = Path(
-        REPORT_DATA_DIRECTORY,
+        current_app.config["REPORT_DATA_DIRECTORY"],
         path_prefix,
         remote_connection.host,
         current_app.config["PERFORMANCE_DIRECTORY_NAME"],


### PR DESCRIPTION
This PR changes the default paths used by TTNN Visualizer for its own app database (`ttnn_0.29.0.db`) and for storing uploaded and synced reports.

The reason this is being done is because the existing paths were ok when working from the cloned repo, but less than ideal when installing from `pip`.

Prior to this PR, the `ttnn-visualizer` command, installed from `pip` and run as root (say it was set up in a Dockerfile like this), would save the data to:

`/usr/local/lib/python3.10/dist-packages/ttnn_0.29.0.db`

That's not an appropriate spot at all. The reports would go to:

`/usr/local/lib/python3.10/dist-packages/ttnn_visualizer/data`

That could be ok as root, but the problem is, if you installed `ttnn-visualizer` system wide instead of in a venv, then ran it as a regular user, the user would not have access to do writes to that directory and it would fail.

The solution implemented in this PR two different directories:

`/var/lib/ttnn-visualizer/` - when run as root (perhaps as a service on a server)
`~/.ttnn-visualizer/` - when run as a non-privileged user

There is code that does a migration if it finds the data in the old location, and moves it to the new location.

[Closes #1033]