### PR TITLE
Render additional tensor details in device ops, format dtype, unify dtype rendering

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -33,7 +33,7 @@ import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
 import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1MemorySize';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
-import { toReadableLayout, toReadableShape } from '../../functions/formatting';
+import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
 import { BufferTypeToStringBufferType, StringBufferType } from '../../model/BufferType';
 
 type BufferDetails = {
@@ -56,14 +56,14 @@ const renderBufferDetails = ({ bufferOrTensorNode, tensorId, optionalOutput, det
     const size: number | undefined = parseInt(bufferOrTensorNode.params.size, 10);
     let layout = '';
     let { type } = bufferOrTensorNode.params;
-
+    let dtype = null;
     if (bufferOrTensorNode.node_type === NodeType.tensor) {
         const { params } = bufferOrTensorNode;
-        address = parseInt(params.address, 10);
+        address = params.address === undefined ? undefined : parseInt(params.address, 10);
         layout = toReadableLayout(params.layout) || '';
         type = BufferTypeToStringBufferType[params.buffer_type];
+        dtype = params.dtype || null;
     }
-
     if (address !== undefined || tensorId !== undefined) {
         const tensor: Tensor | undefined =
             address !== undefined
@@ -94,6 +94,7 @@ const renderBufferDetails = ({ bufferOrTensorNode, tensorId, optionalOutput, det
                 {tensorSquare} {address !== undefined && `${prettyPrintAddress(address, 0)}`}
             </span>
             <span> {formatMemorySize(size, 2)}</span>
+            <span>{dtype && `${toReadableType(dtype)}`}</span>
             <span>
                 <MemoryTag memory={type} />
             </span>
@@ -171,6 +172,9 @@ function createBuffersRender(node: TensorNode, details: OperationDetails) {
 
     if (node.params.address !== undefined) {
         return <>{renderBufferDetails({ bufferOrTensorNode: node, tensorId: node.params.tensor_id, details })}</>;
+    }
+    if (node.buffer === undefined || node.buffer.length === 0) {
+        return renderBufferDetails({ bufferOrTensorNode: node, tensorId: node.params.tensor_id, details });
     }
     return (
         node.buffer?.map((buffer, index) => (

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -52,14 +52,14 @@ const renderBufferDetails = ({ bufferOrTensorNode, tensorId, optionalOutput, det
     const { allocation } = bufferOrTensorNode;
 
     let tensorSquare = null;
-    let address = allocation?.params.address === undefined ? undefined : parseInt(allocation.params.address, 10);
+    let address = allocation?.params.address !== undefined ? parseInt(allocation.params.address, 10) : undefined;
     const size: number | undefined = parseInt(bufferOrTensorNode.params.size, 10);
     let layout = '';
     let { type } = bufferOrTensorNode.params;
     let dtype = null;
     if (bufferOrTensorNode.node_type === NodeType.tensor) {
         const { params } = bufferOrTensorNode;
-        address = params.address === undefined ? undefined : parseInt(params.address, 10);
+        address = params.address !== undefined ? parseInt(params.address, 10) : undefined;
         layout = toReadableLayout(params.layout) || '';
         type = BufferTypeToStringBufferType[params.buffer_type];
         dtype = params.dtype || null;

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -142,13 +142,15 @@ const renderTensorLabel = (
             <span className='tensor-details-layout'>
                 {square}{' '}
                 <span className={classNames(Classes.TOOLTIP_INDICATOR, 'has-tooltip')}>
-                    <strong>{node.params.tensor_id}</strong> {toReadableShape(node.params.shape)}
+                    <strong>{node.params.tensor_id}</strong> {toReadableShape(node.params.shape)}{' '}
+                    <strong>{toReadableType(node.params.dtype)}</strong>
                 </span>
             </span>
         </Tooltip>
     ) : (
         <span className='tensor-details-layout'>
-            {square} <strong>{node.params.tensor_id}</strong> {toReadableShape(node.params.shape)}
+            {square} <strong>{node.params.tensor_id}</strong> {toReadableShape(node.params.shape)}{' '}
+            <strong>{toReadableType(node.params.dtype)}</strong>
         </span>
     );
 };

--- a/src/components/operation-details/TensorDetailsComponent.tsx
+++ b/src/components/operation-details/TensorDetailsComponent.tsx
@@ -124,15 +124,15 @@ const TensorDetailsComponent: React.FC<TensorDetailsComponentProps> = ({
                     Shape:<strong> {toReadableShape(tensor.shape)}</strong>
                 </p>
                 <p>
-                    Dtype:<strong> {toReadableType(tensor.dtype)}</strong>
+                    Type:<strong> {toReadableType(tensor.dtype)}</strong>
                 </p>
                 <p>
-                    Layout:<strong> {tensor.layout}</strong>
+                    Layout:<strong> {toReadableLayout(tensor.layout)}</strong>
                 </p>
                 <p>
                     {tensor.memory_config?.memory_layout && (
                         <>
-                            Memory layout:<strong> {toReadableLayout(tensor.memory_config.memory_layout)}</strong>
+                            Memory:<strong> {toReadableLayout(tensor.memory_config.memory_layout)}</strong>
                         </>
                     )}
                 </p>

--- a/src/functions/formatting.ts
+++ b/src/functions/formatting.ts
@@ -13,11 +13,12 @@ export const toReadableShape = (input: string) => {
 };
 
 export const toReadableType = (input: string) => {
-    return stripEnum(input);
+    return toShortTypeLabel(stripEnum(input));
 };
 
 export const toReadableLayout = (input: TensorMemoryLayout | string) => {
-    return stripEnum(input);
+    // TODO: we may want to consider getting rid of uppercase and underscores in the future
+    return stripEnum(input); // .toLowerCase().replaceAll('_', '-');
 };
 
 export const capitalizeString = (input: string) => {
@@ -25,5 +26,27 @@ export const capitalizeString = (input: string) => {
 };
 
 export const stripEnum = (v: string) => {
-    return v.toString().split('::').pop() || v;
+    if (!v) {
+        return v;
+    }
+    const str = v.toString();
+    const parsed = str.split(/::|\./);
+
+    return parsed[parsed.length - 1] || str;
+};
+
+const TYPE_LABELS: Record<string, string> = {
+    UINT8: 'u8',
+    UINT16: 'u16',
+    INT32: 'i32',
+    UINT32: 'u32',
+    FLOAT32: 'f32',
+    BFLOAT16: 'bf16',
+    BFLOAT8_B: 'bf8',
+    BFLOAT4_B: 'bf4',
+};
+
+const toShortTypeLabel = (input: string) => {
+    const key = stripEnum(input);
+    return TYPE_LABELS[key] ?? key.toLowerCase();
 };

--- a/src/functions/formatting.ts
+++ b/src/functions/formatting.ts
@@ -13,7 +13,7 @@ export const toReadableShape = (input: string) => {
 };
 
 export const toReadableType = (input: string) => {
-    return input.replace(/^DataType\./, '');
+    return stripEnum(input);
 };
 
 export const toReadableLayout = (input: TensorMemoryLayout | string) => {


### PR DESCRIPTION
Show tensor data types in UI and normalize layout/type formatting. Adds dtype display to DeviceOperationsFullRender and renames labels in TensorDetailsComponent ("Dtype" → "Type", "Memory layout" → "Memory"). Introduces toShortTypeLabel and TYPE_LABELS mapping and updates toReadableType to return short type labels (e.g. f32, u8). Enhances stripEnum to handle empty values and dot/:: separators. Keeps toReadableLayout behavior while noting a potential future normalization change.

Add dtype display and improve buffer rendering behavior. DeviceOperationsFullRender: import toReadableType, safely parse tensor address, capture params.dtype and render a readable dtype string in buffer details, and treat nodes with undefined or empty buffer arrays as single buffers so their details are shown. formatting: make toReadableType use stripEnum(input) for cleaner enum stripping. These changes ensure dtype is visible in the UI and avoid missing renders or parse errors when address or buffer lists are absent.


<img width="1610" height="974" alt="image" src="https://github.com/user-attachments/assets/6c0ba650-6243-451b-b353-a011a58eb665" />

closes #1331 