### PR TITLE
Render buffer deallocate details in device operations

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -401,7 +401,6 @@ function useDeviceOperationsFullRenderModel(args: {
                                 operationDetails={details}
                                 onLegendClick={onLegendClick}
                                 bufferType={buffer.type}
-                                // layout={buffer.layout}
                             />
                             <hr />
                         </DeviceOperationNodeComponent>
@@ -534,7 +533,7 @@ const DeviceOperationNodeComponent: React.FC<
     return (
         <div className='device-operation'>
             <hr />
-            <h4 className={`node-type-${_node.node_type}`}>
+            <h4 className={`title node-type-${_node.node_type}`}>
                 {title}
                 {/* DEBUGGING */}
                 {/* <span style={{ color: 'yellow' }}> */}

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -387,7 +387,6 @@ function useDeviceOperationsFullRenderModel(args: {
                             _node={node}
                             memoryInfo={(buffer.type === StringBufferType.L1 && memoryInfo) || undefined}
                             key={index}
-                            // title={`Buffer deallocate ${formatMemorySize(bufferSize)} ${buffer.type} x ${cores} cores`}
                             title='Buffer deallocate'
                         >
                             <MemoryLegendElement

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -387,8 +387,25 @@ function useDeviceOperationsFullRenderModel(args: {
                             _node={node}
                             memoryInfo={(buffer.type === StringBufferType.L1 && memoryInfo) || undefined}
                             key={index}
-                            title={`Buffer deallocate ${formatMemorySize(bufferSize)} ${buffer.type} x ${cores} cores`}
-                        />
+                            // title={`Buffer deallocate ${formatMemorySize(bufferSize)} ${buffer.type} x ${cores} cores`}
+                            title='Buffer deallocate'
+                        >
+                            <MemoryLegendElement
+                                chunk={{
+                                    address: buffer.address !== undefined ? parseInt(buffer.address, 10) : NaN,
+                                    size: bufferSize,
+                                }}
+                                numCores={cores}
+                                key={buffer.address}
+                                memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
+                                selectedTensorAddress={selectedAddress}
+                                operationDetails={details}
+                                onLegendClick={onLegendClick}
+                                bufferType={buffer.type}
+                                // layout={buffer.layout}
+                            />
+                            <hr />
+                        </DeviceOperationNodeComponent>
                     );
                 } else if (nodeType === NodeType.circular_buffer_deallocate_all) {
                     operationContent = (
@@ -518,7 +535,7 @@ const DeviceOperationNodeComponent: React.FC<
     return (
         <div className='device-operation'>
             <hr />
-            <h4>
+            <h4 className={`node-type-${_node.node_type}`}>
                 {title}
                 {/* DEBUGGING */}
                 {/* <span style={{ color: 'yellow' }}> */}

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -82,6 +82,7 @@ export const MemoryLegendElement: React.FC<{
         ...(chunk.markerType === MarkerType.L1_START && {
             backgroundColor: L1_START_MARKER_COLOR,
         }),
+        ...(Number.isNaN(chunk.address) && { backgroundColor: 'white' }),
     };
 
     const isMatchingBufferColour = memorySquare.backgroundColor === selectedBufferColour;
@@ -119,7 +120,9 @@ export const MemoryLegendElement: React.FC<{
                 })}
                 style={memorySquare}
             />
-            <div className='format-numbers monospace'>{prettyPrintAddress(chunk.address, memSize, showHex)}</div>
+            <div className='format-numbers monospace'>
+                {!Number.isNaN(chunk.address) ? prettyPrintAddress(chunk.address, memSize, showHex) : 'N/A'}
+            </div>
             <div className='format-numbers monospace nowrap'>
                 {/* eslint-disable-next-line no-nested-ternary */}
                 {chunk.markerType === MarkerType.L1_SMALL ? (

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -269,7 +269,7 @@ interface BaseMemoryParams {
 }
 
 export interface BufferDeallocateParams extends Omit<BaseMemoryParams, 'address'> {
-    address?: string | undefined;
+    address?: string;
 }
 
 export interface DeviceTensorParams extends BaseMemoryParams {

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -256,41 +256,40 @@ export interface CircularBufferDeallocateParams {
     device_id: number;
 }
 
-interface BufferAllocateParams {
+interface BaseMemoryParams {
     address: string; // '1259520';
     device_id: number;
-    exact_buffer_type: BufferType;
-    layout: DeviceOperationLayoutTypes;
-    max_size_per_bank?: string; // '114688';
     num_cores: string; // '64';
     page_size: string; // '448';
     size: string; // '7340032';
     type: StringBufferType; // 'L1';
-    derived_device_id?: number[];
-}
-interface CircularBufferAllocateParams {
-    address: string; // '1259520';
-    core_range_set: string;
-    device_id: number;
-    globally_allocated: string; // 'false';
-    size: string; // '7340032';
-    num_cores: string;
-    allocateOperationId: number;
-    allocateOperationName: string;
+    exact_buffer_type: BufferType;
+    layout: DeviceOperationLayoutTypes;
+    buffer_type: BufferType;
 }
 
-export interface DeviceTensorParams {
-    address: string;
-    buffer_type: BufferType;
-    device_id: number;
+export interface BufferDeallocateParams extends Omit<BaseMemoryParams, 'address'> {
+    address?: string | undefined;
+}
+
+export interface DeviceTensorParams extends BaseMemoryParams {
     device_tensors: string; // '[{"address": 1374208, "device_id": 0, "mesh_device_id": 0}]';
     dtype: string;
-    layout: string;
     memory_config: string; // 'MemoryConfig(memory_layout=TensorMemoryLayout::HEIGHT_SHARDED,buffer_type=BufferType::L1,shard_spec=ShardSpec{grid=[{"start":{"x":0,"y":0},"end":{"x":5,"y":7}], shape=[224, 224], orientation=ShardOrientation::ROW_MAJOR},nd_shard_spec={"shard_shape":[224, 224],"grid":[{"start":{"x":0,"y":0},"end":{"x":5,"y":7}}],"orientation":"ShardOrientation::ROW_MAJOR","shard_distribution_strategy":"ShardDistributionStrategy::ROUND_ROBIN_1D"},created_with_nd_shard_spec=0)';
     shape: string; // 'Shape([16, 3, 224, 224])';
     tensor_id: number; // '0';
-    size: string; // '602112';
-    type: StringBufferType;
+}
+
+interface BufferAllocateParams extends BaseMemoryParams {
+    max_size_per_bank?: string; // '114688';
+    derivedDeviceId?: number[];
+}
+
+interface CircularBufferAllocateParams extends BaseMemoryParams {
+    core_range_set: string;
+    globally_allocated: string; // 'false';
+    allocateOperationId: number;
+    allocateOperationName: string;
 }
 
 export interface BaseNode<T extends NodeType, P> {
@@ -318,7 +317,7 @@ export type DeviceOperationNodeEnd = BaseNode<NodeType.function_end, DeviceOpera
 
 export type BufferNode = BaseNode<NodeType.buffer, BufferAllocateParams>;
 export type BufferAllocateNode = BaseNode<NodeType.buffer_allocate, BufferAllocateParams>;
-export type BufferDeallocateNode = BaseNode<NodeType.buffer_deallocate, BufferAllocateParams>;
+export type BufferDeallocateNode = BaseNode<NodeType.buffer_deallocate, BufferDeallocateParams>;
 
 export type CircularBufferAllocateNode = BaseNode<NodeType.circular_buffer_allocate, CircularBufferAllocateParams>;
 export type CircularBufferDeallocateAllNode = BaseNode<

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -682,8 +682,8 @@ ${getMemoryAddress(bufferCondensed.address, this.options.showHex)} <br /> ${form
                     if (n.node_type === NodeType.tensor) {
                         if (n.params.device_id !== undefined) {
                             // KEEPING in case device id arrays confirmed
-                            // op.params.derived_device_id = [
-                            //     ...new Set(op.params.derived_device_id || [n.params.device_id]),
+                            // op.params.derivedDeviceId = [
+                            //     ...new Set(op.params.derivedDeviceId || [n.params.device_id]),
                             // ];
                             // op.params.device_id = n.params.device_id;
                         }

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -89,9 +89,11 @@
         }
 
         /* stylelint-disable selector-class-pattern */
-        h4.node-type-buffer_allocate,
-        h4.node-type-buffer_deallocate {
-            margin-bottom: 10px;
+        .title {
+            &.node-type-buffer_allocate,
+            &.node-type-buffer_deallocate {
+                margin-bottom: 10px;
+            }
         }
 
         /* stylelint-enable selector-class-pattern */

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -88,6 +88,14 @@
             margin-top: 10px;
         }
 
+        /* stylelint-disable selector-class-pattern */
+        h4.node-type-buffer_allocate,
+        h4.node-type-buffer_deallocate {
+            margin-bottom: 10px;
+        }
+
+        /* stylelint-enable selector-class-pattern */
+
         .collapsible-controls {
             h4 {
                 margin-top: 0;


### PR DESCRIPTION
Embed a MemoryLegendElement into the Buffer deallocate node render 

Introduce BaseMemoryParams to centralize common memory fields and create specific interfaces (BufferAllocateParams, CircularBufferAllocateParams, BufferDeallocateParams). Make DeviceTensorParams extend BaseMemoryParams,  and update node typings (BufferDeallocateNode). Rename derived_device_id to camelCase derivedDeviceId in types/comments and reorganize related fields for clearer separation of concerns.

<img width="1226" height="881" alt="image" src="https://github.com/user-attachments/assets/039698fd-9f18-4dd9-87ba-b1575b4680e9" />

closes #1340 