### PR TITLE
Feature/Output perf report processing errors

### DIFF
--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -404,18 +404,70 @@ class OpsPerformanceReportQueries:
     DEFAULT_CLASSIC_COLORS = False  # Colour scheme for plotted stacked report
     DEFAULT_GROUP_BY = None  # Group by method for stacked report
 
+    @staticmethod
+    def extract_signposts(csv_file):
+        logger.info("Reading raw CSV for signpost extraction...")
+        csv_file.seek(0)
+        ops_perf_results = []
+        ops_perf_results_reader = csv.DictReader(csv_file)
+
+        for row in ops_perf_results_reader:
+            ops_perf_results.append(row)
+
+        # Returns a list of unique signposts in the order they appear
+        # TODO: Signpost names are not unique but tt-perf-report treats them as such
+        captured_signposts = set()
+        signposts = []
+        for index, row in enumerate(ops_perf_results):
+            if row.get("OP TYPE") == "signpost":
+                op_code = row["OP CODE"]
+                op_id = index + 2  # Match IDs with row numbers in ops perf results csv
+                if not any(s["op_code"] == op_code for s in signposts):
+                    captured_signposts.add(op_code)
+                    signposts.append(
+                        {
+                            "id": op_id,
+                            "op_code": op_code,
+                        }
+                    )
+
+        return ops_perf_results, signposts
+
+    @staticmethod
+    def set_op_type_from_results(processed_row, idx, ops_perf_results):
+        if 0 <= idx < len(ops_perf_results):
+            processed_row["op_type"] = ops_perf_results[idx].get("OP TYPE")
+        else:
+            processed_row["op_type"] = None
+
+        return processed_row
+
+    @staticmethod
+    def set_op_type_from_signposts(processed_row, signposts):
+        if "op_code" in processed_row and any(
+            processed_row["op_code"] in signpost["op_code"] for signpost in signposts
+        ):
+            processed_row["op_type"] = "signpost"
+        else:
+            processed_row["op_type"] = "unknown"
+
+        return processed_row
+
+    @staticmethod
+    def cleanup_temp_files(
+        output_csv_path, summary_csv_path, summary_png_path, csv_summary_file
+    ):
+        if os.path.exists(output_csv_path.name):
+            os.unlink(output_csv_path.name)
+        if os.path.exists(summary_csv_path):
+            os.unlink(summary_csv_path)
+        if os.path.exists(summary_png_path):
+            os.unlink(summary_png_path)
+        if os.path.exists(csv_summary_file.name):
+            os.unlink(csv_summary_file.name)
+
     @classmethod
     def generate_report(cls, instance, **kwargs):
-        def cleanup_temp_files(summary_csv_path, summary_png_path, csv_summary_file):
-            if os.path.exists(csv_output_file.name):
-                os.unlink(csv_output_file.name)
-            if os.path.exists(summary_csv_path):
-                os.unlink(summary_csv_path)
-            if os.path.exists(summary_png_path):
-                os.unlink(summary_png_path)
-            if os.path.exists(csv_summary_file.name):
-                os.unlink(csv_summary_file.name)
-
         raw_csv = OpsPerformanceQueries.get_raw_csv(instance)
         csv_file = StringIO(raw_csv)
 
@@ -492,32 +544,7 @@ class OpsPerformanceReportQueries:
                 ) from e
 
             try:
-                logger.info("Reading raw CSV for signpost extraction...")
-                csv_file.seek(0)
-                ops_perf_results = []
-                ops_perf_results_reader = csv.DictReader(csv_file)
-
-                for row in ops_perf_results_reader:
-                    ops_perf_results.append(row)
-
-                # Returns a list of unique signposts in the order they appear
-                # TODO: Signpost names are not unique but tt-perf-report treats them as such
-                captured_signposts = set()
-                signposts = []
-                for index, row in enumerate(ops_perf_results):
-                    if row.get("OP TYPE") == "signpost":
-                        op_code = row["OP CODE"]
-                        op_id = (
-                            index + 2
-                        )  # Match IDs with row numbers in ops perf results csv
-                        if not any(s["op_code"] == op_code for s in signposts):
-                            captured_signposts.add(op_code)
-                            signposts.append(
-                                {
-                                    "id": op_id,
-                                    "op_code": op_code,
-                                }
-                            )
+                ops_perf_results, signposts = cls.extract_signposts(csv_file)
             except Exception as e:
                 logger.error(f"Error extracting signposts: {e}")
                 ops_perf_results = []
@@ -577,12 +604,9 @@ class OpsPerformanceReportQueries:
                                                 processed_row[key] = None
 
                                         # Get the op type from the raw file for this row as it is not returned from tt-perf-report
-                                        if 0 <= idx < len(ops_perf_results):
-                                            processed_row["op_type"] = ops_perf_results[
-                                                idx
-                                            ].get("OP TYPE")
-                                        else:
-                                            processed_row["op_type"] = None
+                                        cls.set_op_type_from_results(
+                                            processed_row, idx, ops_perf_results
+                                        )
 
                                         report.append(processed_row)
                                     except (ValueError, IndexError) as e:
