### PR TITLE
Feature/Add endpoint to return latest app version number

### DIFF
--- a/backend/ttnn_visualizer/tests/views/test_latest_version.py
+++ b/backend/ttnn_visualizer/tests/views/test_latest_version.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for the /api/latest-version endpoint.
+
+Tests both success and failure cases for fetching the latest version from PyPI.
+"""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_pypi_response():
+    """Fixture providing a mock PyPI RSS response with a version."""
+    xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+        <channel>
+            <title>PyPI Latest Releases</title>
+            <item>
+                <title>3.14.15</title>
+                <description>Latest stable release</description>
+            </item>
+            <item>
+                <title>3.14.14</title>
+                <description>Previous release</description>
+            </item>
+        </channel>
+    </rss>
+    """
+    return xml_content.encode("utf-8")
+
+
+class TestLatestVersionSuccess:
+    """Tests for successful version retrieval."""
+
+    def test_returns_the_latest_version(self, client):
+        """Test that the endpoint extracts the first (latest) version correctly."""
+        xml_with_many_releases = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item><title>01.0.0</title></item>
+                <item><title>1.0.1</title></item>
+                <item><title>2.0.0</title></item>
+                <item><title>2.1.0</title></item>
+            </channel>
+        </rss>
+        """.encode(
+            "utf-8"
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = xml_with_many_releases
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+            mock_urlopen.return_value = mock_response
+
+            response = client.get("/api/latest-version")
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+        # The first match in the XML is returned
+        assert data == "01.0.0"
+
+
+class TestLatestVersionFailures:
+    """Tests for failure scenarios."""
+
+    def test_returns_error_when_http_request_fails(self, client):
+        """Test that the endpoint handles HTTP errors gracefully."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = OSError("Network error")
+
+            response = client.get("/api/latest-version")
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        data = response.get_json()
+        assert "error" in data
+        assert data["error"] == "Failed to fetch releases"
+
+    def test_returns_error_when_pypi_times_out(self, client):
+        """Test that the endpoint handles timeout errors."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            import socket
+
+            mock_urlopen.side_effect = socket.timeout("Request timed out")
+
+            response = client.get("/api/latest-version")
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        data = response.get_json()
+        assert data["error"] == "Failed to fetch releases"
+
+    def test_returns_error_when_correlation_error_occurs(self, client):
+        """Test handling of correlation errors (invalid host, DNS, etc)."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            import urllib.error
+
+            mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+
+            response = client.get("/api/latest-version")
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        data = response.get_json()
+        assert data["error"] == "Failed to fetch releases"
+
+    def test_returns_null_when_no_version_found_in_response(self, client):
+        """Test that endpoint returns null when XML has no valid version."""
+        xml_without_version = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item><title>Release Notes</title></item>
+                <item><title>Latest Update</title></item>
+            </channel>
+        </rss>
+        """.encode(
+            "utf-8"
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = xml_without_version
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+            mock_urlopen.return_value = mock_response
+
+            response = client.get("/api/latest-version")
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+        assert data is None
+
+    def test_returns_error_when_response_is_malformed(self, client):
+        """Test handling of malformed XML response."""
+        malformed_xml = b"Not XML at all, just garbage <title> data"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = malformed_xml
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+            mock_urlopen.return_value = mock_response
+
+            response = client.get("/api/latest-version")
+
+        # Should not crash, but regex will not find a version
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+        assert data is None
+
+    def test_returns_error_when_response_is_empty(self, client):
+        """Test handling of empty response from PyPI."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = b""
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+            mock_urlopen.return_value = mock_response
+
+            response = client.get("/api/latest-version")
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+        assert data is None
+
+
+class TestLatestVersionEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_makes_correct_request_to_pypi(self, client):
+        """Test that the endpoint makes the correct HTTP request to PyPI."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = b"<title>1.0.0</title>"
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+            mock_urlopen.return_value = mock_response
+
+            client.get("/api/latest-version")
+
+        # Verify the request was made with correct parameters
+        assert mock_urlopen.called
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]  # First positional argument
+
+        assert (
+            request_obj.full_url
+            == "https://pypi.org/rss/project/ttnn-visualizer/releases.xml"
+        )
+        assert request_obj.method == "GET"
+        assert request_obj.headers.get("Content-type") == "application/xml"
+
+    def test_request_includes_timeout(self, client):
+        """Test that the request includes a timeout of 2 seconds."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = b"<title>1.0.0</title>"
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+            mock_urlopen.return_value = mock_response
+
+            client.get("/api/latest-version")
+
+        # Verify timeout parameter
+        call_kwargs = mock_urlopen.call_args[1]
+        assert call_kwargs.get("timeout") == 2

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -9,6 +9,7 @@ import platform
 import re
 import shutil
 import time
