### PR TITLE
Improve SSH key handling

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -17,6 +17,7 @@ from ttnn_visualizer.exceptions import (
     SSHException,
 )
 from ttnn_visualizer.instances import get_or_create_instance
+from ttnn_visualizer.ssh_client import _SSH_AUTH_MESSAGE
 
 logger = logging.getLogger(__name__)
 
@@ -69,20 +70,11 @@ def remote_exception_handler(func):
         try:
             return func(*args, **kwargs)
         except AuthenticationException as err:
-            # Log the detailed error for debugging, but don't show full traceback
             current_app.logger.warning(
                 f"SSH authentication failed for {connection.username}@{connection.host}: SSH key authentication required"
             )
-
-            # Return user-friendly error message about SSH keys
-            user_message = (
-                "SSH authentication failed. This application requires SSH key-based authentication."
-                " Please ensure your SSH public key is added to the authorized_keys file on the remote server."
-                "Password authentication is not supported."
-            )
-
             raise AuthenticationFailedException(
-                message=user_message,
+                message=_SSH_AUTH_MESSAGE,
                 status=ConnectionTestStates.FAILED,
             )
         except FileNotFoundError as err:

--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -17,7 +17,7 @@ from ttnn_visualizer.exceptions import (
     SSHException,
 )
 from ttnn_visualizer.instances import get_or_create_instance
-from ttnn_visualizer.ssh_client import _SSH_AUTH_MESSAGE
+from ttnn_visualizer.ssh_client import SSH_AUTH_FAILURE_MESSAGE
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ def remote_exception_handler(func):
                 f"SSH authentication failed for {connection.username}@{connection.host}: SSH key authentication required"
             )
             raise AuthenticationFailedException(
-                message=_SSH_AUTH_MESSAGE,
+                message=SSH_AUTH_FAILURE_MESSAGE,
                 status=ConnectionTestStates.FAILED,
             )
         except FileNotFoundError as err:

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -194,6 +194,7 @@ class RemoteConnection(SerializeableModel):
     port: int = Field(ge=1, le=65535)
     profilerPath: str
     performancePath: Optional[str] = None
+    identityFile: Optional[str] = None
 
 
 class StatusMessage(SerializeableModel):

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -36,7 +37,7 @@ def _ssh_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
     cmd = ["ssh"]
     identity = (getattr(remote_connection, "identityFile", None) or "").strip()
     if identity:
-        cmd.extend(["-F", "/dev/null"])
+        cmd.extend(["-F", os.devnull])
     cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
     if identity:
         cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])
@@ -51,7 +52,7 @@ def _sftp_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
     cmd = ["sftp"]
     identity = (getattr(remote_connection, "identityFile", None) or "").strip()
     if identity:
