### PR TITLE
Feature/Improve stack trace source error messaging

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -14,6 +14,7 @@ from ttnn_visualizer.exceptions import (
     NoProjectsException,
     NoValidConnectionsError,
     RemoteConnectionException,
+    RemoteFileReadException,
     SSHException,
 )
 from ttnn_visualizer.instances import get_or_create_instance
@@ -132,6 +133,8 @@ def remote_exception_handler(func):
             raise RemoteConnectionException(
                 status=ConnectionTestStates.FAILED, message=message
             )
+        except RemoteFileReadException:
+            raise
         except Exception as err:
             # Catch any other unhandled exceptions
             current_app.logger.exception(

--- a/backend/ttnn_visualizer/exceptions.py
+++ b/backend/ttnn_visualizer/exceptions.py
@@ -88,3 +88,22 @@ class NoValidConnectionsError(SSHException):
     """Raised when SSH connection cannot be established"""
 
     pass
+
+
+class RemoteFileReadException(Exception):
+    """Raised when a remote file cannot be read"""
+
+    def __init__(
+        self,
+        message: str,
+        http_status_code: HTTPStatus = HTTPStatus.INTERNAL_SERVER_ERROR,
+        detail: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self._http_status_code = http_status_code
+        self.detail = detail
+
+    @property
+    def http_status(self):
+        return self._http_status_code

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -227,7 +227,7 @@ class SSHClient:
             return result.encode("utf-8")
         except SSHException as e:
             if "No such file" in str(e) or "cannot open" in str(e):
-                return None
+                return f"File at {path} not found."
             raise
 
     def check_path_exists(

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -218,8 +218,8 @@ class SSHClient:
 
         :param remote_path: Path to the remote file
         :param timeout: Timeout in seconds
-        :return: File contents as bytes, or None if file not found
-        :raises: AuthenticationException, NoValidConnectionsError, SSHException, RemoteFileReadException
+        :return: File contents as bytes
+        :raises: RemoteFileReadException
         """
         path = Path(remote_path)
         logger.info(f"Reading remote file {path}")

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -227,7 +227,7 @@ class SSHClient:
             return result.encode("utf-8")
         except SSHException as e:
             if "No such file" in str(e) or "cannot open" in str(e):
-                return f"File at {path} not found."
+                return f"File not found."
             raise
 
     def check_path_exists(

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1287,7 +1287,8 @@ def read_remote_folder(instance: Instance):
     try:
         content = read_remote_file(remote_connection, remote_path=file_path)
     except RemoteConnectionException as e:
-        return Response(status=e.http_status, response=e.message)
+        return jsonify({"error": str(e)}), e.http_status
+
     return Response(status=200, response=content)
 
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1287,6 +1287,8 @@ def read_remote_folder(instance: Instance):
 
     try:
         content = read_remote_file(remote_connection, remote_path=file_path)
+    except RemoteConnectionException as e:
+        return Response(status=e.http_status, response=e.message)
     except RemoteFileReadException as e:
         return jsonify({"error": str(e)}), e.http_status
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -28,6 +28,7 @@ from ttnn_visualizer.exceptions import (
     AuthenticationFailedException,
     DataFormatError,
     RemoteConnectionException,
+    RemoteFileReadException,
 )
 from ttnn_visualizer.file_uploads import (
     extract_folder_name_from_files,
@@ -1286,7 +1287,7 @@ def read_remote_folder(instance: Instance):
 
     try:
         content = read_remote_file(remote_connection, remote_path=file_path)
-    except RemoteConnectionException as e:
+    except RemoteFileReadException as e:
         return jsonify({"error": str(e)}), e.http_status
 
     return Response(status=200, response=content)

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -124,6 +124,8 @@ function StackTrace({
 
             const { data, error } = await readRemoteFile(filePath);
 
+            setErrorDetails('');
+
             if (error) {
                 setErrorDetails(error);
             } else if (data) {

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -118,14 +118,9 @@ function StackTrace({
         if (selectedConnection && !fileContents && isRemote) {
             setIsFetchingFile(true);
 
-            const { data, error } = await readRemoteFile(filePath);
+            const { data } = await readRemoteFile(filePath);
 
-            if (error) {
-                setFileContents(`Failed to read remote file: ${error}`);
-            } else {
-                setFileContents(data);
-            }
-
+            setFileContents(data);
             setIsFetchingFile(false);
             setIsViewingSourceFile(true);
         }

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -118,8 +118,13 @@ function StackTrace({
         if (selectedConnection && !fileContents && isRemote) {
             setIsFetchingFile(true);
 
-            const response = await readRemoteFile(filePath);
-            setFileContents(response);
+            const { data, error } = await readRemoteFile(filePath);
+
+            if (error) {
+                setFileContents(`Failed to read remote file: ${error}`);
+            } else {
+                setFileContents(data);
+            }
 
             setIsFetchingFile(false);
             setIsViewingSourceFile(true);

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -194,7 +194,7 @@ function StackTrace({
 
         return () => scrollContainerEl?.removeEventListener('scroll', handleScroll);
     }, [scrollContainerEl, overlayTopOffset, isViewingSourceFile]);
-  
+
     useEffect(() => {
         setFileContents('');
         setErrorDetails('');
@@ -263,54 +263,56 @@ function StackTrace({
                     lazy={false}
                 >
                     <>
-                        <div
-                            className='source-file-controls'
-                            ref={sourceControlsRef}
-                        >
-                            <div className='buttons'>
-                                <Tooltip content='Scroll to top'>
-                                    <Button
-                                        icon={IconNames.DOUBLE_CHEVRON_UP}
-                                        onClick={() => scrollToTop()}
-                                    />
-                                </Tooltip>
+                        {!errorDetails ? (
+                            <div
+                                className='source-file-controls'
+                                ref={sourceControlsRef}
+                            >
+                                <div className='buttons'>
+                                    <Tooltip content='Scroll to top'>
+                                        <Button
+                                            icon={IconNames.DOUBLE_CHEVRON_UP}
+                                            onClick={() => scrollToTop()}
+                                        />
+                                    </Tooltip>
 
-                                <Tooltip content='Scroll to highlighted line'>
-                                    <Button
-                                        icon={IconNames.LOCATE}
-                                        onClick={() => scrollToLineNumberInFile()}
-                                    />
-                                </Tooltip>
+                                    <Tooltip content='Scroll to highlighted line'>
+                                        <Button
+                                            icon={IconNames.LOCATE}
+                                            onClick={() => scrollToLineNumberInFile()}
+                                        />
+                                    </Tooltip>
 
-                                <Tooltip content='Scroll to bottom'>
-                                    <Button
-                                        icon={IconNames.DOUBLE_CHEVRON_DOWN}
-                                        onClick={() => scrollToBottom()}
-                                    />
-                                </Tooltip>
+                                    <Tooltip content='Scroll to bottom'>
+                                        <Button
+                                            icon={IconNames.DOUBLE_CHEVRON_DOWN}
+                                            onClick={() => scrollToBottom()}
+                                        />
+                                    </Tooltip>
+                                </div>
                             </div>
-                        </div>
+                        ) : null}
                         {errorDetails ? (
-                        <div className='stack-trace-error'>
-                            <p className='stack-trace-path monospace'>{filePath.trim()}</p>
-                            <div className='error-details'>
-                                <pre>{errorDetails}</pre>
+                            <div className='stack-trace-error'>
+                                <p className='stack-trace-path monospace'>{filePath.trim()}</p>
+                                <div className='error-details'>
+                                    <pre>{errorDetails}</pre>
+                                </div>
                             </div>
-                        </div>
-                    ) : null}
+                        ) : null}
 
-                    {fileWithHighlights && !errorDetails ? (
-                        <div className='stack-trace'>
-                            <p className='stack-trace-path monospace'>{filePath.trim()}</p>
-                            <code
-                                className={`language-${language} code-output`}
-                                // eslint-disable-next-line react/no-danger
-                                dangerouslySetInnerHTML={{
-                                    __html: fileWithHighlights,
-                                }}
-                            />
-                        </div>
-                    ) : null}
+                        {fileWithHighlights && !errorDetails ? (
+                            <div className='stack-trace'>
+                                <p className='stack-trace-path monospace'>{filePath.trim()}</p>
+                                <code
+                                    className={`language-${language} code-output`}
+                                    // eslint-disable-next-line react/no-danger
+                                    dangerouslySetInnerHTML={{
+                                        __html: fileWithHighlights,
+                                    }}
+                                />
+                            </div>
+                        ) : null}
                     </>
                 </Overlay>
             </pre>

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -154,6 +154,7 @@ const useRemoteConnection = () => {
         } catch (error: unknown) {
             if (axios.isAxiosError(error)) {
                 const errorMessage = error.response?.data?.error || error.message || 'Failed to read remote file';
+
                 return { data: null, error: errorMessage };
             }
 

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -150,9 +150,14 @@ const useRemoteConnection = () => {
                 },
             );
 
-            return response.data;
-        } catch (error) {
-            return axios.isAxiosError(error) ? error.message : error;
+            return { data: response.data, error: null };
+        } catch (error: unknown) {
+            if (axios.isAxiosError(error)) {
+                const errorMessage = error.response?.data?.error || error.message || 'Failed to read remote file';
+                return { data: null, error: errorMessage };
+            }
+
+            return { data: null, error: 'An unexpected error occurred' };
         }
     };
 


### PR DESCRIPTION
Outputs error message into the UI instead of just nothing like it currently does.

<img width="1346" height="840" alt="Screenshot 2026-02-11 at 11 55 52" src="https://github.com/user-attachments/assets/5c7762bc-8515-49b1-a481-11beed864819" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1199.
