### PR TITLE
Tweak cookie handling to avoid exceeding browser cookie size limits

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -51,7 +51,10 @@ def with_instance(func):
             session["instances"] = []
 
         if instance.instance_id not in session["instances"]:
-            session["instances"] = session.get("instances", []) + [instance.instance_id]
+            max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
+            session["instances"] = (
+                session.get("instances", []) + [instance.instance_id]
+            )[-max_reports:]
 
         return func(*args, **kwargs)
 

--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -97,6 +97,8 @@ class DefaultConfig(object):
     # Session Settings
     SESSION_COOKIE_SAMESITE = "Lax"
     SESSION_COOKIE_SECURE = False  # For development on HTTP
+    # Max uploaded report paths / instance IDs stored in session cookie (FIFO); avoids cookie size limits (e.g. 4KB)
+    SESSION_MAX_UPLOADED_REPORTS = int(os.getenv("SESSION_MAX_UPLOADED_REPORTS", "20"))
 
     def override_with_env_variables(self):
         """Override config values with environment variables."""

--- a/backend/ttnn_visualizer/settings.py
+++ b/backend/ttnn_visualizer/settings.py
@@ -98,7 +98,7 @@ class DefaultConfig(object):
     SESSION_COOKIE_SAMESITE = "Lax"
     SESSION_COOKIE_SECURE = False  # For development on HTTP
     # Max uploaded report paths / instance IDs stored in session cookie (FIFO); avoids cookie size limits (e.g. 4KB)
-    SESSION_MAX_UPLOADED_REPORTS = int(os.getenv("SESSION_MAX_UPLOADED_REPORTS", "20"))
+    SESSION_MAX_UPLOADED_REPORTS = int(os.getenv("SESSION_MAX_UPLOADED_REPORTS", "10"))
 
     def override_with_env_variables(self):
         """Override config values with environment variables."""

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -955,12 +955,13 @@ def create_profiler_files():
         except Exception as e:
             logger.warning(f"Failed to read config.json in {config_file}: {e}")
 
-    # Set session data (FIFO cap to avoid cookie size limits)
-    max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
-    session["profiler_paths"] = (
-        session.get("profiler_paths", []) + [str(profiler_path)]
-    )[-max_reports:]
-    session.permanent = True
+    if current_app.config["SERVER_MODE"]:
+        # Set session data (FIFO cap to avoid cookie size limits)
+        max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
+        session["profiler_paths"] = (
+            session.get("profiler_paths", []) + [str(profiler_path)]
+        )[-max_reports:]
+        session.permanent = True
 
     return {
         "path": parent_folder_name,
@@ -1017,11 +1018,12 @@ def create_performance_files():
         performance_path=performance_path,
     )
 
-    max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
-    session["performance_paths"] = (
-        session.get("performance_paths", []) + [str(performance_path)]
-    )[-max_reports:]
-    session.permanent = True
+    if current_app.config["SERVER_MODE"]:
+        max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
+        session["performance_paths"] = (
+            session.get("performance_paths", []) + [str(performance_path)]
+        )[-max_reports:]
+        session.permanent = True
 
     return StatusMessage(
         status=ConnectionTestStates.OK, message="Success."
@@ -1063,11 +1065,12 @@ def create_npe_files():
         npe_path=npe_path,
     )
 
-    max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
-    session["npe_paths"] = (session.get("npe_paths", []) + [str(npe_path)])[
-        -max_reports:
-    ]
-    session.permanent = True
+    if current_app.config["SERVER_MODE"]:
+        max_reports = current_app.config["SESSION_MAX_UPLOADED_REPORTS"]
+        session["npe_paths"] = (session.get("npe_paths", []) + [str(npe_path)])[
+            -max_reports:
+        ]
+        session.permanent = True
 
     return StatusMessage(status=ConnectionTestStates.OK, message="Success").model_dump()
 


### PR DESCRIPTION
This PR tweaks the cookie handling in the Flask backend to avoid exceeding browser cookie limits.

There are two main changes:

* Cookies are only set in server mode
* Values in session data are rotated out using FIFO strategy

Previous it was appending the new uploaded report paths to the session data whenever a user uploaded a report, but it was only reading the values back in from the session in server mode. Now it won't set them at all by default, when server mode is not enabled.

Because it's still an issue with server mode, I implemented a strategy to trim the report paths, and set a maximum number that will be tracked in the session.

In the session we have a list of profiler paths, performance paths and npe paths. Each stores the full, absolute path to the report, so it could be a 100 characters or longer, depending on storage path and filenames. 

I have chosen 10 as the maximum for each type. That means with the default value, the if the user uploaded the 10th profiler report, the first one from the list would be removed to make room for the 10th.

To get around this limitation, we would need to change the cookie backend to start tracking session data in the app sqlite3 database, instead of in the session cookies.

[Closes #1260]