### PR TITLE
Add robots.txt file

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -87,6 +87,16 @@ def create_app(settings_override=None):
 
     if flask_env == "production":
 
+        @app.route(f"{app.config['BASE_PATH']}robots.txt")
+        def robots_txt():
+            """Serve a permissive robots.txt so analyzers don't get SPA HTML."""
+            body = "User-agent: *\nAllow: /\n"
+            return flask.Response(
+                body,
+                mimetype="text/plain",
+                headers={"Cache-Control": "public, max-age=86400"},
+            )
+
         @app.route(f"{app.config['BASE_PATH']}", defaults={"path": ""})
         @app.route(f"{app.config['BASE_PATH']}<path:path>")
         def catch_all(path):


### PR DESCRIPTION
This PR ensures a valid `robots.txt` file is returned when it is requested. Currently a request to `/robots.txt` returns the HTML to bootstrap the React SPA.

A permissive `robots.txt` file is being added, as the point is to ensure a valid file is returned, not to limit access to the app.

[Closes #669]