### PR TITLE
Feature/Expand report selection space

### DIFF
--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -3,7 +3,8 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { useState } from 'react';
-import { Alert, Button, ButtonVariant, Intent, MenuItem, Position, Tooltip } from '@blueprintjs/core';
+import classNames from 'classnames';
+import { Alert, Button, ButtonVariant, Classes, Intent, MenuItem, Position, Tooltip } from '@blueprintjs/core';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { useInstance } from '../../hooks/useAPI';
@@ -67,7 +68,7 @@ const LocalFolderPicker = ({
             >
                 <MenuItem
                     textClassName='folder-picker-label'
-                    text={`/${getPrettyPath(folder.path)}`}
+                    text={`/${folder.path}`}
                     labelElement={
                         <Tooltip
                             content={folder.reportName}
@@ -80,7 +81,7 @@ const LocalFolderPicker = ({
                             />
                         </Tooltip>
                     }
-                    labelClassName='folder-picker-name-label'
+                    labelClassName={classNames('folder-picker-name-label', Classes.TEXT_OVERFLOW_ELLIPSIS)}
                     roleStructure='listoption'
                     active={folder.path === activePath}
                     disabled={modifiers.disabled}
@@ -162,8 +163,5 @@ const LocalFolderPicker = ({
         </Select>
     );
 };
-
-const PATH_REGEX = /^\d+_/gm;
-const getPrettyPath = (path: string) => (PATH_REGEX.test(path) ? path.replace(PATH_REGEX, '') : path);
 
 export default LocalFolderPicker;

--- a/src/scss/components/FolderPicker.scss
+++ b/src/scss/components/FolderPicker.scss
@@ -31,18 +31,18 @@
 
     > li {
         flex-grow: 1;
-        flex-shrink: 1;
     }
 
     .folder-picker-label {
-        max-width: 145px;
+        max-width: 180px;
     }
 
     .folder-picker-name-label {
-        max-width: 145px;
+        max-width: 120px;
         text-align: right;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+
+        > span {
+            display: inline;
+        }
     }
 }


### PR DESCRIPTION
Tweaks some styles to allow for more space and removes a regex which wasn't doing anything useful. More work to be done.

<img width="1441" height="877" alt="Screenshot 2026-03-13 at 16 28 16" src="https://github.com/user-attachments/assets/053392a9-a031-4689-ac38-58c390347558" />

Related to https://github.com/tenstorrent/ttnn-visualizer/issues/1311.