### PR TITLE
Correcting StringBufferType behaviour across the app

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -21,15 +21,7 @@ import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import hljs from 'highlight.js/lib/core';
 import 'highlight.js/styles/a11y-dark.css';
-import {
-    BufferNode,
-    DeviceOperationNode,
-    Node,
-    NodeType,
-    StringBufferType,
-    Tensor,
-    TensorNode,
-} from '../../model/APIData';
+import { BufferNode, DeviceOperationNode, Node, NodeType, Tensor, TensorNode } from '../../model/APIData';
 import 'styles/components/DeviceOperationFullRender.scss';
 import 'styles/components/DeviceOperationArgumentsComponent.scss';
 import { MemoryLegendElement } from './MemoryLegendElement';
@@ -42,7 +34,7 @@ import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1Memory
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
 import { toReadableLayout, toReadableShape } from '../../functions/formatting';
-import { BufferTypeLabel } from '../../model/BufferType';
+import { BufferTypeLabel, StringBufferType } from '../../model/BufferType';
 
 type BufferDetails = {
     bufferOrTensorNode?: BufferNode | TensorNode;
@@ -69,7 +61,7 @@ const renderBufferDetails = ({ bufferOrTensorNode, tensorId, optionalOutput, det
         const { params } = bufferOrTensorNode;
         address = parseInt(params.address, 10);
         layout = toReadableLayout(params.layout) || '';
-        type = BufferTypeLabel[params.buffer_type] as StringBufferType;
+        type = BufferTypeLabel[params.buffer_type] as StringBufferType; // converting int enum to string representation
     }
 
     if (address !== undefined || tensorId !== undefined) {

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -34,7 +34,7 @@ import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1Memory
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
 import { toReadableLayout, toReadableShape } from '../../functions/formatting';
-import { BufferTypeLabel, StringBufferType } from '../../model/BufferType';
+import { BufferTypeToStringBufferType, StringBufferType } from '../../model/BufferType';
 
 type BufferDetails = {
     bufferOrTensorNode?: BufferNode | TensorNode;
@@ -61,7 +61,7 @@ const renderBufferDetails = ({ bufferOrTensorNode, tensorId, optionalOutput, det
         const { params } = bufferOrTensorNode;
         address = parseInt(params.address, 10);
         layout = toReadableLayout(params.layout) || '';
-        type = BufferTypeLabel[params.buffer_type] as StringBufferType; // converting int enum to string representation
+        type = BufferTypeToStringBufferType[params.buffer_type];
     }
 
     if (address !== undefined || tensorId !== undefined) {

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -23,7 +23,7 @@ export const MemoryLegendElement: React.FC<{
     operationDetails: OperationDetails;
     onLegendClick: (selectedTensorAddress: number, tensorId?: number, colorVariance?: number) => void;
     colorVariance?: number | undefined; // color uniqueness for the CB color
-    bufferType?: StringBufferType;
+    bufferType?: keyof typeof StringBufferType;
     layout?: DeviceOperationLayoutTypes;
     isMultiDeviceBuffer?: boolean;
     isGroupHeader?: boolean;

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Icon, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue } from 'jotai';
-import { DeviceOperationLayoutTypes, FragmentationEntry, MarkerType, StringBufferType } from '../../model/APIData';
+import { DeviceOperationLayoutTypes, FragmentationEntry, MarkerType } from '../../model/APIData';
 import { OperationDetails } from '../../model/OperationDetails';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
@@ -15,6 +15,7 @@ import { toReadableShape, toReadableType } from '../../functions/formatting';
 import 'styles/components/MemoryLegendElement.scss';
 import { L1_SMALL_MARKER_COLOR, L1_START_MARKER_COLOR } from '../../definitions/PlotConfigurations';
 import { selectedBufferColourAtom, showHexAtom } from '../../store/app';
+import { StringBufferType, StringBufferTypeLabel } from '../../model/BufferType';
 
 export const MemoryLegendElement: React.FC<{
     chunk: FragmentationEntry;
@@ -23,7 +24,7 @@ export const MemoryLegendElement: React.FC<{
     operationDetails: OperationDetails;
     onLegendClick: (selectedTensorAddress: number, tensorId?: number, colorVariance?: number) => void;
     colorVariance?: number | undefined; // color uniqueness for the CB color
-    bufferType?: keyof typeof StringBufferType;
+    bufferType?: StringBufferType;
     layout?: DeviceOperationLayoutTypes;
     isMultiDeviceBuffer?: boolean;
     isGroupHeader?: boolean;
@@ -143,7 +144,7 @@ export const MemoryLegendElement: React.FC<{
             </div>
             {(bufferType || layout) && (
                 <div className='extra-info-slot'>
-                    {bufferType && <span className='monospace'>{StringBufferType[bufferType]} </span>}
+                    {bufferType && <span className='monospace'>{StringBufferTypeLabel[bufferType]} </span>}
                     {layout && <span className='monospace'>{DeviceOperationLayoutTypes[layout]}</span>}
                 </div>
             )}

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -22,7 +22,7 @@ import { HIGH_DISPATCH_THRESHOLD_MS, OpType } from '../definitions/Performance';
 import { TypedStackedPerfRow } from '../definitions/StackedPerfTable';
 import { NormalisedPerfData } from './normalisePerformanceData';
 import MemoryTag from '../components/MemoryTag';
-import { BufferTypeLabel } from '../model/BufferType';
+import { BufferType, BufferTypeLabel } from '../model/BufferType';
 
 export enum CellColour {
     White = 'white',
@@ -94,7 +94,7 @@ export const formatCell = (
     }
 
     if (key === ColumnHeaders.buffer_type) {
-        return <MemoryTag memory={BufferTypeLabel[value as number]} />;
+        return <MemoryTag memory={BufferTypeLabel[value as BufferType]} />;
     }
 
     if (key === ColumnHeaders.high_dispatch) {

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -2,8 +2,9 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Node, NodeType, StringBufferType } from '../model/APIData';
+import { Node, NodeType } from '../model/APIData';
 import { L1_NUM_CORES } from '../definitions/L1MemorySize';
+import { StringBufferType } from '../model/BufferType';
 
 export type AllocationDetails = {
     id: number;

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -266,7 +266,7 @@ interface BufferAllocateParams {
     num_cores: string; // '64';
     page_size: string; // '448';
     size: string; // '7340032';
-    type: StringBufferType; // 'L1';
+    type: keyof typeof StringBufferType; // 'L1';
     derived_device_id?: number[];
 }
 interface CircularBufferAllocateParams {
@@ -289,7 +289,7 @@ export interface DeviceTensorParams {
     shape: string; // 'Shape([16, 3, 224, 224])';
     tensor_id: number; // '0';
     size: string; // '602112';
-    type: StringBufferType;
+    type: keyof typeof StringBufferType;
 }
 
 export interface BaseNode<T extends NodeType, P> {
@@ -357,7 +357,7 @@ export interface CircularBuffer extends Chunk {
 
 export interface TensorBuffer extends Chunk {
     layout: DeviceOperationLayoutTypes;
-    type: StringBufferType;
+    type: keyof typeof StringBufferType;
 }
 
 export interface BufferPage {

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -5,7 +5,7 @@
 import { RemoteConnection, RemoteFolder } from '../definitions/RemoteConnection';
 import { ReportLocation } from '../definitions/Reports';
 import { BufferMemoryLayout, MemoryConfig } from '../functions/parseMemoryConfig';
-import { BufferType } from './BufferType';
+import { BufferType, StringBufferType } from './BufferType';
 
 interface OperationError {
     operation_id: number;
@@ -239,14 +239,6 @@ export enum DeviceOperationLayoutTypes {
     TILE = 'TILE',
 }
 
-export enum StringBufferType {
-    DRAM = 'DRAM',
-    L1 = 'L1',
-    SYSTEM_MEMORY = 'SYSTEM MEMORY',
-    L1_SMALL = 'L1 SMALL',
-    TRACE = 'TRACE',
-}
-
 export interface DeviceOperationParams {
     name: string;
     device_id?: number | string;
@@ -266,7 +258,7 @@ interface BufferAllocateParams {
     num_cores: string; // '64';
     page_size: string; // '448';
     size: string; // '7340032';
-    type: keyof typeof StringBufferType; // 'L1';
+    type: StringBufferType; // 'L1';
     derived_device_id?: number[];
 }
 interface CircularBufferAllocateParams {
@@ -289,7 +281,7 @@ export interface DeviceTensorParams {
     shape: string; // 'Shape([16, 3, 224, 224])';
     tensor_id: number; // '0';
     size: string; // '602112';
-    type: keyof typeof StringBufferType;
+    type: StringBufferType;
 }
 
 export interface BaseNode<T extends NodeType, P> {
@@ -357,7 +349,7 @@ export interface CircularBuffer extends Chunk {
 
 export interface TensorBuffer extends Chunk {
     layout: DeviceOperationLayoutTypes;
-    type: keyof typeof StringBufferType;
+    type: StringBufferType;
 }
 
 export interface BufferPage {

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -67,13 +67,13 @@ export interface BufferData {
     device_id: number;
     address: number;
     max_size_per_bank: number;
-    buffer_type: number;
+    buffer_type: BufferType;
     next_usage?: number;
 }
 
 export interface Buffer {
     address: number;
-    buffer_type: number;
+    buffer_type: BufferType;
     device_id: number;
     size: number;
     buffer_layout?: BufferMemoryLayout | null;
@@ -141,7 +141,7 @@ export const defaultOperation: OperationDetailsData = {
 };
 
 export const defaultTensorData: Tensor = {
-    buffer_type: 0,
+    buffer_type: BufferType.L1,
     id: 0,
     shape: '',
     dtype: '',
@@ -163,7 +163,7 @@ export const defaultBuffer: BufferData = {
     device_id: 0,
     address: 0,
     max_size_per_bank: 0,
-    buffer_type: 0,
+    buffer_type: BufferType.L1,
 };
 
 export interface Chunk {
@@ -355,7 +355,7 @@ export interface TensorBuffer extends Chunk {
 export interface BufferPage {
     address: number;
     bank_id: number;
-    buffer_type: number;
+    buffer_type: BufferType;
     core_x: number;
     core_y: number;
     device_id: number;

--- a/src/model/BufferType.ts
+++ b/src/model/BufferType.ts
@@ -13,13 +13,14 @@ export enum BufferType {
     TRACE,
 }
 
-export const BufferTypeLabel: Record<number, string> = {
+export const BufferTypeLabel: Record<BufferType, string> = {
     [BufferType.DRAM]: 'DRAM',
     [BufferType.L1]: 'L1',
     [BufferType.SYSTEM_MEMORY]: 'System Memory',
     [BufferType.L1_SMALL]: 'L1 Small',
     [BufferType.TRACE]: 'Trace',
 };
+
 export enum StringBufferType {
     DRAM = 'DRAM',
     L1 = 'L1',
@@ -34,4 +35,12 @@ export const StringBufferTypeLabel: Record<StringBufferType, string> = {
     [StringBufferType.SYSTEM_MEMORY]: 'System Memory',
     [StringBufferType.L1_SMALL]: 'L1 Small',
     [StringBufferType.TRACE]: 'Trace',
+};
+
+export const BufferTypeToStringBufferType: Record<BufferType, StringBufferType> = {
+    [BufferType.DRAM]: StringBufferType.DRAM,
+    [BufferType.L1]: StringBufferType.L1,
+    [BufferType.SYSTEM_MEMORY]: StringBufferType.SYSTEM_MEMORY,
+    [BufferType.L1_SMALL]: StringBufferType.L1_SMALL,
+    [BufferType.TRACE]: StringBufferType.TRACE,
 };

--- a/src/model/BufferType.ts
+++ b/src/model/BufferType.ts
@@ -20,3 +20,18 @@ export const BufferTypeLabel: Record<number, string> = {
     [BufferType.L1_SMALL]: 'L1 Small',
     [BufferType.TRACE]: 'Trace',
 };
+export enum StringBufferType {
+    DRAM = 'DRAM',
+    L1 = 'L1',
+    SYSTEM_MEMORY = 'SYSTEM_MEMORY',
+    L1_SMALL = 'L1_SMALL',
+    TRACE = 'TRACE',
+}
+
+export const StringBufferTypeLabel: Record<StringBufferType, string> = {
+    [StringBufferType.DRAM]: 'DRAM',
+    [StringBufferType.L1]: 'L1',
+    [StringBufferType.SYSTEM_MEMORY]: 'System Memory',
+    [StringBufferType.L1_SMALL]: 'L1 Small',
+    [StringBufferType.TRACE]: 'Trace',
+};

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -14,10 +14,9 @@ import {
     NodeType,
     OperationDescription,
     OperationDetailsData,
-    StringBufferType,
     Tensor,
 } from './APIData';
-import { BufferType } from './BufferType';
+import { BufferType, StringBufferType } from './BufferType';
 import { DRAM_MEMORY_SIZE } from '../definitions/DRAMMemorySize';
 import { CONDENSED_PLOT_CHUNK_COLOR, PlotDataCustom, PlotDataOverrides } from '../definitions/PlotConfigurations';
 import getChartData from '../functions/getChartData';


### PR DESCRIPTION
Refactor buffer type handling by moving the StringBufferType enum out of APIData into src/model/BufferType, and add a StringBufferTypeLabel mapping for human-readable labels. Update APIData interfaces to reference the new StringBufferType type, and adjust imports/usages across components and functions (DeviceOperationsFullRender, MemoryLegendElement, processMemoryAllocations, OperationDetails) to use the centralized enum and label mapping. This centralizes buffer type definitions and simplifies rendering of buffer type labels in the UI.

fixes #1315 