### PR TITLE
Feature/Check for cluster description locally

### DIFF
--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -166,7 +166,7 @@ def get_cluster_desc(instance: Instance):
     cluster_path = report_path / "cluster_descriptor.yaml"
 
     if cluster_path.exists():
-        with open(cluster_path) as cluster_desc_file:
+        with open(cluster_path, "r", encoding="utf-8") as cluster_desc_file:
             return yaml.safe_load(cluster_desc_file)
     else:
         return None

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -160,6 +160,8 @@ def resolve_file_path(remote_connection, file_path: str) -> str:
 
 
 def get_cluster_desc(instance: Instance):
+    if not instance.profiler_path:
+        return None
     report_path = Path(instance.profiler_path).parent
     cluster_path = report_path / "cluster_descriptor.yaml"
 

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -159,7 +159,6 @@ def resolve_file_path(remote_connection, file_path: str) -> str:
     return file_path
 
 
-@remote_exception_handler
 def get_cluster_desc(instance: Instance):
     report_path = Path(instance.profiler_path).parent
     cluster_path = report_path / "cluster_descriptor.yaml"
@@ -168,7 +167,7 @@ def get_cluster_desc(instance: Instance):
         with open(cluster_path) as cluster_desc_file:
             return yaml.safe_load(cluster_desc_file)
     else:
-        raise FileNotFoundError(f"File not found at {cluster_path}")
+        return None
 
 
 def is_excluded(file_path, exclude_patterns):

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1155,7 +1155,7 @@ def get_cluster_descriptor(instance: Instance):
     except Exception as e:
         return (
             jsonify({"error": f"An unexpected error occurred: {str(e)}"}),
-            HTTPStatus.NOT_FOUND,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
         )
 
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1133,24 +1133,21 @@ def get_remote_folders_performance():
 @with_instance
 def get_cluster_descriptor(instance: Instance):
     try:
-        cluster_desc_file = get_cluster_desc(instance)
+        cluster_desc = get_cluster_desc(instance)
 
-        if not cluster_desc_file:
+        if not cluster_desc:
             return (
                 jsonify({"error": "cluster_descriptor.yaml not found"}),
                 HTTPStatus.NOT_FOUND,
             )
 
-        return jsonify(cluster_desc_file), HTTPStatus.OK
+        return jsonify(cluster_desc), HTTPStatus.OK
 
     except yaml.YAMLError as e:
         return (
             jsonify({"error": f"Failed to parse YAML: {str(e)}"}),
             HTTPStatus.BAD_REQUEST,
         )
-
-    except RemoteConnectionException as e:
-        return jsonify({"error": e.message}), e.http_status
 
     except Exception as e:
         return (

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1132,36 +1132,31 @@ def get_remote_folders_performance():
 @api.route("/cluster-descriptor", methods=["GET"])
 @with_instance
 def get_cluster_descriptor(instance: Instance):
-    if instance.remote_connection:
-        try:
-            cluster_desc_file = get_cluster_desc(instance.remote_connection)
-            if not cluster_desc_file:
-                return jsonify({"error": "cluster_descriptor.yaml not found"}), 404
-            yaml_data = yaml.safe_load(cluster_desc_file.decode("utf-8"))
-            return jsonify(yaml_data), 200
+    try:
+        cluster_desc_file = get_cluster_desc(instance)
 
-        except yaml.YAMLError as e:
-            return jsonify({"error": f"Failed to parse YAML: {str(e)}"}), 400
+        if not cluster_desc_file:
+            return (
+                jsonify({"error": "cluster_descriptor.yaml not found"}),
+                HTTPStatus.NOT_FOUND,
+            )
 
-        except RemoteConnectionException as e:
-            return jsonify({"error": e.message}), e.http_status
+        return jsonify(cluster_desc_file), HTTPStatus.OK
 
-        except Exception as e:
-            return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
-    else:
-        local_path = get_cluster_descriptor_path(instance)
+    except yaml.YAMLError as e:
+        return (
+            jsonify({"error": f"Failed to parse YAML: {str(e)}"}),
+            HTTPStatus.BAD_REQUEST,
+        )
 
-        if not local_path:
-            return jsonify({"error": "cluster_descriptor.yaml not found"}), 404
+    except RemoteConnectionException as e:
+        return jsonify({"error": e.message}), e.http_status
 
-        try:
-            with open(local_path) as cluster_desc_file:
-                yaml_data = yaml.safe_load(cluster_desc_file)
-                return jsonify(yaml_data)  # yaml_data is not compatible with orjson
-        except yaml.YAMLError as e:
-            return jsonify({"error": f"Failed to parse YAML: {str(e)}"}), 400
-
-    return jsonify({"error": "Cluster descriptor not found"}), 404
+    except FileNotFoundError as e:
+        return (
+            jsonify({"error": f"An unexpected error occurred: {str(e)}"}),
+            HTTPStatus.NOT_FOUND,
+        )
 
 
 @api.route("/mesh-descriptor", methods=["GET"])
@@ -1178,7 +1173,7 @@ def get_mesh_descriptor(instance: Instance):
         )
 
     try:
