### PR TITLE
Conditionally include operation file identifier

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -95,7 +95,9 @@ const OperationGraph: React.FC<{
                     .filter((op) => !filterOutDeallocate || !op.name.toLowerCase().includes(DEALLOCATE_OP_NAME))
                     .map((op) => ({
                         id: op.id,
-                        label: `${op.id} ${op.name} \n ${op.operationFileIdentifier}`,
+                        label: `${op.id} ${op.name}${
+                            op.operationFileIdentifier ? `\n${op.operationFileIdentifier}` : ''
+                        }`,
                         shape: 'box',
                         filterString: `${op.name}`,
                         deviceOpFilter: op.deviceOperationNameList.join(' '),


### PR DESCRIPTION
Only append the operationFileIdentifier to the node label when it exists. Previously the label always included a newline and placeholder whitespace which produced an extra blank line when the identifier was empty; this change uses a conditional to include `\n<identifier>` only for truthy values, preserving label formatting and avoiding stray whitespace.

Related to https://github.com/tenstorrent/ttnn-visualizer/issues/1259.