### PR TITLE
Update app to support databases with rank columns

### DIFF
--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -34,6 +34,7 @@ class Operation(SerializeableDataclass):
     operation_id: int
     name: str
     duration: float
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -55,12 +56,14 @@ class Device(SerializeableDataclass):
     total_l1_for_interleaved_buffers: int
     total_l1_for_sharded_buffers: int
     cb_limit: int
+    rank: int = 0
 
 
 @dataclasses.dataclass
 class DeviceOperation(SerializeableDataclass):
     operation_id: int
     captured_graph: str
+    rank: int = 0
 
     def __post_init__(self):
         try:
@@ -83,6 +86,7 @@ class Buffer(SerializeableDataclass):
     max_size_per_bank: int
     buffer_type: BufferType
     buffer_layout: Optional[int] = None
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -97,6 +101,7 @@ class BufferPage(SerializeableDataclass):
     page_address: int
     page_size: int
     buffer_type: BufferType
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -104,6 +109,7 @@ class ProducersConsumers(SerializeableDataclass):
     tensor_id: int
     producers: list[int]
     consumers: list[int]
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -118,6 +124,7 @@ class Tensor(SerializeableDataclass):
     buffer_type: BufferType
     device_addresses: list[int]
     size: Optional[int] = None
+    rank: int = 0
 
     def __post_init__(self):
         self.memory_config = parse_memory_config(self.memory_config)
@@ -128,6 +135,7 @@ class InputTensor(SerializeableDataclass):
     operation_id: int
     input_index: int
     tensor_id: int
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -135,6 +143,7 @@ class OutputTensor(SerializeableDataclass):
     operation_id: int
     output_index: int
     tensor_id: int
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -151,12 +160,14 @@ class OperationArgument(SerializeableDataclass):
     operation_id: int
     name: str
     value: str
+    rank: int = 0
 
 
 @dataclasses.dataclass
 class StackTrace(SerializeableDataclass):
     operation_id: int
     stack_trace: str
+    rank: int = 0
 
 
 @dataclasses.dataclass
@@ -167,6 +178,7 @@ class ErrorRecord(SerializeableDataclass):
     error_message: str
     stack_trace: str
     timestamp: str
+    rank: int = 0
 
     def to_nested_dict(self) -> dict:
         """

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -202,6 +202,26 @@ class DatabaseQueries:
 
         return self.query_runner.execute_query(query, params)
 
+    def merge_rank_filter(
+        self,
+        table_name: str,
+        filters: Optional[Dict[str, Any]],
+        rank: Optional[int],
+    ) -> Dict[str, Any]:
+        """
+        Return a copy of filters with rank = rank if the table has a rank column.
+        No-op when rank is None or the schema has no rank (old reports).
+        """
+        out = dict(filters or {})
+        if rank is None:
+            return out
+        if not self._check_table_exists(table_name):
+            return out
+        if "rank" not in self._get_table_columns(table_name):
+            return out
+        out["rank"] = rank
+        return out
+
     def query_device_operations(
         self, filters: Optional[Dict[str, Union[Any, List[Any]]]] = None
     ) -> List[DeviceOperation]:
@@ -448,7 +468,9 @@ class DatabaseQueries:
         for row in rows:
             yield Device(*row)
 
-    def query_producers_consumers(self) -> Generator[ProducersConsumers, None, None]:
+    def query_producers_consumers(
+        self, rank: Optional[int] = None
+    ) -> Generator[ProducersConsumers, None, None]:
         rank_on_tensors = "rank" in self._get_table_columns("tensors")
         it_rank = "rank" in self._get_table_columns("input_tensors")
         ot_rank = "rank" in self._get_table_columns("output_tensors")
@@ -463,6 +485,12 @@ class DatabaseQueries:
         rank_select = ", t.rank" if rank_on_tensors else ""
         group_by = "t.tensor_id" + (", t.rank" if rank_on_tensors else "")
 
+        where_sql = "WHERE 1=1"
+        params: List[Any] = []
+        if rank_on_tensors and rank is not None:
+            where_sql += " AND t.rank = ?"
+            params.append(rank)
+
         query = f"""
             SELECT
                 t.tensor_id{rank_select},
@@ -474,10 +502,11 @@ class DatabaseQueries:
                 input_tensors it ON {it_join}
             LEFT JOIN
                 output_tensors ot ON {ot_join}
+            {where_sql}
             GROUP BY
                 {group_by}
         """
-        rows = self.query_runner.execute_query(query)
+        rows = self.query_runner.execute_query(query, params)
         for row in rows:
             # SQL aliases: ot AS "consumers", it AS "producers" (names are swapped vs semantics).
             if rank_on_tensors:
@@ -507,7 +536,9 @@ class DatabaseQueries:
         rows = self._query_table("report_metadata", columns=["key", "value"])
         return rows
 
-    def query_next_buffer(self, operation_id: int, address: str) -> Optional[Buffer]:
+    def query_next_buffer(
+        self, operation_id: int, address: str, rank: Optional[int] = None
+    ) -> Optional[Buffer]:
         buf_cols = self._get_table_columns("buffers")
         ordered = [
             c
@@ -523,6 +554,11 @@ class DatabaseQueries:
             if c in buf_cols
         ]
         col_sql = ", ".join(f"buffers.{c}" for c in ordered)
+        where_extra = ""
+        params: List[Any] = [address, operation_id]
+        if rank is not None and "rank" in buf_cols:
+            where_extra = " AND buffers.rank = ?"
+            params.append(rank)
         query = f"""
             SELECT
                 {col_sql}
@@ -530,10 +566,10 @@ class DatabaseQueries:
                 buffers
             WHERE
                 buffers.address = ?
