### PR TITLE
Add multicast util metric to timeline and model, refactor npe timeline rendering for readability

### DIFF
--- a/src/components/npe/NPEMetadata.tsx
+++ b/src/components/npe/NPEMetadata.tsx
@@ -47,7 +47,7 @@ const NPEMetadata: React.FC<NPEMetadataProps> = ({ info, numTransfers }) => {
                             if (hasKey(key) && info[key] !== undefined) {
                                 return (
                                     <div key={key}>
-                                        <span>{formatMetadataLabel(key)}: </span>
+                                        <span>{formatMetadataLabel(key)} </span>
                                         <span>{formatMetadataValue(key, info[key])}</span>
                                     </div>
                                 );

--- a/src/components/npe/NPEMetadata.tsx
+++ b/src/components/npe/NPEMetadata.tsx
@@ -24,7 +24,7 @@ const NPEMetadata: React.FC<NPEMetadataProps> = ({ info, numTransfers }) => {
         const kpi = NPE_KPI_METADATA[key] as NPE_KPI;
         const unit = kpi.units;
         const decimals = kpi.decimals !== undefined ? kpi.decimals : 2;
-        return `${typeof value === 'number' ? Number(value).toFixed(decimals) : value} ${unit}`;
+        return `${typeof value === 'number' ? Number(value).toFixed(decimals) : value}${unit}`;
     };
     const formatMetadataLabel = (key: keyof CommonInfo) => {
         const KPI: NPE_KPI | null = NPE_KPI_METADATA[key];
@@ -57,7 +57,7 @@ const NPEMetadata: React.FC<NPEMetadataProps> = ({ info, numTransfers }) => {
                 </div>
                 <hr />
                 <div>
-                    <span>Active transfers:</span>
+                    <span>Active transfers: </span>
                     <span>{numTransfers}</span>
                 </div>
             </Collapsible>

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -100,7 +100,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
 
         for (const timestep of timestepList) {
             const links = nocType
-                ? timestep.link_demand.filter((linkData) => String(linkData[NPE_LINK.NOC_ID]).startsWith(nocType))
+                ? timestep.link_demand.filter((linkData) => linkData[NPE_LINK.NOC_ID].startsWith(nocType))
                 : timestep.link_demand;
 
             const worst = Math.max(-1, ...links.map((linkData) => linkData[NPE_LINK.DEMAND]));

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -17,7 +17,9 @@ import {
 } from '../../model/NPEModel';
 import { altCongestionColorsAtom } from '../../store/app';
 
+type MetricPoint = { value: number; color: string };
 type Rect = { x: number; y: number; width: number; height: number };
+
 interface NPEHeatMapProps {
     timestepList: TimestepData[];
     canvasWidth: number;
@@ -86,57 +88,50 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
 
     const canvasZoneHeight = zoneRanges.maxZoneDepth * ZONE_HEIGHT;
     const [tooltip, setTooltip] = useState<{ x: number; y: number; text: React.JSX.Element } | null>(null);
+
     const congestionMapPerTimestamp = useMemo(() => {
-        return {
-            worst: timestepList.map((timestep) => {
-                if (nocType) {
-                    const value = Math.max(
-                        -1,
-                        ...timestep.link_demand
-                            .filter((linkData) => linkData[NPE_LINK.NOC_ID].indexOf(nocType) === 0)
-                            .map((linkData) => linkData[NPE_LINK.DEMAND]),
-                    );
-                    const color = calculateLinkCongestionColor(value, 0, altCongestionColors);
-                    return { value, color };
-                }
-                const value = Math.max(-1, ...timestep.link_demand.map((linkData) => linkData[NPE_LINK.DEMAND]));
-                const color = calculateLinkCongestionColor(value, 0, altCongestionColors);
-                return { value, color };
-            }),
-
-            utilization: timestepList.map((timestep) => {
-                if (nocType) {
-                    const nocData = timestep.noc[nocType];
-                    if (nocData) {
-                        return {
-                            value: nocData.avg_link_util,
-                            color: calculateLinkCongestionColor(nocData.avg_link_util, 0, altCongestionColors),
-                        };
-                    }
-                }
-                return {
-                    value: timestep.avg_link_util,
-                    color: calculateLinkCongestionColor(timestep.avg_link_util, 0, altCongestionColors),
-                };
-            }),
-
-            demand: timestepList.map((timestep) => {
-                if (nocType) {
-                    const nocData = timestep.noc[nocType];
-                    if (nocData) {
-                        return {
-                            value: nocData.avg_link_demand,
-                            color: calculateLinkCongestionColor(nocData.avg_link_demand, 0, altCongestionColors),
-                        };
-                    }
-                }
-                const color = calculateLinkCongestionColor(timestep.avg_link_demand, 0, altCongestionColors);
-                return {
-                    value: timestep.avg_link_demand,
-                    color,
-                };
-            }),
+        const result = {
+            worst: [] as Array<MetricPoint>,
+            utilization: [] as Array<MetricPoint>,
+            demand: [] as Array<MetricPoint>,
+            mcast: [] as Array<MetricPoint>,
         };
+        const color = (v: number) => calculateLinkCongestionColor(v, 0, altCongestionColors);
+
+        for (const timestep of timestepList) {
+            const links = nocType
+                ? timestep.link_demand.filter((linkData) => String(linkData[NPE_LINK.NOC_ID]).startsWith(nocType))
+                : timestep.link_demand;
+
+            const worst = Math.max(-1, ...links.map((linkData) => linkData[NPE_LINK.DEMAND]));
+
+            result.worst.push({
+                value: worst,
+                color: color(worst),
+            });
+
+            const nocData = nocType ? timestep.noc?.[nocType] : undefined;
+
+            const utilization = nocData?.avg_link_util ?? timestep.avg_link_util;
+            result.utilization.push({
+                value: utilization,
+                color: color(utilization),
+            });
+
+            const demand = nocData?.avg_link_demand ?? timestep.avg_link_demand;
+            result.demand.push({
+                value: demand,
+                color: color(demand),
+            });
+
+            const mcast = timestep.mcast_write_link_util;
+            result.mcast.push({
+                value: mcast,
+                color: color(mcast || -1),
+            });
+        }
+
+        return result;
     }, [nocType, timestepList, altCongestionColors]);
 
     useEffect(() => {
@@ -147,19 +142,28 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
         }
 
         ctx.clearRect(0, 0, canvas.width, HEATMAP_HEIGHT + canvasZoneHeight);
-        const chunkWidth = canvas.width / congestionMapPerTimestamp.worst.length;
-        congestionMapPerTimestamp.worst.forEach(({ color }, index) => {
-            ctx.fillStyle = color;
-            ctx.fillRect(index * chunkWidth, 0, chunkWidth, HEATMAP_HEIGHT / 3);
-        });
-        congestionMapPerTimestamp.utilization.forEach(({ color }, index) => {
-            ctx.fillStyle = color;
-            ctx.fillRect(index * chunkWidth, HEATMAP_HEIGHT / 3, chunkWidth, (HEATMAP_HEIGHT / 3) * 2);
-        });
-        congestionMapPerTimestamp.demand.forEach(({ color }, index) => {
-            ctx.fillStyle = color;
-            ctx.fillRect(index * chunkWidth, (HEATMAP_HEIGHT / 3) * 2, chunkWidth, HEATMAP_HEIGHT / 3);
-        });
+        const dataSize = congestionMapPerTimestamp.worst.length;
+
+        const metricDataArray = [
+            congestionMapPerTimestamp.worst,
+            congestionMapPerTimestamp.utilization,
+            congestionMapPerTimestamp.demand,
+            congestionMapPerTimestamp.mcast,
+        ];
+        const numLines = metricDataArray.length;
+
+        const chunkWidth = canvas.width / dataSize;
+        const rowHeight = HEATMAP_HEIGHT / numLines;
+
+        for (let row = 0; row < numLines; row++) {
+            const y = row * rowHeight;
+            const pointList = metricDataArray[row];
+
+            pointList.forEach((point, index) => {
+                ctx.fillStyle = point.color;
+                ctx.fillRect(index * chunkWidth, y, chunkWidth, rowHeight);
+            });
+        }
 
         const groupBaseY = new Map<number, number>();
         {
@@ -295,6 +299,19 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
                                             }}
                                         />
                                         {` Avg Demand: ${congestionMapPerTimestamp.demand[hoveredIndex].value.toFixed(3)} %`}
+                                    </div>
+
+                                    <div>
+                                        <span
+                                            className='color-square'
+                                            style={{
+                                                backgroundColor: congestionMapPerTimestamp.mcast[hoveredIndex].color,
+                                            }}
+                                        />
+                                        {` Multicast Utilisation:`}{' '}
+                                        {congestionMapPerTimestamp.mcast[hoveredIndex].value !== undefined
+                                            ? `${congestionMapPerTimestamp.mcast[hoveredIndex].value.toFixed(3)} %`
+                                            : 'N/A'}
                                     </div>
                                 </>
                             )}

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -127,7 +127,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
             const mcast = timestep.mcast_write_link_util;
             result.mcast.push({
                 value: mcast,
-                color: color(mcast || -1),
+                color: color(mcast ?? -1),
             });
         }
 

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -16,9 +16,19 @@ import {
     getKernelColor,
 } from '../../model/NPEModel';
 import { altCongestionColorsAtom } from '../../store/app';
+import { formatPercentage } from '../../functions/math';
 
-type MetricPoint = { value: number; color: string };
-type Rect = { x: number; y: number; width: number; height: number };
+interface MetricPoint {
+    value: number;
+    color: string;
+}
+
+interface Rect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
 
 interface NPEHeatMapProps {
     timestepList: TimestepData[];
@@ -91,10 +101,10 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
 
     const congestionMapPerTimestamp = useMemo(() => {
         const result = {
-            worst: [] as Array<MetricPoint>,
-            utilization: [] as Array<MetricPoint>,
-            demand: [] as Array<MetricPoint>,
-            mcast: [] as Array<MetricPoint>,
+            worst: [] as MetricPoint[],
+            utilization: [] as MetricPoint[],
+            demand: [] as MetricPoint[],
+            mcast: [] as MetricPoint[],
         };
         const color = (v: number) => calculateLinkCongestionColor(v, 0, altCongestionColors);
 
@@ -278,7 +288,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
                                         />{' '}
                                         Max Demand:{' '}
                                         {congestionMapPerTimestamp.worst[hoveredIndex].value > -1
-                                            ? `${congestionMapPerTimestamp.worst[hoveredIndex].value.toFixed(3)} %`
+                                            ? `${formatPercentage(congestionMapPerTimestamp.worst[hoveredIndex].value, 3)}`
                                             : 'N/A'}
                                     </div>
                                     <div>
@@ -289,7 +299,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
                                                     congestionMapPerTimestamp.utilization[hoveredIndex].color,
                                             }}
                                         />
-                                        {` Avg Utilization: ${congestionMapPerTimestamp.utilization[hoveredIndex].value.toFixed(3)} %`}
+                                        {` Avg Utilization: ${formatPercentage(congestionMapPerTimestamp.utilization[hoveredIndex].value, 3)}`}
                                     </div>
                                     <div>
                                         <span
@@ -298,7 +308,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
                                                 backgroundColor: congestionMapPerTimestamp.demand[hoveredIndex].color,
                                             }}
                                         />
-                                        {` Avg Demand: ${congestionMapPerTimestamp.demand[hoveredIndex].value.toFixed(3)} %`}
+                                        {` Avg Demand: ${formatPercentage(congestionMapPerTimestamp.demand[hoveredIndex].value, 3)}`}
                                     </div>
 
                                     <div>
@@ -310,7 +320,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
                                         />
                                         {` Multicast Utilization:`}{' '}
                                         {congestionMapPerTimestamp.mcast[hoveredIndex].value !== undefined
-                                            ? `${congestionMapPerTimestamp.mcast[hoveredIndex].value.toFixed(3)} %`
+                                            ? `${formatPercentage(congestionMapPerTimestamp.mcast[hoveredIndex].value, 3)}`
                                             : 'N/A'}
                                     </div>
                                 </>

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -308,7 +308,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
                                                 backgroundColor: congestionMapPerTimestamp.mcast[hoveredIndex].color,
                                             }}
                                         />
-                                        {` Multicast Utilisation:`}{' '}
+                                        {` Multicast Utilization:`}{' '}
                                         {congestionMapPerTimestamp.mcast[hoveredIndex].value !== undefined
                                             ? `${congestionMapPerTimestamp.mcast[hoveredIndex].value.toFixed(3)} %`
                                             : 'N/A'}

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -9,6 +9,7 @@ export interface CommonInfo {
     arch: string;
     congestion_model_name: string;
     cycles_per_timestep: number;
+    mcast_write_link_util: number;
     device_name: string;
     dram_bw_util: number;
     link_demand: number;
@@ -68,6 +69,11 @@ export const NPE_KPI_METADATA = {
         units: '%',
         label: 'Max NoC Link Demand',
         description: 'Maximum observed link demand over all timesteps. See link_demand for more details.',
+    },
+    mcast_write_link_util: {
+        units: '%',
+        label: 'Multicast Write Link Utilization',
+        description: '',
     },
     num_cols: {
         decimals: 0,
@@ -174,6 +180,7 @@ export interface TimestepData {
     link_demand: LinkUtilization[];
     avg_link_demand: number; // percentage
     avg_link_util: number; // percentage
+    mcast_write_link_util: number;
     noc: {
         [K in NoCType]: {
             avg_link_demand: number; //  percentage

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -39,7 +39,7 @@ export const NPE_KPI_METADATA = {
         description: 'Congestion model used in simulation to infer congestion (default: fast)',
     },
     cycles_per_timestep: {
-        units: 'cycles',
+        units: ' cycles',
         label: 'Device Cycles Per Timestep',
         description: 'How many cycles each simulation timestep/frame spans',
     },

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -73,7 +73,8 @@ export const NPE_KPI_METADATA = {
     mcast_write_link_util: {
         units: '%',
         label: 'Multicast Write Link Utilization',
-        description: '',
+        description:
+            'Average utilization of NoC links for multicast write operations over entire runtime. Represents the portion of link bandwidth used specifically for multicast writes.',
     },
     num_cols: {
         decimals: 0,


### PR DESCRIPTION
Compute and render multicast write link utilization in the NPE timeline: introduced a MetricPoint type and refactored congestionMapPerTimestamp to produce worst/utilization/demand/mcast series with colors, updated canvas drawing to render four metric rows, and added a tooltip entry for multicast util. Also added mcast_write_link_util to CommonInfo, NPE_KPI_METADATA, and TimestepData in the model to expose the metric. Minor UI tweak: removed the colon after metadata labels in NPEMetadata.tsx.

closes #1247 

[sampe data](https://github.com/user-attachments/files/25497049/npe-multicast.json)

<img width="683" height="383" alt="image" src="https://github.com/user-attachments/assets/152f4928-c628-453c-9c6a-b2019be55a45" />