-        cmd.extend(["-F", "/dev/null"])
+        cmd.extend(["-F", os.devnull])
     cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
     if identity:
         cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -127,7 +127,7 @@ def resolve_file_path(remote_connection, file_path: str) -> str:
     """
     if "*" in file_path:
         # Build SSH command to list files matching the pattern (never prompts for password)
-        ssh_cmd = _ssh_cmd_prefix(remote_connection) + [f"ls -1 {file_path}"]
+        ssh_cmd = _ssh_cmd_prefix(remote_connection) + [f"ls -1 '{file_path}'"]
 
         try:
             result = subprocess.run(ssh_cmd, capture_output=True, text=True, check=True)

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -22,7 +22,7 @@ from ttnn_visualizer.exceptions import (
 )
 from ttnn_visualizer.models import RemoteConnection, RemoteReportFolder
 from ttnn_visualizer.sockets import FileProgress, FileStatus, emit_file_status
-from ttnn_visualizer.ssh_client import _SSH_AUTH_MESSAGE, SSHClient
+from ttnn_visualizer.ssh_client import SSH_AUTH_FAILURE_MESSAGE, SSHClient
 from ttnn_visualizer.utils import update_last_synced
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ def handle_ssh_subprocess_error(
             "host key verification failed",
         ]
     ):
-        raise AuthenticationException(_SSH_AUTH_MESSAGE)
+        raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)
     if any(
         conn_err in stderr
         for conn_err in [

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -33,15 +33,13 @@ TEST_PROFILER_FILE = "profile_log_device.csv"
 
 def _ssh_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
     """Build SSH command prefix (never prompts for password). Includes BatchMode=yes and optional identity file."""
-    cmd = [
-        "ssh",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "PasswordAuthentication=no",
-    ]
-    if getattr(remote_connection, "identityFile", None):
-        cmd.extend(["-i", remote_connection.identityFile])
+    cmd = ["ssh"]
+    identity = (getattr(remote_connection, "identityFile", None) or "").strip()
+    if identity:
+        cmd.extend(["-F", "/dev/null"])
+    cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
+    if identity:
+        cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])
     if remote_connection.port != 22:
         cmd.extend(["-p", str(remote_connection.port)])
     cmd.append(f"{remote_connection.username}@{remote_connection.host}")
@@ -50,15 +48,13 @@ def _ssh_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
 
 def _sftp_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
     """Build SFTP command prefix (never prompts for password). Includes BatchMode=yes and optional identity file."""
-    cmd = [
-        "sftp",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "PasswordAuthentication=no",
-    ]
-    if getattr(remote_connection, "identityFile", None):
-        cmd.extend(["-i", remote_connection.identityFile])
+    cmd = ["sftp"]
+    identity = (getattr(remote_connection, "identityFile", None) or "").strip()
+    if identity:
+        cmd.extend(["-F", "/dev/null"])
+    cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
+    if identity:
+        cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])
     if remote_connection.port != 22:
         cmd.extend(["-P", str(remote_connection.port)])
     cmd.extend(["-b", "-", f"{remote_connection.username}@{remote_connection.host}"])

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -20,7 +20,7 @@ from ttnn_visualizer.models import RemoteConnection
 logger = logging.getLogger(__name__)
 
 # User-facing message for SSH auth failures (key-based auth required, no password).
-_SSH_AUTH_MESSAGE = (
+SSH_AUTH_FAILURE_MESSAGE = (
     "SSH authentication failed. This application requires SSH key-based authentication. "
     "Add your public key to ~/.ssh/authorized_keys on the remote server. "
     "Password authentication is not supported. "
@@ -103,7 +103,7 @@ class SSHClient:
                 "host key verification failed",
             ]
         ):
-            raise AuthenticationException(_SSH_AUTH_MESSAGE)
+            raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)
 
         # Check for connection failures (including DNS resolution failures)
         elif any(
@@ -179,7 +179,7 @@ class SSHClient:
             )
             raw_error = getattr(self, "_last_raw_error", None)
             raise AuthenticationFailedException(
-                message=_SSH_AUTH_MESSAGE, detail=raw_error
+                message=SSH_AUTH_FAILURE_MESSAGE, detail=raw_error
             )
         except NoValidConnectionsError as ssh_err:
             user_message = (

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import logging
+import os
 import subprocess
 from pathlib import Path
 from typing import List, Optional, Union
@@ -50,7 +51,7 @@ class SSHClient:
         identity = (getattr(self.connection, "identityFile", None) or "").strip()
         if identity:
             # Use empty config so only our -i key is tried (ignore ~/.ssh/config IdentityFile).
-            cmd.extend(["-F", "/dev/null"])
+            cmd.extend(["-F", os.devnull])
         cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
         if identity:
             cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])
@@ -64,7 +65,7 @@ class SSHClient:
         cmd = ["sftp"]
         identity = (getattr(self.connection, "identityFile", None) or "").strip()
         if identity:
-            cmd.extend(["-F", "/dev/null"])
+            cmd.extend(["-F", os.devnull])
         cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
         if identity:
             cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -37,7 +37,7 @@ class SSHClient:
     def __init__(self, connection: RemoteConnection):
         self.connection = connection
         identity = getattr(connection, "identityFile", None)
-        logger.info(
+        logger.debug(
             "SSHClient connection.identityFile=%r (will use only this key if set)",
             identity,
         )

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1197,7 +1197,7 @@ def test_remote_folder():
         )
 
     connection = RemoteConnection.model_validate(connection_data, strict=False)
-    logger.info(
+    logger.debug(
         "test_remote_folder request identityFile=%r, connection.identityFile=%r",
         connection_data.get("identityFile"),
         getattr(connection, "identityFile", None),

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1196,7 +1196,12 @@ def test_remote_folder():
             status=HTTPStatus.BAD_REQUEST, response="Missing connection data"
         )
 
-    connection = RemoteConnection.model_validate(connection_data)
+    connection = RemoteConnection.model_validate(connection_data, strict=False)
+    logger.info(
+        "test_remote_folder request identityFile=%r, connection.identityFile=%r",
+        connection_data.get("identityFile"),
+        getattr(connection, "identityFile", None),
+    )
     statuses = []
 
     def add_status(status, message, detail=None):

--- a/docs/src/remote-sync.md
+++ b/docs/src/remote-sync.md
@@ -83,7 +83,7 @@ ssh username@hostname
 ```
 You should get a shell without being asked for a password (or passphrase, if you used ssh-add).
 
-### For developers: why the app never prompts
+### Why the app never prompts
 
 The app runs `ssh`/`sftp` via subprocess with no TTY and with `BatchMode=yes`, so the SSH client never prompts for a password or passphrase. If key-based auth isn’t already satisfied (e.g. key in ssh-agent), the connection fails and the app shows an error. When the user sets a custom identity file, the app also passes `-F /dev/null` for that run so SSH does not read `~/.ssh/config`; that way a catch-all `IdentityFile` in config (e.g. `Host * IdentityFile ~/.ssh/id_ed25519`) doesn’t override or conflict with the key the user chose in the UI.
 

--- a/docs/src/remote-sync.md
+++ b/docs/src/remote-sync.md
@@ -11,41 +11,83 @@ TT-NN Visualizer supports syncing data from remote servers via SSH. This feature
 
 ## SSH Setup
 
+### How SSH key authentication works (overview)
+
+Remote sync uses **SSH key-based authentication only**. The app never asks for a password or passphrase in the UI, and the underlying SSH commands are run in a way that prevents the terminal from prompting you. You must set things up so that the key is usable without interaction.
+
+**The pieces:**
+
+1. **Key pair** – You have a **private key** (e.g. `~/.ssh/id_ed25519`) and a **public key** (e.g. `~/.ssh/id_ed25519.pub`). The private key stays on your machine; the public key is what the server trusts.
+
+2. **Server** – On the remote host, your **public key** must be in the right place: one line per key in `~/.ssh/authorized_keys` for the user you connect as (e.g. `ctr-smountenay@aus-wh-05` → that user’s `~/.ssh/authorized_keys` on the server).
+
+3. **Identity file** – The “SSH identity file” in the app is the **path to your private key** on your machine. If you leave it empty, SSH uses its default (e.g. `~/.ssh/id_ed25519`). If you use a different key or path, enter it here (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). When you set a custom identity, the app tells SSH to use only that key (and to ignore `~/.ssh/config` for that connection) so the right key is used.
+
+4. **Passphrase** – If your private key has a **passphrase**, SSH would normally prompt for it. The app does not have a place to type that, and the SSH process has no terminal. So you must **unlock the key once** using **ssh-agent**; after that, the agent provides the key and no prompt is needed:
+   ```bash
+   ssh-add ~/.ssh/id_ed25519
+   ```
+   (Use the same path as your identity file.) Enter the passphrase once; then the app (and any `ssh` that uses that agent) can use the key without prompting. If the app is started from a terminal, run `ssh-add` in that same terminal before starting the app so the agent is available.
+
+**Quick checklist before using remote sync:**
+
+- [ ] Public key is in `~/.ssh/authorized_keys` on the **remote** server (for the user you connect as).
+- [ ] You can log in from a terminal without a password: `ssh username@hostname` (or `ssh -i /path/to/key username@hostname` if you use a non-default key).
+- [ ] If the key has a passphrase: you’ve run `ssh-add /path/to/private_key` in an environment the app can use (e.g. the same terminal where you start the app), so the agent holds the unlocked key.
+
 ### Prerequisites
+
 **Important:** Remote sync requires SSH key-based authentication. Password authentication is not supported.
 
 Before using remote sync, ensure that:
-1. Your SSH public key is added to the `~/.ssh/authorized_keys` file on the remote server
-2. You can successfully connect to the remote server using SSH without a password prompt
-3. Your SSH agent is running and has your private key loaded (if using a passphrase-protected key)
 
-To test SSH key authentication:
+1. Your SSH **public** key is in the `~/.ssh/authorized_keys` file on the **remote** server (for the username you use in the app).
+2. You can connect from a terminal without a password (and without a passphrase prompt if you use ssh-agent).
+3. If your key has a passphrase: the key is loaded in ssh-agent (e.g. `ssh-add /path/to/key`) in the same environment you use to start the app.
+
+To test from a terminal (use the same host and user as in the app):
+
 ```bash
 ssh username@hostname
+# Or, if you use a custom key:
+ssh -i /path/to/your_private_key username@hostname
 ```
 
-If you're prompted for a password, SSH key authentication is not properly configured.
+If you’re prompted for a password, the public key is not correctly set up on the server. If you’re prompted for a passphrase, use `ssh-add` as above.
 
-### Setting Up SSH Key Authentication
+### Setting up SSH key authentication (first time)
 
-If you haven't set up SSH key authentication yet, follow these steps:
+If you don’t have a key yet or haven’t set up the server:
 
-#### 1. Generate SSH Key Pair (if you don't have one)
+#### 1. Generate a key pair (if you don’t have one)
 ```bash
 ssh-keygen -t ed25519 -C "your_email@example.com"
 ```
 
-#### 2. Copy Public Key to Remote Server
+#### 2. Put your public key on the remote server
 ```bash
 ssh-copy-id username@hostname
 ```
+This appends your public key to `~/.ssh/authorized_keys` on the server. If you use a non-default key:
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519.pub username@hostname
+```
 
-#### 3. Verify SSH Key Authentication
+#### 3. If the key has a passphrase: load it into ssh-agent (so the app can use it)
+```bash
+ssh-add ~/.ssh/id_ed25519
+```
+Use the path to your **private** key. Enter the passphrase once; after that, the agent provides the key and you won’t be prompted when using the app (as long as the app runs in an environment that has access to the same agent, e.g. started from the same terminal).
+
+#### 4. Verify from a terminal
 ```bash
 ssh username@hostname
 ```
+You should get a shell without being asked for a password (or passphrase, if you used ssh-add).
 
-You should be able to connect without entering a password.
+### For developers: why the app never prompts
+
+The app runs `ssh`/`sftp` via subprocess with no TTY and with `BatchMode=yes`, so the SSH client never prompts for a password or passphrase. If key-based auth isn’t already satisfied (e.g. key in ssh-agent), the connection fails and the app shows an error. When the user sets a custom **identity file**, the app also passes `-F /dev/null` for that run so SSH does not read `~/.ssh/config`; that way a catch-all `IdentityFile` in config (e.g. `Host * IdentityFile ~/.ssh/id_ed25519`) doesn’t override or conflict with the key the user chose in the UI.
 
 ## Using Remote Sync
 
@@ -54,14 +96,14 @@ sync the individual reports you would like to use.
 
 ### Add SSH Connection
 
-1. Open TT-NN Visualizer and navigate to the Reports tab
-2. In the "Remote Sync" section, click the "+ Add New Connection" button
-3. Enter your SSH connection details (hostname, username, and report paths)
-4. Optionally specify an **SSH identity file** (path to your private key, e.g. `~/.ssh/id_ed25519`) if you use a non-default key or have multiple keys.
-5. Click the "Test Connection" button to ensure a connection can be made
-6. If connection is valid, click the "Add connection" button to save the connection details
+1. Open TT-NN Visualizer and navigate to the Reports tab.
+2. In the "Remote Sync" section, click "+ Add New Connection".
+3. Enter your SSH connection details (hostname, username, and report paths).
+4. **SSH identity file (optional):** Path to your **private** key on this machine (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). Leave empty to use SSH’s default. Use this if you have multiple keys or the key is not in the default location. When set, the app uses only this key and ignores `~/.ssh/config` for this connection.
+5. **Passphrase:** The app never prompts for a passphrase. If your key has one, run `ssh-add /path/to/your_private_key` once (in the same terminal you use to start the app, or in an environment the app can see), then start the app.
+6. Click "Test Connection". If it succeeds, click "Add connection".
 
-If authentication fails, the app will show a message explaining that key-based authentication is required: add your public key to `~/.ssh/authorized_keys` on the remote server. Password authentication is not supported. If your key has a passphrase, add it to ssh-agent once (e.g. `ssh-add ~/.ssh/id_ed25519`) so you are not prompted.
+If authentication fails, the app will show a short message. Common causes: public key not in `~/.ssh/authorized_keys` on the server; wrong identity file path; or key has a passphrase and is not in ssh-agent (run `ssh-add` and restart the app from that environment). See [How SSH key authentication works](#how-ssh-key-authentication-works-overview) above for the full picture.
 
 Make sure you have sufficient local storage space for the files you want to sync.
 

--- a/docs/src/remote-sync.md
+++ b/docs/src/remote-sync.md
@@ -18,11 +18,11 @@ Remote sync uses SSH key-based authentication only. The app never asks for a pas
 The pieces:
 1. Key pair – You have a private key (e.g. `~/.ssh/id_ed25519`) and a public key (e.g. `~/.ssh/id_ed25519.pub`). The private key stays on your machine; the public key is what the server trusts.
 
-2. Server – On the remote host, your public key must be in the right place: one line per key in `~/.ssh/authorized_keys` for the user you connect as (e.g. `ctr-smountenay@aus-wh-05` → that user’s `~/.ssh/authorized_keys` on the server).
+2. Server – On the remote host, your public key must be in the right place: one line per key in `~/.ssh/authorized_keys` for the user you connect as.
 
-3. Identity file – The “SSH identity file” in the app is the path to your private key on your machine. If you leave it empty, SSH uses its default (e.g. `~/.ssh/id_ed25519`). If you use a different key or path, enter it here (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). When you set a custom identity, the app tells SSH to use only that key (and to ignore `~/.ssh/config` for that connection) so the right key is used.
+3. Identity file – The “SSH identity file” in the app is the path to your private key on your machine. If you leave it empty, SSH uses its default (e.g. `~/.ssh/id_ed25519`). If you use a different key or path, enter the path here. When you set a custom identity, the app tells SSH to use only that key (and to ignore `~/.ssh/config` for that connection) so the right key is used.
 
-4. Passphrase – If your private key has a passphrase, SSH would normally prompt for it. The app does not have a place to type that, and the SSH process has no terminal. So you must unlock the key once using ssh-agent; after that, the agent provides the key and no prompt is needed:
+4. Passphrase – If your private key has a passphrase, SSH would normally prompt for it. The app does not have a place to type that, and the SSH process has no terminal. You must unlock the key once using ssh-agent; after that, the agent provides the key and no prompt is needed:
    ```bash
    ssh-add ~/.ssh/id_ed25519
    ```

--- a/docs/src/remote-sync.md
+++ b/docs/src/remote-sync.md
@@ -57,8 +57,11 @@ sync the individual reports you would like to use.
 1. Open TT-NN Visualizer and navigate to the Reports tab
 2. In the "Remote Sync" section, click the "+ Add New Connection" button
 3. Enter your SSH connection details (hostname, username, and report paths)
-4. Click the "Test Connection" button to ensure a connection can be made
-5. If connection is valid, click the "Add connection" button to save the connection details
+4. Optionally specify an **SSH identity file** (path to your private key, e.g. `~/.ssh/id_ed25519`) if you use a non-default key or have multiple keys.
+5. Click the "Test Connection" button to ensure a connection can be made
+6. If connection is valid, click the "Add connection" button to save the connection details
+
+If authentication fails, the app will show a message explaining that key-based authentication is required: add your public key to `~/.ssh/authorized_keys` on the remote server. Password authentication is not supported. If your key has a passphrase, add it to ssh-agent once (e.g. `ssh-add ~/.ssh/id_ed25519`) so you are not prompted.
 
 Make sure you have sufficient local storage space for the files you want to sync.
 

--- a/docs/src/remote-sync.md
+++ b/docs/src/remote-sync.md
@@ -13,35 +13,33 @@ TT-NN Visualizer supports syncing data from remote servers via SSH. This feature
 
 ### How SSH key authentication works (overview)
 
-Remote sync uses **SSH key-based authentication only**. The app never asks for a password or passphrase in the UI, and the underlying SSH commands are run in a way that prevents the terminal from prompting you. You must set things up so that the key is usable without interaction.
+Remote sync uses SSH key-based authentication only. The app never asks for a password or passphrase in the UI, and the underlying SSH commands are run in a way that prevents the terminal from prompting you. You must set things up so that the key is usable without interaction.
 
-**The pieces:**
+The pieces:
+1. Key pair – You have a private key (e.g. `~/.ssh/id_ed25519`) and a public key (e.g. `~/.ssh/id_ed25519.pub`). The private key stays on your machine; the public key is what the server trusts.
 
-1. **Key pair** – You have a **private key** (e.g. `~/.ssh/id_ed25519`) and a **public key** (e.g. `~/.ssh/id_ed25519.pub`). The private key stays on your machine; the public key is what the server trusts.
+2. Server – On the remote host, your public key must be in the right place: one line per key in `~/.ssh/authorized_keys` for the user you connect as (e.g. `ctr-smountenay@aus-wh-05` → that user’s `~/.ssh/authorized_keys` on the server).
 
-2. **Server** – On the remote host, your **public key** must be in the right place: one line per key in `~/.ssh/authorized_keys` for the user you connect as (e.g. `ctr-smountenay@aus-wh-05` → that user’s `~/.ssh/authorized_keys` on the server).
+3. Identity file – The “SSH identity file” in the app is the path to your private key on your machine. If you leave it empty, SSH uses its default (e.g. `~/.ssh/id_ed25519`). If you use a different key or path, enter it here (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). When you set a custom identity, the app tells SSH to use only that key (and to ignore `~/.ssh/config` for that connection) so the right key is used.
 
-3. **Identity file** – The “SSH identity file” in the app is the **path to your private key** on your machine. If you leave it empty, SSH uses its default (e.g. `~/.ssh/id_ed25519`). If you use a different key or path, enter it here (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). When you set a custom identity, the app tells SSH to use only that key (and to ignore `~/.ssh/config` for that connection) so the right key is used.
-
-4. **Passphrase** – If your private key has a **passphrase**, SSH would normally prompt for it. The app does not have a place to type that, and the SSH process has no terminal. So you must **unlock the key once** using **ssh-agent**; after that, the agent provides the key and no prompt is needed:
+4. Passphrase – If your private key has a passphrase, SSH would normally prompt for it. The app does not have a place to type that, and the SSH process has no terminal. So you must unlock the key once using ssh-agent; after that, the agent provides the key and no prompt is needed:
    ```bash
    ssh-add ~/.ssh/id_ed25519
    ```
    (Use the same path as your identity file.) Enter the passphrase once; then the app (and any `ssh` that uses that agent) can use the key without prompting. If the app is started from a terminal, run `ssh-add` in that same terminal before starting the app so the agent is available.
 
-**Quick checklist before using remote sync:**
-
-- [ ] Public key is in `~/.ssh/authorized_keys` on the **remote** server (for the user you connect as).
+Quick checklist before using remote sync:
+- [ ] Public key is in `~/.ssh/authorized_keys` on the remote server (for the user you connect as).
 - [ ] You can log in from a terminal without a password: `ssh username@hostname` (or `ssh -i /path/to/key username@hostname` if you use a non-default key).
 - [ ] If the key has a passphrase: you’ve run `ssh-add /path/to/private_key` in an environment the app can use (e.g. the same terminal where you start the app), so the agent holds the unlocked key.
 
 ### Prerequisites
 
-**Important:** Remote sync requires SSH key-based authentication. Password authentication is not supported.
+Important: Remote sync requires SSH key-based authentication. Password authentication is not supported.
 
 Before using remote sync, ensure that:
 
-1. Your SSH **public** key is in the `~/.ssh/authorized_keys` file on the **remote** server (for the username you use in the app).
+1. Your SSH public key is in the `~/.ssh/authorized_keys` file on the remote server (for the username you use in the app).
 2. You can connect from a terminal without a password (and without a passphrase prompt if you use ssh-agent).
 3. If your key has a passphrase: the key is loaded in ssh-agent (e.g. `ssh-add /path/to/key`) in the same environment you use to start the app.
 
@@ -77,7 +75,7 @@ ssh-copy-id -i ~/.ssh/id_ed25519.pub username@hostname
 ```bash
 ssh-add ~/.ssh/id_ed25519
 ```
-Use the path to your **private** key. Enter the passphrase once; after that, the agent provides the key and you won’t be prompted when using the app (as long as the app runs in an environment that has access to the same agent, e.g. started from the same terminal).
+Use the path to your private key. Enter the passphrase once; after that, the agent provides the key and you won’t be prompted when using the app (as long as the app runs in an environment that has access to the same agent, e.g. started from the same terminal).
 
 #### 4. Verify from a terminal
 ```bash
@@ -87,7 +85,7 @@ You should get a shell without being asked for a password (or passphrase, if you
 
 ### For developers: why the app never prompts
 
-The app runs `ssh`/`sftp` via subprocess with no TTY and with `BatchMode=yes`, so the SSH client never prompts for a password or passphrase. If key-based auth isn’t already satisfied (e.g. key in ssh-agent), the connection fails and the app shows an error. When the user sets a custom **identity file**, the app also passes `-F /dev/null` for that run so SSH does not read `~/.ssh/config`; that way a catch-all `IdentityFile` in config (e.g. `Host * IdentityFile ~/.ssh/id_ed25519`) doesn’t override or conflict with the key the user chose in the UI.
+The app runs `ssh`/`sftp` via subprocess with no TTY and with `BatchMode=yes`, so the SSH client never prompts for a password or passphrase. If key-based auth isn’t already satisfied (e.g. key in ssh-agent), the connection fails and the app shows an error. When the user sets a custom identity file, the app also passes `-F /dev/null` for that run so SSH does not read `~/.ssh/config`; that way a catch-all `IdentityFile` in config (e.g. `Host * IdentityFile ~/.ssh/id_ed25519`) doesn’t override or conflict with the key the user chose in the UI.
 
 ## Using Remote Sync
 
@@ -99,8 +97,8 @@ sync the individual reports you would like to use.
 1. Open TT-NN Visualizer and navigate to the Reports tab.
 2. In the "Remote Sync" section, click "+ Add New Connection".
 3. Enter your SSH connection details (hostname, username, and report paths).
-4. **SSH identity file (optional):** Path to your **private** key on this machine (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). Leave empty to use SSH’s default. Use this if you have multiple keys or the key is not in the default location. When set, the app uses only this key and ignores `~/.ssh/config` for this connection.
-5. **Passphrase:** The app never prompts for a passphrase. If your key has one, run `ssh-add /path/to/your_private_key` once (in the same terminal you use to start the app, or in an environment the app can see), then start the app.
+4. SSH identity file (optional): Path to your private key on this machine (e.g. `~/.ssh/id_ed25519` or `/Users/you/break_id_ed25519_test`). Leave empty to use SSH’s default. Use this if you have multiple keys or the key is not in the default location. When set, the app uses only this key and ignores `~/.ssh/config` for this connection.
+5. Passphrase: The app never prompts for a passphrase. If your key has one, run `ssh-add /path/to/your_private_key` once (in the same terminal you use to start the app, or in an environment the app can see), then start the app.
 6. Click "Test Connection". If it succeeds, click "Add connection".
 
 If authentication fails, the app will show a short message. Common causes: public key not in `~/.ssh/authorized_keys` on the server; wrong identity file path; or key has a passphrase and is not in ssh-agent (run `ssh-add` and restart the app from that environment). See [How SSH key authentication works](#how-ssh-key-authentication-works-overview) above for the full picture.

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -173,7 +173,7 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
 
                 <FormGroup
                     label='SSH identity file (optional)'
-                    subLabel='Path to private key (e.g. ~/.ssh/id_ed25519). Your public key must be in ~/.ssh/authorized_keys on the server. If the key has a passphrase, add it to ssh-agent (ssh-add) first.'
+                    subLabel='Path to your private key on this machine (e.g. ~/.ssh/id_ed25519). Leave empty for default. The matching public key must be in ~/.ssh/authorized_keys on the server. If the key has a passphrase, run: ssh-add /path/to/key (once, in the same environment where you start this app).'
                     labelFor='remote-ssh-identity'
                 >
                     <InputGroup

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -172,6 +172,24 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
                 </FormGroup>
 
                 <FormGroup
+                    label='SSH identity file (optional)'
+                    subLabel='Path to private key (e.g. ~/.ssh/id_ed25519). Your public key must be in ~/.ssh/authorized_keys on the server. If the key has a passphrase, add it to ssh-agent (ssh-add) first.'
+                    labelFor='remote-ssh-identity'
+                >
+                    <InputGroup
+                        id='remote-ssh-identity'
+                        placeholder='Leave empty for default key'
+                        value={connection.identityFile ?? ''}
+                        onChange={(e) =>
+                            setConnection({
+                                ...connection,
+                                identityFile: e.target.value.trim() || undefined,
+                            })
+                        }
+                    />
+                </FormGroup>
+
+                <FormGroup
                     label='Memory report folder path'
                     subLabel='Path to a remote folder containing memory reports (e.g., "/<PATH TO TT METAL>/generated/ttnn/reports/")'
                     labelFor='remote-memory-path'

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -173,7 +173,7 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
 
                 <FormGroup
                     label='SSH identity file (optional)'
-                    subLabel='Path to your private key on this machine (e.g. ~/.ssh/id_ed25519). Leave empty for default. The matching public key must be in ~/.ssh/authorized_keys on the server. If the key has a passphrase, run: ssh-add /path/to/key (once, in the same environment where you start this app).'
+                    subLabel='Path to your private key on this machine (e.g. ~/.ssh/id_ed25519). Leave empty for default.'
                     labelFor='remote-ssh-identity'
                 >
                     <InputGroup

--- a/src/definitions/RemoteConnection.ts
+++ b/src/definitions/RemoteConnection.ts
@@ -11,8 +11,7 @@ export interface RemoteConnection {
     port: number;
     profilerPath: string;
     performancePath?: string;
-    /** Optional path to SSH private key (e.g. ~/.ssh/id_ed25519). Key must be in authorized_keys on the server. */
-    identityFile?: string;
+    identityFile?: string; // Optional path to SSH private key.
 }
 
 export interface RemoteFolder {

--- a/src/definitions/RemoteConnection.ts
+++ b/src/definitions/RemoteConnection.ts
@@ -11,6 +11,8 @@ export interface RemoteConnection {
     port: number;
     profilerPath: string;
     performancePath?: string;
+    /** Optional path to SSH private key (e.g. ~/.ssh/id_ed25519). Key must be in authorized_keys on the server. */
+    identityFile?: string;
 }
 
 export interface RemoteFolder {


### PR DESCRIPTION
This PR improves SSH invocation in the app, to ensure it is called with consistent parameters. It also adds the ability to specific a custom private key file, and improves the documentation to emphasize the need to be able to connect to the remote host without a password or passphrase.

Prior to this PR, there was not a common method to call the `ssh` command. In most of the spots where `ssh` was called, it was being called with parameters to ensure it did not prompt for a password, but there were a few places that were missed and where it did prompt for a password in the terminal. It was unintended that users could ever be prompted for a password in the Flask terminal, and with this PR, it should prevent the user ever being prompted in the terminal for a password. Moving to a command function for calling `ssh` helps to ensure this.

A new feature has been added to allow the user to set the key to use when connecting to the remote host. Previously it was assumed that it was already configured in the `~/.ssh/config` file, but now the user can specify the key in the UI.

The docs and error messages were updated to reflect that the private key must be added to `ssh-agent` also. The reason this is necessary is because if the private key file is locked, there is no way to enter the passphrase in the web ui. We don't want to handle passwords and passphrases in the Flask app, but it wasn't obvious that the key also needs to be added to `ssh-agent` to prevent being prompted for a passphrase. It was never intended for a user to enter a passphrase, but it was an side-effect of the paramiko to cli ssh refactor that the user could get prompted in the Flask terminal if the key had a passphrase. This should not happen now.

If a key file is set when configuring the remote connection, it will exclusively use that key, and ignore the `~/.ssh/config` file. I did that because I was getting confusing errors during dev, which made it look like it wasn't using the key I was specifying, when really it was failing due to other issues from the user's SSH config.

[Closes #1189]