### PR TITLE
Support multiple deallocate operation names

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -19,9 +19,9 @@ import { toReadableShape, toReadableType } from '../functions/formatting';
 import SearchField from './SearchField';
 import MemoryTag from './MemoryTag';
 import { GRAPH_COLORS } from '../definitions/GraphColors';
+import { DEALLOCATE_OP_NAME_LIST } from '../definitions/Deallocate';
 
 type OperationList = OperationDescription[];
-const DEALLOCATE_OP_NAME = 'ttnn.deallocate';
 
 const OperationGraph: React.FC<{
     operationList: OperationList;
@@ -92,7 +92,7 @@ const OperationGraph: React.FC<{
             new DataSet(
                 operationList
                     .filter((op) => connectedNodeIds.has(op.id))
-                    .filter((op) => !filterOutDeallocate || !op.name.toLowerCase().includes(DEALLOCATE_OP_NAME))
+                    .filter((op) => !filterOutDeallocate || !DEALLOCATE_OP_NAME_LIST.includes(op.name.toLowerCase()))
                     .map((op) => ({
                         id: op.id,
                         label: `${op.id} ${op.name}${

--- a/src/definitions/Deallocate.ts
+++ b/src/definitions/Deallocate.ts
@@ -1,1 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
 export const DEALLOCATE_OP_NAME_LIST = ['ttnn.deallocate', 'ttnn::deallocate'];

--- a/src/definitions/Deallocate.ts
+++ b/src/definitions/Deallocate.ts
@@ -1,0 +1,1 @@
+export const DEALLOCATE_OP_NAME_LIST = ['ttnn.deallocate', 'ttnn::deallocate'];

--- a/src/functions/getDeallocationOperation.ts
+++ b/src/functions/getDeallocationOperation.ts
@@ -3,18 +3,17 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { OperationDescription, Tensor } from '../model/APIData';
+import { DEALLOCATE_OP_NAME_LIST } from '../definitions/Deallocate';
 
 function getDeallocationOperation(
     tensor: Tensor,
     operations: OperationDescription[],
 ): OperationDescription | undefined {
-    // TODO: Maybe we can strengthen this logic to ensure we're looking at deallocations rather than just checking the name
-    const matchingInputs = operations.filter(
+    return operations.find(
         (operation) =>
-            operation.name.includes('deallocate') && operation.inputs.find((input) => input.id === tensor.id),
+            DEALLOCATE_OP_NAME_LIST.includes(operation.name.toLowerCase()) &&
+            operation.inputs.find((input) => input.id === tensor.id),
     );
-
-    return matchingInputs?.[0];
 }
 
 export default getDeallocationOperation;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -57,6 +57,7 @@ import Endpoints from '../definitions/Endpoints';
 import { ReportFolder } from '../definitions/Reports';
 import { RemoteFolder } from '../definitions/RemoteConnection';
 import createToastNotification, { ToastType } from '../functions/createToastNotification';
+import { DEALLOCATE_OP_NAME_LIST } from '../definitions/Deallocate';
 
 const EMPTY_PERF_RETURN = { report: [], stacked_report: [], signposts: [] };
 
@@ -1154,7 +1155,7 @@ export const useGetTensorDeallocationReportByOperation = () => {
                 const lastConsumerOperationId = list.sort().pop() || -1;
                 const lastConsumerName = operationsById.get(lastConsumerOperationId)?.name || '';
 
-                if (lastConsumerOperationId > -1 && !lastConsumerName.includes('ttnn.deallocate')) {
+                if (lastConsumerOperationId > -1 && !DEALLOCATE_OP_NAME_LIST.includes(lastConsumerName.toLowerCase())) {
                     return { lastConsumerOperationId, lastConsumerName };
                 }
             }


### PR DESCRIPTION
Add a canonical list of deallocate operation names and use it everywhere instead of a single hardcoded string. Created src/definitions/Deallocate.ts exporting DEALLOCATE_OP_NAME_LIST, updated OperationGraphComponent and useAPI hooks to check includes(...) (case-insensitive) so both 'ttnn.deallocate' and 'ttnn::deallocate' are recognized.

closes #1318 