### PR TITLE
Feature/Add file path to stack trace source

### DIFF
--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -200,7 +200,8 @@ function StackTrace({
                     onClose={toggleViewingFile}
                 >
                     {fileWithHighlights && (
-                        <pre className='stack-trace'>
+                        <div className='stack-trace'>
+                            <p className='stack-trace-path monospace'>{filePath.trim()}</p>
                             <code
                                 className={`language-${language} code-output`}
                                 // eslint-disable-next-line react/no-danger
@@ -208,7 +209,7 @@ function StackTrace({
                                     __html: fileWithHighlights,
                                 }}
                             />
-                        </pre>
+                        </div>
                     )}
                 </Overlay>
             </pre>

--- a/src/scss/components/StackTrace.scss
+++ b/src/scss/components/StackTrace.scss
@@ -48,7 +48,6 @@
         color: $tt-grey-5;
         margin-top: 5px;
         margin-bottom: 20px;
-        word-break: break-all;
     }
 
     .code-wrapper {

--- a/src/scss/components/StackTrace.scss
+++ b/src/scss/components/StackTrace.scss
@@ -5,6 +5,8 @@
 @use '../definitions/colours' as *;
 
 .stack-trace {
+    margin-top: 0;
+
     .stack-trace-title {
         font-size: 16px;
         font-weight: bold;
@@ -42,6 +44,13 @@
         }
     }
 
+    .stack-trace-path {
+        color: $tt-grey-5;
+        margin-top: 5px;
+        margin-bottom: 20px;
+        word-break: break-all;
+    }
+
     .code-wrapper {
         flex-basis: 100%;
         flex-shrink: 1;
@@ -74,9 +83,9 @@
             position: absolute;
             text-align: right;
             left: 5px;
-            min-width: 30px;
             font-size: 1em;
             color: $tt-grey-5;
+            min-width: 35px;
         }
 
         &::before {


### PR DESCRIPTION
Outputs the file path at the top of the souce file output.

<img width="1296" height="706" alt="Screenshot 2026-02-05 at 11 00 23" src="https://github.com/user-attachments/assets/08e9b2b8-2af7-47cc-9ace-2f899f235fb5" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1198.

