### PR TITLE
Feature/Format remote report paths

### DIFF
--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -108,7 +108,7 @@ function FooterInfobar() {
                             <div className='title'>
                                 <strong>Memory:</strong>
                                 <span className={classNames('report-name', Classes.TOOLTIP_INDICATOR)}>
-                                    {activeProfilerReportName}
+                                    {formatName(activeProfilerReportName)}
                                 </span>
                             </div>
                         </Tooltip>
@@ -125,7 +125,7 @@ function FooterInfobar() {
                             <div className='title'>
                                 <strong>Performance:</strong>
                                 <span className={classNames('report-name', Classes.TOOLTIP_INDICATOR)}>
-                                    {activePerformanceReportPath}
+                                    {formatName(activePerformanceReportPath)}
                                 </span>
                             </div>
                         </Tooltip>
@@ -184,7 +184,20 @@ const formatPath = (str?: string): string => {
         return '';
     }
 
-    return str.startsWith('/') ? str : `/${str}`;
+    const endPath = str.includes('/') ? str.split('/').at(-1) : str;
+
+    return endPath?.startsWith('/') ? endPath : `/${endPath}`;
+};
+
+// If the name is a path, return the parent folder name otherwise return the name (name is optional)
+const formatName = (str: string): string => {
+    const isPath = str.includes('/');
+
+    if (isPath) {
+        return str.split('/').at(-1) || str;
+    }
+
+    return str;
 };
 
 export default FooterInfobar;


### PR DESCRIPTION
Remote report paths show the full path due to the way they are stored. This PR adds a function to format them so they display in the same manner as local reports.

**Before**
<img width="936" height="152" alt="Screenshot 2026-03-30 at 12 17 43" src="https://github.com/user-attachments/assets/fba7336b-2615-44c5-93e9-22382401b92c" />

**After**
<img width="936" height="152" alt="Screenshot 2026-03-30 at 12 17 31" src="https://github.com/user-attachments/assets/130623a2-24c4-4a62-bf1e-7a27ed3c2c4d" />


Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1357.