### PR TITLE
Feature/Remove requirement for config.json

### DIFF
--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -30,6 +30,7 @@ from ttnn_visualizer.utils import update_last_synced
 logger = logging.getLogger(__name__)
 
 TEST_CONFIG_FILE = "config.json"
+TEST_DB_FILE = "db.sqlite"
 TEST_PROFILER_FILE = "profile_log_device.csv"
 
 
@@ -407,6 +408,9 @@ def get_remote_profiler_folder_from_config_path(
     remote_connection: RemoteConnection, config_path: str
 ) -> RemoteReportFolder:
     """Read a remote config file and return RemoteFolder object."""
+    folder_path = Path(config_path).parent
+    parent_folder_name = folder_path.name
+
     try:
         # Build SSH command to get file modification time (never prompts for password)
         stat_cmd = _ssh_cmd_prefix(remote_connection) + [
@@ -427,10 +431,9 @@ def get_remote_profiler_folder_from_config_path(
         # Parse JSON data
         data = json.loads(cat_result.stdout)
         report_name = data.get("report_name")
-        logger.info(f"********* report_name: {report_name}")
 
         return RemoteReportFolder(
-            remotePath=str(Path(config_path).parent),
+            remotePath=str(folder_path),
             reportName=report_name,
             lastModified=last_modified,
         )
@@ -444,23 +447,23 @@ def get_remote_profiler_folder_from_config_path(
             handle_ssh_subprocess_error(e, remote_connection)
             # This line never executes as handle_ssh_subprocess_error raises an exception
             return RemoteReportFolder(
-                remotePath=str(Path(config_path).parent),
-                reportName="",
+                remotePath=str(folder_path),
+                reportName=parent_folder_name,
                 lastModified=int(time.time()),
             )
         else:
             # Fall back to current time if we can't get modification time
             return RemoteReportFolder(
-                remotePath=str(Path(config_path).parent),
-                reportName="",
+                remotePath=str(folder_path),
+                reportName=parent_folder_name,
                 lastModified=int(time.time()),
             )
     except (json.JSONDecodeError, ValueError) as e:
         logger.error(f"Error parsing config file {config_path}: {e}")
         # Fall back to current time and no report name
         return RemoteReportFolder(
-            remotePath=str(Path(config_path).parent),
-            reportName="",
+            remotePath=str(folder_path),
+            reportName=parent_folder_name,
             lastModified=int(time.time()),
         )
 
@@ -528,7 +531,7 @@ def check_remote_path_for_reports(remote_connection):
     remote_profiler_paths = []
     if remote_connection.profilerPath:
         remote_profiler_paths = find_folders_by_files(
-            remote_connection, remote_connection.profilerPath, [TEST_CONFIG_FILE]
+            remote_connection, remote_connection.profilerPath, [TEST_DB_FILE]
         )
     else:
         logger.info("No profiler path configured; skipping check")
@@ -703,12 +706,12 @@ def get_remote_performance_folders(
 def get_remote_profiler_folders(
     remote_connection: RemoteConnection,
 ) -> List[RemoteReportFolder]:
-    """Return a list of remote folders containing a config.json file."""
+    """Return a list of remote folders containing a db.sqlite file."""
     profiler_paths = []
 
     if remote_connection.profilerPath:
         profiler_paths = find_folders_by_files(
-            remote_connection, remote_connection.profilerPath, [TEST_CONFIG_FILE]
+            remote_connection, remote_connection.profilerPath, [TEST_DB_FILE]
         )
     else:
         error = f"No profiler reports found at {remote_connection.profilerPath}"

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -517,12 +517,13 @@ def get_profiler_data_list(instance: Instance):
                     report_name = config_data.get("report_name")
             except Exception as e:
                 logger.warning(f"Failed to read config.json in {dir_path}: {e}")
+        else:
+            report_name = dir_path.name
 
         # Would like to use the existing validate_files function but there's a type difference I'm not sure how to handle
         if not any(file.name == "db.sqlite" for file in files):
             continue
-        if not any(file.name == "config.json" for file in files):
-            continue
+
         valid_dirs.append({"path": dir_path.name, "reportName": report_name})
 
     return Response(orjson.dumps(valid_dirs), mimetype="application/json")
@@ -911,7 +912,7 @@ def create_profiler_files():
         / current_app.config["PROFILER_DIRECTORY_NAME"]
     )
 
-    if not validate_files(files, {"db.sqlite", "config.json"}, folder_name=folder_name):
+    if not validate_files(files, {"db.sqlite"}, folder_name=folder_name):
         return StatusMessage(
             status=ConnectionTestStates.FAILED,
             message="Invalid project directory.",
@@ -954,6 +955,8 @@ def create_profiler_files():
                 report_name = config_data.get("report_name")
         except Exception as e:
             logger.warning(f"Failed to read config.json in {config_file}: {e}")
+    else:
+        report_name = parent_folder_name
 
     if current_app.config["SERVER_MODE"]:
         # Set session data (FIFO cap to avoid cookie size limits)

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -38,7 +38,7 @@ To run a test with custom input data, you can use the following command with sui
 pytest --disable-warnings --input-path="path/to/input.json" path/to/test_file.py::test_function[param]
 ```
 
-The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file.
+The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file (config.json is optional for the visualizer).
 
 <img width="909" alt="Screenshot 2024-12-13 at 12 29 24 PM" src="https://github.com/user-attachments/assets/ab31892a-2779-4fe1-9ad5-0f35f8329f9a" />
 

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -38,7 +38,7 @@ To run a test with custom input data, you can use the following command with sui
 pytest --disable-warnings --input-path="path/to/input.json" path/to/test_file.py::test_function[param]
 ```
 
-The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `config.json` and a `db.sqlite` file.
+The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file.
 
 <img width="909" alt="Screenshot 2024-12-13 at 12 29 24 PM" src="https://github.com/user-attachments/assets/ab31892a-2779-4fe1-9ad5-0f35f8329f9a" />
 

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -299,6 +299,7 @@ export const useOperationBuffers = (operationId: number) => {
     });
 };
 
+// Not currently used
 // const fetchReportMeta = async (): Promise<ReportMetaData> => {
 //     const { data: meta } = await axiosInstance.get<ReportMetaData>(Endpoints.CONFIG);
 

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -21,7 +21,6 @@ import {
     Operation,
     OperationDescription,
     OperationDetailsData,
-    ReportMetaData,
     Tensor,
     defaultBuffer,
     defaultOperation,
@@ -300,11 +299,11 @@ export const useOperationBuffers = (operationId: number) => {
     });
 };
 
-const fetchReportMeta = async (): Promise<ReportMetaData> => {
-    const { data: meta } = await axiosInstance.get<ReportMetaData>(Endpoints.CONFIG);
+// const fetchReportMeta = async (): Promise<ReportMetaData> => {
+//     const { data: meta } = await axiosInstance.get<ReportMetaData>(Endpoints.CONFIG);
 
-    return meta;
-};
+//     return meta;
+// };
 
 const fetchDevices = async (report: ReportFolder | RemoteFolder) => {
     const { data: meta } = await axiosInstance.get<DeviceInfo[]>(Endpoints.DEVICES);
@@ -696,14 +695,14 @@ export const usePerformanceRange = (): NumberRange | null => {
 };
 
 // Not currently used
-export const useReportMeta = () => {
-    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
+// export const useReportMeta = () => {
+//     const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
 
-    return useQuery<ReportMetaData, AxiosError>({
-        queryKey: ['get-report-config', activeProfilerReport?.path],
-        queryFn: () => fetchReportMeta(),
-    });
-};
+//     return useQuery<ReportMetaData, AxiosError>({
+//         queryKey: ['get-report-config', activeProfilerReport?.path],
+//         queryFn: () => fetchReportMeta(),
+//     });
+// };
 
 export const useBufferPages = (operationId: number, address?: number | string, bufferType?: BufferType) => {
     return useQuery<BufferPage[], AxiosError>({

--- a/src/hooks/useLocal.tsx
+++ b/src/hooks/useLocal.tsx
@@ -83,7 +83,7 @@ const useLocalConnection = () => {
     };
 
     const checkRequiredReportFiles = (files: FileList): boolean => {
-        const requiredFiles = ['db.sqlite', 'config.json'];
+        const requiredFiles = ['db.sqlite'];
         const fileSet = new Set<string>();
 
         Array.from(files).forEach((file) => {

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -185,22 +185,22 @@ export interface FragmentationEntry extends Chunk {
     colorVariance?: number | undefined;
 }
 
-export interface ReportMetaData {
-    cache_path: string;
-    model_cache_path: string;
-    tmp_dir: string;
-    enable_model_cache: boolean;
-    enable_fast_runtime_mode: boolean;
-    throw_exception_on_fallback: boolean;
-    enable_logging: boolean;
-    enable_graph_report: boolean;
-    enable_detailed_buffer_report: boolean;
-    enable_detailed_tensor_report: boolean;
-    enable_comparison_mode: boolean;
-    comparison_mode_pcc: number;
-    root_profiler_path: string;
-    profiler_name: string;
-}
+// export interface ReportMetaData {
+//     cache_path: string;
+//     model_cache_path: string;
+//     tmp_dir: string;
+//     enable_model_cache: boolean;
+//     enable_fast_runtime_mode: boolean;
+//     throw_exception_on_fallback: boolean;
+//     enable_logging: boolean;
+//     enable_graph_report: boolean;
+//     enable_detailed_buffer_report: boolean;
+//     enable_detailed_tensor_report: boolean;
+//     enable_comparison_mode: boolean;
+//     comparison_mode_pcc: number;
+//     root_profiler_path: string;
+//     profiler_name: string;
+// }
 
 export interface OperationDescription extends Operation {
     duration: number;

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -200,7 +200,7 @@ it('handles valid memory report upload', async () => {
         WAIT_FOR_OPTIONS,
     );
 
-    await waitFor(() => expect(input.nextElementSibling?.textContent).to.equal('2 files uploaded'), WAIT_FOR_OPTIONS);
+    await waitFor(() => expect(input.nextElementSibling?.textContent).to.equal('1 files uploaded'), WAIT_FOR_OPTIONS);
 
     const { reportName } = mockProfilerFolderList[0];
     expect(getAllButtonsWithText(reportName)).toHaveLength(1);

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -185,13 +185,12 @@ it('handles valid memory report upload', async () => {
     );
 
     const mockDb = createMockFile('db.sqlite', 'text/x-sqlite3');
-    const mockConfig = createMockFile('config.json', 'application/json');
 
     const input = screen.getByTestId(TEST_IDS.LOCAL_PROFILER_UPLOAD);
 
     expect(input.nextElementSibling?.textContent).to.equal('Choose directory...');
 
-    fireEvent.change(input, { target: { files: [mockDb, mockConfig] } });
+    fireEvent.change(input, { target: { files: [mockDb] } });
 
     await waitFor(
         () =>


### PR DESCRIPTION
`config.json` is used for reportName if present, otherwise we fallback to the folder name similar to perf reports.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1295.

