### PR TITLE
Adjust grid columns in MemoryLegend

### DIFF
--- a/src/scss/components/MemoryLegendElement.scss
+++ b/src/scss/components/MemoryLegendElement.scss
@@ -29,12 +29,12 @@
 
 .legend-item {
     display: inline-grid;
-    grid-template-columns: 15px 0.2fr 0.2fr 7fr 3fr;
+    grid-template-columns: 15px 0.5fr 2fr 13fr 3fr;
     column-gap: 15px;
     text-align: left;
 
     &.extra-info {
-        grid-template-columns: 15px 0.2fr 0.2fr 6fr 3fr 3fr;
+        grid-template-columns: 15px 0.5fr 2fr 10fr 3fr 3fr;
     }
 
     &.button {


### PR DESCRIPTION
This PR adjusts the CSS grid column proportions used by the Memory Legend rows to fix/avoid misalignment and improve readability of the legend entries

**before**:
<img width="823" height="366" alt="image" src="https://github.com/user-attachments/assets/fb5e1199-a963-43ef-a648-e1cba3ff7d91" />

**after**:
<img width="1577" height="370" alt="image" src="https://github.com/user-attachments/assets/6d3c2ca5-05a9-42b2-a672-f65113e2fef4" />
<img width="1475" height="239" alt="image" src="https://github.com/user-attachments/assets/37a812d2-b747-48a3-bfe7-fbf2bec75e00" />



closes #1344 