### PR TITLE
Feature/Avoid multiple buffer focus

### DIFF
--- a/src/components/operation-details/DRAMPlots.tsx
+++ b/src/components/operation-details/DRAMPlots.tsx
@@ -31,7 +31,7 @@ interface DramPlotProps {
     zoomedInViewMainMemory: boolean;
     onDramBufferClick: (event: Readonly<PlotMouseEventCustom>) => void;
     onDramDeltaClick: (event: Readonly<PlotMouseEventCustom>) => void;
-    onLegendClick: (address: number, tensorId?: number) => void;
+    onLegendClick: (address: number, tensorId?: number, colorVariance?: number) => void;
 }
 
 function DRAMPlots({

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -203,7 +203,7 @@ const renderMemoryInfo = (
 function useDeviceOperationsFullRenderModel(args: {
     deviceOperations: Node[];
     details: OperationDetails;
-    onLegendClick: (address: number, tensorId?: number) => void;
+    onLegendClick: (address: number, tensorId?: number, colorVariance?: number) => void;
 }) {
     const { deviceOperations, details, onLegendClick } = args;
 
@@ -400,7 +400,7 @@ function useDeviceOperationsFullRenderModel(args: {
 const DeviceOperationsFullRender: React.FC<{
     deviceOperations: Node[];
     details: OperationDetails;
-    onLegendClick: (address: number, tensorId?: number) => void;
+    onLegendClick: (address: number, tensorId?: number, colorVariance?: number) => void;
 }> = ({ deviceOperations, details, onLegendClick }) => {
     const { peakMemoryLoad, renderOperations } = useDeviceOperationsFullRenderModel({
         deviceOperations,

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -37,7 +37,7 @@ interface L1PlotsProps {
     showCircularBuffer: boolean;
     showL1Small: boolean;
     onBufferClick: (event: Readonly<PlotMouseEventCustom>) => void;
-    onLegendClick: (address: number, tensorId?: number) => void;
+    onLegendClick: (address: number, tensorId?: number, colorVariance?: number) => void;
 }
 
 const MEMORY_ZOOM_PADDING_RATIO = 0.01;

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -23,7 +23,7 @@ import {
     PlotMouseEventCustom,
 } from '../../definitions/PlotConfigurations';
 import { BufferType } from '../../model/BufferType';
-import { FragmentationEntry } from '../../model/APIData';
+import { ChunkBufferType, FragmentationEntry } from '../../model/APIData';
 import { MemoryLegendGroup } from './MemoryLegendGroup';
 import { useGetL1SmallMarker, useGetL1StartMarker } from '../../hooks/useAPI';
 import useScrollShade from '../../hooks/useScrollShade';
@@ -291,7 +291,7 @@ function L1Plots({
                         chunk={{
                             size: 0,
                             address: l1StartMarker,
-                            bufferType: 'L1_START',
+                            bufferType: ChunkBufferType.L1_START,
                         }}
                         key='l1start-marker'
                         memSize={memorySizeL1}
@@ -342,7 +342,7 @@ function L1Plots({
                         chunk={{
                             size: 0,
                             address: l1SmallMarker,
-                            bufferType: 'L1_SMALL',
+                            bufferType: ChunkBufferType.L1_SMALL,
                         }}
                         key='l1small-marker'
                         memSize={memorySizeL1}

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -111,7 +111,7 @@ function L1Plots({
                     (cb) =>
                         ({
                             ...cb,
-                            bufferType: MarkerType.CB,
+                            markerType: MarkerType.CB,
                             colorVariance: op.id,
                         }) as FragmentationEntry,
                 ),
@@ -291,7 +291,7 @@ function L1Plots({
                         chunk={{
                             size: 0,
                             address: l1StartMarker,
-                            bufferType: MarkerType.L1_START,
+                            markerType: MarkerType.L1_START,
                         }}
                         key='l1start-marker'
                         memSize={memorySizeL1}
@@ -342,7 +342,7 @@ function L1Plots({
                         chunk={{
                             size: 0,
                             address: l1SmallMarker,
-                            bufferType: MarkerType.L1_SMALL,
+                            markerType: MarkerType.L1_SMALL,
                         }}
                         key='l1small-marker'
                         memSize={memorySizeL1}

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -77,7 +77,7 @@ function L1Plots({
         .sort((a, b) => a - b)[0];
 
     const cbZoomEnd = operationDetails.deviceOperations
-        .map((op) => op.cbList.map((cd) => cd.address + cd.size))
+        .map((op) => op.cbList.map((cb) => cb.address + cb.size))
         .flat()
         .sort((a, b) => a - b)
         .reverse()[0];

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -23,7 +23,7 @@ import {
     PlotMouseEventCustom,
 } from '../../definitions/PlotConfigurations';
 import { BufferType } from '../../model/BufferType';
-import { ChunkBufferType, FragmentationEntry } from '../../model/APIData';
+import { FragmentationEntry, MarkerType } from '../../model/APIData';
 import { MemoryLegendGroup } from './MemoryLegendGroup';
 import { useGetL1SmallMarker, useGetL1StartMarker } from '../../hooks/useAPI';
 import useScrollShade from '../../hooks/useScrollShade';
@@ -111,7 +111,7 @@ function L1Plots({
                     (cb) =>
                         ({
                             ...cb,
-                            bufferType: 'CB',
+                            bufferType: MarkerType.CB,
                             colorVariance: op.id,
                         }) as FragmentationEntry,
                 ),
@@ -291,7 +291,7 @@ function L1Plots({
                         chunk={{
                             size: 0,
                             address: l1StartMarker,
-                            bufferType: ChunkBufferType.L1_START,
+                            bufferType: MarkerType.L1_START,
                         }}
                         key='l1start-marker'
                         memSize={memorySizeL1}
@@ -342,7 +342,7 @@ function L1Plots({
                         chunk={{
                             size: 0,
                             address: l1SmallMarker,
-                            bufferType: ChunkBufferType.L1_SMALL,
+                            bufferType: MarkerType.L1_SMALL,
                         }}
                         key='l1small-marker'
                         memSize={memorySizeL1}

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -83,7 +83,7 @@ export const MemoryLegendElement: React.FC<{
         }),
     };
 
-    const isMatchingBufferColor = memorySquare.backgroundColor === selectedBufferColour;
+    const isMatchingBufferColour = memorySquare.backgroundColor === selectedBufferColour;
 
     return (
         <Component
@@ -95,11 +95,11 @@ export const MemoryLegendElement: React.FC<{
                         !chunk.empty &&
                         chunk.bufferType !== ChunkBufferType.L1_SMALL &&
                         chunk.bufferType !== ChunkBufferType.L1_START,
-                    active: selectedTensorAddress === chunk.address && isMatchingBufferColor,
+                    active: selectedTensorAddress === chunk.address && isMatchingBufferColour,
                     dimmed:
                         selectedBufferColour !== null &&
                         selectedTensorAddress !== null &&
-                        (selectedTensorAddress !== chunk.address || !isMatchingBufferColor),
+                        (selectedTensorAddress !== chunk.address || !isMatchingBufferColour),
                     'extra-info': bufferType || layout,
                 },
                 className,

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -7,7 +7,12 @@ import classNames from 'classnames';
 import { Icon, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
-import { DeviceOperationLayoutTypes, DeviceOperationTypes, FragmentationEntry } from '../../model/APIData';
+import {
+    ChunkBufferType,
+    DeviceOperationLayoutTypes,
+    DeviceOperationTypes,
+    FragmentationEntry,
+} from '../../model/APIData';
 import { OperationDetails } from '../../model/OperationDetails';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
@@ -15,14 +20,15 @@ import { toReadableShape, toReadableType } from '../../functions/formatting';
 import 'styles/components/MemoryLegendElement.scss';
 import { L1_SMALL_MARKER_COLOR, L1_START_MARKER_COLOR } from '../../definitions/PlotConfigurations';
 import { showHexAtom } from '../../store/app';
+import useBufferFocus from '../../hooks/useBufferFocus';
 
 export const MemoryLegendElement: React.FC<{
     chunk: FragmentationEntry;
     memSize: number;
     selectedTensorAddress: number | null;
     operationDetails: OperationDetails;
-    onLegendClick: (selectedTensorAddress: number, tensorId?: number | undefined) => void;
-    colorVariance?: number | undefined; // color uniqueness for the CB color
+    onLegendClick: (selectedTensorAddress: number, tensorId?: number, colorVariance?: number) => void;
+    colorVariance?: number; // color uniqueness for the CB color
     bufferType?: DeviceOperationTypes;
     layout?: DeviceOperationLayoutTypes;
     isMultiDeviceBuffer?: boolean;
@@ -44,7 +50,11 @@ export const MemoryLegendElement: React.FC<{
     numCores,
 }) => {
     const showHex = useAtomValue(showHexAtom);
-    const Component = chunk.empty ? 'div' : 'button';
+    const { selectedBufferColour } = useBufferFocus();
+    const Component =
+        chunk.empty || chunk.bufferType === ChunkBufferType.L1_SMALL || chunk.bufferType === ChunkBufferType.L1_START
+            ? 'div'
+            : 'button';
     const emptyChunkLabel = (
         <>
             <span>Empty space </span>
@@ -61,24 +71,52 @@ export const MemoryLegendElement: React.FC<{
 
     const derivedTensor = operationDetails.getTensorForAddress(chunk.address);
     const numCoresLabel = numCores && numCores > 1 ? ` x ${numCores} cores` : '';
+
+    const memorySquare = {
+        ...(chunk.empty
+            ? {}
+            : {
+                  backgroundColor:
+                      chunk.tensorId || derivedTensor
+                          ? getTensorColor(chunk.tensorId) || getTensorColor(derivedTensor?.id)
+                          : getBufferColor(chunk.address + (colorVariance || 0)),
+              }),
+        ...(chunk.bufferType === ChunkBufferType.L1_SMALL && {
+            backgroundColor: L1_SMALL_MARKER_COLOR,
+        }),
+        ...(chunk.bufferType === ChunkBufferType.L1_START && {
+            backgroundColor: L1_START_MARKER_COLOR,
+        }),
+    };
+
+    const isMatchingBufferColor = memorySquare.backgroundColor === selectedBufferColour;
+
     return (
         <Component
             key={chunk.address}
             className={classNames(
                 'legend-item',
                 {
-                    button: !chunk.empty && chunk.bufferType !== 'L1_SMALL' && chunk.bufferType !== 'L1_START',
-                    active: selectedTensorAddress === chunk.address,
-                    dimmed: selectedTensorAddress !== null && selectedTensorAddress !== chunk.address,
+                    button:
+                        !chunk.empty &&
+                        chunk.bufferType !== ChunkBufferType.L1_SMALL &&
+                        chunk.bufferType !== ChunkBufferType.L1_START,
+                    active: selectedTensorAddress === chunk.address && isMatchingBufferColor,
+                    dimmed:
+                        selectedBufferColour !== undefined &&
+                        selectedTensorAddress !== null &&
+                        (selectedTensorAddress !== chunk.address || !isMatchingBufferColor),
                     'extra-info': bufferType || layout,
                 },
                 className,
             )}
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...(!chunk.empty && chunk.bufferType !== 'L1_SMALL' && chunk.bufferType !== 'L1_START'
+            {...(!chunk.empty &&
+            chunk.bufferType !== ChunkBufferType.L1_SMALL &&
+            chunk.bufferType !== ChunkBufferType.L1_START
                 ? {
                       type: 'button',
-                      onClick: () => onLegendClick(chunk.address, chunk.tensorId),
+                      onClick: () => onLegendClick(chunk.address, chunk.tensorId, colorVariance),
                   }
                 : {})}
         >
@@ -86,29 +124,14 @@ export const MemoryLegendElement: React.FC<{
                 className={classNames('memory-color-block', {
                     empty: chunk.empty,
                 })}
-                style={{
-                    ...(chunk.empty
-                        ? {}
-                        : {
-                              backgroundColor:
-                                  chunk.tensorId || derivedTensor
-                                      ? getTensorColor(chunk.tensorId) || getTensorColor(derivedTensor?.id)
-                                      : getBufferColor(chunk.address + (colorVariance || 0)),
-                          }),
-                    ...(chunk.bufferType === 'L1_SMALL' && {
-                        backgroundColor: L1_SMALL_MARKER_COLOR,
-                    }),
-                    ...(chunk.bufferType === 'L1_START' && {
-                        backgroundColor: L1_START_MARKER_COLOR,
-                    }),
-                }}
+                style={memorySquare}
             />
             <div className='format-numbers monospace'>{prettyPrintAddress(chunk.address, memSize, showHex)}</div>
             <div className='format-numbers monospace nowrap'>
                 {/* eslint-disable-next-line no-nested-ternary */}
-                {chunk.bufferType === 'L1_SMALL' ? (
+                {chunk.bufferType === ChunkBufferType.L1_SMALL ? (
                     'L1 SMALL region'
-                ) : chunk.bufferType === 'L1_START' ? (
+                ) : chunk.bufferType === ChunkBufferType.L1_START ? (
                     'L1 START'
                 ) : (
                     <>

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Icon, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
-import { ChunkBufferType, DeviceOperationLayoutTypes, FragmentationEntry, StringBufferType } from '../../model/APIData';
+import { DeviceOperationLayoutTypes, FragmentationEntry, MarkerType, StringBufferType } from '../../model/APIData';
 import { OperationDetails } from '../../model/OperationDetails';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
@@ -46,7 +46,7 @@ export const MemoryLegendElement: React.FC<{
     const showHex = useAtomValue(showHexAtom);
     const selectedBufferColour = useAtomValue(selectedBufferColourAtom);
     const Component =
-        chunk.empty || chunk.bufferType === ChunkBufferType.L1_SMALL || chunk.bufferType === ChunkBufferType.L1_START
+        chunk.empty || chunk.bufferType === MarkerType.L1_SMALL || chunk.bufferType === MarkerType.L1_START
             ? 'div'
             : 'button';
     const emptyChunkLabel = (
@@ -75,10 +75,10 @@ export const MemoryLegendElement: React.FC<{
                           ? getTensorColor(chunk.tensorId) || getTensorColor(derivedTensor?.id)
                           : getBufferColor(chunk.address + (colorVariance || 0)),
               }),
-        ...(chunk.bufferType === ChunkBufferType.L1_SMALL && {
+        ...(chunk.bufferType === MarkerType.L1_SMALL && {
             backgroundColor: L1_SMALL_MARKER_COLOR,
         }),
-        ...(chunk.bufferType === ChunkBufferType.L1_START && {
+        ...(chunk.bufferType === MarkerType.L1_START && {
             backgroundColor: L1_START_MARKER_COLOR,
         }),
     };
@@ -93,8 +93,8 @@ export const MemoryLegendElement: React.FC<{
                 {
                     button:
                         !chunk.empty &&
-                        chunk.bufferType !== ChunkBufferType.L1_SMALL &&
-                        chunk.bufferType !== ChunkBufferType.L1_START,
+                        chunk.bufferType !== MarkerType.L1_SMALL &&
+                        chunk.bufferType !== MarkerType.L1_START,
                     active: selectedTensorAddress === chunk.address && isMatchingBufferColour,
                     dimmed:
                         selectedBufferColour !== null &&
@@ -105,9 +105,7 @@ export const MemoryLegendElement: React.FC<{
                 className,
             )}
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...(!chunk.empty &&
-            chunk.bufferType !== ChunkBufferType.L1_SMALL &&
-            chunk.bufferType !== ChunkBufferType.L1_START
+            {...(!chunk.empty && chunk.bufferType !== MarkerType.L1_SMALL && chunk.bufferType !== MarkerType.L1_START
                 ? {
                       type: 'button',
                       onClick: () => onLegendClick(chunk.address, chunk.tensorId, colorVariance),
@@ -123,9 +121,9 @@ export const MemoryLegendElement: React.FC<{
             <div className='format-numbers monospace'>{prettyPrintAddress(chunk.address, memSize, showHex)}</div>
             <div className='format-numbers monospace nowrap'>
                 {/* eslint-disable-next-line no-nested-ternary */}
-                {chunk.bufferType === ChunkBufferType.L1_SMALL ? (
+                {chunk.bufferType === MarkerType.L1_SMALL ? (
                     'L1 SMALL region'
-                ) : chunk.bufferType === ChunkBufferType.L1_START ? (
+                ) : chunk.bufferType === MarkerType.L1_START ? (
                     'L1 START'
                 ) : (
                     <>

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -14,8 +14,7 @@ import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
 import { toReadableShape, toReadableType } from '../../functions/formatting';
 import 'styles/components/MemoryLegendElement.scss';
 import { L1_SMALL_MARKER_COLOR, L1_START_MARKER_COLOR } from '../../definitions/PlotConfigurations';
-import { showHexAtom } from '../../store/app';
-import useBufferFocus from '../../hooks/useBufferFocus';
+import { selectedBufferColourAtom, showHexAtom } from '../../store/app';
 
 export const MemoryLegendElement: React.FC<{
     chunk: FragmentationEntry;
@@ -45,7 +44,7 @@ export const MemoryLegendElement: React.FC<{
     numCores,
 }) => {
     const showHex = useAtomValue(showHexAtom);
-    const { selectedBufferColour } = useBufferFocus();
+    const selectedBufferColour = useAtomValue(selectedBufferColourAtom);
     const Component =
         chunk.empty || chunk.bufferType === ChunkBufferType.L1_SMALL || chunk.bufferType === ChunkBufferType.L1_START
             ? 'div'
@@ -98,7 +97,7 @@ export const MemoryLegendElement: React.FC<{
                         chunk.bufferType !== ChunkBufferType.L1_START,
                     active: selectedTensorAddress === chunk.address && isMatchingBufferColor,
                     dimmed:
-                        selectedBufferColour !== undefined &&
+                        selectedBufferColour !== null &&
                         selectedTensorAddress !== null &&
                         (selectedTensorAddress !== chunk.address || !isMatchingBufferColor),
                     'extra-info': bufferType || layout,

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -46,7 +46,7 @@ export const MemoryLegendElement: React.FC<{
     const showHex = useAtomValue(showHexAtom);
     const selectedBufferColour = useAtomValue(selectedBufferColourAtom);
     const Component =
-        chunk.empty || chunk.bufferType === MarkerType.L1_SMALL || chunk.bufferType === MarkerType.L1_START
+        chunk.empty || chunk.markerType === MarkerType.L1_SMALL || chunk.markerType === MarkerType.L1_START
             ? 'div'
             : 'button';
     const emptyChunkLabel = (
@@ -75,10 +75,10 @@ export const MemoryLegendElement: React.FC<{
                           ? getTensorColor(chunk.tensorId) || getTensorColor(derivedTensor?.id)
                           : getBufferColor(chunk.address + (colorVariance || 0)),
               }),
-        ...(chunk.bufferType === MarkerType.L1_SMALL && {
+        ...(chunk.markerType === MarkerType.L1_SMALL && {
             backgroundColor: L1_SMALL_MARKER_COLOR,
         }),
-        ...(chunk.bufferType === MarkerType.L1_START && {
+        ...(chunk.markerType === MarkerType.L1_START && {
             backgroundColor: L1_START_MARKER_COLOR,
         }),
     };
@@ -93,8 +93,8 @@ export const MemoryLegendElement: React.FC<{
                 {
                     button:
                         !chunk.empty &&
-                        chunk.bufferType !== MarkerType.L1_SMALL &&
-                        chunk.bufferType !== MarkerType.L1_START,
+                        chunk.markerType !== MarkerType.L1_SMALL &&
+                        chunk.markerType !== MarkerType.L1_START,
                     active: selectedTensorAddress === chunk.address && isMatchingBufferColour,
                     dimmed:
                         selectedBufferColour !== null &&
@@ -105,7 +105,7 @@ export const MemoryLegendElement: React.FC<{
                 className,
             )}
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...(!chunk.empty && chunk.bufferType !== MarkerType.L1_SMALL && chunk.bufferType !== MarkerType.L1_START
+            {...(!chunk.empty && chunk.markerType !== MarkerType.L1_SMALL && chunk.markerType !== MarkerType.L1_START
                 ? {
                       type: 'button',
                       onClick: () => onLegendClick(chunk.address, chunk.tensorId, colorVariance),
@@ -121,9 +121,9 @@ export const MemoryLegendElement: React.FC<{
             <div className='format-numbers monospace'>{prettyPrintAddress(chunk.address, memSize, showHex)}</div>
             <div className='format-numbers monospace nowrap'>
                 {/* eslint-disable-next-line no-nested-ternary */}
-                {chunk.bufferType === MarkerType.L1_SMALL ? (
+                {chunk.markerType === MarkerType.L1_SMALL ? (
                     'L1 SMALL region'
-                ) : chunk.bufferType === MarkerType.L1_START ? (
+                ) : chunk.markerType === MarkerType.L1_START ? (
                     'L1 START'
                 ) : (
                     <>

--- a/src/components/operation-details/MemoryLegendGroup.tsx
+++ b/src/components/operation-details/MemoryLegendGroup.tsx
@@ -15,7 +15,7 @@ export const MemoryLegendGroup: React.FC<{
     memSize: number;
     selectedTensorAddress: number | null;
     operationDetails: OperationDetails;
-    onLegendClick: (selectedTensorAddress: number, tensorId?: number) => void;
+    onLegendClick: (selectedTensorAddress: number, tensorId?: number, colorVariance?: number) => void;
 }> = ({
     // no wrap eslint
     group,

--- a/src/components/operation-details/MemoryLegendGroup.tsx
+++ b/src/components/operation-details/MemoryLegendGroup.tsx
@@ -15,7 +15,7 @@ export const MemoryLegendGroup: React.FC<{
     memSize: number;
     selectedTensorAddress: number | null;
     operationDetails: OperationDetails;
-    onLegendClick: (selectedTensorAddress: number, tensorId?: number | undefined) => void;
+    onLegendClick: (selectedTensorAddress: number, tensorId?: number) => void;
 }> = ({
     // no wrap eslint
     group,

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -173,16 +173,21 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
     };
 
     const onBufferClick = (event: Readonly<PlotMouseEventCustom>): void => {
-        const { address, tensor } = event.points[0].data.memoryData;
-        updateBufferFocus(address, tensor?.id);
+        // TODO: Find a more robust way to determine if the click should not produce a toast
+        const isCBSummary = event.points[0].data.hovertemplate.includes('CBs Summary');
+        const { address, tensor, colorVariance } = event.points[0].data.memoryData;
+
+        if (!isCBSummary) {
+            updateBufferFocus(address, tensor?.id, colorVariance);
+        }
     };
 
     const onTensorClick = (address?: number, tensorId?: number): void => {
         updateBufferFocus(address, tensorId);
     };
 
-    const onLegendClick = (address: number, tensorId?: number) => {
-        updateBufferFocus(address, tensorId);
+    const onLegendClick = (address: number, tensorId?: number, colorVariance?: number) => {
+        updateBufferFocus(address, tensorId, colorVariance);
     };
 
     const inputOutputList = details.inputs.concat(details.outputs);

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -174,7 +174,8 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
 
     const onBufferClick = (event: Readonly<PlotMouseEventCustom>): void => {
         // TODO: Find a more robust way to determine if the click should not produce a toast
-        const isCBSummary = event.points[0].data.hovertemplate.includes('CBs Summary');
+        const { hovertemplate } = event.points[0].data;
+        const isCBSummary = typeof hovertemplate === 'string' && hovertemplate.includes('CBs Summary');
         const { address, tensor, colorVariance } = event.points[0].data.memoryData;
 
         if (!isCBSummary) {

--- a/src/components/operation-details/ToastTensorMessage.tsx
+++ b/src/components/operation-details/ToastTensorMessage.tsx
@@ -2,8 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import 'styles/components/ToastTensorMessage.scss';
 import { useAtomValue } from 'jotai';
+import 'styles/components/ToastTensorMessage.scss';
 import { prettyPrintAddress } from '../../functions/math';
 import { showHexAtom } from '../../store/app';
 

--- a/src/definitions/PlotConfigurations.ts
+++ b/src/definitions/PlotConfigurations.ts
@@ -141,6 +141,7 @@ export interface PlotDataCustom extends PlotData {
         address: number;
         size: number;
         tensor: Tensor | null;
+        colorVariance?: number;
     };
 }
 

--- a/src/functions/colorGenerator.ts
+++ b/src/functions/colorGenerator.ts
@@ -30,6 +30,7 @@ const colorList = [
 
 function* colorGenerator(): IterableIterator<string> {
     let i = 0;
+
     while (true) {
         yield colorList[i];
         i = (i + 1) % colorList.length;
@@ -43,11 +44,14 @@ export const getBufferColor = (address: number | null): string | undefined => {
     if (address === null) {
         return 'rgb(255,255,255)';
     }
+
     if (!bufferColorCache.has(address)) {
         bufferColorCache.set(address, getNextGroupColor.next().value);
     }
+
     return bufferColorCache.get(address);
 };
+
 const tensorNextColor = colorGenerator();
 const tensorColorCache = new Map<number, string>();
 
@@ -55,8 +59,10 @@ export const getTensorColor = (tensorId: number | undefined): string | undefined
     if (tensorId === undefined) {
         return undefined;
     }
+
     if (!tensorColorCache.has(tensorId)) {
         tensorColorCache.set(tensorId, tensorNextColor.next().value);
     }
+
     return tensorColorCache.get(tensorId);
 };

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -19,14 +19,16 @@ export default function getChartData(
         const { address, size } = chunk;
         const tensor = getTensorForAddress(address);
         const tensorColor = getTensorColor(tensor?.id);
+        const colorVariance = overrides?.colorVariance || 0;
         let color;
+
         if (overrides?.color) {
             color = overrides?.color;
         } else if ('color' in chunk && typeof chunk.color === 'string' && chunk.color) {
             // check for ColoredChunk
             color = chunk.color;
         } else {
-            color = tensorColor !== undefined ? tensorColor : getBufferColor(address + (overrides?.colorVariance || 0));
+            color = tensorColor !== undefined ? tensorColor : getBufferColor(address + colorVariance);
         }
 
         const tensorMemoryLayout = tensor?.memory_config?.memory_layout;
@@ -97,6 +99,7 @@ export default function getChartData(
                 address,
                 size,
                 tensor,
+                colorVariance,
             },
             hovertemplate:
                 overrides?.hovertemplate !== undefined

--- a/src/hooks/useBufferFocus.tsx
+++ b/src/hooks/useBufferFocus.tsx
@@ -6,21 +6,23 @@ import { Id, toast } from 'react-toastify';
 import { useAtom } from 'jotai';
 import { getBufferColor, getTensorColor } from '../functions/colorGenerator';
 import ToastTensorMessage from '../components/operation-details/ToastTensorMessage';
-import { activeToastAtom, selectedAddressAtom, selectedTensorIdAtom } from '../store/app';
+import { activeToastAtom, selectedAddressAtom, selectedBufferColourAtom, selectedTensorIdAtom } from '../store/app';
 
 const useBufferFocus = () => {
     const [activeToast, setActiveToast] = useAtom(activeToastAtom);
     const [selectedTensorId, setSelectedTensorId] = useAtom(selectedTensorIdAtom);
     const [selectedAddress, setSelectedAddress] = useAtom(selectedAddressAtom);
+    const [selectedBufferColour, setSelectedBufferColour] = useAtom(selectedBufferColourAtom);
 
     const resetToasts = () => {
         setSelectedTensorId(null);
         setSelectedAddress(null);
+        setSelectedBufferColour(null);
         setActiveToast(null);
         toast.dismiss();
     };
 
-    const createToast = (address?: number, tensorId?: number) => {
+    const createToast = (address?: number, tensorId?: number, colorVariance?: number) => {
         if (activeToast) {
             toast.dismiss(activeToast);
         }
@@ -28,8 +30,10 @@ const useBufferFocus = () => {
         let colour = getTensorColor(tensorId);
 
         if (address && !colour) {
-            colour = getBufferColor(address);
+            colour = getBufferColor(address + (colorVariance || 0));
         }
+
+        setSelectedBufferColour(colour ?? null);
 
         const toastInstance: Id = toast(
             <ToastTensorMessage
@@ -47,13 +51,21 @@ const useBufferFocus = () => {
         setActiveToast(toastInstance);
     };
 
-    const updateBufferFocus = (address?: number, tensorId?: number): void => {
+    const updateBufferFocus = (address?: number, tensorId?: number, colorVariance?: number): void => {
         setSelectedAddress(address ?? null);
         setSelectedTensorId(tensorId ?? null);
-        createToast(address, tensorId);
+        createToast(address, tensorId, colorVariance);
     };
 
-    return { selectedTensorId, selectedAddress, activeToast, resetToasts, setActiveToast, updateBufferFocus };
+    return {
+        selectedTensorId,
+        selectedAddress,
+        activeToast,
+        resetToasts,
+        setActiveToast,
+        updateBufferFocus,
+        selectedBufferColour,
+    };
 };
 
 export default useBufferFocus;

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -178,10 +178,16 @@ export interface ColoredChunk extends Chunk {
     color: string | undefined;
 }
 
+export enum ChunkBufferType {
+    CB = 'CB',
+    L1_START = 'L1_START',
+    L1_SMALL = 'L1_SMALL',
+}
+
 export interface FragmentationEntry extends Chunk {
     empty?: boolean;
     largestEmpty?: boolean;
-    bufferType?: 'CB' | 'L1_START' | 'L1_SMALL' | undefined;
+    bufferType?: ChunkBufferType | undefined;
     colorVariance?: number | undefined;
 }
 

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -185,7 +185,7 @@ export enum MarkerType {
 }
 
 export interface FragmentationEntry extends Chunk {
-    bufferType?: MarkerType | undefined;
+    markerType?: MarkerType | undefined;
     colorVariance?: number | undefined;
     empty?: boolean;
     largestEmpty?: boolean;

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -178,17 +178,17 @@ export interface ColoredChunk extends Chunk {
     color: string | undefined;
 }
 
-export enum ChunkBufferType {
+export enum MarkerType {
     CB = 'CB',
-    L1_START = 'L1_START',
     L1_SMALL = 'L1_SMALL',
+    L1_START = 'L1_START',
 }
 
 export interface FragmentationEntry extends Chunk {
+    bufferType?: MarkerType | undefined;
+    colorVariance?: number | undefined;
     empty?: boolean;
     largestEmpty?: boolean;
-    bufferType?: ChunkBufferType | undefined;
-    colorVariance?: number | undefined;
 }
 
 export interface ReportMetaData {

--- a/src/scss/components/MemoryLegendElement.scss
+++ b/src/scss/components/MemoryLegendElement.scss
@@ -38,11 +38,8 @@
     }
 
     &.button {
+        &:hover,
         &:focus {
-            background-color: $tt-bg-highlight;
-        }
-
-        &:hover {
             background-color: rgba($tt-bg-highlight, 0.5);
         }
     }

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -21,6 +21,7 @@ import { SortingOptions } from '../definitions/SortingOptions';
 export const activeToastAtom = atom<Id | null>(null);
 export const selectedAddressAtom = atom<number | null>(null);
 export const selectedTensorIdAtom = atom<number | null>(null);
+export const selectedBufferColourAtom = atom<string | null>(null);
 export const scrollPositionsAtom = atom<ScrollPosition | null>(null);
 export const fileTransferProgressAtom = atom<FileProgress>({
     currentFileName: '',


### PR DESCRIPTION
Multiple buffers can be highlighted if they share the same address, which can be most frequently seen with CBs. This PR adds the associated buffer colour as an additional check when focussing on a buffer and cleans up surrounding code.

**Before** (square colour in toast is wrong, multiple lines highlighted)
<img width="1309" height="631" alt="Screenshot 2026-03-09 at 15 40 29" src="https://github.com/user-attachments/assets/ce0f3009-2f7d-405f-baf0-392e90dcea7d" />

**After**
<img width="1309" height="631" alt="Screenshot 2026-03-09 at 15 41 49" src="https://github.com/user-attachments/assets/90921626-d6a1-42d3-a691-344deea67789" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1279.