-                AND buffers.operation_id > ?
+                AND buffers.operation_id > ?{where_extra}
             ORDER BY buffers.operation_id
         """
-        rows = self.query_runner.execute_query(query, [address, operation_id])
+        rows = self.query_runner.execute_query(query, params)
         return _buffer_from_row(rows[0]) if rows else None
 
     def __enter__(self):

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -222,6 +222,15 @@ class DatabaseQueries:
         out["rank"] = rank
         return out
 
+    def report_has_rank_column(self) -> bool:
+        """
+        True if the report DB uses the multi-host schema (``rank`` on ``operations``).
+        Used to reject ``?rank=N`` (N != 0) on legacy databases that only represent rank 0.
+        """
+        if not self._check_table_exists("operations"):
+            return False
+        return "rank" in self._get_table_columns("operations")
+
     def query_device_operations(
         self, filters: Optional[Dict[str, Union[Any, List[Any]]]] = None
     ) -> List[DeviceOperation]:

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -26,6 +26,77 @@ from ttnn_visualizer.models import (
 )
 
 
+def _buffer_from_row(row: tuple) -> Buffer:
+    n = len(row)
+    if n == 5:
+        return Buffer(row[0], row[1], row[2], row[3], row[4], None, 0)
+    if n == 6:
+        return Buffer(row[0], row[1], row[2], row[3], row[4], row[5], 0)
+    if n == 7:
+        return Buffer(row[0], row[1], row[2], row[3], row[4], row[5], row[6])
+    raise ValueError(f"Unexpected buffers row width: {n}")
+
+
+def _stack_trace_from_row(row: tuple) -> StackTrace:
+    if len(row) == 2:
+        return StackTrace(row[0], stack_trace=row[1], rank=0)
+    return StackTrace(row[0], stack_trace=row[1], rank=row[2])
+
+
+def _error_record_from_row(row: tuple) -> ErrorRecord:
+    if len(row) == 6:
+        return ErrorRecord(row[0], row[1], row[2], row[3], row[4], row[5], rank=0)
+    return ErrorRecord(*row)
+
+
+def _buffer_page_from_row(row: tuple) -> BufferPage:
+    if len(row) == 10:
+        return BufferPage(
+            row[0],
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+            row[5],
+            row[6],
+            row[7],
+            row[8],
+            row[9],
+            rank=0,
+        )
+    return BufferPage(*row)
+
+
+def _operation_argument_from_row(row: tuple) -> OperationArgument:
+    if len(row) == 3:
+        return OperationArgument(row[0], row[1], row[2], 0)
+    return OperationArgument(*row)
+
+
+def _operation_from_row(row: tuple) -> Operation:
+    if len(row) == 3:
+        return Operation(row[0], row[1], row[2], 0)
+    return Operation(*row)
+
+
+def _device_operation_from_row(row: tuple) -> DeviceOperation:
+    if len(row) == 2:
+        return DeviceOperation(row[0], row[1], 0)
+    return DeviceOperation(*row)
+
+
+def _input_tensor_from_row(row: tuple) -> InputTensor:
+    if len(row) == 3:
+        return InputTensor(row[0], row[1], row[2], 0)
+    return InputTensor(*row)
+
+
+def _output_tensor_from_row(row: tuple) -> OutputTensor:
+    if len(row) == 3:
+        return OutputTensor(row[0], row[1], row[2], 0)
+    return OutputTensor(*row)
+
+
 class LocalQueryRunner:
     def __init__(self, instance: Optional[Instance] = None, connection=None):
 
@@ -137,43 +208,42 @@ class DatabaseQueries:
         if not self._check_table_exists("captured_graph"):
             return []
         rows = self._query_table("captured_graph", filters)
-        return [DeviceOperation(*row) for row in rows]
+        return [_device_operation_from_row(row) for row in rows]
 
     def query_operation_arguments(
         self, filters: Optional[Dict[str, Union[Any, List[Any]]]] = None
     ) -> Generator[OperationArgument, None, None]:
         rows = self._query_table("operation_arguments", filters)
         for row in rows:
-            yield OperationArgument(*row)
+            yield _operation_argument_from_row(row)
 
     def query_operations(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[Operation, None, None]:
         rows = self._query_table("operations", filters)
         for row in rows:
-            yield Operation(*row)
+            yield _operation_from_row(row)
 
     def query_buffers(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[Buffer, None, None]:
         rows = self._query_table("buffers", filters)
         for row in rows:
-            yield Buffer(*row[:6])
+            yield _buffer_from_row(row)
 
     def query_stack_traces(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[StackTrace, None, None]:
         rows = self._query_table("stack_traces", filters)
         for row in rows:
-            operation_id, stack_trace = row
-            yield StackTrace(operation_id, stack_trace=stack_trace)
+            yield _stack_trace_from_row(row)
 
     def query_error_records(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[ErrorRecord, None, None]:
         rows = self._query_table("errors", filters)
         for row in rows:
-            yield ErrorRecord(*row)
+            yield _error_record_from_row(row)
 
     def query_tensor_comparisons(
         self, local: bool = True, filters: Optional[Dict[str, Any]] = None
@@ -191,76 +261,100 @@ class DatabaseQueries:
     ) -> Generator[BufferPage, None, None]:
         rows = self._query_table("buffer_pages", filters)
         for row in rows:
-            yield BufferPage(*row)
+            yield _buffer_page_from_row(row)
 
     def query_tensors(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[Tensor, None, None]:
-        # Check if tensors table has a size column (new schema) or we need to infer from joins
         tensor_columns = self._get_table_columns("tensors")
         size_on_tensors = "size" in tensor_columns
+        rank_on_tensors = "rank" in tensor_columns
 
         device_tensors_exists = self._check_table_exists("device_tensors")
+        dt_rank = device_tensors_exists and "rank" in self._get_table_columns(
+            "device_tensors"
+        )
+        it_rank = "rank" in self._get_table_columns("input_tensors")
+        ot_rank = "rank" in self._get_table_columns("output_tensors")
+        buf_rank = "rank" in self._get_table_columns("buffers")
+
+        it_join = "it.tensor_id = t.tensor_id"
+        if it_rank and rank_on_tensors:
+            it_join += " AND it.rank = t.rank"
+        ot_join = "ot.tensor_id = t.tensor_id"
+        if ot_rank and rank_on_tensors:
+            ot_join += " AND ot.rank = t.rank"
+
+        buf_join = (
+            "b.operation_id = COALESCE(it.operation_id, ot.operation_id) "
+            "AND t.address = b.address AND t.device_id = b.device_id"
+        )
+        if buf_rank and rank_on_tensors:
+            buf_join += " AND b.rank = t.rank"
+
+        dt_join = "dt.tensor_id = t.tensor_id"
+        if dt_rank and rank_on_tensors:
+            dt_join += " AND dt.rank = t.rank"
+
+        select_core = """
+                        t.tensor_id, t.shape, t.dtype, t.layout, t.memory_config,
+                        t.device_id, t.address, t.buffer_type"""
+        select_parts = [select_core.strip()]
+        if rank_on_tensors:
+            select_parts.append("t.rank")
+        if size_on_tensors:
+            select_parts.append("t.size")
+        else:
+            select_parts.append("b.max_size_per_bank AS size")
+
+        if device_tensors_exists:
+            select_parts.append(
+                "GROUP_CONCAT(dt.device_id || ':' || dt.address, ',') AS device_tensors_data"
+            )
+        else:
+            select_parts.append("NULL AS device_tensors_data")
+
+        select_sql = ",\n                        ".join(select_parts)
+
+        group_by = "t.tensor_id"
+        if rank_on_tensors:
+            group_by += ", t.rank"
 
         if size_on_tensors:
-            # New schema: size is on tensors table — simple select without buffer/op joins
+            join_lines = []
             if device_tensors_exists:
-                query = """
+                join_lines.append(f"LEFT JOIN device_tensors dt ON {dt_join}")
+            join_sql = (
+                "\n                    " + "\n                    ".join(join_lines)
+                if join_lines
+                else ""
+            )
+            query = f"""
                     SELECT
-                        t.tensor_id, t.shape, t.dtype, t.layout, t.memory_config,
-                        t.device_id, t.address, t.buffer_type,
-                        t.size,
-                        GROUP_CONCAT(dt.device_id || ':' || dt.address, ',') as device_tensors_data
-                    FROM tensors t
-                    LEFT JOIN device_tensors dt ON dt.tensor_id = t.tensor_id
-                    WHERE 1=1
-                """
-            else:
-                query = """
-                    SELECT
-                        t.tensor_id, t.shape, t.dtype, t.layout, t.memory_config,
-                        t.device_id, t.address, t.buffer_type,
-                        t.size,
-                        NULL as device_tensors_data
-                    FROM tensors t
+                        {select_sql}
+                    FROM tensors t{join_sql}
                     WHERE 1=1
                 """
         else:
-            # Old schema: infer size from buffers via input_tensors/output_tensors joins
+            join_lines = [
+                f"LEFT JOIN input_tensors it ON {it_join}",
+                f"LEFT JOIN output_tensors ot ON {ot_join}",
+                f"LEFT JOIN buffers b ON {buf_join}",
+            ]
             if device_tensors_exists:
-                query = """
+                join_lines.append(f"LEFT JOIN device_tensors dt ON {dt_join}")
+            join_sql = "\n                    " + "\n                    ".join(
+                join_lines
+            )
+            query = f"""
                     SELECT
-                        t.tensor_id, t.shape, t.dtype, t.layout, t.memory_config,
-                        t.device_id, t.address, t.buffer_type,
-                        b.max_size_per_bank as size,
-                        GROUP_CONCAT(dt.device_id || ':' || dt.address, ',') as device_tensors_data
+                        {select_sql}
                     FROM tensors t
-                    LEFT JOIN input_tensors it ON it.tensor_id = t.tensor_id
-                    LEFT JOIN output_tensors ot ON ot.tensor_id = t.tensor_id
-                    LEFT JOIN buffers b ON b.operation_id = COALESCE(it.operation_id, ot.operation_id)
-                        AND t.address = b.address
-                        AND t.device_id = b.device_id
-                    LEFT JOIN device_tensors dt ON dt.tensor_id = t.tensor_id
+                    {join_sql}
                     WHERE 1=1
                 """
-            else:
-                query = """
-                    SELECT
-                        t.tensor_id, t.shape, t.dtype, t.layout, t.memory_config,
-                        t.device_id, t.address, t.buffer_type,
-                        b.max_size_per_bank as size,
-                        NULL as device_tensors_data
-                    FROM tensors t
-                    LEFT JOIN input_tensors it ON it.tensor_id = t.tensor_id
-                    LEFT JOIN output_tensors ot ON ot.tensor_id = t.tensor_id
-                    LEFT JOIN buffers b ON b.operation_id = COALESCE(it.operation_id, ot.operation_id)
-                        AND t.address = b.address
-                        AND t.device_id = b.device_id
-                    WHERE 1=1
-                """
-        params = []
+        params: List[Any] = []
 
-        # Apply filters to tensors table
         if filters:
             for column, value in filters.items():
                 if value is None:
@@ -276,18 +370,21 @@ class DatabaseQueries:
                     query += f" AND t.{column} = ?"
                     params.append(value)
 
-        query += " GROUP BY t.tensor_id"
+        query += f" GROUP BY {group_by}"
 
         rows = self.query_runner.execute_query(query, params)
         for row in rows:
-            tensor_row = row[:8]
-            size = row[8]
-            device_tensors_data = row[9]
+            i = 8
+            rank_val = row[i] if rank_on_tensors else 0
+            if rank_on_tensors:
+                i += 1
+            size = row[i]
+            i += 1
+            device_tensors_data = row[i]
 
-            device_addresses = []
+            device_addresses: List[Any] = []
 
             if device_tensors_data:
-                # Parse the concatenated device_id:address pairs
                 pairs = device_tensors_data.split(",")
                 device_tensor_list = []
                 for pair in pairs:
@@ -297,7 +394,6 @@ class DatabaseQueries:
                         address = int(address_str)
                         device_tensor_list.append((device_id, address))
 
-                # Sort by device_id and build the list with proper indexing
                 for device_id, address in sorted(
                     device_tensor_list, key=lambda x: x[0]
                 ):
@@ -305,21 +401,33 @@ class DatabaseQueries:
                         device_addresses.append(None)
                     device_addresses.append(address)
 
-            yield Tensor(*tensor_row, device_addresses, size=size)
+            yield Tensor(
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+                device_addresses,
+                size=size,
+                rank=rank_val,
+            )
 
     def query_input_tensors(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[InputTensor, None, None]:
         rows = self._query_table("input_tensors", filters)
         for row in rows:
-            yield InputTensor(*row)
+            yield _input_tensor_from_row(row)
 
     def query_output_tensors(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[OutputTensor, None, None]:
         rows = self._query_table("output_tensors", filters)
         for row in rows:
-            yield OutputTensor(*row)
+            yield _output_tensor_from_row(row)
 
     def query_devices(
         self, filters: Optional[Dict[str, Any]] = None
@@ -341,23 +449,42 @@ class DatabaseQueries:
             yield Device(*row)
 
     def query_producers_consumers(self) -> Generator[ProducersConsumers, None, None]:
-        query = """
+        rank_on_tensors = "rank" in self._get_table_columns("tensors")
+        it_rank = "rank" in self._get_table_columns("input_tensors")
+        ot_rank = "rank" in self._get_table_columns("output_tensors")
+
+        it_join = "it.tensor_id = t.tensor_id"
+        if it_rank and rank_on_tensors:
+            it_join += " AND it.rank = t.rank"
+        ot_join = "ot.tensor_id = t.tensor_id"
+        if ot_rank and rank_on_tensors:
+            ot_join += " AND ot.rank = t.rank"
+
+        rank_select = ", t.rank" if rank_on_tensors else ""
+        group_by = "t.tensor_id" + (", t.rank" if rank_on_tensors else "")
+
+        query = f"""
             SELECT
-                t.tensor_id,
+                t.tensor_id{rank_select},
                 GROUP_CONCAT(ot.operation_id, ', ') AS consumers,
                 GROUP_CONCAT(it.operation_id, ', ') AS producers
             FROM
                 tensors t
             LEFT JOIN
-                input_tensors it ON t.tensor_id = it.tensor_id
+                input_tensors it ON {it_join}
             LEFT JOIN
-                output_tensors ot on t.tensor_id = ot.tensor_id
+                output_tensors ot ON {ot_join}
             GROUP BY
-                t.tensor_id
+                {group_by}
         """
         rows = self.query_runner.execute_query(query)
         for row in rows:
