### PR TITLE
Fix in place operations tensor id mapping

### DIFF
--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -558,13 +558,13 @@ ${getMemoryAddress(bufferCondensed.address, this.options.showHex)} <br /> ${form
 
             for (let i = this.operations.indexOf(currentOperation!); i >= 0; i--) {
                 const op = this.operations[i];
-                tensor = op.inputs.find((input) => input.address === bufferAddress);
+                tensor = op.outputs.find((output) => output.address === bufferAddress);
 
                 if (tensor !== undefined) {
                     break;
                 }
 
-                tensor = op.outputs.find((output) => output.address === bufferAddress);
+                tensor = op.inputs.find((input) => input.address === bufferAddress);
 
                 if (tensor !== undefined) {
                     break;


### PR DESCRIPTION
Fix the lookup order when scanning operations for a tensor address in OperationDetails.ts: check op.outputs first, then op.inputs. This ensures tensors produced by earlier operations are found before matching inputs, correcting the previous input-first logic that could return the wrong tensor reference.

<img width="1604" height="1117" alt="image" src="https://github.com/user-attachments/assets/90027ec4-b502-446e-ab9c-3ba2c125d61d" />


fixes #1293 