### PR TITLE
Show consumer count and high-consumer warning

### DIFF
--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -449,7 +449,7 @@ const TensorList = () => {
                                                 >
                                                     {tensor.consumers.length > MAX_NUM_CONSUMERS ? (
                                                         <Tooltip
-                                                            content={`Unusually high number of consumers - ${tensor.consumers.length}`}
+                                                            content={`Unusually high number of consumers (${tensor.consumers.length})`}
                                                             position={PopoverPosition.TOP}
                                                             className='high-number-consumers'
                                                         >

--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -449,7 +449,7 @@ const TensorList = () => {
                                                 >
                                                     {tensor.consumers.length > MAX_NUM_CONSUMERS ? (
                                                         <Tooltip
-                                                            content='Unusually high number of consumers'
+                                                            content={`Unusually high number of consumers - ${tensor.consumers.length}`}
                                                             position={PopoverPosition.TOP}
                                                             className='high-number-consumers'
                                                         >
@@ -517,6 +517,12 @@ const TensorList = () => {
                                                     operations={operations}
                                                 />
                                             </div>
+                                            {tensor.consumers.length > MAX_NUM_CONSUMERS ? (
+                                                <p className='arguments-wrapper high-consumer-warning'>
+                                                    This tensor has {tensor.consumers.length} consumers, which is
+                                                    unusually high and may indicate an issue in the model.
+                                                </p>
+                                            ) : null}
                                         </Collapsible>
                                     </li>
                                 );


### PR DESCRIPTION

<img width="858" height="723" alt="image" src="https://github.com/user-attachments/assets/60aef893-fef2-4490-b2f1-5fb043a586f8" />

Include the actual consumer count in the tooltip and add an inline warning paragraph when a tensor's consumers exceed MAX_NUM_CONSUMERS.

closes #1274 