@@ -631,13 +655,9 @@ class OpsPerformanceReportQueries:
                                         ]
                                         del processed_row["OP Code Joined"]
 
-                                    if "op_code" in processed_row and any(
-                                        processed_row["op_code"] in signpost["op_code"]
-                                        for signpost in signposts
-                                    ):
-                                        processed_row["op_type"] = "signpost"
-                                    else:
-                                        processed_row["op_type"] = "unknown"
+                                    cls.set_op_type_from_signposts(
+                                        processed_row, signposts
+                                    )
 
                                     stacked_report.append(processed_row)
                         except csv.Error as e:
@@ -661,4 +681,6 @@ class OpsPerformanceReportQueries:
 
         finally:
             # Ensure cleanup always happens, even if exceptions are raised
-            cleanup_temp_files(summary_csv_path, summary_png_path, csv_summary_file)
+            cls.cleanup_temp_files(
+                csv_output_file, summary_csv_path, summary_png_path, csv_summary_file
+            )

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -454,17 +454,10 @@ class OpsPerformanceReportQueries:
         return processed_row
 
     @staticmethod
-    def cleanup_temp_files(
-        output_csv_path, summary_csv_path, summary_png_path, csv_summary_file
-    ):
-        if os.path.exists(output_csv_path.name):
-            os.unlink(output_csv_path.name)
-        if os.path.exists(summary_csv_path):
-            os.unlink(summary_csv_path)
-        if os.path.exists(summary_png_path):
-            os.unlink(summary_png_path)
-        if os.path.exists(csv_summary_file.name):
-            os.unlink(csv_summary_file.name)
+    def cleanup_temp_files(files):
+        for file in files:
+            if os.path.exists(file.name):
+                os.unlink(file.name)
 
     @classmethod
     def generate_report(cls, instance, **kwargs):
@@ -537,11 +530,9 @@ class OpsPerformanceReportQueries:
                     not merge_devices,
                 )
             except Exception as e:
-                logger.error(f"Error generating performance report: {e}")
+                logger.error(f"Error loading report: {e}")
                 logger.error(f"Full traceback:\n{traceback.format_exc()}")
-                raise DataFormatError(
-                    f"Error generating performance report: {e}"
-                ) from e
+                raise DataFormatError(e)
 
             try:
                 ops_perf_results, signposts = cls.extract_signposts(csv_file)
@@ -682,5 +673,5 @@ class OpsPerformanceReportQueries:
         finally:
             # Ensure cleanup always happens, even if exceptions are raised
             cls.cleanup_temp_files(
-                csv_output_file, summary_csv_path, summary_png_path, csv_summary_file
+                [csv_output_file, summary_csv_path, summary_png_path, csv_summary_file]
             )

--- a/backend/ttnn_visualizer/csv_queries.py
+++ b/backend/ttnn_visualizer/csv_queries.py
@@ -456,8 +456,16 @@ class OpsPerformanceReportQueries:
     @staticmethod
     def cleanup_temp_files(files):
         for file in files:
-            if os.path.exists(file.name):
-                os.unlink(file.name)
+            if isinstance(file, tempfile._TemporaryFileWrapper):
+                file_path = file.name
+            else:
+                file_path = file
+            if os.path.exists(file_path):
+                try:
+                    os.unlink(file_path)
+                    logger.info(f"Deleted temporary file: {file_path}")
+                except Exception as e:
+                    logger.warning(f"Could not delete temporary file {file_path}: {e}")
 
     @classmethod
     def generate_report(cls, instance, **kwargs):

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -11,7 +11,6 @@ import time
 from http import HTTPStatus
 from pathlib import Path
 from typing import List
-from unittest import result
 
 import orjson
 import yaml

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -11,6 +11,7 @@ import time
 from http import HTTPStatus
 from pathlib import Path
 from typing import List
+from unittest import result
 
 import orjson
 import yaml
@@ -767,8 +768,11 @@ def get_performance_results_report(instance: Instance):
             tracing_mode=tracing_mode,
             group_by=group_by,
         )
