### PR TITLE
Feature/Empty device operation lists are collapsible

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -316,8 +316,12 @@ function useDeviceOperationsFullRenderModel(args: {
                                 [COLLAPSIBLE_EMPTY_CLASS]: !hasContent,
                             })}
                         >
-                            <div className='function-content'>{innerContent}</div>
-                            <div className='end-function'>{/* staying for now */}</div>
+                            {hasContent ? (
+                                <>
+                                    <div className='function-content'>{innerContent}</div>
+                                    <div className='end-function'>{/* staying for now */}</div>
+                                </>
+                            ) : null}
                         </Collapsible>
                     );
 

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -72,6 +72,8 @@
     }
 
     .device-operation {
+        margin-bottom: 10px;
+
         hr {
             opacity: 0.2;
             padding-top: 5px;
@@ -93,6 +95,12 @@
             }
         }
 
+        .collapsible-label-wrap {
+            display: inline-flex;
+            padding-left: 8px;
+            padding-right: 8px;
+        }
+
         .params {
             font-weight: lighter;
 
@@ -104,6 +112,10 @@
 
     .end-function {
         padding-top: 10px;
+
+        &:empty {
+            display: none;
+        }
     }
 
     .function-content {


### PR DESCRIPTION
- Device ops with no child ops are no longer expandable
- Added additional margin
- Hid or removed empty containers

**Before (closed)**
<img width="1278" height="807" alt="Screenshot 2026-03-19 at 10 28 56" src="https://github.com/user-attachments/assets/640cef9a-ac5c-4742-9292-a9bd63330cfe" />

**After (closed)**
<img width="1278" height="807" alt="Screenshot 2026-03-19 at 10 29 02" src="https://github.com/user-attachments/assets/a202cb47-cc5e-4d24-b988-af6ae094b478" />


Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1312.