### PR TITLE
Feature/NPE demo select aligned with local folder selector

### DIFF
--- a/src/components/npe/NPEDemoSelect.tsx
+++ b/src/components/npe/NPEDemoSelect.tsx
@@ -40,22 +40,23 @@ const NPEDemoSelect: FC<{
     setDemoData: (data: NPEData | null) => void;
 }> = ({ selectedDemo, setSelectedDemo, setDemoData }) => {
     const renderItem: ItemRenderer<NPEDemoData> = (item, { handleClick, modifiers }) => (
-        <MenuItem
+        <div
+            className='folder-picker-menu-item'
             key={item.reportFile}
-            textClassName='folder-picker-label'
-            text={item.label}
-            labelClassName='folder-picker-name-label'
-            active={item.reportFile === selectedDemo?.reportFile}
-            roleStructure='listoption'
-            disabled={modifiers.disabled}
-            onClick={handleClick}
-            icon={IconNames.SAVED}
-        />
+        >
+            <MenuItem
+                text={item.label}
+                active={item.reportFile === selectedDemo?.reportFile}
+                roleStructure='listoption'
+                disabled={modifiers.disabled}
+                onClick={handleClick}
+                icon={IconNames.SAVED}
+            />
+        </div>
     );
 
     return (
         <Select
-            className=''
             items={NPE_DEMO_DATA}
             itemRenderer={renderItem}
             noResults={

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -51,7 +51,6 @@ const LocalFolderPicker = ({
                 key={`${folder.path} - ${folder.reportName}`}
             >
                 <MenuItem
-                    textClassName='folder-picker-label'
                     text={
                         <>
                             <HighlightedText

--- a/src/scss/components/FolderPicker.scss
+++ b/src/scss/components/FolderPicker.scss
@@ -33,6 +33,7 @@ $folder-text-size: 15px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    font-size: $folder-text-size;
 
     .bp6-menu-item {
         padding-left: 5px; // Aligns with search icon padding in the filter field
@@ -41,20 +42,6 @@ $folder-text-size: 15px;
     > li {
         flex-grow: 1; // Lets the item take up the full width of the menu
         overflow: hidden; // Ensures text-overflow ellipsis works when the text is too long
-    }
-
-    .folder-picker-label {
-        font-size: $folder-text-size;
-    }
-
-    // TODO: Used for NPE - move style rule out of here or refactor NPE picker UI
-    .folder-picker-name-label {
-        text-align: right;
-        font-size: $folder-text-size;
-
-        > span {
-            display: inline;
-        }
     }
 
     .folder-picker-sub-label {


### PR DESCRIPTION
Aligns markup and styles so NPEDemoSelect doesn't use non-standard styles.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1338.