-    except DataFormatError:
-        return Response(status=HTTPStatus.UNPROCESSABLE_ENTITY)
+    except DataFormatError as error:
+        return (
+            jsonify(f"{str(error)}"),
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+        )
 
     return Response(orjson.dumps(report), mimetype="application/json")
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -770,7 +770,7 @@ def get_performance_results_report(instance: Instance):
         )
     except DataFormatError as error:
         return (
-            jsonify(f"{str(error)}"),
+            jsonify(str(error)),
             HTTPStatus.UNPROCESSABLE_ENTITY,
         )
 

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -38,7 +38,7 @@ const RANGE_STEP = 25;
 
 function Range() {
     const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
-    const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
+    const [activePerformanceReport, setActivePerformanceReport] = useAtom(activePerformanceReportAtom);
     const setOperationRange = useSetAtom(operationRangeAtom);
     const [selectedOperationRange, setSelectedOperationRange] = useAtom(selectedOperationRangeAtom);
     const setPerformanceRange = useSetAtom(performanceRangeAtom);
@@ -167,8 +167,9 @@ function Range() {
                 : 'Failed to load performance data';
 
             createToastNotification(message, activePerformanceReport?.reportName, ToastType.ERROR);
+            setActivePerformanceReport(null);
         }
-    }, [perfDataError, activePerformanceReport]);
+    }, [perfDataError, activePerformanceReport, setActivePerformanceReport]);
 
     useEffect(() => {
         if (clusterError && activeProfilerReport) {

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -163,7 +163,7 @@ function Range() {
     useEffect(() => {
         if (perfDataError && activePerformanceReport) {
             const message = axios.isAxiosError(perfDataError)
-                ? (perfDataError.response?.data as string)
+                ? `Error loading report: ${perfDataError.response?.data as string}`
                 : 'Failed to load performance data';
 
             createToastNotification(message, activePerformanceReport?.reportName, ToastType.ERROR);

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -7,6 +7,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { IconNames } from '@blueprintjs/icons';
 import { useLocation } from 'react-router';
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 import {
     activePerformanceReportAtom,
     activeProfilerReportAtom,
@@ -161,11 +162,11 @@ function Range() {
 
     useEffect(() => {
         if (perfDataError && activePerformanceReport) {
-            createToastNotification(
-                'Performance data format is not supported, use TT-NN Visualizer v0.49.0',
-                activePerformanceReport?.reportName,
-                ToastType.WARNING,
-            );
+            const message = axios.isAxiosError(perfDataError)
+                ? (perfDataError.response?.data as string)
+                : 'Failed to load performance data';
+
+            createToastNotification(message, activePerformanceReport?.reportName, ToastType.ERROR);
         }
     }, [perfDataError, activePerformanceReport]);
 

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -64,17 +64,17 @@ const invalidReportStatus: ConnectionStatus = {
 
 const invalidProfilerStatus: ConnectionStatus = {
     status: ConnectionTestStates.FAILED,
-    message: 'Selected directory is not a valid profiler run',
+    message: 'Selected directory does not contain a valid report',
 };
 
 const directoryErrorStatus: ConnectionStatus = {
     status: ConnectionTestStates.FAILED,
-    message: 'Selected directory does not contain a valid report.',
+    message: 'Selected directory does not contain a valid report',
 };
 
 const connectionFailedStatus: ConnectionStatus = {
     status: ConnectionTestStates.FAILED,
-    message: 'Unable to upload selected directory.',
+    message: 'Unable to upload selected directory',
 };
 
 const LocalFolderOptions: FC = () => {

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -135,7 +135,7 @@ export default function Performance() {
     if (perfDataError?.status === HttpStatusCode.UnprocessableEntity) {
         return (
             <>
-                <h2>Unable to process performance data</h2>
+                <h2>Unable to load performance data</h2>
                 <p>
                     Data format is not supported, try using{' '}
                     <a href='https://github.com/tenstorrent/ttnn-visualizer/releases/tag/v0.49.0'>
@@ -144,6 +144,8 @@ export default function Performance() {
                     or earlier, or regenerate performance report using a newer version of{' '}
                     <a href='https://github.com/tenstorrent/tt-metal/'>TT-Metal</a>.
                 </p>
+
+                <code className='formatted-code'>{perfDataError?.response?.data as string}</code>
             </>
         );
     }

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -224,7 +224,7 @@ it('handles invalid performance report upload', async () => {
     await waitFor(
         () =>
             expect(screen.getByTestId(TEST_IDS.LOCAL_PERFORMANCE_STATUS).textContent).to.equal(
-                'Selected directory is not a valid profiler run',
+                'Selected directory is not a valid performance report',
             ),
         WAIT_FOR_OPTIONS,
     );

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -224,7 +224,7 @@ it('handles invalid performance report upload', async () => {
     await waitFor(
         () =>
             expect(screen.getByTestId(TEST_IDS.LOCAL_PERFORMANCE_STATUS).textContent).to.equal(
-                'Selected directory is not a valid performance report',
+                'Selected directory does not contain a valid performance report',
             ),
         WAIT_FOR_OPTIONS,
     );

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -224,7 +224,7 @@ it('handles invalid performance report upload', async () => {
     await waitFor(
         () =>
             expect(screen.getByTestId(TEST_IDS.LOCAL_PERFORMANCE_STATUS).textContent).to.equal(
-                'Selected directory does not contain a valid performance report',
+                'Selected directory does not contain a valid report',
             ),
         WAIT_FOR_OPTIONS,
     );


### PR DESCRIPTION
Instead of giving a generic, perhaps inaccurate suggestion, we now output the error returned from the back end.

<img width="1728" height="886" alt="Screenshot 2026-03-12 at 12 49 25" src="https://github.com/user-attachments/assets/50c2814e-a73f-45ac-87ec-186341d0fa0a" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1302.