### PR TITLE
Add device operation analysis and UI indicators for usless Tensor::reshape

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -35,6 +35,11 @@ import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
 import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
 import { BufferTypeToStringBufferType, StringBufferType } from '../../model/BufferType';
+import {
+    DEVICE_OPERATION_ANALYSIS_RESULT,
+    DEVICE_OPERATION_ANALYSIS_RESULT_LABEL,
+    analyseDeviceOperation,
+} from '../../functions/analyseDeviceOperation';
 
 type BufferDetails = {
     bufferOrTensorNode?: BufferNode | TensorNode;
@@ -249,14 +254,25 @@ function useDeviceOperationsFullRenderModel(args: {
 
                     const opArgs = node.operation?.arguments;
 
+                    const opAnalysisResult = analyseDeviceOperation(node.operation);
+                    const opAnalysisLabel = DEVICE_OPERATION_ANALYSIS_RESULT_LABEL[opAnalysisResult];
+                    const labelClass = classNames('device-operation-label', {
+                        'failed-op-analysis': opAnalysisResult !== DEVICE_OPERATION_ANALYSIS_RESULT.OK,
+                    });
                     const label = (
-                        <h4 className='device-operation-label'>
-                            <Icon
-                                className='operation-icon'
-                                size={13}
-                                intent={Intent.SUCCESS}
-                                icon={IconNames.CUBE_ADD}
-                            />
+                        <h4 className={labelClass}>
+                            <Tooltip content={opAnalysisLabel}>
+                                <Icon
+                                    className='operation-icon'
+                                    size={13}
+                                    intent={
+                                        opAnalysisResult === DEVICE_OPERATION_ANALYSIS_RESULT.NOOP
+                                            ? Intent.WARNING
+                                            : Intent.SUCCESS
+                                    }
+                                    icon={IconNames.CUBE_ADD}
+                                />
+                            </Tooltip>
                             {opName} <DeviceID _node={node} /> (
                             {node.operation?.inputs.map((inputNode, i) => (
                                 <span

--- a/src/functions/analyseDeviceOperation.ts
+++ b/src/functions/analyseDeviceOperation.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { DeviceOperationNode, TensorNode } from '../model/APIData';
+
+const DEVICE_OPERATION_NAME = {
+    RESHAPE: 'tensor::reshape',
+};
+
+export enum DEVICE_OPERATION_ANALYSIS_RESULT {
+    OK,
+    NOOP,
+}
+
+export const DEVICE_OPERATION_ANALYSIS_RESULT_LABEL = {
+    [DEVICE_OPERATION_ANALYSIS_RESULT.OK]: '',
+    [DEVICE_OPERATION_ANALYSIS_RESULT.NOOP]: 'Operations appears to be a no-op and may be removable',
+};
+
+export const analyseDeviceOperation = (operation?: DeviceOperationNode) => {
+    if (!operation) {
+        return DEVICE_OPERATION_ANALYSIS_RESULT.OK;
+    }
+    const { params, inputs, outputs } = operation;
+    const { name } = params;
+
+    if (name.toLowerCase() === DEVICE_OPERATION_NAME.RESHAPE) {
+        const inputTensor: TensorNode = inputs?.[0] as TensorNode;
+        const outputTensor = outputs?.[0] as TensorNode;
+        if (inputTensor && outputTensor) {
+            const inputShape = inputTensor.params.shape;
+            const outputShape = outputTensor.params.shape;
+            if (inputShape === outputShape) {
+                return DEVICE_OPERATION_ANALYSIS_RESULT.NOOP;
+            }
+        }
+    }
+    return DEVICE_OPERATION_ANALYSIS_RESULT.OK;
+};

--- a/src/functions/analyseDeviceOperation.ts
+++ b/src/functions/analyseDeviceOperation.ts
@@ -28,10 +28,8 @@ export const analyseDeviceOperation = (operation?: DeviceOperationNode) => {
     if (name.toLowerCase() === DEVICE_OPERATION_NAME.RESHAPE) {
         const inputTensor: TensorNode = inputs?.[0] as TensorNode;
         const outputTensor = outputs?.[0] as TensorNode;
-        if (inputTensor && outputTensor) {
-            const inputShape = inputTensor.params.shape;
-            const outputShape = outputTensor.params.shape;
-            if (inputShape === outputShape) {
+        if (inputTensor && outputTensor && inputTensor.params.shape && outputTensor.params.shape) {
+            if (inputTensor.params.shape === outputTensor.params.shape) {
                 return DEVICE_OPERATION_ANALYSIS_RESULT.NOOP;
             }
         }

--- a/src/functions/analyseDeviceOperation.ts
+++ b/src/functions/analyseDeviceOperation.ts
@@ -15,7 +15,7 @@ export enum DEVICE_OPERATION_ANALYSIS_RESULT {
 
 export const DEVICE_OPERATION_ANALYSIS_RESULT_LABEL = {
     [DEVICE_OPERATION_ANALYSIS_RESULT.OK]: '',
-    [DEVICE_OPERATION_ANALYSIS_RESULT.NOOP]: 'Operations appears to be a no-op and may be removable',
+    [DEVICE_OPERATION_ANALYSIS_RESULT.NOOP]: 'Operation appears to be a no-op and may be removable',
 };
 
 export const analyseDeviceOperation = (operation?: DeviceOperationNode) => {

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -110,7 +110,7 @@ export const processInputsOutputs = (graph: Node[]): DeviceOperationNode[] => {
         return [];
     }
     const operations: DeviceOperationNode[] = [];
-    const nodeByNodeId = new Map<number, Node>(graph.map((op) => [op.id, op]));
+    const nodeByNodeId = new Map<number, Node>(graph.map((op) => [op.id, { ...op }]));
 
     const connected = (node: Node): Node[] =>
         (node.connections ?? []).map((id) => nodeByNodeId.get(id)).filter((n): n is Node => Boolean(n));

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -130,5 +130,6 @@ export const processInputsOutputs = (graph: Node[]): DeviceOperationNode[] => {
             .flatMap((end) => connected(end))
             .filter((n): n is Node => n.node_type === NodeType.tensor);
     }
+
     return operations;
 };

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Node, NodeType } from '../model/APIData';
+import { DeviceOperationNode, Node, NodeType } from '../model/APIData';
 import { L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { StringBufferType } from '../model/BufferType';
 
@@ -104,3 +104,31 @@ export function processMemoryAllocations(
 
     return { peakMemoryLoad, memoryAllocationList };
 }
+
+export const processInputsOutputs = (graph: Node[]): DeviceOperationNode[] => {
+    if (!Array.isArray(graph)) {
+        return [];
+    }
+    const operations: DeviceOperationNode[] = [];
+    const nodeByNodeId = new Map<number, Node>(graph.map((op) => [op.id, op]));
+
+    const connected = (node: Node): Node[] =>
+        (node.connections ?? []).map((id) => nodeByNodeId.get(id)).filter((n): n is Node => Boolean(n));
+
+    for (const op of graph) {
+        if (op.node_type !== NodeType.function_start) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+        operations.push(op);
+        op.inputs = (op.input_tensors ?? [])
+            .map((id) => nodeByNodeId.get(id))
+            .filter((n): n is Node => Boolean(n && n.node_type === NodeType.tensor));
+
+        op.outputs = connected(op)
+            .filter((n) => n.node_type === NodeType.function_end)
+            .flatMap((end) => connected(end))
+            .filter((n): n is Node => n.node_type === NodeType.tensor);
+    }
+    return operations;
+};

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -115,12 +115,14 @@ export const processInputsOutputs = (graph: Node[]): DeviceOperationNode[] => {
     const connected = (node: Node): Node[] =>
         (node.connections ?? []).map((id) => nodeByNodeId.get(id)).filter((n): n is Node => Boolean(n));
 
-    for (const op of graph) {
+    for (const op of nodeByNodeId.values()) {
         if (op.node_type !== NodeType.function_start) {
             // eslint-disable-next-line no-continue
             continue;
         }
+
         operations.push(op);
+
         op.inputs = (op.input_tensors ?? [])
             .map((id) => nodeByNodeId.get(id))
             .filter((n): n is Node => Boolean(n && n.node_type === NodeType.tensor));

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -58,6 +58,7 @@ import { ReportFolder } from '../definitions/Reports';
 import { RemoteFolder } from '../definitions/RemoteConnection';
 import createToastNotification, { ToastType } from '../functions/createToastNotification';
 import { DEALLOCATE_OP_NAME_LIST } from '../definitions/Deallocate';
+import { processInputsOutputs } from '../functions/processMemoryAllocations';
 
 const EMPTY_PERF_RETURN = { report: [], stacked_report: [], signposts: [] };
 
@@ -192,6 +193,7 @@ const fetchOperations = async (): Promise<OperationDescription[]> => {
             inputs,
             arguments: argumentsWithParsedValues,
             deviceOperationNameList: getDeviceOperationNameList(operation),
+            processedConnections: processInputsOutputs(operation.device_operations),
         } as OperationDescription;
     });
 };

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -306,6 +306,7 @@ export interface BaseNode<T extends NodeType, P> {
 }
 
 export interface DeviceOperationNode extends BaseNode<NodeType.function_start, DeviceOperationParams> {
+    input_tensors: number[];
     arguments: string[];
     stack_trace: string[];
 }

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -221,6 +221,7 @@ export interface OperationDescription extends Operation {
         value: string;
         parsedValue: MemoryConfig | null;
     }[];
+    processedConnections: DeviceOperationNode[];
     deviceOperationNameList: string[]; // List of device operation names. actual device ops only
 }
 

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -18,6 +18,10 @@
         font-size: 12px;
         padding-top: 1px;
     }
+
+    &.failed-op-analysis {
+        background-color: rgba($tt-yellow-accent, 0.2);
+    }
 }
 
 .tensor-details-layout {
@@ -97,8 +101,9 @@
 
         .collapsible-label-wrap {
             display: inline-flex;
-            padding-left: 8px;
             padding-right: 8px;
+
+            // padding-left: 8px;
         }
 
         .params {


### PR DESCRIPTION
Introduce analyseDeviceOperation to detect simple no-op device ops (currently checks reshape with identical shapes) and export analysis enums/labels. Integrate analysis into DeviceOperationsFullRender to show an icon tooltip and apply a 'failed-op-analysis' class so potentially removable ops are surfaced in the UI. Add processedConnections to OperationDescription in APIData to carry processed device op links.


<img width="1375" height="948" alt="image" src="https://github.com/user-attachments/assets/51aaac79-bdde-458a-a104-55715d0bb425" />
<img width="1375" height="948" alt="image" src="https://github.com/user-attachments/assets/728e2d03-bd05-4104-97e8-d7aad81bf94c" />

closes #1294 