-            tensor_id, producers_data, consumers_data = row
+            # SQL aliases: ot AS "consumers", it AS "producers" (names are swapped vs semantics).
+            if rank_on_tensors:
+                tensor_id, rank_val, producers_data, consumers_data = row
+            else:
+                tensor_id, producers_data, consumers_data = row
+                rank_val = 0
             producers = sorted(
                 set(map(int, producers_data.strip('"').split(",")))
                 if producers_data
@@ -368,7 +495,7 @@ class DatabaseQueries:
                 if consumers_data
                 else []
             )
-            yield ProducersConsumers(tensor_id, producers, consumers)
+            yield ProducersConsumers(tensor_id, producers, consumers, rank_val)
 
     def query_report_metadata(
         self,
@@ -381,13 +508,24 @@ class DatabaseQueries:
         return rows
 
     def query_next_buffer(self, operation_id: int, address: str) -> Optional[Buffer]:
-        query = """
+        buf_cols = self._get_table_columns("buffers")
+        ordered = [
+            c
+            for c in (
+                "operation_id",
+                "device_id",
+                "address",
+                "max_size_per_bank",
+                "buffer_type",
+                "buffer_layout",
+                "rank",
+            )
+            if c in buf_cols
+        ]
+        col_sql = ", ".join(f"buffers.{c}" for c in ordered)
+        query = f"""
             SELECT
-                buffers.operation_id,
-                buffers.device_id,
-                buffers.address,
-                buffers.max_size_per_bank,
-                buffers.buffer_type
+                {col_sql}
             FROM
                 buffers
             WHERE
@@ -396,7 +534,7 @@ class DatabaseQueries:
             ORDER BY buffers.operation_id
         """
         rows = self.query_runner.execute_query(query, [address, operation_id])
-        return Buffer(*rows[0]) if rows else None
+        return _buffer_from_row(rows[0]) if rows else None
 
     def __enter__(self):
         return self

--- a/backend/ttnn_visualizer/serializers.py
+++ b/backend/ttnn_visualizer/serializers.py
@@ -9,6 +9,27 @@ from typing import List
 from ttnn_visualizer.models import BufferType, Operation, TensorComparisonRecord
 
 
+def _stack_trace_for_operation(stack_traces_by_key, operation):
+    key = (operation.operation_id, operation.rank)
+    if key in stack_traces_by_key:
+        return stack_traces_by_key[key]
+    return stack_traces_by_key.get((operation.operation_id, 0))
+
+
+def _error_for_operation(errors_by_key, operation):
+    key = (operation.operation_id, operation.rank)
+    if key in errors_by_key:
+        return errors_by_key[key]
+    return errors_by_key.get((operation.operation_id, 0))
+
+
+def _device_ops_for_operation(device_ops_by_key, operation):
+    key = (operation.operation_id, operation.rank)
+    if key in device_ops_by_key:
+        return device_ops_by_key[key]
+    return device_ops_by_key.get((operation.operation_id, 0), [])
+
+
 def serialize_operations(
     inputs,
     operation_arguments,
@@ -21,19 +42,21 @@ def serialize_operations(
     device_operations,
     error_records=None,
 ):
-    tensors_dict = {t.tensor_id: t for t in tensors}
+    tensors_dict = {(t.tensor_id, t.rank): t for t in tensors}
     device_operations_dict = {
-        do.operation_id: do.captured_graph
+        (do.operation_id, do.rank): do.captured_graph
         for do in device_operations
         if hasattr(do, "operation_id")
     }
 
-    stack_traces_dict = {st.operation_id: st.stack_trace for st in stack_traces}
+    stack_traces_dict = {
+        (st.operation_id, st.rank): st.stack_trace for st in stack_traces
+    }
 
     errors_dict = {}
     if error_records:
         for error in error_records:
-            errors_dict[error.operation_id] = error.to_nested_dict()
+            errors_dict[(error.operation_id, error.rank)] = error.to_nested_dict()
 
     arguments_dict = defaultdict(list)
     for argument in operation_arguments:
@@ -50,18 +73,18 @@ def serialize_operations(
         arguments = [a.to_dict() for a in arguments_dict[operation.operation_id]]
         operation_data = operation.to_dict()
         operation_data["id"] = operation.operation_id
-        operation_device_operations = device_operations_dict.get(
-            operation.operation_id, []
+        operation_device_operations = _device_ops_for_operation(
+            device_operations_dict, operation
         )
         id = operation_data.pop("operation_id", None)
 
-        error_data = errors_dict.get(operation.operation_id)
+        error_data = _error_for_operation(errors_dict, operation)
 
         results.append(
             {
                 **operation_data,
                 "id": id,
-                "stack_trace": stack_traces_dict.get(operation.operation_id),
+                "stack_trace": _stack_trace_for_operation(stack_traces_dict, operation),
                 "device_operations": operation_device_operations,
                 "arguments": arguments,
                 "inputs": inputs,
@@ -79,14 +102,22 @@ def serialize_inputs_outputs(
     tensors_dict,
     comparisons=None,
 ):
-    producers_consumers_dict = {pc.tensor_id: pc for pc in producers_consumers}
+    producers_consumers_dict = {
+        (pc.tensor_id, pc.rank): pc for pc in producers_consumers
+    }
 
     def attach_tensor_data(values):
         values_dict = defaultdict(list)
         for value in values:
-            tensor = tensors_dict.get(value.tensor_id)
+            tensor = tensors_dict.get((value.tensor_id, value.rank))
+            if tensor is None:
+                tensor = tensors_dict.get((value.tensor_id, 0))
+            if tensor is None:
+                continue
             tensor_dict = tensor.to_dict()
-            pc = producers_consumers_dict.get(value.tensor_id)
+            pc = producers_consumers_dict.get((value.tensor_id, value.rank))
+            if pc is None:
+                pc = producers_consumers_dict.get((value.tensor_id, 0))
             value_dict = dataclasses.asdict(value)
             value_dict.pop("tensor_id", None)
             value_dict.update(
@@ -155,7 +186,7 @@ def serialize_operation(
     device_operations,
     error_record=None,
 ):
-    tensors_dict = {t.tensor_id: t for t in tensors}
+    tensors_dict = {(t.tensor_id, t.rank): t for t in tensors}
     comparisons = comparisons_by_tensor_id(
         local_tensor_comparisons, global_tensor_comparisons
     )
@@ -181,10 +212,17 @@ def serialize_operation(
     id = operation_data.pop("operation_id", None)
 
     device_operations_data = []
+    chosen = False
     for do in device_operations:
-        if do.operation_id == operation.operation_id:
+        if do.operation_id == operation.operation_id and do.rank == operation.rank:
             device_operations_data = do.captured_graph
+            chosen = True
             break
+    if not chosen:
+        for do in device_operations:
+            if do.operation_id == operation.operation_id:
+                device_operations_data = do.captured_graph
+                break
 
     # Convert error record to nested dict if it exists (excludes operation_id and operation_name)
     error_data = error_record.to_nested_dict() if error_record else None
@@ -216,6 +254,7 @@ def serialize_operation_buffers(operation: Operation, operation_buffers):
             ),
             "buffer_layout": b.buffer_layout,
             "size": b.max_size_per_bank,
+            "rank": b.rank,
         }
         buffer_data.append(buffer_dict)
 
@@ -244,6 +283,7 @@ def serialize_operations_buffers(operations, buffers):
             ),
             "buffer_layout": b.buffer_layout,
             "size": b.max_size_per_bank,
+            "rank": b.rank,
         }
         serialized_buffers[b.operation_id].append(buffer_dict)
 
@@ -267,32 +307,30 @@ def serialize_buffer(buffer):
         "device_id": buffer.device_id,
         "size": buffer.max_size_per_bank,
         "address": buffer.address,
+        "rank": buffer.rank,
     }
 
 
 def serialize_tensors(
     tensors, producers_consumers, local_comparisons, global_comparisons
 ):
-    producers_consumers_dict = {pc.tensor_id: pc for pc in producers_consumers}
+    producers_consumers_dict = {
+        (pc.tensor_id, pc.rank): pc for pc in producers_consumers
+    }
     results = []
     comparisons = comparisons_by_tensor_id(local_comparisons, global_comparisons)
     for tensor in tensors:
         tensor_data = tensor.to_dict()
         tensor_id = tensor_data.pop("tensor_id")
+        pc = producers_consumers_dict.get((tensor_id, tensor.rank))
+        if pc is None:
+            pc = producers_consumers_dict.get((tensor_id, 0))
         tensor_data.update(
             {
                 "id": tensor_id,
                 "comparison": comparisons.get(tensor_id),
-                "consumers": (
-                    producers_consumers_dict[tensor_id].consumers
-                    if tensor_id in producers_consumers_dict
-                    else []
-                ),
-                "producers": (
-                    producers_consumers_dict[tensor_id].producers
-                    if tensor_id in producers_consumers_dict
-                    else []
-                ),
+                "consumers": pc.consumers if pc else [],
+                "producers": pc.producers if pc else [],
             }
         )
         results.append(tensor_data)

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -65,7 +65,9 @@ class TestSerializers(unittest.TestCase):
                 [25],
             ),
         ]
-        devices = [Device(1, 4, 4, 2, 2, 256, 4, 64, 0, 0, 1, 2, 256, 128, 64, 1, 512)]
+        devices = [
+            Device(1, 4, 4, 2, 2, 256, 4, 64, 0, 0, 1, 2, 256, 128, 64, 1, 512, 0)
+        ]
         producers_consumers = [ProducersConsumers(1, [2], [3])]
         device_operations = [DeviceOperation(1, '[{"counter": 1, "op_id": 1}]')]
 
@@ -86,17 +88,29 @@ class TestSerializers(unittest.TestCase):
                 "id": 1,
                 "name": "op1",
                 "duration": 0.5,
+                "rank": 0,
                 "stack_trace": "trace1",
                 "device_operations": [{"id": 1, "op_id": 1}],
                 "arguments": [
-                    {"operation_id": 1, "name": "arg1", "value": "value1"},
-                    {"operation_id": 1, "name": "arg2", "value": "value2"},
+                    {
+                        "operation_id": 1,
+                        "name": "arg1",
+                        "value": "value1",
+                        "rank": 0,
+                    },
+                    {
+                        "operation_id": 1,
+                        "name": "arg2",
+                        "value": "value2",
+                        "rank": 0,
+                    },
                 ],
                 "inputs": [
                     {
                         "input_index": 0,
                         "id": 1,
                         "operation_id": 1,
+                        "rank": 0,
                         "consumers": [3],
                         "producers": [2],
                         "shape": "shape1",
@@ -118,6 +132,7 @@ class TestSerializers(unittest.TestCase):
                         "output_index": 0,
                         "id": 1,
                         "operation_id": 1,
+                        "rank": 0,
                         "consumers": [3],
                         "producers": [2],
                         "shape": "shape1",
@@ -164,6 +179,7 @@ class TestSerializers(unittest.TestCase):
                         "buffer_type": 0,
                         "buffer_layout": None,
                         "size": 256,
+                        "rank": 0,
                     },
                     {
                         "device_id": 2,
@@ -171,6 +187,7 @@ class TestSerializers(unittest.TestCase):
                         "buffer_type": 1,
                         "buffer_layout": None,
                         "size": 512,
+                        "rank": 0,
                     },
                 ],
             },
@@ -184,6 +201,7 @@ class TestSerializers(unittest.TestCase):
                         "buffer_type": 1,
                         "buffer_layout": None,
                         "size": 1024,
+                        "rank": 0,
                     },
                 ],
             },
@@ -193,8 +211,8 @@ class TestSerializers(unittest.TestCase):
 
     def test_serialize_devices(self):
         devices = [
-            Device(1, 4, 4, 2, 2, 256, 4, 64, 0, 0, 1, 2, 256, 128, 64, 1, 512),
-            Device(2, 8, 8, 4, 4, 512, 8, 128, 1, 1, 2, 4, 512, 256, 128, 2, 1024),
+            Device(1, 4, 4, 2, 2, 256, 4, 64, 0, 0, 1, 2, 256, 128, 64, 1, 512, 0),
+            Device(2, 8, 8, 4, 4, 512, 8, 128, 1, 1, 2, 4, 512, 256, 128, 2, 1024, 0),
         ]
 
         result = serialize_devices(devices)
@@ -218,6 +236,7 @@ class TestSerializers(unittest.TestCase):
                 "total_l1_for_tensors": 128,
                 "total_l1_memory": 256,
                 "worker_l1_size": 256,
+                "rank": 0,
             },
             {
                 "address_at_first_l1_bank": 1,
@@ -237,6 +256,7 @@ class TestSerializers(unittest.TestCase):
                 "total_l1_for_tensors": 256,
                 "total_l1_memory": 512,
                 "worker_l1_size": 512,
+                "rank": 0,
             },
         ]
 
@@ -262,6 +282,7 @@ class TestSerializers(unittest.TestCase):
                     "buffer_type": 0,
                     "buffer_layout": None,
                     "size": 256,
+                    "rank": 0,
                 },
                 {
                     "device_id": 2,
@@ -269,6 +290,7 @@ class TestSerializers(unittest.TestCase):
                     "buffer_type": 1,
                     "buffer_layout": None,
                     "size": 512,
+                    "rank": 0,
                 },
             ],
         }
@@ -280,7 +302,7 @@ class TestSerializers(unittest.TestCase):
         outputs = [OutputTensor(1, 0, 1)]
         producers_consumers = [ProducersConsumers(1, [2], [3])]
         tensors_dict = {
-            1: Tensor(
+            (1, 0): Tensor(
                 1,
                 "shape1",
                 "dtype1",
@@ -303,6 +325,7 @@ class TestSerializers(unittest.TestCase):
                     "operation_id": 1,
                     "input_index": 0,
                     "id": 1,
+                    "rank": 0,
                     "consumers": [3],
                     "producers": [2],
                     "shape": "shape1",
@@ -327,6 +350,7 @@ class TestSerializers(unittest.TestCase):
                     "operation_id": 1,
                     "output_index": 0,
                     "id": 1,
+                    "rank": 0,
                     "consumers": [3],
                     "producers": [2],
                     "shape": "shape1",
@@ -367,7 +391,9 @@ class TestSerializers(unittest.TestCase):
                 [200, 300],
             )
         ]
-        devices = [Device(1, 4, 4, 2, 2, 256, 4, 64, 0, 0, 1, 2, 256, 128, 64, 1, 512)]
+        devices = [
+            Device(1, 4, 4, 2, 2, 256, 4, 64, 0, 0, 1, 2, 256, 128, 64, 1, 512, 0)
+        ]
         producers_consumers = [ProducersConsumers(1, [2], [3])]
         device_operations = [DeviceOperation(1, '[{"counter": 1, "op_id": 1}]')]
 
@@ -386,7 +412,9 @@ class TestSerializers(unittest.TestCase):
             device_operations,
         )
         expected = {
-            "arguments": [{"name": "arg1", "operation_id": 1, "value": "value1"}],
+            "arguments": [
+                {"name": "arg1", "operation_id": 1, "value": "value1", "rank": 0}
+            ],
             "buffers": [
                 {
                     "address": 1000,
@@ -395,11 +423,13 @@ class TestSerializers(unittest.TestCase):
                     "device_id": 1,
                     "max_size_per_bank": 256,
                     "operation_id": 1,
+                    "rank": 0,
                 }
             ],
             "device_operations": [{"id": 1, "op_id": 1}],
             "duration": 0.5,
             "id": 1,
+            "rank": 0,
             "inputs": [
                 {
                     "address": 1000,
@@ -419,6 +449,7 @@ class TestSerializers(unittest.TestCase):
                     "shape": "shape1",
                     "device_addresses": [200, 300],
                     "size": None,
+                    "rank": 0,
                 }
             ],
             "l1_sizes": [256],
@@ -442,6 +473,7 @@ class TestSerializers(unittest.TestCase):
                     "shape": "shape1",
                     "device_addresses": [200, 300],
                     "size": None,
+                    "rank": 0,
                 }
             ],
             "stack_trace": "trace1",
@@ -492,6 +524,7 @@ class TestSerializers(unittest.TestCase):
                 "page_address": 1000,
                 "page_size": 4096,
                 "buffer_type": 0,
+                "rank": 0,
                 "id": "1_0",
             },
             {
@@ -505,6 +538,7 @@ class TestSerializers(unittest.TestCase):
                 "page_address": 2000,
                 "page_size": 8192,
                 "buffer_type": 1,
+                "rank": 0,
                 "id": "2_1",
             },
         ]
@@ -561,6 +595,7 @@ class TestSerializers(unittest.TestCase):
                 "producers": [2],
                 "device_addresses": [500, 1500],
                 "size": None,
+                "rank": 0,
             },
             {
                 "id": 2,
@@ -579,6 +614,7 @@ class TestSerializers(unittest.TestCase):
                 "producers": [],
                 "device_addresses": [2000, 2500],
                 "size": None,
+                "rank": 0,
             },
         ]
 

--- a/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
+++ b/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+API tests for optional ``?rank=`` filtering on multi-host report databases.
+"""
+
+import sqlite3
+import tempfile
+from http import HTTPStatus
+from pathlib import Path
+
+from ttnn_visualizer.extensions import db
+from ttnn_visualizer.models import InstanceTable
+
+INSTANCE_ID = "pytest-rank-filter"
+
+# Minimal schema with rank on all tables the list/detail endpoints touch.
+_RANKED_REPORT_SQL = """
+CREATE TABLE operations (
+    operation_id int UNIQUE,
+    name text,
+    duration float,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO operations VALUES (1, 'op_r0', 1.0, 0), (2, 'op_r1', 2.0, 1);
+
+CREATE TABLE operation_arguments (
+    operation_id int,
+    name text,
+    value text,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE stack_traces (
+    operation_id int,
+    stack_trace text,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE input_tensors (
+    operation_id int,
+    input_index int,
+    tensor_id int,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE output_tensors (
+    operation_id int,
+    output_index int,
+    tensor_id int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO output_tensors VALUES (1, 0, 100, 0), (2, 0, 200, 1);
+
+CREATE TABLE tensors (
+    tensor_id int,
+    shape text,
+    dtype text,
+    layout text,
+    memory_config text,
+    device_id int,
+    address int,
+    buffer_type int,
+    rank int NOT NULL DEFAULT 0,
+    size int,
+    UNIQUE(tensor_id, rank)
+);
+INSERT INTO tensors VALUES
+(100, '(1,)', 'float32', 'TILE', '{}', 0, 0, 0, 0, 4096),
+(200, '(2,)', 'float32', 'TILE', '{}', 0, 0, 0, 1, 8192);
+
+CREATE TABLE devices (
+    device_id int,
+    num_y_cores int,
+    num_x_cores int,
+    num_y_compute_cores int,
+    num_x_compute_cores int,
+    worker_l1_size int,
+    l1_num_banks int,
+    l1_bank_size int,
+    address_at_first_l1_bank int,
+    address_at_first_l1_cb_buffer int,
+    num_banks_per_storage_core int,
+    num_compute_cores int,
+    total_l1_memory int,
+    total_l1_for_tensors int,
+    total_l1_for_interleaved_buffers int,
+    total_l1_for_sharded_buffers int,
+    cb_limit int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO devices VALUES
+(0, 4, 4, 2, 2, 1024, 4, 256, 0, 0, 1, 2, 4096, 2048, 2048, 2048, 256, 0),
+(1, 4, 4, 2, 2, 1024, 4, 256, 0, 0, 1, 2, 4096, 2048, 2048, 2048, 256, 1);
+
+CREATE TABLE errors (
+    operation_id int,
+    operation_name text,
+    error_type text,
+    error_message text,
+    stack_trace text,
+    timestamp text,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO errors VALUES
+(1, 'op_r0', 'TypeError', 'oops', 'trace0', 't0', 0),
+(2, 'op_r1', 'ValueError', 'nope', 'trace1', 't1', 1);
+
+CREATE TABLE buffers (
+    operation_id int,
+    device_id int,
+    address int,
+    max_size_per_bank int,
+    buffer_type int,
+    buffer_layout int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO buffers VALUES (1, 0, 100, 512, 0, 0, 0), (2, 0, 200, 1024, 0, 0, 1);
+
+CREATE TABLE buffer_pages (
+    operation_id int,
+    device_id int,
+    address int,
+    core_y int,
+    core_x int,
+    bank_id int,
+    page_index int,
+    page_address int,
+    page_size int,
+    buffer_type int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO buffer_pages VALUES
+(1, 0, 100, 0, 0, 0, 0, 100, 4096, 0, 0),
+(2, 0, 200, 0, 0, 0, 0, 200, 4096, 0, 1);
+
+CREATE TABLE local_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE global_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+"""
+
+
+def _write_ranked_report_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(_RANKED_REPORT_SQL)
+    conn.commit()
+    conn.close()
+
+
+def _register_profiler_instance(app, sqlite_path: str) -> None:
+    with app.app_context():
+        existing = InstanceTable.query.filter_by(instance_id=INSTANCE_ID).first()
+        if existing:
+            db.session.delete(existing)
+            db.session.commit()
+        row = InstanceTable(
+            instance_id=INSTANCE_ID,
+            active_report={},
+            profiler_path=sqlite_path,
+        )
+        db.session.add(row)
+        db.session.commit()
+
+
+def test_operations_list_without_rank_returns_all_ranks(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        response = client.get(
+            "/api/operations",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+        names = {op["name"] for op in data}
+        assert names == {"op_r0", "op_r1"}
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_operations_list_rank_filter_limits_operations_and_nested_tensors(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        r0 = client.get(
+            "/api/operations",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert r0.status_code == HTTPStatus.OK
+        data0 = r0.get_json()
+        assert len(data0) == 1
+        assert data0[0]["name"] == "op_r0"
+        assert data0[0]["rank"] == 0
+        assert len(data0[0]["outputs"]) == 1
+        assert data0[0]["outputs"][0]["id"] == 100
+        assert data0[0]["outputs"][0]["rank"] == 0
+
+        r1 = client.get(
+            "/api/operations",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert r1.status_code == HTTPStatus.OK
+        data1 = r1.get_json()
+        assert len(data1) == 1
+        assert data1[0]["name"] == "op_r1"
+        assert data1[0]["outputs"][0]["id"] == 200
+        assert data1[0]["outputs"][0]["rank"] == 1
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_tensors_list_rank_filter(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        r0 = client.get(
+            "/api/tensors",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert r0.status_code == HTTPStatus.OK
+        t0 = r0.get_json()
+        assert len(t0) == 1
+        assert t0[0]["id"] == 100
+        assert t0[0]["rank"] == 0
+
+        r1 = client.get(
+            "/api/tensors",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert r1.status_code == HTTPStatus.OK
+        t1 = r1.get_json()
+        assert len(t1) == 1
+        assert t1[0]["id"] == 200
+        assert t1[0]["rank"] == 1
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_tensor_detail_rank_filter(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        ok = client.get(
+            "/api/tensors/100",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert ok.status_code == HTTPStatus.OK
+        assert ok.get_json()["tensor_id"] == 100
+        assert ok.get_json()["rank"] == 0
+
+        missing = client.get(
+            "/api/tensors/100",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert missing.status_code == HTTPStatus.NOT_FOUND
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_devices_list_rank_filter(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        r0 = client.get(
+            "/api/devices",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert r0.status_code == HTTPStatus.OK
+        d0 = r0.get_json()
+        assert len(d0) == 1
+        assert d0[0]["device_id"] == 0
+        assert d0[0]["rank"] == 0
+
+        r1 = client.get(
+            "/api/devices",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert r1.status_code == HTTPStatus.OK
+        d1 = r1.get_json()
+        assert len(d1) == 1
+        assert d1[0]["device_id"] == 1
+        assert d1[0]["rank"] == 1
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_errors_list_rank_filter(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        r0 = client.get(
+            "/api/errors",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert r0.status_code == HTTPStatus.OK
+        e0 = r0.get_json()
+        assert len(e0) == 1
+        assert e0[0]["operation_id"] == 1
+        assert e0[0]["error_message"] == "oops"
+        assert e0[0]["rank"] == 0
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_buffers_list_rank_filter(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        r0 = client.get(
+            "/api/buffers",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert r0.status_code == HTTPStatus.OK
+        b0 = r0.get_json()
+        assert len(b0) == 1
+        assert b0[0]["address"] == 100
+        assert b0[0]["rank"] == 0
+
+        r1 = client.get(
+            "/api/buffers",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert r1.status_code == HTTPStatus.OK
+        b1 = r1.get_json()
+        assert len(b1) == 1
+        assert b1[0]["address"] == 200
+        assert b1[0]["rank"] == 1
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_operation_detail_rank_mismatch_returns_404(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        bad = client.get(
+            "/api/operations/1",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert bad.status_code == HTTPStatus.NOT_FOUND
+
+        good = client.get(
+            "/api/operations/1",
+            query_string={"instanceId": INSTANCE_ID, "rank": "0"},
+        )
+        assert good.status_code == HTTPStatus.OK
+        body = good.get_json()
+        assert body["name"] == "op_r0"
+        assert body["rank"] == 0
+        assert len(body["outputs"]) == 1
+        assert body["outputs"][0]["id"] == 100
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_invalid_rank_query_returns_400(app, client):
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_ranked_report_db(path)
+        _register_profiler_instance(app, path)
+
+        response = client.get(
+            "/api/tensors",
+            query_string={"instanceId": INSTANCE_ID, "rank": "not-an-int"},
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+    finally:
+        Path(path).unlink(missing_ok=True)

--- a/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
+++ b/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
@@ -15,6 +15,97 @@ from ttnn_visualizer.extensions import db
 from ttnn_visualizer.models import InstanceTable
 
 INSTANCE_ID = "pytest-rank-filter"
+LEGACY_INSTANCE_ID = "pytest-legacy-no-rank"
+
+# Pre-rank schema (no ``rank`` columns) — same shape as historical profiler DBs.
+_LEGACY_REPORT_SQL = """
+CREATE TABLE devices (
+    device_id int,
+    num_y_cores int,
+    num_x_cores int,
+    num_y_compute_cores int,
+    num_x_compute_cores int,
+    worker_l1_size int,
+    l1_num_banks int,
+    l1_bank_size int,
+    address_at_first_l1_bank int,
+    address_at_first_l1_cb_buffer int,
+    num_banks_per_storage_core int,
+    num_compute_cores int,
+    total_l1_memory int,
+    total_l1_for_tensors int,
+    total_l1_for_interleaved_buffers int,
+    total_l1_for_sharded_buffers int,
+    cb_limit int
+);
+CREATE TABLE captured_graph (operation_id int, captured_graph text);
+CREATE TABLE buffers (
+    operation_id int,
+    device_id int,
+    address int,
+    max_size_per_bank int,
+    buffer_type int
+);
+CREATE TABLE tensors (
+    tensor_id int UNIQUE,
+    shape text,
+    dtype text,
+    layout text,
+    memory_config text,
+    device_id int,
+    address int,
+    buffer_type int
+);
+CREATE TABLE operation_arguments (
+    operation_id int,
+    name text,
+    value text
+);
+CREATE TABLE stack_traces (operation_id int, stack_trace text);
+CREATE TABLE input_tensors (
+    operation_id int,
+    input_index int,
+    tensor_id int
+);
+CREATE TABLE output_tensors (
+    operation_id int,
+    output_index int,
+    tensor_id int
+);
+CREATE TABLE operations (operation_id int UNIQUE, name text, duration float);
+CREATE TABLE buffer_pages (
+    operation_id INT,
+    device_id INT,
+    address INT,
+    core_y INT,
+    core_x INT,
+    bank_id INT,
+    page_index INT,
+    page_address INT,
+    page_size INT,
+    buffer_type INT
+);
+CREATE TABLE local_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE global_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+INSERT INTO operations VALUES (1, 'legacy_op', 0.5);
+INSERT INTO tensors VALUES (1, '(1,)', 'float32', 'TILE', '{}', 0, 100, 0);
+INSERT INTO output_tensors VALUES (1, 0, 1);
+INSERT INTO buffers VALUES (1, 0, 100, 4096, 0);
+INSERT INTO devices VALUES
+(0, 4, 4, 2, 2, 1024, 4, 256, 0, 0, 1, 2, 4096, 2048, 2048, 2048, 256);
+"""
 
 # Minimal schema with rank on all tables the list/detail endpoints touch.
 _RANKED_REPORT_SQL = """
@@ -160,14 +251,23 @@ def _write_ranked_report_db(path: str) -> None:
     conn.close()
 
 
-def _register_profiler_instance(app, sqlite_path: str) -> None:
+def _write_legacy_report_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(_LEGACY_REPORT_SQL)
+    conn.commit()
+    conn.close()
+
+
+def _register_profiler_instance(
+    app, sqlite_path: str, instance_id: str = INSTANCE_ID
+) -> None:
     with app.app_context():
-        existing = InstanceTable.query.filter_by(instance_id=INSTANCE_ID).first()
+        existing = InstanceTable.query.filter_by(instance_id=instance_id).first()
         if existing:
             db.session.delete(existing)
             db.session.commit()
         row = InstanceTable(
-            instance_id=INSTANCE_ID,
+            instance_id=instance_id,
             active_report={},
             profiler_path=sqlite_path,
         )
@@ -404,5 +504,54 @@ def test_invalid_rank_query_returns_400(app, client):
             query_string={"instanceId": INSTANCE_ID, "rank": "not-an-int"},
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_nonzero_rank_on_legacy_db_returns_422(app, client):
+    """Unranked DB cannot satisfy rank > 0; do not return all rows as rank 0."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_legacy_report_db(path)
+        _register_profiler_instance(app, path, instance_id=LEGACY_INSTANCE_ID)
+
+        response = client.get(
+            "/api/operations",
+            query_string={"instanceId": LEGACY_INSTANCE_ID, "rank": "1"},
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        err = response.get_json()
+        assert err is not None
+        assert "error" in err
+        assert "per-rank" in err["error"].lower()
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_rank_zero_explicit_allowed_on_legacy_db(app, client):
+    """Explicit rank=0 (or omitting rank) still returns legacy data."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_legacy_report_db(path)
+        _register_profiler_instance(app, path, instance_id=LEGACY_INSTANCE_ID)
+
+        r0 = client.get(
+            "/api/operations",
+            query_string={"instanceId": LEGACY_INSTANCE_ID, "rank": "0"},
+        )
+        assert r0.status_code == HTTPStatus.OK
+        data0 = r0.get_json()
+        assert len(data0) == 1
+        assert data0[0]["name"] == "legacy_op"
+        assert data0[0]["rank"] == 0
+
+        r_none = client.get(
+            "/api/operations",
+            query_string={"instanceId": LEGACY_INSTANCE_ID},
+        )
+        assert r_none.status_code == HTTPStatus.OK
+        assert len(r_none.get_json()) == 1
     finally:
         Path(path).unlink(missing_ok=True)

--- a/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
+++ b/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
@@ -11,6 +11,7 @@ import tempfile
 from http import HTTPStatus
 from pathlib import Path
 
+import pytest
 from ttnn_visualizer.extensions import db
 from ttnn_visualizer.models import InstanceTable
 
@@ -508,25 +509,61 @@ def test_invalid_rank_query_returns_400(app, client):
         Path(path).unlink(missing_ok=True)
 
 
-def test_nonzero_rank_on_legacy_db_returns_422(app, client):
-    """Unranked DB cannot satisfy rank > 0; do not return all rows as rank 0."""
+@pytest.mark.parametrize(
+    "path,extra_query",
+    [
+        ("/api/operations", {}),
+        ("/api/tensors", {}),
+        ("/api/devices", {}),
+        ("/api/buffers", {}),
+        ("/api/operation-buffers", {}),
+        ("/api/errors", {}),
+        ("/api/operations/1", {}),
+        ("/api/operation-buffers/1", {}),
+        ("/api/tensors/1", {}),
+        (
+            "/api/buffer",
+            {"address": "100", "operation_id": "1"},
+        ),
+        (
+            "/api/buffer-pages",
+            {"operation_id": "1", "address": "100"},
+        ),
+    ],
+)
+def test_legacy_nonzero_rank_returns_422_not_rank_zero_payload(
+    app, client, path, extra_query
+):
+    """
+    Regression: unranked DBs only represent rank 0. ``?rank`` with a non-zero value
+    must not succeed with HTTP 200 and legacy rows (which would appear as rank 0 in JSON).
+    """
     with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
+        path_db = f.name
     try:
-        _write_legacy_report_db(path)
-        _register_profiler_instance(app, path, instance_id=LEGACY_INSTANCE_ID)
+        _write_legacy_report_db(path_db)
+        _register_profiler_instance(app, path_db, instance_id=LEGACY_INSTANCE_ID)
 
-        response = client.get(
-            "/api/operations",
-            query_string={"instanceId": LEGACY_INSTANCE_ID, "rank": "1"},
+        query_string = {
+            "instanceId": LEGACY_INSTANCE_ID,
+            "rank": "2",
+            **extra_query,
+        }
+        response = client.get(path, query_string=query_string)
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, (
+            f"expected 422 for {path} with rank=2 on unranked DB, got "
+            f"{response.status_code}"
         )
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         err = response.get_json()
         assert err is not None
         assert "error" in err
         assert "per-rank" in err["error"].lower()
+        # A mistaken 200 would typically be a JSON list or object with legacy data — we
+        # never return that shape for this error path.
+        assert not isinstance(err, list)
     finally:
-        Path(path).unlink(missing_ok=True)
+        Path(path_db).unlink(missing_ok=True)
 
 
 def test_rank_zero_explicit_allowed_on_legacy_db(app, client):

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -109,6 +109,28 @@ def _optional_rank_query_param() -> Optional[int]:
         )
 
 
+_NONZERO_RANK_UNSUPPORTED_MSG = (
+    "This report database does not store per-rank data. "
+    "Omit the rank query parameter or use rank=0 only."
+)
+
+
+def _reject_nonzero_rank_on_legacy_db(db: DatabaseQueries, rank: Optional[int]):
+    """
+    Legacy reports only represent rank 0. If the client asks for a different rank
+    but the schema has no ``rank`` column, return 422 instead of returning all rows
+    (which would misleadingly appear as rank 0 in the API).
+    """
+    if rank is None or rank == 0:
+        return None
+    if db.report_has_rank_column():
+        return None
+    return (
+        jsonify({"error": _NONZERO_RANK_UNSUPPORTED_MSG}),
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+    )
+
+
 @api.before_request
 def _trim_session_report_lists():
     """Keep session cookie under size limits by capping report lists (FIFO)."""
@@ -145,6 +167,9 @@ def get_system_capabilities():
 def operation_list(instance: Instance):
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         operations = list(
             db.query_operations(db.merge_rank_filter("operations", None, rank))
         )
@@ -202,6 +227,9 @@ def operation_list(instance: Instance):
 def operation_detail(operation_id, instance: Instance):
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
 
         device_id = request.args.get("device_id", None)
         operations = list(
@@ -373,6 +401,9 @@ def operation_history(instance: Instance):
 def errors_list(instance: Instance):
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         if not db._check_table_exists("errors"):
             return (
                 jsonify(
@@ -436,6 +467,9 @@ def get_config(instance: Instance):
 def tensors_list(instance: Instance):
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         device_id = request.args.get("device_id", None)
         tensor_filters: dict = {}
         if device_id is not None:
@@ -487,6 +521,9 @@ def buffer_detail(instance: Instance):
 
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         buffer = db.query_next_buffer(operation_id, address, rank=rank)
         if not buffer:
             return Response(status=HTTPStatus.NOT_FOUND)
@@ -517,6 +554,9 @@ def buffer_pages(instance: Instance):
 
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         page_filters = {
             "operation_id": operation_id,
             "device_id": device_id,
@@ -542,6 +582,9 @@ def buffer_pages(instance: Instance):
 def tensor_detail(tensor_id, instance: Instance):
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         tensors = list(
             db.query_tensors(
                 db.merge_rank_filter("tensors", {"tensor_id": tensor_id}, rank)
@@ -568,6 +611,9 @@ def get_all_buffers(instance: Instance):
 
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         buffers = list(
             db.query_buffers(
                 db.merge_rank_filter(
@@ -594,6 +640,9 @@ def get_operations_buffers(instance: Instance):
 
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         buffers = list(
             db.query_buffers(
                 db.merge_rank_filter(
@@ -624,6 +673,9 @@ def get_operation_buffers(operation_id, instance: Instance):
 
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         operations = list(
             db.query_operations(
                 db.merge_rank_filter(
@@ -1103,6 +1155,9 @@ def get_zone_statistics(zone, instance: Instance):
 def get_devices(instance: Instance):
     rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
+        if rejected is not None:
+            return rejected
         devices = list(db.query_devices(db.merge_rank_filter("devices", None, rank)))
         return Response(
             orjson.dumps(serialize_devices(devices)),

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -305,21 +305,29 @@ def operation_detail(operation_id, instance: Instance):
         input_tensor_ids = [i.tensor_id for i in inputs]
         output_tensor_ids = [o.tensor_id for o in outputs]
         tensor_ids = input_tensor_ids + output_tensor_ids
-        tensors = list(
-            db.query_tensors(
-                db.merge_rank_filter(
-                    "tensors",
-                    {"tensor_id": tensor_ids},
-                    rank,
+        # Empty tensor_ids: query_tensors skips empty IN lists and would return all tensors.
+        if not tensor_ids:
+            tensors = []
+            local_comparisons = []
+            global_comparisons = []
+        else:
+            tensors = list(
+                db.query_tensors(
+                    db.merge_rank_filter(
+                        "tensors",
+                        {"tensor_id": tensor_ids},
+                        rank,
+                    )
                 )
             )
-        )
-        local_comparisons = list(
-            db.query_tensor_comparisons(filters={"tensor_id": tensor_ids})
-        )
-        global_comparisons = list(
-            db.query_tensor_comparisons(local=False, filters={"tensor_id": tensor_ids})
-        )
+            local_comparisons = list(
+                db.query_tensor_comparisons(filters={"tensor_id": tensor_ids})
+            )
+            global_comparisons = list(
+                db.query_tensor_comparisons(
+                    local=False, filters={"tensor_id": tensor_ids}
+                )
+            )
 
         device_operations = db.query_device_operations(
             db.merge_rank_filter(

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -13,12 +13,12 @@ import urllib
 import urllib.request
 from http import HTTPStatus
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import orjson
 import yaml
 import zstd
-from flask import Blueprint, Response, current_app, jsonify, request, session
+from flask import Blueprint, Response, abort, current_app, jsonify, request, session
 from ttnn_visualizer.csv_queries import (
     DeviceLogProfilerQueries,
     NPEQueries,
@@ -90,6 +90,25 @@ logger = logging.getLogger(__name__)
 api = Blueprint("api", __name__)
 
 
+def _optional_rank_query_param() -> Optional[int]:
+    """
+    Parse optional ``?rank=`` for multi-host report DBs.
+    Returns None if the parameter is absent or empty.
+    """
+    if "rank" not in request.args:
+        return None
+    raw = request.args.get("rank")
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        abort(
+            400,
+            description="Invalid query parameter 'rank': expected an integer.",
+        )
+
+
 @api.before_request
 def _trim_session_report_lists():
     """Keep session cookie under size limits by capping report lists (FIFO)."""
@@ -124,21 +143,40 @@ def get_system_capabilities():
 @with_instance
 @timer
 def operation_list(instance: Instance):
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
-        operations = list(db.query_operations())
+        operations = list(
+            db.query_operations(db.merge_rank_filter("operations", None, rank))
+        )
         operations.sort(key=lambda o: o.operation_id)
-        operation_arguments = list(db.query_operation_arguments())
-        device_operations = list(db.query_device_operations())
-        stack_traces = list(db.query_stack_traces())
-        outputs = list(db.query_output_tensors())
-        tensors = list(db.query_tensors())
-        inputs = list(db.query_input_tensors())
-        devices = list(db.query_devices())
-        producers_consumers = list(db.query_producers_consumers())
+        operation_arguments = list(
+            db.query_operation_arguments(
+                db.merge_rank_filter("operation_arguments", None, rank)
+            )
+        )
+        device_operations = list(
+            db.query_device_operations(
+                db.merge_rank_filter("captured_graph", None, rank)
+            )
+        )
+        stack_traces = list(
+            db.query_stack_traces(db.merge_rank_filter("stack_traces", None, rank))
+        )
+        outputs = list(
+            db.query_output_tensors(db.merge_rank_filter("output_tensors", None, rank))
+        )
+        tensors = list(db.query_tensors(db.merge_rank_filter("tensors", None, rank)))
+        inputs = list(
+            db.query_input_tensors(db.merge_rank_filter("input_tensors", None, rank))
+        )
+        devices = list(db.query_devices(db.merge_rank_filter("devices", None, rank)))
+        producers_consumers = list(db.query_producers_consumers(rank=rank))
 
         error_records = None
         if db._check_table_exists("errors"):
-            error_records = list(db.query_error_records())
+            error_records = list(
+                db.query_error_records(db.merge_rank_filter("errors", None, rank))
+            )
 
         serialized_operations = serialize_operations(
             inputs,
@@ -162,10 +200,19 @@ def operation_list(instance: Instance):
 @with_instance
 @timer
 def operation_detail(operation_id, instance: Instance):
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
 
         device_id = request.args.get("device_id", None)
-        operations = list(db.query_operations(filters={"operation_id": operation_id}))
+        operations = list(
+            db.query_operations(
+                db.merge_rank_filter(
+                    "operations",
+                    {"operation_id": operation_id},
+                    rank,
+                )
+            )
+        )
 
         if not operations:
             return Response(status=HTTPStatus.NOT_FOUND)
@@ -174,14 +221,30 @@ def operation_detail(operation_id, instance: Instance):
 
         buffers = list(
             db.query_buffers(
-                filters={"operation_id": operation_id, "device_id": device_id}
+                db.merge_rank_filter(
+                    "buffers",
+                    {"operation_id": operation_id, "device_id": device_id},
+                    rank,
+                )
             )
         )
         operation_arguments = list(
-            db.query_operation_arguments(filters={"operation_id": operation_id})
+            db.query_operation_arguments(
+                db.merge_rank_filter(
+                    "operation_arguments",
+                    {"operation_id": operation_id},
+                    rank,
+                )
+            )
         )
         stack_traces = list(
-            db.query_stack_traces(filters={"operation_id": operation_id})
+            db.query_stack_traces(
+                db.merge_rank_filter(
+                    "stack_traces",
+                    {"operation_id": operation_id},
+                    rank,
+                )
+            )
         )
 
         stack_trace = None
@@ -192,13 +255,37 @@ def operation_detail(operation_id, instance: Instance):
         if stack_trace is None and stack_traces:
             stack_trace = stack_traces[0]
 
-        inputs = list(db.query_input_tensors(filters={"operation_id": operation_id}))
-        outputs = list(db.query_output_tensors({"operation_id": operation_id}))
+        inputs = list(
+            db.query_input_tensors(
+                db.merge_rank_filter(
+                    "input_tensors",
+                    {"operation_id": operation_id},
+                    rank,
+                )
+            )
+        )
+        outputs = list(
+            db.query_output_tensors(
+                db.merge_rank_filter(
+                    "output_tensors",
+                    {"operation_id": operation_id},
+                    rank,
+                )
+            )
+        )
 
         input_tensor_ids = [i.tensor_id for i in inputs]
         output_tensor_ids = [o.tensor_id for o in outputs]
         tensor_ids = input_tensor_ids + output_tensor_ids
-        tensors = list(db.query_tensors(filters={"tensor_id": tensor_ids}))
+        tensors = list(
+            db.query_tensors(
+                db.merge_rank_filter(
+                    "tensors",
+                    {"tensor_id": tensor_ids},
+                    rank,
+                )
+            )
+        )
         local_comparisons = list(
             db.query_tensor_comparisons(filters={"tensor_id": tensor_ids})
         )
@@ -207,21 +294,32 @@ def operation_detail(operation_id, instance: Instance):
         )
 
         device_operations = db.query_device_operations(
-            filters={"operation_id": operation_id}
+            db.merge_rank_filter(
+                "captured_graph",
+                {"operation_id": operation_id},
+                rank,
+            )
         )
 
         producers_consumers = list(
             filter(
-                lambda pc: pc.tensor_id in tensor_ids, db.query_producers_consumers()
+                lambda pc: pc.tensor_id in tensor_ids,
+                db.query_producers_consumers(rank=rank),
             )
         )
 
-        devices = list(db.query_devices())
+        devices = list(db.query_devices(db.merge_rank_filter("devices", None, rank)))
 
         error_record = None
         if db._check_table_exists("errors"):
             error_records = list(
-                db.query_error_records(filters={"operation_id": operation_id})
+                db.query_error_records(
+                    db.merge_rank_filter(
+                        "errors",
+                        {"operation_id": operation_id},
+                        rank,
+                    )
+                )
             )
             for e in error_records:
                 if e.rank == operation.rank:
@@ -273,6 +371,7 @@ def operation_history(instance: Instance):
 @with_instance
 @timer
 def errors_list(instance: Instance):
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
         if not db._check_table_exists("errors"):
             return (
@@ -284,7 +383,9 @@ def errors_list(instance: Instance):
                 HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        error_records = list(db.query_error_records())
+        error_records = list(
+            db.query_error_records(db.merge_rank_filter("errors", None, rank))
+        )
         serialized_errors = [dataclasses.asdict(error) for error in error_records]
 
         return Response(
@@ -333,12 +434,33 @@ def get_config(instance: Instance):
 @with_instance
 @timer
 def tensors_list(instance: Instance):
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
         device_id = request.args.get("device_id", None)
-        tensors = list(db.query_tensors(filters={"device_id": device_id}))
-        local_comparisons = list(db.query_tensor_comparisons())
-        global_comparisons = list(db.query_tensor_comparisons(local=False))
-        producers_consumers = list(db.query_producers_consumers())
+        tensor_filters: dict = {}
+        if device_id is not None:
+            tensor_filters["device_id"] = device_id
+        tensors = list(
+            db.query_tensors(db.merge_rank_filter("tensors", tensor_filters, rank))
+        )
+        if rank is not None and "rank" in db._get_table_columns("tensors"):
+            tensor_ids = [t.tensor_id for t in tensors]
+            if tensor_ids:
+                local_comparisons = list(
+                    db.query_tensor_comparisons(filters={"tensor_id": tensor_ids})
+                )
+                global_comparisons = list(
+                    db.query_tensor_comparisons(
+                        local=False, filters={"tensor_id": tensor_ids}
+                    )
+                )
+            else:
+                local_comparisons = []
+                global_comparisons = []
+        else:
+            local_comparisons = list(db.query_tensor_comparisons())
+            global_comparisons = list(db.query_tensor_comparisons(local=False))
+        producers_consumers = list(db.query_producers_consumers(rank=rank))
         serialized_tensors = serialize_tensors(
             tensors, producers_consumers, local_comparisons, global_comparisons
         )
@@ -363,8 +485,9 @@ def buffer_detail(instance: Instance):
     else:
         return Response(status=HTTPStatus.BAD_REQUEST)
 
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
-        buffer = db.query_next_buffer(operation_id, address)
+        buffer = db.query_next_buffer(operation_id, address, rank=rank)
         if not buffer:
             return Response(status=HTTPStatus.NOT_FOUND)
         return Response(
@@ -392,16 +515,18 @@ def buffer_pages(instance: Instance):
     else:
         buffer_type = None
 
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
+        page_filters = {
+            "operation_id": operation_id,
+            "device_id": device_id,
+            "address": addresses,
+            "buffer_type": buffer_type,
+        }
         buffers = list(
             list(
                 db.query_buffer_pages(
-                    filters={
-                        "operation_id": operation_id,
-                        "device_id": device_id,
-                        "address": addresses,
-                        "buffer_type": buffer_type,
-                    }
+                    db.merge_rank_filter("buffer_pages", page_filters, rank)
                 )
             )
         )
@@ -415,8 +540,13 @@ def buffer_pages(instance: Instance):
 @with_instance
 @timer
 def tensor_detail(tensor_id, instance: Instance):
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
-        tensors = list(db.query_tensors(filters={"tensor_id": tensor_id}))
+        tensors = list(
+            db.query_tensors(
+                db.merge_rank_filter("tensors", {"tensor_id": tensor_id}, rank)
+            )
+        )
         if not tensors:
             return Response(status=HTTPStatus.NOT_FOUND)
 
@@ -436,10 +566,15 @@ def get_all_buffers(instance: Instance):
     else:
         buffer_type = None
 
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
         buffers = list(
             db.query_buffers(
-                filters={"buffer_type": buffer_type, "device_id": device_id}
+                db.merge_rank_filter(
+                    "buffers",
+                    {"buffer_type": buffer_type, "device_id": device_id},
+                    rank,
+                )
             )
         )
         serialized = [serialize_buffer(b) for b in buffers]
@@ -457,13 +592,20 @@ def get_operations_buffers(instance: Instance):
     else:
         buffer_type = None
 
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
         buffers = list(
             db.query_buffers(
-                filters={"buffer_type": buffer_type, "device_id": device_id}
+                db.merge_rank_filter(
+                    "buffers",
+                    {"buffer_type": buffer_type, "device_id": device_id},
+                    rank,
+                )
             )
         )
-        operations = list(db.query_operations())
+        operations = list(
+            db.query_operations(db.merge_rank_filter("operations", None, rank))
+        )
         return Response(
             orjson.dumps(serialize_operations_buffers(operations, buffers)),
             mimetype="application/json",
@@ -480,18 +622,31 @@ def get_operation_buffers(operation_id, instance: Instance):
     else:
         buffer_type = None
 
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
-        operations = list(db.query_operations(filters={"operation_id": operation_id}))
+        operations = list(
+            db.query_operations(
+                db.merge_rank_filter(
+                    "operations",
+                    {"operation_id": operation_id},
+                    rank,
+                )
+            )
+        )
         if not operations:
             return Response(status=HTTPStatus.NOT_FOUND)
         operation = operations[0]
         buffers = list(
             db.query_buffers(
-                filters={
-                    "operation_id": operation_id,
-                    "buffer_type": buffer_type,
-                    "device_id": device_id,
-                }
+                db.merge_rank_filter(
+                    "buffers",
+                    {
+                        "operation_id": operation_id,
+                        "buffer_type": buffer_type,
+                        "device_id": device_id,
+                    },
+                    rank,
+                )
             )
         )
         if not operation:
@@ -946,8 +1101,9 @@ def get_zone_statistics(zone, instance: Instance):
 @api.route("/devices", methods=["GET"])
 @with_instance
 def get_devices(instance: Instance):
+    rank = _optional_rank_query_param()
     with DatabaseQueries(instance) as db:
-        devices = list(db.query_devices())
+        devices = list(db.query_devices(db.merge_rank_filter("devices", None, rank)))
         return Response(
             orjson.dumps(serialize_devices(devices)),
             mimetype="application/json",

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -180,14 +180,17 @@ def operation_detail(operation_id, instance: Instance):
         operation_arguments = list(
             db.query_operation_arguments(filters={"operation_id": operation_id})
         )
-        stack_trace = list(
+        stack_traces = list(
             db.query_stack_traces(filters={"operation_id": operation_id})
         )
 
-        if stack_trace:
-            stack_trace = stack_trace[0]
-        else:
-            stack_trace = None
+        stack_trace = None
+        for st in stack_traces:
+            if st.rank == operation.rank:
+                stack_trace = st
+                break
+        if stack_trace is None and stack_traces:
+            stack_trace = stack_traces[0]
 
         inputs = list(db.query_input_tensors(filters={"operation_id": operation_id}))
         outputs = list(db.query_output_tensors({"operation_id": operation_id}))
@@ -220,7 +223,11 @@ def operation_detail(operation_id, instance: Instance):
             error_records = list(
                 db.query_error_records(filters={"operation_id": operation_id})
             )
-            if error_records:
+            for e in error_records:
+                if e.rank == operation.rank:
+                    error_record = e
+                    break
+            if error_record is None and error_records:
                 error_record = error_records[0]
 
         serialized_operation = serialize_operation(


### PR DESCRIPTION
This PR adds backend support for uploading databases that have a `rank` column on several tables. This is to support multi-host reports, where `rank` corresponds to "host".

If you retrieve operations, each one will have a `rank` field now, which corresponds to which host the operation ran on.

The endpoints for data with a rank field in the response have been made filterable by `rank` as a query var in the request: `GET /api/operations?rank=1`, for example. This will allow the frontend to retrieve only the operations for the host with rank 1.

Backwards compatibility for uploading databases that do not have `rank` columns is maintained, and it will consider everything to be on `rank` 0 in that case.

[Closes #1239]