### PR TITLE
Fix style collision in memory tags and all other tags by tightening css selector scope

### DIFF
--- a/src/components/MemoryTag.tsx
+++ b/src/components/MemoryTag.tsx
@@ -16,6 +16,6 @@ const MemoryTag = ({ memory }: MemoryTagProps) => {
     const memoryLabel = stripEnum(memory).replace(' ', '-');
     const memoryType = memoryLabel?.toLowerCase();
 
-    return <Tag className={`tag-${memoryType}`}>{memoryLabel}</Tag>;
+    return <Tag className={`memory-tag tag-${memoryType}`}>{memoryLabel}</Tag>;
 };
 export default MemoryTag;

--- a/src/components/SimpleMultiselect.tsx
+++ b/src/components/SimpleMultiselect.tsx
@@ -11,13 +11,13 @@ const SimpleMultiselect = ({
     optionList,
     onUpdateHandler,
     initialValue,
-    classNames,
+    className,
 }: {
     label: string;
     optionList: string[];
     onUpdateHandler: (values: string[]) => void;
     initialValue?: string[];
-    classNames?: string;
+    className?: string;
 }) => {
     const [selected, setSelected] = useState<string[]>(initialValue ?? []);
     const handleItemSelect = (item: string) => {
@@ -56,7 +56,7 @@ const SimpleMultiselect = ({
 
     return (
         <MultiSelect<string>
-            className={classNames}
+            className={className ?? ''}
             items={optionList}
             itemRenderer={renderOption}
             onItemSelect={handleItemSelect}

--- a/src/components/SimpleMultiselect.tsx
+++ b/src/components/SimpleMultiselect.tsx
@@ -11,11 +11,13 @@ const SimpleMultiselect = ({
     optionList,
     onUpdateHandler,
     initialValue,
+    classNames,
 }: {
     label: string;
     optionList: string[];
     onUpdateHandler: (values: string[]) => void;
     initialValue?: string[];
+    classNames?: string;
 }) => {
     const [selected, setSelected] = useState<string[]>(initialValue ?? []);
     const handleItemSelect = (item: string) => {
@@ -54,6 +56,7 @@ const SimpleMultiselect = ({
 
     return (
         <MultiSelect<string>
+            className={classNames}
             items={optionList}
             itemRenderer={renderOption}
             onItemSelect={handleItemSelect}

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -188,18 +188,20 @@ $row-background: $tt-grey-2;
 }
 
 .bp6-tag {
-    background-color: $tt-grey-6;
+    &.memory-tag {
+        background-color: $tt-grey-6;
 
-    &.tag-l1 {
-        background-color: $tt-yellow-accent;
-    }
+        &.tag-l1 {
+            background-color: $tt-yellow-accent;
+        }
 
-    &.tag-dram {
-        background-color: $tt-teal-shade;
-    }
+        &.tag-dram {
+            background-color: $tt-teal-shade;
+        }
 
-    &.tag-l1-small {
-        background-color: $tt-yellow-tint-1;
+        &.tag-l1-small {
+            background-color: $tt-yellow-tint-1;
+        }
     }
 }
 


### PR DESCRIPTION
Add a memory-tag CSS class to MemoryTag component and scope .bp6-tag styles under .memory-tag in _common.scss to avoid globally affecting other bp6-tag elements. Expose a classNames prop on SimpleMultiselect and pass it to the underlying MultiSelect via className to allow custom styling of the multiselect instance. 
fixes #1343