+import urllib
 from http import HTTPStatus
 from pathlib import Path
 from typing import List
@@ -1627,15 +1628,17 @@ def notify_report_update():
 @api.route("/latest-version", methods=["GET"])
 def get_app_versions():
     try:
-        import requests
-
-        response = requests.get(
-            "https://pypi.org/rss/project/ttnn-visualizer/releases.xml"
+        headers = {"Content-Type": "application/xml"}
+        request = urllib.request.Request(
+            "https://pypi.org/rss/project/ttnn-visualizer/releases.xml",
+            headers=headers,
+            method="GET",
         )
-        response.raise_for_status()
 
-        # Extract version number from RSS feed
-        match = re.search(r"<title>(\d+\.\d+\.\d+)</title>", response.text)
+        urllib.response = urllib.request.urlopen(request, timeout=2)
+        response = urllib.response.read().decode("utf-8")
+
+        match = re.search(r"<title>(\d+\.\d+\.\d+)</title>", response)
         latest_version = match.group(1) if match else None
 
         return Response(
@@ -1644,6 +1647,7 @@ def get_app_versions():
         )
     except Exception as e:
         logger.error(f"Error fetching releases XML: {str(e)}")
+
         return Response(
             orjson.dumps({"error": "Failed to fetch releases"}),
             mimetype="application/json",

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import time
 import urllib
+import urllib.request
 from http import HTTPStatus
 from pathlib import Path
 from typing import List
@@ -1629,14 +1630,14 @@ def notify_report_update():
 def get_app_versions():
     try:
         headers = {"Content-Type": "application/xml"}
-        request = urllib.request.Request(
+        releases_request = urllib.request.Request(
             "https://pypi.org/rss/project/ttnn-visualizer/releases.xml",
             headers=headers,
             method="GET",
         )
 
-        urllib.response = urllib.request.urlopen(request, timeout=2)
-        response = urllib.response.read().decode("utf-8")
+        with urllib.request.urlopen(releases_request, timeout=2) as url_response:
+            response = url_response.read().decode("utf-8")
 
         match = re.search(r"<title>(\d+\.\d+\.\d+)</title>", response)
         latest_version = match.group(1) if match else None

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1627,7 +1627,7 @@ def notify_report_update():
 
 
 @api.route("/latest-version", methods=["GET"])
-def get_app_versions():
+def get_latest_version():
     try:
         headers = {"Content-Type": "application/xml"}
         releases_request = urllib.request.Request(

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1622,3 +1622,30 @@ def notify_report_update():
             mimetype="application/json",
             status=HTTPStatus.INTERNAL_SERVER_ERROR,
         )
+
+
+@api.route("/latest-version", methods=["GET"])
+def get_app_versions():
+    try:
+        import requests
+
+        response = requests.get(
+            "https://pypi.org/rss/project/ttnn-visualizer/releases.xml"
+        )
+        response.raise_for_status()
+
+        # Extract version number from RSS feed
+        match = re.search(r"<title>(\d+\.\d+\.\d+)</title>", response.text)
+        latest_version = match.group(1) if match else None
+
+        return Response(
+            orjson.dumps(latest_version),
+            mimetype="application/json",
+        )
+    except Exception as e:
+        logger.error(f"Error fetching releases XML: {str(e)}")
+        return Response(
+            orjson.dumps({"error": "Failed to fetch releases"}),
+            mimetype="application/json",
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )

--- a/src/definitions/Endpoints.ts
+++ b/src/definitions/Endpoints.ts
@@ -19,6 +19,7 @@ enum Endpoints {
     PROFILER = '/api/profiler',
     REMOTE = '/api/remote',
     TENSOR_LIST = '/api/tensors',
+    VERSIONS = '/api/latest-version',
 }
 
 export default Endpoints;

--- a/src/definitions/Endpoints.ts
+++ b/src/definitions/Endpoints.ts
@@ -19,7 +19,7 @@ enum Endpoints {
     PROFILER = '/api/profiler',
     REMOTE = '/api/remote',
     TENSOR_LIST = '/api/tensors',
-    VERSIONS = '/api/latest-version',
+    LATEST_VERSION = '/api/latest-version',
 }
 
 export default Endpoints;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1200,22 +1200,22 @@ export const useGetTensorDeallocationReportByOperation = () => {
     }, [operationsById, tensorListByOperation]);
 };
 
-const fetchLatestReleaseVersion = async (): Promise<string> => {
+const fetchLatestAppVersion = async (): Promise<string | null> => {
     try {
-        const response = await axiosInstance.get(Endpoints.VERSIONS);
+        const response = await axiosInstance.get<string>(Endpoints.VERSIONS);
 
         return response.data;
     } catch (error) {
         // eslint-disable-next-line no-console
-        console.error('Failed to fetch latest release version:', error);
+        console.error('Failed to fetch latest app version:', error);
         throw error;
     }
 };
 
-export const useGetLatestReleaseVersion = () => {
-    const response = useQuery<string, AxiosError>({
-        queryFn: () => fetchLatestReleaseVersion(),
-        queryKey: ['get-latest-release-version'],
+export const useGetLatestAppVersion = () => {
+    const response = useQuery<string | null, AxiosError>({
+        queryFn: () => fetchLatestAppVersion(),
+        queryKey: ['get-latest-app-version'],
         retry: false,
         staleTime: Infinity,
     });

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1202,7 +1202,7 @@ export const useGetTensorDeallocationReportByOperation = () => {
 
 const fetchLatestAppVersion = async (): Promise<string | null> => {
     try {
-        const response = await axiosInstance.get<string>(Endpoints.VERSIONS);
+        const response = await axiosInstance.get<string>(Endpoints.LATEST_VERSION);
 
         return response.data;
     } catch (error) {

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1199,3 +1199,26 @@ export const useGetTensorDeallocationReportByOperation = () => {
         return { lateDeallocationsByOperation, nonDeallocatedTensorList: nonDeallocatedTensorListById };
     }, [operationsById, tensorListByOperation]);
 };
+
+const fetchLatestReleaseVersion = async (): Promise<string> => {
+    try {
+        const response = await axiosInstance.get(Endpoints.VERSIONS);
+
+        return response.data;
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch latest release version:', error);
+        throw error;
+    }
+};
+
+export const useGetLatestReleaseVersion = () => {
+    const response = useQuery<string, AxiosError>({
+        queryFn: () => fetchLatestReleaseVersion(),
+        queryKey: ['get-latest-release-version'],
+        retry: false,
+        staleTime: Infinity,
+    });
+
+    return response.data;
+};


### PR DESCRIPTION
Adds an endpoint to return the latest release version number so we can use it in a later PR to inform users that updates are available.

A successful request will return something like `0.78.0`.

Related to https://github.com/tenstorrent/ttnn-visualizer/issues/1355.