-        with open(paths[0]) as mesh_descriptor_path:
+        with open(paths[0], "r", encoding="utf-8") as mesh_descriptor_path:
             yaml_data = yaml.safe_load(mesh_descriptor_path)
             return jsonify(yaml_data)  # yaml_data is not compatible with orjson
     except yaml.YAMLError as e:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1152,7 +1152,7 @@ def get_cluster_descriptor(instance: Instance):
     except RemoteConnectionException as e:
         return jsonify({"error": e.message}), e.http_status
 
-    except FileNotFoundError as e:
+    except Exception as e:
         return (
             jsonify({"error": f"An unexpected error occurred: {str(e)}"}),
             HTTPStatus.NOT_FOUND,

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -47,7 +47,7 @@ function Range() {
 
     const { data: operations } = useOperationsList();
     const { data: perfData, error: perfDataError } = usePerformanceReport(activePerformanceReport?.reportName || null);
-    const { data: clusterData } = useGetClusterDescription();
+    const { data: clusterData, error: clusterError } = useGetClusterDescription();
     const location = useLocation();
     const listPerf = useGetDeviceOperationListPerf();
     const isInSync = listPerf?.length > 0;
@@ -166,6 +166,12 @@ function Range() {
             );
         }
     }, [perfDataError, activePerformanceReport]);
+
+    useEffect(() => {
+        if (clusterError) {
+            createToastNotification('Cluster description not found', 'Topology unavailable', ToastType.WARNING);
+        }
+    }, [clusterError]);
 
     return selectedOperationRange || selectedPerformanceRange ? (
         <div className='range-slider'>

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -9,6 +9,7 @@ import { useLocation } from 'react-router';
 import { useEffect, useState } from 'react';
 import {
     activePerformanceReportAtom,
+    activeProfilerReportAtom,
     comparisonPerformanceReportListAtom,
     hasClusterDescriptionAtom,
     operationRangeAtom,
@@ -35,6 +36,7 @@ import createToastNotification, { ToastType } from '../functions/createToastNoti
 const RANGE_STEP = 25;
 
 function Range() {
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const setOperationRange = useSetAtom(operationRangeAtom);
     const [selectedOperationRange, setSelectedOperationRange] = useAtom(selectedOperationRangeAtom);
@@ -168,10 +170,14 @@ function Range() {
     }, [perfDataError, activePerformanceReport]);
 
     useEffect(() => {
-        if (clusterError) {
-            createToastNotification('Cluster description not found', 'Topology unavailable', ToastType.WARNING);
+        if (clusterError && activeProfilerReport) {
+            createToastNotification(
+                'Cluster description not found, Topology unavailable',
+                activeProfilerReport?.reportName,
+                ToastType.WARNING,
+            );
         }
-    }, [clusterError]);
+    }, [clusterError, activeProfilerReport]);
 
     return selectedOperationRange || selectedPerformanceRange ? (
         <div className='range-slider'>

--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -24,8 +24,8 @@ const CLUSTER_CHIP_SIZE_SMALL = 150;
 
 function ClusterRenderer() {
     const navigate = useNavigate();
-    const clusterDescription = useGetClusterDescription();
-    const { data } = clusterDescription;
+    const { data } = useGetClusterDescription();
+
     // we don't support mixed architecture for now
     // we will default to wormhole
     const arch = stringToArchitecture((data?.arch.length && data.arch[0]) || DEFAULT_ARCHITECTURE);

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -399,8 +399,10 @@ const fetchDeviceMeta = async (name: string | null) => {
 
 const fetchClusterDescription = async (): Promise<ClusterModel> => {
     const { data } = await axiosInstance.get<ClusterModel>(Endpoints.CLUSTER_DESCRIPTOR);
+
     try {
         const { data: meshData } = await axiosInstance.get<MeshData>(Endpoints.MESH_DESCRIPTOR);
+
         if (meshData?.chips) {
             data.chips = meshData.chips;
         }
@@ -408,6 +410,7 @@ const fetchClusterDescription = async (): Promise<ClusterModel> => {
         // eslint-disable-next-line no-console
         console.error('mesh-descriptor not found', err);
     }
+
     return data;
 };
 

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -295,14 +295,14 @@ const fetchReportMeta = async (): Promise<ReportMetaData> => {
     return meta;
 };
 
-const fetchDevices = async (reportName: string) => {
+const fetchDevices = async (reportPath: string) => {
     const { data: meta } = await axiosInstance.get<DeviceInfo[]>(Endpoints.DEVICES);
 
     if (meta.length === 0) {
         // TODO: Report Name here is actually the path because that's what we store in the atom - atom should store ReportFolder object
         createToastNotification(
             'Data integrity warning: No device information provided.',
-            `/${reportName}`,
+            `${reportPath}`,
             ToastType.WARNING,
         );
     }


### PR DESCRIPTION
Discussed that providing more error details is not useful, but I have added a toast warning if there is not cluster description at all (very unlikely).

Most of this PR refactors where we look for the cluster description. Instead of checking a `/tmp/umd_*` folder we always look at the synced folder on the local machine now.

**Python changes**
- Removes get_cluster_desc_path
- Simplified get_cluster_desc
- /cluster-descriptor now uses the simplified get_cluster_desc to look in the active report folder for cluster_description.yaml

**New warning toast**
<img width="1288" height="783" alt="Screenshot 2026-02-17 at 15 12 55" src="https://github.com/user-attachments/assets/b52ffe6a-05a2-460f-9ca6-de6434c5ad29" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1190.