### PR TITLE
fix memory zoom slider causing horizontal page scroll

### DIFF
--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -403,23 +403,24 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                         memorySize={memorySizeL1}
                                         configuration={L1RenderZoomoutConfiguration}
                                     />
-
-                                    <RangeSlider
-                                        min={plotZoomRangeStart}
-                                        max={plotZoomRangeEnd}
-                                        disabled={!zoomedInViewMainMemory}
-                                        intent={Intent.WARNING}
-                                        labelStepSize={
-                                            (plotZoomRangeEnd - plotZoomRangeStart) / 3 || L1_DEFAULT_MEMORY_SIZE
-                                        }
-                                        labelRenderer={(value) => getMemoryAddress(value, showHex)}
-                                        value={[zoomRangeStart, zoomRangeEnd]}
-                                        onChange={(value: number[]) => {
-                                            setZoomRangeStart(value[0]);
-                                            setZoomRangeEnd(value[1]);
-                                        }}
-                                        className='memory-zoom-range'
-                                    />
+                                    <div className='zoom-range-wrap'>
+                                        <RangeSlider
+                                            min={plotZoomRangeStart}
+                                            max={plotZoomRangeEnd}
+                                            disabled={!zoomedInViewMainMemory}
+                                            intent={Intent.WARNING}
+                                            labelStepSize={
+                                                (plotZoomRangeEnd - plotZoomRangeStart) / 3 || L1_DEFAULT_MEMORY_SIZE
+                                            }
+                                            labelRenderer={(value) => getMemoryAddress(value, showHex)}
+                                            value={[zoomRangeStart, zoomRangeEnd]}
+                                            onChange={(value: number[]) => {
+                                                setZoomRangeStart(value[0]);
+                                                setZoomRangeEnd(value[1]);
+                                            }}
+                                            className='memory-zoom-range'
+                                        />
+                                    </div>
 
                                     <L1Plots
                                         operationDetails={details}

--- a/src/scss/components/OperationDetailsComponent.scss
+++ b/src/scss/components/OperationDetailsComponent.scss
@@ -128,6 +128,11 @@
         padding-left: 18px;
     }
 
+    .zoom-range-wrap {
+        position: relative;
+        overflow-x: hidden;
+    }
+
     .memory-zoom-range {
         $zoom-range-margin: 15px;
 


### PR DESCRIPTION
Wrap the RangeSlider in a .zoom-range-wrap div and add CSS to contain its overflow

closes #1309 