### PR TITLE
Render device operation arguments

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -2,13 +2,34 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { Fragment, JSX, useCallback } from 'react';
-import { Classes, Icon, Intent, PopoverPosition, Tooltip } from '@blueprintjs/core';
+import React, { Fragment, JSX, useCallback, useState } from 'react';
+import {
+    Button,
+    ButtonVariant,
+    Card,
+    Classes,
+    Icon,
+    Intent,
+    Overlay2,
+    PopoverPosition,
+    Size,
+    Tooltip,
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
-import { BufferNode, Node, NodeType, StringBufferType, Tensor, TensorNode } from '../../model/APIData';
+import hljs from 'highlight.js/lib/core';
+import {
+    BufferNode,
+    DeviceOperationNode,
+    Node,
+    NodeType,
+    StringBufferType,
+    Tensor,
+    TensorNode,
+} from '../../model/APIData';
 import 'styles/components/DeviceOperationFullRender.scss';
+import 'styles/components/DeviceOperationArgumentsComponent.scss';
 import { MemoryLegendElement } from './MemoryLegendElement';
 import { OperationDetails } from '../../model/OperationDetails';
 import { selectedAddressAtom } from '../../store/app';
@@ -204,8 +225,10 @@ function useDeviceOperationsFullRenderModel(args: {
     deviceOperations: Node[];
     details: OperationDetails;
     onLegendClick: (address: number, tensorId?: number) => void;
+    setDeviceOperationsArgsNode: React.Dispatch<React.SetStateAction<DeviceOperationNode | null>>;
+    setDeviceOperationsArgsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
-    const { deviceOperations, details, onLegendClick } = args;
+    const { deviceOperations, details, onLegendClick, setDeviceOperationsArgsOpen, setDeviceOperationsArgsNode } = args;
 
     const selectedAddress = useAtomValue(selectedAddressAtom);
     const { memoryAllocationList, peakMemoryLoad } = processMemoryAllocations(deviceOperations);
@@ -234,6 +257,8 @@ function useDeviceOperationsFullRenderModel(args: {
                     const innerContent = stack.pop();
                     const opName = node.params.name;
 
+                    const opArgs = node.operation?.arguments;
+
                     const label = (
                         <h4>
                             <Icon
@@ -242,7 +267,22 @@ function useDeviceOperationsFullRenderModel(args: {
                                 intent={Intent.SUCCESS}
                                 icon={IconNames.CUBE_ADD}
                             />
-                            {opName} <DeviceID _node={node} /> (
+                            {opName}{' '}
+                            {opArgs && opArgs.length && (
+                                <Button
+                                    icon={IconNames.COMPARISON}
+                                    size={Size.SMALL}
+                                    variant={ButtonVariant.MINIMAL}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setDeviceOperationsArgsNode(node.operation!);
+                                        setDeviceOperationsArgsOpen(true);
+                                    }}
+                                    title='View operation arguments'
+                                    className={`${Classes.TOOLTIP_INDICATOR} view-args-button`}
+                                />
+                            )}
+                            <DeviceID _node={node} /> (
                             {node.operation?.inputs.map((inputNode, i) => (
                                 <span
                                     className='params'
@@ -386,7 +426,16 @@ function useDeviceOperationsFullRenderModel(args: {
 
             return output;
         },
-        [details, formatTensor, memoryAllocationList, onLegendClick, peakMemoryLoad, selectedAddress],
+        [
+            details,
+            formatTensor,
+            memoryAllocationList,
+            onLegendClick,
+            peakMemoryLoad,
+            selectedAddress,
+            setDeviceOperationsArgsNode,
+            setDeviceOperationsArgsOpen,
+        ],
     );
 
     return {
@@ -402,14 +451,22 @@ const DeviceOperationsFullRender: React.FC<{
     details: OperationDetails;
     onLegendClick: (address: number, tensorId?: number) => void;
 }> = ({ deviceOperations, details, onLegendClick }) => {
+    const [deviceOperationsArgsOpen, setDeviceOperationsArgsOpen] = useState(false);
+    const [deviceOperationsArgsNode, setDeviceOperationsArgsNode] = useState<DeviceOperationNode | null>(null);
     const { peakMemoryLoad, renderOperations } = useDeviceOperationsFullRenderModel({
         deviceOperations,
         details,
         onLegendClick,
+        setDeviceOperationsArgsNode,
+        setDeviceOperationsArgsOpen,
     });
-
     return (
         <div className='device-operations-full-render-wrap'>
+            <DeviceOperationArgumentsComponent
+                node={deviceOperationsArgsNode}
+                open={deviceOperationsArgsOpen}
+                onClose={() => setDeviceOperationsArgsOpen(false)}
+            />
             <h3 className='peak-load monospace'>
                 Peak L1 memory load per core:{' '}
                 <span className='format-numbers'>{formatMemorySize(peakMemoryLoad, 2)}</span>
@@ -473,5 +530,64 @@ const DeviceID: React.FC<{ _deviceId?: number | string; _node?: Node }> = ({ _de
     // );
     // return _deviceId !== undefined && <span className='device-id'>{_deviceId}</span>;
 };
+const DeviceOperationArgumentsComponent: React.FC<{
+    node: DeviceOperationNode | null;
+    open: boolean;
+    onClose: () => void;
+}> = ({ node, open, onClose }) => {
+    return (
+        <Overlay2
+            isOpen={open}
+            enforceFocus
+            hasBackdrop
+            usePortal
+            canEscapeKeyClose
+            transitionDuration={0}
+            onClose={onClose}
+            canOutsideClickClose
+            portalClassName='device-operation-arguments-visualisation-overlay'
+        >
+            <Card className='contents'>
+                <div className='header'>
+                    <h3 className='title'>
+                        {node?.params.name}
+                        <Button
+                            icon={IconNames.CROSS}
+                            variant={ButtonVariant.MINIMAL}
+                            size={Size.SMALL}
+                            onClick={onClose}
+                        />
+                    </h3>
+                </div>
 
+                <div className='operation-arguments'>
+                    {node?.arguments.map((arg, index) => {
+                        const parsed = hljs.highlight(
+                            arg //
+                                .replaceAll('=', ' = ')
+                                .replaceAll(',', ', '),
+                            {
+                                language: 'cpp',
+                            },
+                        ).value;
+                        return (
+                            <div
+                                className='argument'
+                                key={`arg-${index}`}
+                            >
+                                <code
+                                    className='arg'
+                                    // eslint-disable-next-line react/no-danger
+                                    dangerouslySetInnerHTML={{
+                                        __html: parsed,
+                                    }}
+                                />
+                            </div>
+                        );
+                    })}
+                </div>
+            </Card>
+        </Overlay2>
+    );
+};
 export default DeviceOperationsFullRender;

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -268,7 +268,7 @@ function useDeviceOperationsFullRenderModel(args: {
                                 icon={IconNames.CUBE_ADD}
                             />
                             {opName}{' '}
-                            {opArgs && opArgs.length && (
+                            {opArgs && opArgs.length > 0 && (
                                 <Button
                                     icon={IconNames.COMPARISON}
                                     size={Size.SMALL}

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -15,6 +15,7 @@ import {
     Size,
     Tooltip,
 } from '@blueprintjs/core';
+import cpp from 'highlight.js/lib/languages/cpp';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
@@ -451,6 +452,7 @@ const DeviceOperationsFullRender: React.FC<{
     details: OperationDetails;
     onLegendClick: (address: number, tensorId?: number) => void;
 }> = ({ deviceOperations, details, onLegendClick }) => {
+    hljs.registerLanguage('cpp', cpp);
     const [deviceOperationsArgsOpen, setDeviceOperationsArgsOpen] = useState(false);
     const [deviceOperationsArgsNode, setDeviceOperationsArgsNode] = useState<DeviceOperationNode | null>(null);
     const { peakMemoryLoad, renderOperations } = useDeviceOperationsFullRenderModel({

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -20,6 +20,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import hljs from 'highlight.js/lib/core';
+import 'highlight.js/styles/a11y-dark.css';
 import {
     BufferNode,
     DeviceOperationNode,
@@ -561,33 +562,34 @@ const DeviceOperationArgumentsComponent: React.FC<{
                         />
                     </h3>
                 </div>
-
-                <div className='operation-arguments'>
-                    {node?.arguments.map((arg, index) => {
-                        const parsed = hljs.highlight(
-                            arg //
-                                .replaceAll('=', ' = ')
-                                .replaceAll(',', ', '),
-                            {
-                                language: 'cpp',
-                            },
-                        ).value;
-                        return (
-                            <div
-                                className='argument'
-                                key={`arg-${index}`}
-                            >
-                                <code
-                                    className='arg'
-                                    // eslint-disable-next-line react/no-danger
-                                    dangerouslySetInnerHTML={{
-                                        __html: parsed,
-                                    }}
-                                />
-                            </div>
-                        );
-                    })}
-                </div>
+                {node?.arguments && (
+                    <div className='operation-arguments'>
+                        {node?.arguments.map((arg, index) => {
+                            const parsed = hljs.highlight(
+                                arg //
+                                    .replaceAll('=', ' = ')
+                                    .replaceAll(',', ', '),
+                                {
+                                    language: 'cpp',
+                                },
+                            ).value;
+                            return (
+                                <div
+                                    className='argument'
+                                    key={`arg-${index}`}
+                                >
+                                    <code
+                                        className='arg'
+                                        // eslint-disable-next-line react/no-danger
+                                        dangerouslySetInnerHTML={{
+                                            __html: parsed,
+                                        }}
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
             </Card>
         </Overlay2>
     );

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -196,7 +196,7 @@ function formatTensorRendering(node: Node, details: OperationDetails) {
     }
 
     if (node.node_type === NodeType.circular_buffer_deallocate_all) {
-        return '';
+        return null;
     }
 
     return node.node_type;
@@ -262,7 +262,7 @@ function useDeviceOperationsFullRenderModel(args: {
                     const opArgs = node.operation?.arguments;
 
                     const label = (
-                        <h4>
+                        <h4 className='device-operation-label'>
                             <Icon
                                 className='operation-icon'
                                 size={13}
@@ -278,7 +278,7 @@ function useDeviceOperationsFullRenderModel(args: {
                                     {formatTensor(inputNode)}
                                 </span>
                             ))}
-                            ) &nbsp;{' => '}
+                            )<span className='operation-arrow'> =&gt; </span>
                             {node.operation?.outputs.map((outputNode, i) => (
                                 <span
                                     className='params'

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -149,13 +149,13 @@ const renderTensorLabel = (
             <span className='tensor-details-layout'>
                 {square}{' '}
                 <span className={classNames(Classes.TOOLTIP_INDICATOR, 'has-tooltip')}>
-                    Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
+                    <strong>{node.params.tensor_id}</strong> {toReadableShape(node.params.shape)}
                 </span>
             </span>
         </Tooltip>
     ) : (
         <span className='tensor-details-layout'>
-            {square} Tensor {node.params.tensor_id} {toReadableShape(node.params.shape)}
+            {square} <strong>{node.params.tensor_id}</strong> {toReadableShape(node.params.shape)}
         </span>
     );
 };
@@ -269,22 +269,7 @@ function useDeviceOperationsFullRenderModel(args: {
                                 intent={Intent.SUCCESS}
                                 icon={IconNames.CUBE_ADD}
                             />
-                            {opName}{' '}
-                            {opArgs && opArgs.length > 0 && (
-                                <Button
-                                    icon={IconNames.COMPARISON}
-                                    size={Size.SMALL}
-                                    variant={ButtonVariant.MINIMAL}
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        setDeviceOperationsArgsNode(node.operation!);
-                                        setDeviceOperationsArgsOpen(true);
-                                    }}
-                                    title='View operation arguments'
-                                    className={`${Classes.TOOLTIP_INDICATOR} view-args-button`}
-                                />
-                            )}
-                            <DeviceID _node={node} /> (
+                            {opName} <DeviceID _node={node} /> (
                             {node.operation?.inputs.map((inputNode, i) => (
                                 <span
                                     className='params'
@@ -312,6 +297,28 @@ function useDeviceOperationsFullRenderModel(args: {
                             key={`end-${index}`}
                             label={label}
                             isOpen
+                            additionalElements={
+                                opArgs && opArgs.length > 0 ? (
+                                    <Button
+                                        icon={
+                                            <Icon
+                                                icon={IconNames.COMPARISON}
+                                                size={12}
+                                            />
+                                        }
+                                        size={Size.SMALL}
+                                        variant={ButtonVariant.OUTLINED}
+                                        intent={Intent.PRIMARY}
+                                        onClick={() => {
+                                            setDeviceOperationsArgsNode(node.operation!);
+                                            setDeviceOperationsArgsOpen(true);
+                                        }}
+                                        title='View operation arguments'
+                                    >
+                                        Arguments
+                                    </Button>
+                                ) : undefined
+                            }
                             collapseClassName={classNames('device-operation function-container', {
                                 [COLLAPSIBLE_EMPTY_CLASS]: !hasContent,
                             })}

--- a/src/functions/formatting.ts
+++ b/src/functions/formatting.ts
@@ -24,4 +24,6 @@ export const capitalizeString = (input: string) => {
     return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
 };
 
-export const stripEnum = (v: string) => v.split('::').pop() || v;
+export const stripEnum = (v: string) => {
+    return v.toString().split('::').pop() || v;
+};

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -49,7 +49,7 @@ export function processMemoryAllocations(
             curOp.push({ name, id: node.id, deviceId: node.params.device_id });
         }
 
-        if (node.params.device_id !== undefined && curOp.length > 1) {
+        if (node.params?.device_id !== undefined && curOp.length > 1) {
             curOp[curOp.length - 1].deviceId = node.params.device_id;
         }
 

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -293,14 +293,19 @@ export interface BaseNode<T extends NodeType, P> {
     params: P;
     inputs: Node[]; // tree specific
     outputs: Node[]; // tree specific
-    operation?: Node;
+    operation?: DeviceOperationNode;
     buffer?: BufferNode[];
     allocation?: BufferAllocateNode;
     stacking_level: number;
 }
+
+export interface DeviceOperationNode extends BaseNode<NodeType.function_start, DeviceOperationParams> {
+    arguments: string[];
+    stack_trace: string[];
+}
+
 export type CaptureStartNode = BaseNode<NodeType.capture_start, DeviceOperationParams>;
 export type CaptureEndNode = BaseNode<NodeType.capture_end, DeviceOperationParams>;
-export type DeviceOperationNode = BaseNode<NodeType.function_start, DeviceOperationParams>;
 export type DeviceOperationNodeEnd = BaseNode<NodeType.function_end, DeviceOperationParams>;
 
 export type BufferNode = BaseNode<NodeType.buffer, BufferAllocateParams>;

--- a/src/scss/components/Collapsible.scss
+++ b/src/scss/components/Collapsible.scss
@@ -40,7 +40,7 @@
 
     &.empty-collapsible {
         .collapsible-controls {
-            [type='button'] {
+            [type='button'].collapsible-button {
                 cursor: default;
 
                 &:hover {

--- a/src/scss/components/DeviceOperationArgumentsComponent.scss
+++ b/src/scss/components/DeviceOperationArgumentsComponent.scss
@@ -33,7 +33,7 @@
     }
 
     .contents {
-        width: 100%;
+        width: calc(100vw - 100px);
         background-color: $tt-grey-4;
 
         .title {

--- a/src/scss/components/DeviceOperationArgumentsComponent.scss
+++ b/src/scss/components/DeviceOperationArgumentsComponent.scss
@@ -26,6 +26,10 @@
         justify-content: center;
         height: 100vh;
         width: 100%;
+
+        &:empty {
+            display: none;
+        }
     }
 
     .loading-container {

--- a/src/scss/components/DeviceOperationArgumentsComponent.scss
+++ b/src/scss/components/DeviceOperationArgumentsComponent.scss
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+@use 'styles/definitions/colours' as *;
+
+.view-args-button {
+    border: none;
+    border-radius: 0;
+
+    &.bp6-button.bp6-minimal {
+        &:hover {
+            // background: $tt-green-accent;
+
+            svg {
+                color: $tt-teal-tint-2;
+            }
+        }
+    }
+}
+
+.device-operation-arguments-visualisation-overlay {
+    .bp6-overlay {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        width: 100%;
+    }
+
+    .loading-container {
+        background-color: transparent;
+    }
+
+    .contents {
+        width: 100%;
+        background-color: $tt-grey-4;
+
+        .title {
+            display: flex;
+            justify-content: space-between;
+            margin-top: 0;
+
+            svg {
+                fill: $tt-white;
+            }
+        }
+
+        .operation-arguments {
+            .argument {
+                margin-bottom: 10px;
+                margin-right: 20px;
+
+                .arg {
+                    word-wrap: break-word;
+                    text-wrap: auto;
+                }
+            }
+        }
+    }
+}

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -13,6 +13,13 @@
     }
 }
 
+.device-operation-label {
+    .operation-arrow {
+        font-size: 12px;
+        padding-top: 1px;
+    }
+}
+
 .tensor-details-layout {
     display: flex;
     justify-content: space-between;
@@ -30,8 +37,8 @@
     .has-tooltip {
         border-bottom-color: $tt-teal;
         border-bottom-width: 2px;
-        margin-top: 3px;
-        padding-bottom: 2px;
+        padding-bottom: 1px;
+        margin-top: 2px;
     }
 }
 
@@ -88,6 +95,10 @@
 
         .params {
             font-weight: lighter;
+
+            &:empty {
+                display: none;
+            }
         }
     }
 

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -20,6 +20,12 @@
     gap: 5px;
     position: relative;
     top: 1px;
+    font-size: 14px;
+
+    .memory-color-block {
+        width: 11px;
+        height: 11px;
+    }
 
     .has-tooltip {
         border-bottom-color: $tt-teal;


### PR DESCRIPTION
Add a UI to view device operation arguments in an overlay. Introduces a DeviceOperationArgumentsComponent that renders operation.arguments with highlight.js and a minimal button on operation labels to open the overlay.

closes #1305

<img width="1598" height="1117" alt="image" src="https://github.com/user-attachments/assets/4c7b2662-b444-4b03-aa76-f2a50099ff4e" />


<img width="1598" height="1117" alt="image" src="https://github.com/user-attachments/assets/0d9a974b-dec9-45fb-a21a-1fb079281c64" />

