### PR TITLE
Refactor/Resolve excessive prop passing

### DIFF
--- a/src/components/buffer-summary/BufferSummaryPlotControls.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotControls.tsx
@@ -14,6 +14,7 @@ import {
     showMemoryRegionsAtom,
 } from '../../store/app';
 import { TAB_IDS } from '../../definitions/BufferSummary';
+import 'styles/components/BufferSummaryControls.scss';
 
 const BufferSummaryPlotControls = () => {
     const [showDeallocationReport, setShowDeallocationReport] = useAtom(showDeallocationReportAtom);
@@ -24,7 +25,7 @@ const BufferSummaryPlotControls = () => {
     const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
 
     return (
-        <div className='controls'>
+        <div className='buffer-summary-controls'>
             <Switch
                 label='Buffer zoom'
                 checked={isZoomedIn}

--- a/src/components/buffer-summary/BufferSummaryPlotControls.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotControls.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { Switch } from '@blueprintjs/core';
+import { useAtom, useAtomValue } from 'jotai';
+import GlobalSwitch from '../GlobalSwitch';
+import {
+    renderMemoryLayoutAtom,
+    selectedBufferSummaryTabAtom,
+    showBufferSummaryZoomedAtom,
+    showDeallocationReportAtom,
+    showHexAtom,
+    showMemoryRegionsAtom,
+} from '../../store/app';
+import { TAB_IDS } from '../../definitions/BufferSummary';
+
+const BufferSummaryPlotControls = () => {
+    const [showDeallocationReport, setShowDeallocationReport] = useAtom(showDeallocationReportAtom);
+    const [renderMemoryLayout, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
+    const [showHex, setShowHex] = useAtom(showHexAtom);
+    const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
+    const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);
+    const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
+
+    return (
+        <div className='controls'>
+            <Switch
+                label='Buffer zoom'
+                checked={isZoomedIn}
+                onChange={() => {
+                    setIsZoomedIn(!isZoomedIn);
+                }}
+            />
+
+            {selectedTabId === TAB_IDS.L1 ? (
+                <GlobalSwitch
+                    label='Mark late tensor deallocations'
+                    checked={showDeallocationReport}
+                    onChange={() => {
+                        setShowDeallocationReport(!showDeallocationReport);
+                    }}
+                />
+            ) : null}
+
+            <GlobalSwitch
+                label='Use Hex'
+                checked={showHex}
+                onChange={() => {
+                    setShowHex(!showHex);
+                }}
+            />
+
+            <GlobalSwitch
+                label='Tensor memory layout overlay'
+                checked={renderMemoryLayout}
+                onChange={() => {
+                    setRenderMemoryLayout(!renderMemoryLayout);
+                }}
+            />
+
+            {selectedTabId === TAB_IDS.L1 ? (
+                <GlobalSwitch
+                    label='Memory regions'
+                    checked={showMemoryRegions}
+                    onChange={() => {
+                        setShowMemoryRegions(!showMemoryRegions);
+                    }}
+                />
+            ) : null}
+        </div>
+    );
+};
+
+export default BufferSummaryPlotControls;

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -54,6 +54,12 @@ interface BufferSummaryPlotRendererProps {
 }
 
 function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSummaryPlotRendererProps) {
+    const showDeallocationReport = useAtomValue(showDeallocationReportAtom);
+    const renderMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
+    const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
+    const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
+    const [activeRow, setActiveRow] = useState<number | null>(null);
+
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
     const navigate = useNavigate();
@@ -63,12 +69,6 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
     const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY);
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
     const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.L1);
-
-    const showDeallocationReport = useAtomValue(showDeallocationReportAtom);
-    const renderMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
-    const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
-    const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
-    const [activeRow, setActiveRow] = useState<number | null>(null);
 
     const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
         useMemo(() => getListState(), [getListState]) ?? {};
@@ -240,7 +240,7 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
                                         memoryStart={isZoomedIn ? zoomedMemorySizeStart : 0}
                                         memoryEnd={isZoomedIn ? zoomedMemorySizeEnd : memorySize}
                                         memoryPadding={memoryPadding}
-                                        tensorList={tensorListByOperation.get(operation.id)!}
+                                        tensorList={tensorListByOperation?.get(operation.id)}
                                         tensorDeallocationReport={
                                             showDeallocationReport
                                                 ? nonDeallocatedTensorsByOperationId.get(operation.id) || []

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -37,7 +37,7 @@ import { ScrollLocations } from '../../definitions/VirtualLists';
 import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
 import useScrollShade from '../../hooks/useScrollShade';
 
-import { BuffersByOperation } from '../../model/APIData';
+import { BuffersByOperation, MarkerTypeLabel } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
 import BufferSummaryPlotControls from './BufferSummaryPlotControls';
@@ -131,8 +131,8 @@ function BufferSummaryPlotRenderer({
 
     const memoryRegionsMarkers = showMemoryRegions
         ? [
-              { color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker, label: 'L1 SMALL' },
-              { color: L1_START_MARKER_COLOR, address: l1StartMarker, label: '' },
+              { color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker, label: MarkerTypeLabel.L1_SMALL },
+              { color: L1_START_MARKER_COLOR, address: l1StartMarker, label: MarkerTypeLabel.L1_START },
           ]
         : [];
     const zoomedMemorySizeStart = zoomedMemorySize[0] || 0;
@@ -242,7 +242,7 @@ function BufferSummaryPlotRenderer({
                                         memoryStart={isZoomedIn ? zoomedMemorySizeStart : 0}
                                         memoryEnd={isZoomedIn ? zoomedMemorySizeEnd : memorySize}
                                         memoryPadding={memoryPadding}
-                                        tensorList={tensorListByOperation?.get(operation.id)}
+                                        tensorList={tensorListByOperation.get(operation.id)}
                                         tensorDeallocationReport={
                                             showDeallocationReport
                                                 ? nonDeallocatedTensorsByOperationId.get(operation.id) || []

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -82,6 +82,12 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
         initialOffset: restoredOffset || 0,
     });
 
+    useBufferNavigation({
+        buffersByOperation: uniqueBuffersByOperationList,
+        tensorListByOperation,
+        virtualizer,
+    });
+
     const virtualItems = virtualizer.getVirtualItems();
     const virtualHeight = virtualizer.getTotalSize() - TOTAL_SHADE_HEIGHT;
 
@@ -121,6 +127,16 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
         return minValue && maxValue ? [minValue, maxValue] : [0, memorySize];
     }, [uniqueBuffersByOperationList, memorySize]);
 
+    const memoryRegionsMarkers = showMemoryRegions
+        ? [
+              { color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker, label: 'L1 SMALL' },
+              { color: L1_START_MARKER_COLOR, address: l1StartMarker, label: '' },
+          ]
+        : [];
+    const zoomedMemorySizeStart = zoomedMemorySize[0] || 0;
+    const zoomedMemorySizeEnd = zoomedMemorySize[1] || memorySize;
+    const memoryPadding = (zoomedMemorySizeEnd - zoomedMemorySizeStart) * MEMORY_ZOOM_PADDING_RATIO;
+
     const handleUserScrolling = useCallback(() => {
         if (scrollElementRef.current) {
             updateScrollShade(scrollElementRef.current);
@@ -150,22 +166,6 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
             });
         };
     }, [updateListState, uniqueBuffersByOperationList]);
-
-    useBufferNavigation({
-        buffersByOperation: uniqueBuffersByOperationList,
-        tensorListByOperation,
-        virtualizer,
-    });
-
-    const memoryRegionsMarkers = showMemoryRegions
-        ? [
-              { color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker, label: 'L1 SMALL' },
-              { color: L1_START_MARKER_COLOR, address: l1StartMarker, label: '' },
-          ]
-        : [];
-    const zoomedMemorySizeStart = zoomedMemorySize[0] || 0;
-    const zoomedMemorySizeEnd = zoomedMemorySize[1] || memorySize;
-    const memoryPadding = (zoomedMemorySizeEnd - zoomedMemorySizeStart) * MEMORY_ZOOM_PADDING_RATIO;
 
     return uniqueBuffersByOperationList && !isLoadingDevices && tensorListByOperation ? (
         <div className='buffer-summary-chart'>

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -100,7 +100,7 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
         [uniqueBuffersByOperationList],
     );
 
-    const { lateDeallocationsByOperation: nondeallocatedTensorsByOperationId } =
+    const { lateDeallocationsByOperation: nonDeallocatedTensorsByOperationId } =
         useGetTensorDeallocationReportByOperation();
 
     const memorySize = useMemo(getMemorySize, [devices, isLoadingDevices]);
@@ -243,7 +243,7 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
                                         tensorList={tensorListByOperation.get(operation.id)!}
                                         tensorDeallocationReport={
                                             showDeallocationReport
-                                                ? nondeallocatedTensorsByOperationId.get(operation.id) || []
+                                                ? nonDeallocatedTensorsByOperationId.get(operation.id) || []
                                                 : []
                                         }
                                         showMemoryLayout={renderMemoryLayout}

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -5,9 +5,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
-import { Switch, Tooltip } from '@blueprintjs/core';
+import { Tooltip } from '@blueprintjs/core';
 import { useNavigate } from 'react-router-dom';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import {
     BufferSummaryAxisConfiguration,
     L1_SMALL_MARKER_COLOR,
@@ -31,10 +31,8 @@ import {
     renderMemoryLayoutAtom,
     showBufferSummaryZoomedAtom,
     showDeallocationReportAtom,
-    showHexAtom,
     showMemoryRegionsAtom,
 } from '../../store/app';
-import GlobalSwitch from '../GlobalSwitch';
 import { L1_DEFAULT_MEMORY_SIZE } from '../../definitions/L1MemorySize';
 import { ScrollLocations } from '../../definitions/ScrollPositions';
 import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
@@ -44,6 +42,7 @@ import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
 import { BufferType } from '../../model/BufferType';
+import BufferSummaryPlotControls from './BufferSummaryPlotControls';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
@@ -65,11 +64,10 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
     const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.L1);
 
-    const [showDeallocationReport, setShowDeallocationReport] = useAtom(showDeallocationReportAtom);
-    const [renderMemoryLayout, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
-    const [showHex, setShowHex] = useAtom(showHexAtom);
-    const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
-    const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);
+    const showDeallocationReport = useAtomValue(showDeallocationReportAtom);
+    const renderMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
+    const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
+    const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
     const [activeRow, setActiveRow] = useState<number | null>(null);
 
     const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
@@ -171,43 +169,7 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
 
     return uniqueBuffersByOperationList && !isLoadingDevices && tensorListByOperation ? (
         <div className='buffer-summary-chart'>
-            <div className='controls'>
-                <Switch
-                    label='Buffer zoom'
-                    checked={isZoomedIn}
-                    onChange={() => {
-                        setIsZoomedIn(!isZoomedIn);
-                    }}
-                />
-                <GlobalSwitch
-                    label='Mark late tensor deallocations'
-                    checked={showDeallocationReport}
-                    onChange={() => {
-                        setShowDeallocationReport(!showDeallocationReport);
-                    }}
-                />
-                <GlobalSwitch
-                    label='Use Hex'
-                    checked={showHex}
-                    onChange={() => {
-                        setShowHex(!showHex);
-                    }}
-                />
-                <GlobalSwitch
-                    label='Tensor memory layout overlay'
-                    checked={renderMemoryLayout}
-                    onChange={() => {
-                        setRenderMemoryLayout(!renderMemoryLayout);
-                    }}
-                />
-                <GlobalSwitch
-                    label='Memory regions'
-                    checked={showMemoryRegions}
-                    onChange={() => {
-                        setShowMemoryRegions(!showMemoryRegions);
-                    }}
-                />
-            </div>
+            <BufferSummaryPlotControls />
 
             <p className='x-axis-label'>Memory Address</p>
 

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -14,7 +14,6 @@ import {
     L1_START_MARKER_COLOR,
 } from '../../definitions/PlotConfigurations';
 import {
-    useCreateTensorsByOperationByIdList,
     useDevices,
     useGetL1SmallMarker,
     useGetL1StartMarker,
@@ -41,8 +40,8 @@ import useScrollShade from '../../hooks/useScrollShade';
 import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
-import { BufferType } from '../../model/BufferType';
 import BufferSummaryPlotControls from './BufferSummaryPlotControls';
+import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
@@ -51,9 +50,13 @@ const MEMORY_ZOOM_PADDING_RATIO = 0.01;
 
 interface BufferSummaryPlotRendererProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
+    tensorListByOperation: TensorsByOperationByAddress;
 }
 
-function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSummaryPlotRendererProps) {
+function BufferSummaryPlotRenderer({
+    uniqueBuffersByOperationList,
+    tensorListByOperation,
+}: BufferSummaryPlotRendererProps) {
     const showDeallocationReport = useAtomValue(showDeallocationReportAtom);
     const renderMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
@@ -68,7 +71,6 @@ function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSumma
     const l1SmallMarker = useGetL1SmallMarker();
     const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY);
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
-    const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.L1);
 
     const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
         useMemo(() => getListState(), [getListState]) ?? {};

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -14,6 +14,7 @@ import {
     L1_START_MARKER_COLOR,
 } from '../../definitions/PlotConfigurations';
 import {
+    useCreateTensorsByOperationByIdList,
     useDevices,
     useGetL1SmallMarker,
     useGetL1StartMarker,
@@ -26,7 +27,6 @@ import BufferSummaryRow from './BufferSummaryRow';
 import 'styles/components/BufferSummaryPlot.scss';
 import ROUTES from '../../definitions/Routes';
 import isValidNumber from '../../functions/isValidNumber';
-import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 import {
     renderMemoryLayoutAtom,
     showBufferSummaryZoomedAtom,
@@ -43,6 +43,7 @@ import useScrollShade from '../../hooks/useScrollShade';
 import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
+import { BufferType } from '../../model/BufferType';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
@@ -51,20 +52,9 @@ const MEMORY_ZOOM_PADDING_RATIO = 0.01;
 
 interface BufferSummaryPlotRendererProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
-    tensorListByOperation: TensorsByOperationByAddress;
 }
 
-function BufferSummaryPlotRenderer({
-    uniqueBuffersByOperationList,
-    tensorListByOperation,
-}: BufferSummaryPlotRendererProps) {
-    const [showDeallocationReport, setShowDeallocationReport] = useAtom(showDeallocationReportAtom);
-    const [renderMemoryLayout, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
-    const [showHex, setShowHex] = useAtom(showHexAtom);
-    const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
-    const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);
-    const [activeRow, setActiveRow] = useState<number | null>(null);
-
+function BufferSummaryPlotRenderer({ uniqueBuffersByOperationList }: BufferSummaryPlotRendererProps) {
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
     const navigate = useNavigate();
@@ -73,6 +63,14 @@ function BufferSummaryPlotRenderer({
     const l1SmallMarker = useGetL1SmallMarker();
     const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY);
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
+    const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.L1);
+
+    const [showDeallocationReport, setShowDeallocationReport] = useAtom(showDeallocationReportAtom);
+    const [renderMemoryLayout, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
+    const [showHex, setShowHex] = useAtom(showHexAtom);
+    const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
+    const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);
+    const [activeRow, setActiveRow] = useState<number | null>(null);
 
     const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
         useMemo(() => getListState(), [getListState]) ?? {};
@@ -265,7 +263,7 @@ function BufferSummaryPlotRenderer({
                         {virtualItems.map((virtualRow) => {
                             const operation = uniqueBuffersByOperationList[virtualRow.index];
 
-                            return (
+                            return operation ? (
                                 <div
                                     className='buffer-summary-plot-container'
                                     key={virtualRow.key}
@@ -303,7 +301,7 @@ function BufferSummaryPlotRenderer({
                                         </a>
                                     </Tooltip>
                                 </div>
-                            );
+                            ) : null;
                         })}
                     </div>
                 </div>

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -52,12 +52,12 @@ interface BufferSummaryPlotRendererDRAMProps {
 }
 
 function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferSummaryPlotRendererDRAMProps) {
+    const [activeRow, setActiveRow] = useState<number | null>(null);
+    const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
+
     const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY_DRAM);
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
     const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.DRAM);
-
-    const [activeRow, setActiveRow] = useState<number | null>(null);
-    const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const scrollElementRef = useRef(null);
 
     const segmentedChartData: BuffersByOperation[][] = useMemo(() => {

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -117,6 +117,12 @@ function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferS
         }
     }, [updateScrollShade]);
 
+    useBufferNavigation({
+        buffersByOperation: segmentedChartData[0],
+        tensorListByOperation,
+        virtualizer,
+    });
+
     // Keep stored refs updated
     useEffect(() => {
         scrollOffsetRef.current = virtualizer.scrollOffset;
@@ -135,12 +141,6 @@ function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferS
             });
         };
     }, [updateListState, uniqueBuffersByOperationList]);
-
-    useBufferNavigation({
-        buffersByOperation: segmentedChartData[0],
-        tensorListByOperation,
-        virtualizer,
-    });
 
     return uniqueBuffersByOperationList && tensorListByOperation ? (
         <div className='buffer-summary-chart'>
@@ -208,7 +208,7 @@ function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferS
                                                 memoryStart={isZoomedIn ? zoomedMemoryOptions[index].start : 0}
                                                 memoryEnd={isZoomedIn ? zoomedMemoryOptions[index].end : MEMORY_SIZE}
                                                 memoryPadding={zoomedMemoryOptions[index].padding}
-                                                tensorList={tensorListByOperation.get(operation.id)!}
+                                                tensorList={tensorListByOperation?.get(operation.id)}
                                             />
 
                                             <Tooltip

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -15,7 +15,7 @@ import LoadingSpinner from '../LoadingSpinner';
 import BufferSummaryRow from './BufferSummaryRow';
 import 'styles/components/BufferSummaryPlot.scss';
 import ROUTES from '../../definitions/Routes';
-import { showBufferSummaryZoomedAtom } from '../../store/app';
+import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../../store/app';
 import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
 import { ScrollLocations } from '../../definitions/ScrollPositions';
 import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
@@ -23,9 +23,8 @@ import useScrollShade from '../../hooks/useScrollShade';
 
 import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
-import { useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
-import { BufferType } from '../../model/BufferType';
 import BufferSummaryPlotControls from './BufferSummaryPlotControls';
+import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
@@ -49,15 +48,19 @@ const CHART_DATA: Partial<PlotData>[][] = [
 
 interface BufferSummaryPlotRendererDRAMProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
+    tensorListByOperation: TensorsByOperationByAddress;
 }
 
-function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferSummaryPlotRendererDRAMProps) {
+function BufferSummaryPlotRendererDRAM({
+    uniqueBuffersByOperationList,
+    tensorListByOperation,
+}: BufferSummaryPlotRendererDRAMProps) {
     const [activeRow, setActiveRow] = useState<number | null>(null);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
+    const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
 
     const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY_DRAM);
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
-    const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.DRAM);
     const scrollElementRef = useRef(null);
 
     const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
@@ -209,6 +212,7 @@ function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferS
                                                 memoryEnd={isZoomedIn ? zoomedMemoryOptions[index].end : MEMORY_SIZE}
                                                 memoryPadding={zoomedMemoryOptions[index].padding}
                                                 tensorList={tensorListByOperation?.get(operation.id)}
+                                                showMemoryLayout={showMemoryLayout}
                                             />
 
                                             <Tooltip

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -211,7 +211,7 @@ function BufferSummaryPlotRendererDRAM({
                                                 memoryStart={isZoomedIn ? zoomedMemoryOptions[index].start : 0}
                                                 memoryEnd={isZoomedIn ? zoomedMemoryOptions[index].end : MEMORY_SIZE}
                                                 memoryPadding={zoomedMemoryOptions[index].padding}
-                                                tensorList={tensorListByOperation?.get(operation.id)}
+                                                tensorList={tensorListByOperation.get(operation.id)}
                                                 showMemoryLayout={showMemoryLayout}
                                             />
 

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -5,9 +5,9 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
-import { Switch, Tooltip } from '@blueprintjs/core';
+import { Tooltip } from '@blueprintjs/core';
 import { Link } from 'react-router-dom';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { PlotData } from 'plotly.js';
 import { BufferSummaryAxisConfiguration } from '../../definitions/PlotConfigurations';
 import MemoryPlotRenderer from '../operation-details/MemoryPlotRenderer';
@@ -15,8 +15,7 @@ import LoadingSpinner from '../LoadingSpinner';
 import BufferSummaryRow from './BufferSummaryRow';
 import 'styles/components/BufferSummaryPlot.scss';
 import ROUTES from '../../definitions/Routes';
-import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom, showHexAtom } from '../../store/app';
-import GlobalSwitch from '../GlobalSwitch';
+import { showBufferSummaryZoomedAtom } from '../../store/app';
 import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
 import { ScrollLocations } from '../../definitions/ScrollPositions';
 import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
@@ -26,6 +25,7 @@ import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
 import { useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
 import { BufferType } from '../../model/BufferType';
+import BufferSummaryPlotControls from './BufferSummaryPlotControls';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
@@ -57,9 +57,7 @@ function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferS
     const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.DRAM);
 
     const [activeRow, setActiveRow] = useState<number | null>(null);
-    const [showHex, setShowHex] = useAtom(showHexAtom);
-    const [renderMemoryLayout, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
-    const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
+    const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const scrollElementRef = useRef(null);
 
     const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
@@ -146,31 +144,7 @@ function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferS
 
     return uniqueBuffersByOperationList && tensorListByOperation ? (
         <div className='buffer-summary-chart'>
-            <div className='controls'>
-                <Switch
-                    label='Buffer zoom'
-                    checked={isZoomedIn}
-                    onChange={() => {
-                        setIsZoomedIn(!isZoomedIn);
-                    }}
-                />
-
-                <GlobalSwitch
-                    label='Use Hex'
-                    checked={showHex}
-                    onChange={() => {
-                        setShowHex(!showHex);
-                    }}
-                />
-
-                <GlobalSwitch
-                    label='Tensor memory layout overlay'
-                    checked={renderMemoryLayout}
-                    onChange={() => {
-                        setRenderMemoryLayout(!renderMemoryLayout);
-                    }}
-                />
-            </div>
+            <BufferSummaryPlotControls />
 
             <p className='x-axis-label'>Memory Address</p>
 

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -15,7 +15,6 @@ import LoadingSpinner from '../LoadingSpinner';
 import BufferSummaryRow from './BufferSummaryRow';
 import 'styles/components/BufferSummaryPlot.scss';
 import ROUTES from '../../definitions/Routes';
-import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom, showHexAtom } from '../../store/app';
 import GlobalSwitch from '../GlobalSwitch';
 import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
@@ -25,6 +24,8 @@ import useScrollShade from '../../hooks/useScrollShade';
 
 import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
+import { useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
+import { BufferType } from '../../model/BufferType';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
@@ -48,21 +49,18 @@ const CHART_DATA: Partial<PlotData>[][] = [
 
 interface BufferSummaryPlotRendererDRAMProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
-    tensorListByOperation: TensorsByOperationByAddress;
 }
 
-function BufferSummaryPlotRendererDRAM({
-    uniqueBuffersByOperationList,
-    tensorListByOperation,
-}: BufferSummaryPlotRendererDRAMProps) {
+function BufferSummaryPlotRendererDRAM({ uniqueBuffersByOperationList }: BufferSummaryPlotRendererDRAMProps) {
+    const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY_DRAM);
+    const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
+    const tensorListByOperation = useCreateTensorsByOperationByIdList(BufferType.DRAM);
+
     const [activeRow, setActiveRow] = useState<number | null>(null);
     const [showHex, setShowHex] = useAtom(showHexAtom);
     const [renderMemoryLayout, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
     const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
     const scrollElementRef = useRef(null);
-
-    const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY_DRAM);
-    const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
 
     const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
         if (isZoomedIn) {

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -39,7 +39,7 @@ const BufferSummaryRow = ({
     memoryStart,
     memoryEnd,
     memoryPadding,
-    tensorList,
+    tensorList = new Map(),
     className = '',
     tensorDeallocationReport = [],
     showMemoryLayout,
@@ -57,7 +57,7 @@ const BufferSummaryRow = ({
         return buffers.map((buffer) => {
             const size = (buffer.size / computedMemorySize) * TARGET_SCALE;
             const position = ((buffer.address - memoryStart) / computedMemorySize) * TARGET_SCALE;
-            const tensor = tensorList?.get(buffer.address);
+            const tensor = tensorList.get(buffer.address);
             const color = (tensor ? getTensorColor(tensor.id) : getBufferColor(buffer.address)) || 'black';
             const dimmedColor = getDimmedColour(color);
             let notDeallocated = false;

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -23,7 +23,7 @@ interface BufferSummaryRowProps {
     memoryStart: number;
     memoryEnd: number;
     memoryPadding: number;
-    tensorList: Map<number, Tensor>;
+    tensorList?: Map<number, Tensor>;
     showMemoryLayout?: boolean;
     className?: string;
     tensorDeallocationReport?: TensorDeallocationReport[];
@@ -57,7 +57,7 @@ const BufferSummaryRow = ({
         return buffers.map((buffer) => {
             const size = (buffer.size / computedMemorySize) * TARGET_SCALE;
             const position = ((buffer.address - memoryStart) / computedMemorySize) * TARGET_SCALE;
-            const tensor = tensorList.get(buffer.address);
+            const tensor = tensorList?.get(buffer.address);
             const color = (tensor ? getTensorColor(tensor.id) : getBufferColor(buffer.address)) || 'black';
             const dimmedColor = getDimmedColour(color);
             let notDeallocated = false;

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -66,7 +66,7 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
         );
     }
 
-    return buffersByOperation && uniqueBuffersByOperationList ? (
+    return buffersByOperation && uniqueBuffersByOperationList && tensorListByOperation ? (
         <>
             <h2>Plot view</h2>
             <div

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -4,25 +4,35 @@
 
 import { RefObject, useMemo } from 'react';
 import { useAtomValue } from 'jotai';
+import { Callout, Intent } from '@blueprintjs/core';
 import BufferSummaryPlotRenderer from './BufferSummaryPlotRenderer';
 import BufferSummaryTable from './BufferSummaryTable';
 import { SECTION_IDS, TAB_IDS } from '../../definitions/BufferSummary';
 import BufferSummaryPlotRendererDRAM from './BufferSummaryPlotRendererDRAM';
-import { Buffer, BuffersByOperation } from '../../model/APIData';
-import { selectedBufferSummaryTabAtom } from '../../store/app';
+import { Buffer } from '../../model/APIData';
+import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../../store/app';
+import { BufferType } from '../../model/BufferType';
+import { useBuffers } from '../../hooks/useAPI';
+import LoadingSpinner from '../LoadingSpinner';
 
 interface BufferSummaryTabProps {
     plotRef: RefObject<HTMLHeadingElement>;
     tableRef: RefObject<HTMLHeadingElement>;
-    buffersByOperation: BuffersByOperation[];
 }
 
-function BufferSummaryTab({ plotRef, tableRef, buffersByOperation }: BufferSummaryTabProps) {
+function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
     const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
+    const activePerformanceReport = useAtomValue(activeProfilerReportAtom);
+
+    const { data: buffersByOperation, error: buffersError } = useBuffers(
+        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
+        true,
+    );
 
     const uniqueBuffersByOperationList = useMemo(
         () =>
-            buffersByOperation.map((operation) => {
+            buffersByOperation?.map((operation) => {
                 const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
                 operation.buffers.forEach((buffer) => {
                     const { address, size } = buffer;
@@ -42,7 +52,25 @@ function BufferSummaryTab({ plotRef, tableRef, buffersByOperation }: BufferSumma
         [buffersByOperation],
     );
 
-    return (
+    if (buffersError) {
+        const activeReport = selectedTabId === TAB_IDS.L1 ? activeProfilerReport : activePerformanceReport;
+
+        return (
+            <Callout
+                intent={Intent.WARNING}
+                title='Error loading buffer data'
+                compact
+            >
+                <p>
+                    {`We've been unable to load the ${selectedTabId === TAB_IDS.L1 ? 'L1' : 'DRAM'} buffer data for /${activeReport?.path}.`}
+                    <br />
+                    {buffersError.message}
+                </p>
+            </Callout>
+        );
+    }
+
+    return buffersByOperation && uniqueBuffersByOperationList ? (
         <>
             <h2>Plot view</h2>
             <div
@@ -64,6 +92,8 @@ function BufferSummaryTab({ plotRef, tableRef, buffersByOperation }: BufferSumma
                 <BufferSummaryTable buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)} />
             </div>
         </>
+    ) : (
+        <LoadingSpinner />
     );
 }
 

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -12,7 +12,7 @@ import BufferSummaryPlotRendererDRAM from './BufferSummaryPlotRendererDRAM';
 import { Buffer } from '../../model/APIData';
 import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../../store/app';
 import { BufferType } from '../../model/BufferType';
-import { useBuffers } from '../../hooks/useAPI';
+import { useBuffers, useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
 import LoadingSpinner from '../LoadingSpinner';
 
 interface BufferSummaryTabProps {
@@ -22,13 +22,11 @@ interface BufferSummaryTabProps {
 
 function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
     const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
-    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
     const activePerformanceReport = useAtomValue(activeProfilerReportAtom);
+    const selectedBufferType = selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM;
 
-    const { data: buffersByOperation, error: buffersError } = useBuffers(
-        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
-        true,
-    );
+    const tensorListByOperation = useCreateTensorsByOperationByIdList(selectedBufferType);
+    const { data: buffersByOperation, error: buffersError } = useBuffers(selectedBufferType, true);
 
     const uniqueBuffersByOperationList = useMemo(
         () =>
@@ -53,8 +51,6 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
     );
 
     if (buffersError) {
-        const activeReport = selectedTabId === TAB_IDS.L1 ? activeProfilerReport : activePerformanceReport;
-
         return (
             <Callout
                 intent={Intent.WARNING}
@@ -62,7 +58,7 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
                 compact
             >
                 <p>
-                    {`We've been unable to load the ${selectedTabId === TAB_IDS.L1 ? 'L1' : 'DRAM'} buffer data for /${activeReport?.path}.`}
+                    {`We've been unable to load the ${selectedTabId === TAB_IDS.L1 ? 'L1' : 'DRAM'} buffer data for /${activePerformanceReport?.path}.`}
                     <br />
                     {buffersError.message}
                 </p>
@@ -78,9 +74,15 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
                 id={SECTION_IDS.PLOT}
             >
                 {selectedTabId === TAB_IDS.DRAM ? (
-                    <BufferSummaryPlotRendererDRAM uniqueBuffersByOperationList={uniqueBuffersByOperationList} />
+                    <BufferSummaryPlotRendererDRAM
+                        uniqueBuffersByOperationList={uniqueBuffersByOperationList}
+                        tensorListByOperation={tensorListByOperation}
+                    />
                 ) : (
-                    <BufferSummaryPlotRenderer uniqueBuffersByOperationList={uniqueBuffersByOperationList} />
+                    <BufferSummaryPlotRenderer
+                        uniqueBuffersByOperationList={uniqueBuffersByOperationList}
+                        tensorListByOperation={tensorListByOperation}
+                    />
                 )}
             </div>
 
@@ -89,7 +91,10 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
                 ref={tableRef}
                 id={SECTION_IDS.TABLE}
             >
-                <BufferSummaryTable buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)} />
+                <BufferSummaryTable
+                    buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
+                    tensorListByOperation={tensorListByOperation}
+                />
             </div>
         </>
     ) : (

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -3,21 +3,23 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { RefObject, useMemo } from 'react';
+import { useAtomValue } from 'jotai';
 import BufferSummaryPlotRenderer from './BufferSummaryPlotRenderer';
 import BufferSummaryTable from './BufferSummaryTable';
-import { SECTION_IDS } from '../../definitions/BufferSummary';
+import { SECTION_IDS, TAB_IDS } from '../../definitions/BufferSummary';
 import BufferSummaryPlotRendererDRAM from './BufferSummaryPlotRendererDRAM';
 import { Buffer, BuffersByOperation } from '../../model/APIData';
-import { BufferType } from '../../model/BufferType';
+import { selectedBufferSummaryTabAtom } from '../../store/app';
 
 interface BufferSummaryTabProps {
     plotRef: RefObject<HTMLHeadingElement>;
     tableRef: RefObject<HTMLHeadingElement>;
     buffersByOperation: BuffersByOperation[];
-    bufferType: BufferType;
 }
 
-function BufferSummaryTab({ plotRef, tableRef, buffersByOperation, bufferType }: BufferSummaryTabProps) {
+function BufferSummaryTab({ plotRef, tableRef, buffersByOperation }: BufferSummaryTabProps) {
+    const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
+
     const uniqueBuffersByOperationList = useMemo(
         () =>
             buffersByOperation.map((operation) => {
@@ -47,7 +49,7 @@ function BufferSummaryTab({ plotRef, tableRef, buffersByOperation, bufferType }:
                 ref={plotRef}
                 id={SECTION_IDS.PLOT}
             >
-                {bufferType === BufferType.DRAM ? (
+                {selectedTabId === TAB_IDS.DRAM ? (
                     <BufferSummaryPlotRendererDRAM uniqueBuffersByOperationList={uniqueBuffersByOperationList} />
                 ) : (
                     <BufferSummaryPlotRenderer uniqueBuffersByOperationList={uniqueBuffersByOperationList} />
@@ -59,10 +61,7 @@ function BufferSummaryTab({ plotRef, tableRef, buffersByOperation, bufferType }:
                 ref={tableRef}
                 id={SECTION_IDS.TABLE}
             >
-                <BufferSummaryTable
-                    buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
-                    bufferType={bufferType}
-                />
+                <BufferSummaryTable buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)} />
             </div>
         </>
     );

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -5,44 +5,40 @@
 import { RefObject, useMemo } from 'react';
 import BufferSummaryPlotRenderer from './BufferSummaryPlotRenderer';
 import BufferSummaryTable from './BufferSummaryTable';
-import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 import { SECTION_IDS } from '../../definitions/BufferSummary';
 import BufferSummaryPlotRendererDRAM from './BufferSummaryPlotRendererDRAM';
 import { Buffer, BuffersByOperation } from '../../model/APIData';
+import { BufferType } from '../../model/BufferType';
 
 interface BufferSummaryTabProps {
     plotRef: RefObject<HTMLHeadingElement>;
     tableRef: RefObject<HTMLHeadingElement>;
     buffersByOperation: BuffersByOperation[];
-    tensorListByOperation: TensorsByOperationByAddress;
-    isDram?: boolean;
+    bufferType: BufferType;
 }
 
-function BufferSummaryTab({
-    plotRef,
-    tableRef,
-    buffersByOperation,
-    tensorListByOperation,
-    isDram = false,
-}: BufferSummaryTabProps) {
-    const uniqueBuffersByOperationList = useMemo(() => {
-        return buffersByOperation.map((operation) => {
-            const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
-            operation.buffers.forEach((buffer) => {
-                const { address, size } = buffer;
-                if (address) {
-                    const existingBuffer = uniqueBuffers.get(address);
-                    if (!existingBuffer || size > existingBuffer.size) {
-                        uniqueBuffers.set(address, buffer);
+function BufferSummaryTab({ plotRef, tableRef, buffersByOperation, bufferType }: BufferSummaryTabProps) {
+    const uniqueBuffersByOperationList = useMemo(
+        () =>
+            buffersByOperation.map((operation) => {
+                const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
+                operation.buffers.forEach((buffer) => {
+                    const { address, size } = buffer;
+                    if (address) {
+                        const existingBuffer = uniqueBuffers.get(address);
+                        if (!existingBuffer || size > existingBuffer.size) {
+                            uniqueBuffers.set(address, buffer);
+                        }
                     }
-                }
-            });
-            return {
-                ...operation,
-                buffers: Array.from(uniqueBuffers.values()),
-            };
-        });
-    }, [buffersByOperation]);
+                });
+
+                return {
+                    ...operation,
+                    buffers: Array.from(uniqueBuffers.values()),
+                };
+            }),
+        [buffersByOperation],
+    );
 
     return (
         <>
@@ -51,16 +47,10 @@ function BufferSummaryTab({
                 ref={plotRef}
                 id={SECTION_IDS.PLOT}
             >
-                {isDram ? (
-                    <BufferSummaryPlotRendererDRAM
-                        uniqueBuffersByOperationList={uniqueBuffersByOperationList}
-                        tensorListByOperation={tensorListByOperation}
-                    />
+                {bufferType === BufferType.DRAM ? (
+                    <BufferSummaryPlotRendererDRAM uniqueBuffersByOperationList={uniqueBuffersByOperationList} />
                 ) : (
-                    <BufferSummaryPlotRenderer
-                        uniqueBuffersByOperationList={uniqueBuffersByOperationList}
-                        tensorListByOperation={tensorListByOperation}
-                    />
+                    <BufferSummaryPlotRenderer uniqueBuffersByOperationList={uniqueBuffersByOperationList} />
                 )}
             </div>
 
@@ -71,7 +61,7 @@ function BufferSummaryTab({
             >
                 <BufferSummaryTable
                     buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
-                    tensorListByOperation={tensorListByOperation}
+                    bufferType={bufferType}
                 />
             </div>
         </>

--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -8,7 +8,7 @@ import { useAtomValue } from 'jotai';
 import { Table2 as BlueprintTable, Cell, Column, ColumnHeaderCell, Table2 } from '@blueprintjs/table';
 import { Checkbox, HotkeysProvider, Icon, InputGroup, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { BufferType, BufferTypeLabel } from '../../model/BufferType';
+import { BufferTypeLabel } from '../../model/BufferType';
 import LoadingSpinner from '../LoadingSpinner';
 import '@blueprintjs/table/lib/css/table.css';
 import 'styles/components/BufferSummaryTable.scss';
@@ -17,16 +17,17 @@ import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
 import { formatMemorySize, toHex } from '../../functions/math';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { Buffer, BufferData, BuffersByOperation } from '../../model/APIData';
-import { BufferTableFilters, ColumnKeys, Columns, TAB_IDS } from '../../definitions/BufferSummary';
+import { BufferTableFilters, ColumnKeys, Columns } from '../../definitions/BufferSummary';
 import useBufferFocus from '../../hooks/useBufferFocus';
-import { useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
-import { selectedBufferSummaryTabAtom, showHexAtom } from '../../store/app';
+import { showHexAtom } from '../../store/app';
 import { BufferMemoryLayout } from '../../functions/parseMemoryConfig';
 import isValidNumber from '../../functions/isValidNumber';
 import { toReadableShape, toReadableType } from '../../functions/formatting';
+import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 
 interface BufferSummaryTableProps {
     buffersByOperation: BuffersByOperation[];
+    tensorListByOperation: TensorsByOperationByAddress;
 }
 
 interface SummaryTableBuffer extends BufferData {
@@ -38,8 +39,7 @@ interface SummaryTableBuffer extends BufferData {
     shape?: string;
 }
 
-function BufferSummaryTable({ buffersByOperation }: BufferSummaryTableProps) {
-    const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
+function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: BufferSummaryTableProps) {
     const [userSelectedRows, setUserSelectedRows] = useState<number[]>([]);
     const [showOnlySelected, setShowOnlySelected] = useState(false);
     const [mergedByDevice, setMergedByDevice] = useState(true);
@@ -48,9 +48,6 @@ function BufferSummaryTable({ buffersByOperation }: BufferSummaryTableProps) {
     const { selectedTensorId } = useBufferFocus();
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(Columns[0].key);
     const tableRef = useRef<Table2 | null>(null);
-    const tensorListByOperation = useCreateTensorsByOperationByIdList(
-        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
-    );
 
     const filterableColumnKeys = useMemo(
         () => Columns.filter((column) => column.filterable).map((column) => column.key),

--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Table2 as BlueprintTable, Cell, Column, ColumnHeaderCell, Table2 } from '@blueprintjs/table';
 import { Checkbox, HotkeysProvider, Icon, InputGroup, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
+import { useAtomValue } from 'jotai';
 import { BufferType, BufferTypeLabel } from '../../model/BufferType';
 import LoadingSpinner from '../LoadingSpinner';
 import '@blueprintjs/table/lib/css/table.css';
@@ -16,13 +17,13 @@ import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
 import { formatMemorySize, toHex } from '../../functions/math';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { Buffer, BufferData, BuffersByOperation } from '../../model/APIData';
-import { BufferTableFilters, ColumnKeys, Columns } from '../../definitions/BufferSummary';
+import { BufferTableFilters, ColumnKeys, Columns, TAB_IDS } from '../../definitions/BufferSummary';
 import useBufferFocus from '../../hooks/useBufferFocus';
 import { useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
+import { selectedBufferSummaryTabAtom } from '../../store/app';
 
 interface BufferSummaryTableProps {
     buffersByOperation: BuffersByOperation[];
-    bufferType: BufferType;
 }
 
 interface SummaryTableBuffer extends BufferData {
@@ -32,15 +33,18 @@ interface SummaryTableBuffer extends BufferData {
     hexAddress: string;
 }
 
-function BufferSummaryTable({ buffersByOperation, bufferType }: BufferSummaryTableProps) {
-    const { selectedTensorId } = useBufferFocus();
-    const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(Columns[0].key);
-    const tableRef = useRef<Table2 | null>(null);
-    const tensorListByOperation = useCreateTensorsByOperationByIdList(bufferType);
-
+function BufferSummaryTable({ buffersByOperation }: BufferSummaryTableProps) {
+    const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
     const [userSelectedRows, setUserSelectedRows] = useState<number[]>([]);
     const [showOnlySelected, setShowOnlySelected] = useState(false);
     const [mergedByDevice, setMergedByDevice] = useState(true);
+
+    const { selectedTensorId } = useBufferFocus();
+    const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(Columns[0].key);
+    const tableRef = useRef<Table2 | null>(null);
+    const tensorListByOperation = useCreateTensorsByOperationByIdList(
+        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
+    );
 
     const filterableColumnKeys = useMemo(
         () => Columns.filter((column) => column.filterable).map((column) => column.key),

--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -7,22 +7,22 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Table2 as BlueprintTable, Cell, Column, ColumnHeaderCell, Table2 } from '@blueprintjs/table';
 import { Checkbox, HotkeysProvider, Icon, InputGroup, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { BufferTypeLabel } from '../../model/BufferType';
+import { BufferType, BufferTypeLabel } from '../../model/BufferType';
 import LoadingSpinner from '../LoadingSpinner';
 import '@blueprintjs/table/lib/css/table.css';
 import 'styles/components/BufferSummaryTable.scss';
 import HighlightedText from '../HighlightedText';
 import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
-import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 import { formatMemorySize, toHex } from '../../functions/math';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { Buffer, BufferData, BuffersByOperation } from '../../model/APIData';
 import { BufferTableFilters, ColumnKeys, Columns } from '../../definitions/BufferSummary';
 import useBufferFocus from '../../hooks/useBufferFocus';
+import { useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
 
 interface BufferSummaryTableProps {
     buffersByOperation: BuffersByOperation[];
-    tensorListByOperation: TensorsByOperationByAddress;
+    bufferType: BufferType;
 }
 
 interface SummaryTableBuffer extends BufferData {
@@ -32,14 +32,15 @@ interface SummaryTableBuffer extends BufferData {
     hexAddress: string;
 }
 
-function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: BufferSummaryTableProps) {
-    const [userSelectedRows, setUserSelectedRows] = useState<number[]>([]);
-    const [showOnlySelected, setShowOnlySelected] = useState(false);
-    const [mergedByDevice, setMergedByDevice] = useState(true);
-
+function BufferSummaryTable({ buffersByOperation, bufferType }: BufferSummaryTableProps) {
     const { selectedTensorId } = useBufferFocus();
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(Columns[0].key);
     const tableRef = useRef<Table2 | null>(null);
+    const tensorListByOperation = useCreateTensorsByOperationByIdList(bufferType);
+
+    const [userSelectedRows, setUserSelectedRows] = useState<number[]>([]);
+    const [showOnlySelected, setShowOnlySelected] = useState(false);
+    const [mergedByDevice, setMergedByDevice] = useState(true);
 
     const filterableColumnKeys = useMemo(
         () => Columns.filter((column) => column.filterable).map((column) => column.key),
@@ -67,7 +68,7 @@ function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: Buffe
                     const existingBuffer = uniqueBuffers.get(address);
                     if (!existingBuffer || size > existingBuffer.size) {
                         uniqueBuffers.set(address, buffer);
-                        // TODO: add device list to buffer fro rendering maybe
+                        // TODO: add device list to buffer for rendering maybe
                     }
                 }
             });

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Icon, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
-import { DeviceOperationLayoutTypes, FragmentationEntry, MarkerType } from '../../model/APIData';
+import { DeviceOperationLayoutTypes, FragmentationEntry, MarkerType, MarkerTypeLabel } from '../../model/APIData';
 import { OperationDetails } from '../../model/OperationDetails';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
@@ -123,9 +123,9 @@ export const MemoryLegendElement: React.FC<{
             <div className='format-numbers monospace nowrap'>
                 {/* eslint-disable-next-line no-nested-ternary */}
                 {chunk.markerType === MarkerType.L1_SMALL ? (
-                    'L1 SMALL region'
+                    MarkerTypeLabel.L1_SMALL
                 ) : chunk.markerType === MarkerType.L1_START ? (
-                    'L1 START'
+                    MarkerTypeLabel.L1_START
                 ) : (
                     <>
                         {formatMemorySize(chunk.size, 2)}

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1057,7 +1057,6 @@ export const useCreateTensorsByOperationByIdList = (bufferType: BufferType = Buf
     const { data: buffersByOperation } = useBuffers(bufferType);
     const { data: operations } = useOperationsList();
 
-    const tensorsByOperationByAddress: TensorsByOperationByAddress = new Map();
     const uniqueBuffersByOperationList = useMemo(() => {
         return buffersByOperation?.map((operation) => {
             const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
@@ -1079,60 +1078,66 @@ export const useCreateTensorsByOperationByIdList = (bufferType: BufferType = Buf
         });
     }, [buffersByOperation]);
 
-    if (!operations || !buffersByOperation) {
-        return tensorsByOperationByAddress;
-    }
+    const tensorsByOperationByAddress = useMemo(() => {
+        const result: TensorsByOperationByAddress = new Map();
 
-    const buffersByOpId = new Map<number, Buffer[]>();
-    uniqueBuffersByOperationList?.forEach((op) => {
-        buffersByOpId.set(op.id, op.buffers);
-    });
+        if (!operations || !buffersByOperation) {
+            return result;
+        }
 
-    const latestTensorByAddress = new Map<number, Tensor>();
+        const buffersByOpId = new Map<number, Buffer[]>();
+        uniqueBuffersByOperationList?.forEach((op) => {
+            buffersByOpId.set(op.id, op.buffers);
+        });
 
-    for (const op of operations) {
-        if (op.inputs) {
-            for (const t of op.inputs) {
-                if (t && t.address !== null && t.address !== undefined) {
-                    latestTensorByAddress.set(t.address, t);
+        const latestTensorByAddress = new Map<number, Tensor>();
+
+        for (const op of operations) {
+            if (op.inputs) {
+                for (const t of op.inputs) {
+                    if (t && t.address !== null && t.address !== undefined) {
+                        latestTensorByAddress.set(t.address, t);
+                    }
                 }
             }
-        }
-        if (op.outputs) {
-            for (const t of op.outputs) {
-                if (t && t.address !== null && t.address !== undefined) {
-                    latestTensorByAddress.set(t.address, t);
+            if (op.outputs) {
+                for (const t of op.outputs) {
+                    if (t && t.address !== null && t.address !== undefined) {
+                        latestTensorByAddress.set(t.address, t);
+                    }
                 }
             }
-        }
 
-        const buffers = buffersByOpId.get(op.id);
-        if (!buffers?.length) {
-            tensorsByOperationByAddress.set(op.id, new Map());
-            // eslint-disable-next-line no-continue
-            continue;
-        }
-
-        const tensorsByBufferAddress = new Map<number, Tensor>();
-
-        for (const buffer of buffers) {
-            const addr = buffer.address;
-            if (addr === null || addr === undefined) {
+            const buffers = buffersByOpId.get(op.id);
+            if (!buffers?.length) {
+                result.set(op.id, new Map());
                 // eslint-disable-next-line no-continue
                 continue;
             }
 
-            const tensor = latestTensorByAddress.get(addr);
-            if (tensor) {
-                tensorsByBufferAddress.set(addr, {
-                    ...tensor,
-                    buffer_type: buffer.buffer_type,
-                });
+            const tensorsByBufferAddress = new Map<number, Tensor>();
+
+            for (const buffer of buffers) {
+                const addr = buffer.address;
+                if (addr === null || addr === undefined) {
+                    // eslint-disable-next-line no-continue
+                    continue;
+                }
+
+                const tensor = latestTensorByAddress.get(addr);
+                if (tensor) {
+                    tensorsByBufferAddress.set(addr, {
+                        ...tensor,
+                        buffer_type: buffer.buffer_type,
+                    });
+                }
             }
+
+            result.set(op.id, tensorsByBufferAddress);
         }
 
-        tensorsByOperationByAddress.set(op.id, tensorsByBufferAddress);
-    }
+        return result;
+    }, [buffersByOperation, operations, uniqueBuffersByOperationList]);
 
     return tensorsByOperationByAddress;
 };

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1060,6 +1060,7 @@ export const useCreateTensorsByOperationByIdList = (bufferType: BufferType = Buf
     const uniqueBuffersByOperationList = useMemo(() => {
         return buffersByOperation?.map((operation) => {
             const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
+
             operation.buffers.forEach((buffer) => {
                 const { address, size } = buffer;
                 if (address) {
@@ -1069,6 +1070,7 @@ export const useCreateTensorsByOperationByIdList = (bufferType: BufferType = Buf
                     }
                 }
             });
+
             return {
                 ...operation,
                 buffers: Array.from(uniqueBuffers.values()),

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -184,6 +184,12 @@ export enum MarkerType {
     L1_START = 'L1_START',
 }
 
+export const MarkerTypeLabel: Record<MarkerType, string> = {
+    [MarkerType.CB]: 'Circular Buffer',
+    [MarkerType.L1_SMALL]: 'L1 SMALL',
+    [MarkerType.L1_START]: 'L1 START',
+};
+
 export interface FragmentationEntry extends Chunk {
     markerType?: MarkerType | undefined;
     colorVariance?: number | undefined;

--- a/src/routes/BufferSummary.tsx
+++ b/src/routes/BufferSummary.tsx
@@ -4,33 +4,23 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { AnchorButton, ButtonGroup, ButtonVariant, Callout, Intent, Size, Tab, Tabs } from '@blueprintjs/core';
+import { AnchorButton, ButtonGroup, ButtonVariant, Intent, Size, Tab, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useAtom, useAtomValue } from 'jotai';
-import { useBuffers, useOperationsList } from '../hooks/useAPI';
+import { useAtom } from 'jotai';
 import useBufferFocus from '../hooks/useBufferFocus';
 import ROUTES from '../definitions/Routes';
 import BufferSummaryTab from '../components/buffer-summary/BufferSummaryTab';
-import LoadingSpinner from '../components/LoadingSpinner';
 import 'styles/components/BufferSummary.scss';
 import { SECTION_IDS, TAB_IDS } from '../definitions/BufferSummary';
-import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../store/app';
-import { BufferType } from '../model/BufferType';
+import { selectedBufferSummaryTabAtom } from '../store/app';
 
 function BufferSummary() {
-    const { data: operationsList } = useOperationsList();
     const { activeToast, resetToasts } = useBufferFocus();
 
     const plotRef = useRef<HTMLHeadingElement>(null);
     const tableRef = useRef<HTMLHeadingElement>(null);
     const [activeSection, setActiveSection] = useState<SECTION_IDS>(SECTION_IDS.PLOT);
     const [selectedTabId, setSelectedTabId] = useAtom(selectedBufferSummaryTabAtom);
-    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
-
-    const { data: buffersByOperation, error: buffersError } = useBuffers(
-        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
-        true,
-    );
 
     useEffect(() => {
         const scrollRefs = [plotRef, tableRef];
@@ -101,29 +91,10 @@ function BufferSummary() {
                     title='L1'
                     icon={IconNames.PAGE_LAYOUT}
                     panel={
-                        // Excessive prop passing - https://github.com/tenstorrent/ttnn-visualizer/issues/1266
-                        // eslint-disable-next-line no-nested-ternary
-                        buffersByOperation && operationsList ? (
-                            <BufferSummaryTab
-                                plotRef={plotRef}
-                                tableRef={tableRef}
-                                buffersByOperation={buffersByOperation}
-                            />
-                        ) : buffersError ? (
-                            <Callout
-                                intent={Intent.WARNING}
-                                title='Error loading buffer data'
-                                compact
-                            >
-                                <p>
-                                    {`We've been unable to load the L1 buffer data for /${activeProfilerReport?.path}.`}
-                                    <br />
-                                    {buffersError.message}
-                                </p>
-                            </Callout>
-                        ) : (
-                            <LoadingSpinner />
-                        )
+                        <BufferSummaryTab
+                            plotRef={plotRef}
+                            tableRef={tableRef}
+                        />
                     }
                 />
 
@@ -132,29 +103,10 @@ function BufferSummary() {
                     title='DRAM'
                     icon={IconNames.PAGE_LAYOUT}
                     panel={
-                        // Excessive prop passing - https://github.com/tenstorrent/ttnn-visualizer/issues/1266
-                        // eslint-disable-next-line no-nested-ternary
-                        buffersByOperation && operationsList ? (
-                            <BufferSummaryTab
-                                plotRef={plotRef}
-                                tableRef={tableRef}
-                                buffersByOperation={buffersByOperation}
-                            />
-                        ) : buffersError ? (
-                            <Callout
-                                intent={Intent.WARNING}
-                                title='Error loading buffer data'
-                                compact
-                            >
-                                <p>
-                                    {`We've been unable to load the DRAM buffer data for /${activeProfilerReport?.path}.`}
-                                    <br />
-                                    {buffersError.message}
-                                </p>
-                            </Callout>
-                        ) : (
-                            <LoadingSpinner />
-                        )
+                        <BufferSummaryTab
+                            plotRef={plotRef}
+                            tableRef={tableRef}
+                        />
                     }
                 />
             </Tabs>

--- a/src/routes/BufferSummary.tsx
+++ b/src/routes/BufferSummary.tsx
@@ -108,7 +108,6 @@ function BufferSummary() {
                                 plotRef={plotRef}
                                 tableRef={tableRef}
                                 buffersByOperation={buffersByOperation}
-                                bufferType={BufferType.L1}
                             />
                         ) : buffersError ? (
                             <Callout
@@ -140,7 +139,6 @@ function BufferSummary() {
                                 plotRef={plotRef}
                                 tableRef={tableRef}
                                 buffersByOperation={buffersByOperation}
-                                bufferType={BufferType.DRAM}
                             />
                         ) : buffersError ? (
                             <Callout

--- a/src/routes/BufferSummary.tsx
+++ b/src/routes/BufferSummary.tsx
@@ -7,33 +7,29 @@ import { Helmet } from 'react-helmet-async';
 import { AnchorButton, ButtonGroup, ButtonVariant, Callout, Intent, Size, Tab, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom, useAtomValue } from 'jotai';
-import { useBuffers, useCreateTensorsByOperationByIdList, useOperationsList } from '../hooks/useAPI';
+import { useBuffers, useOperationsList } from '../hooks/useAPI';
 import useBufferFocus from '../hooks/useBufferFocus';
-import { BufferType } from '../model/BufferType';
 import ROUTES from '../definitions/Routes';
 import BufferSummaryTab from '../components/buffer-summary/BufferSummaryTab';
 import LoadingSpinner from '../components/LoadingSpinner';
 import 'styles/components/BufferSummary.scss';
 import { SECTION_IDS, TAB_IDS } from '../definitions/BufferSummary';
 import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../store/app';
+import { BufferType } from '../model/BufferType';
 
 function BufferSummary() {
+    const { data: operationsList } = useOperationsList();
+    const { activeToast, resetToasts } = useBufferFocus();
+
     const plotRef = useRef<HTMLHeadingElement>(null);
     const tableRef = useRef<HTMLHeadingElement>(null);
     const [activeSection, setActiveSection] = useState<SECTION_IDS>(SECTION_IDS.PLOT);
     const [selectedTabId, setSelectedTabId] = useAtom(selectedBufferSummaryTabAtom);
     const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
 
-    // TODO: this requires further optimization
     const { data: buffersByOperation, error: buffersError } = useBuffers(
         selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
         true,
-    );
-    const { data: operationsList } = useOperationsList();
-    const { activeToast, resetToasts } = useBufferFocus();
-
-    const tensorListByOperation = useCreateTensorsByOperationByIdList(
-        selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM,
     );
 
     useEffect(() => {
@@ -107,12 +103,12 @@ function BufferSummary() {
                     panel={
                         // Excessive prop passing - https://github.com/tenstorrent/ttnn-visualizer/issues/1266
                         // eslint-disable-next-line no-nested-ternary
-                        buffersByOperation && operationsList && tensorListByOperation ? (
+                        buffersByOperation && operationsList ? (
                             <BufferSummaryTab
                                 plotRef={plotRef}
                                 tableRef={tableRef}
                                 buffersByOperation={buffersByOperation}
-                                tensorListByOperation={tensorListByOperation}
+                                bufferType={BufferType.L1}
                             />
                         ) : buffersError ? (
                             <Callout
@@ -139,13 +135,12 @@ function BufferSummary() {
                     panel={
                         // Excessive prop passing - https://github.com/tenstorrent/ttnn-visualizer/issues/1266
                         // eslint-disable-next-line no-nested-ternary
-                        buffersByOperation && operationsList && tensorListByOperation ? (
+                        buffersByOperation && operationsList ? (
                             <BufferSummaryTab
                                 plotRef={plotRef}
                                 tableRef={tableRef}
                                 buffersByOperation={buffersByOperation}
-                                tensorListByOperation={tensorListByOperation}
-                                isDram
+                                bufferType={BufferType.DRAM}
                             />
                         ) : buffersError ? (
                             <Callout

--- a/src/scss/components/BufferSummaryControls.scss
+++ b/src/scss/components/BufferSummaryControls.scss
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+.buffer-summary-controls {
+    display: inline-flex;
+    flex-direction: column;
+    margin-bottom: 0;
+    align-items: flex-start;
+}

--- a/src/scss/components/BufferSummaryPlot.scss
+++ b/src/scss/components/BufferSummaryPlot.scss
@@ -13,13 +13,6 @@ $height-offset: 15px;
 .buffer-summary-chart {
     margin-bottom: $height-offset * 2;
 
-    .controls {
-        display: inline-flex;
-        flex-direction: column;
-        margin-bottom: 0;
-        align-items: flex-start;
-    }
-
     .chart-position {
         position: relative;
     }


### PR DESCRIPTION
Simplified prop passing to BufferSummaryTab, moved data controls to their own component to simplify plot renderer components and used atoms instead of passing props where it made sense.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1266.