### PR TITLE
Feature/Sort remote folders

### DIFF
--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -730,7 +730,7 @@ def get_remote_profiler_folders(
         )
         remote_folder_data.append(remote_folder)
 
-    return remote_folder_data
+    return sorted(remote_folder_data, key=lambda x: x.lastModified, reverse=True)
 
 
 @remote_exception_handler

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -699,7 +699,7 @@ def get_remote_performance_folders(
             get_remote_performance_folder(remote_connection, path)
         )
 
-    return remote_folder_data
+    return sorted(remote_folder_data, key=lambda x: x.lastModified, reverse=True)
 
 
 @remote_exception_handler


### PR DESCRIPTION
Sorts remote folders by creation date which aligns with how the local folders are sorted (upload time).

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1211.