### PR TITLE
Chore/Update tt-perf-report dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic==2.10.3",
     "python-dotenv==1.0.1",
     "PyYAML==6.0.2",
-    "tt-perf-report==1.2.1",
+    "tt-perf-report==1.2.2",
     "uvicorn==0.30.1",
     "zstd==1.5.7.0"
 ]


### PR DESCRIPTION
Updates to latest tt-perf-report version which fixes a bug when generating the stacked report and improves op categorisation.