### PR TITLE
Fix/Perf chart op code filter not applying to charts

### DIFF
--- a/src/components/performance/PerfOpCountVsRuntimeChart.tsx
+++ b/src/components/performance/PerfOpCountVsRuntimeChart.tsx
@@ -25,10 +25,15 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
         [flattenedData],
     );
 
+    const filteredOpCodes = useMemo(
+        () => opCodes.filter((opCode) => selectedOpCodes.some((selected) => selected.opCode === opCode)),
+        [opCodes, selectedOpCodes],
+    );
+
     const opCountData = useMemo(
         () =>
             datasets.map((data, dataIndex) =>
-                opCodes.map(
+                filteredOpCodes.map(
                     (opCode) =>
                         ({
                             x: [`Op Count % ${datasets.length > 1 ? `(${dataIndex + 1})` : ''}`],
@@ -42,13 +47,13 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
                         }) as Partial<PlotData>,
                 ),
             ),
-        [datasets, opCodes, selectedOpCodes, perfReport, comparisonReportList],
+        [datasets, filteredOpCodes, selectedOpCodes, perfReport, comparisonReportList],
     );
 
     const opDeviceTimeData = useMemo(
         () =>
             datasets.map((data, dataIndex) =>
-                opCodes.map(
+                filteredOpCodes.map(
                     (opCode) =>
                         ({
                             x: [`Device Time % ${datasets.length > 1 ? `(${dataIndex + 1})` : ''}`],
@@ -65,7 +70,7 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
                         }) as Partial<PlotData>,
                 ),
             ),
-        [datasets, opCodes, selectedOpCodes, perfReport, comparisonReportList],
+        [datasets, filteredOpCodes, selectedOpCodes, perfReport, comparisonReportList],
     );
 
     const configuration: PlotConfiguration = {

--- a/src/components/performance/PerfOpCountVsRuntimeChart.tsx
+++ b/src/components/performance/PerfOpCountVsRuntimeChart.tsx
@@ -25,9 +25,14 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
         [flattenedData],
     );
 
+    const selectedOpCodeSet = useMemo(
+        () => new Set(selectedOpCodes.map((selected) => selected.opCode)),
+        [selectedOpCodes],
+    );
+
     const filteredOpCodes = useMemo(
-        () => opCodes.filter((opCode) => selectedOpCodes.some((selected) => selected.opCode === opCode)),
-        [opCodes, selectedOpCodes],
+        () => opCodes.filter((opCode) => selectedOpCodeSet.has(opCode)),
+        [opCodes, selectedOpCodeSet],
     );
 
     const opCountData = useMemo(

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { Helmet } from 'react-helmet-async';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Size, Tab, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom, useAtomValue } from 'jotai';
@@ -43,6 +43,12 @@ export default function Performance() {
     const [selectedRange, setSelectedRange] = useAtom(selectedPerformanceRangeAtom);
     const [selectedTabId, setSelectedTabId] = useAtom(perfSelectedTabAtom);
     const [selectedOpCodes, setSelectedOpCodes] = useState<Marker[]>([]);
+    const [hasUserChangedOpCodeFilter, setHasUserChangedOpCodeFilter] = useState(false);
+
+    const setSelectedOpCodesFromUser = useCallback((update: Marker[] | ((previous: Marker[]) => Marker[])) => {
+        setHasUserChangedOpCodeFilter(true);
+        setSelectedOpCodes(update);
+    }, []);
 
     const {
         data,
@@ -103,23 +109,50 @@ export default function Performance() {
         [comparisonPerfData, opIdsMap],
     );
 
-    const filteredEnrichedData = useMemo(
-        () =>
-            selectedOpCodes.length > 0
-                ? enrichedData.filter((row) => selectedOpCodes.some((selected) => selected.opCode === row.raw_op_code))
-                : enrichedData,
-        [enrichedData, selectedOpCodes],
+    const selectedOpCodeSet = useMemo(
+        () => new Set(selectedOpCodes.map((selected) => selected.opCode)),
+        [selectedOpCodes],
     );
 
-    const filteredEnrichedComparisonData = useMemo(
-        () =>
-            selectedOpCodes.length > 0
-                ? enrichedComparisonData.map((dataset) =>
-                      dataset.filter((row) => selectedOpCodes.some((selected) => selected.opCode === row.raw_op_code)),
-                  )
-                : enrichedComparisonData,
-        [enrichedComparisonData, selectedOpCodes],
-    );
+    const filteredEnrichedData = useMemo(() => {
+        if (opCodeOptions.length === 0) {
+            return enrichedData;
+        }
+
+        if (selectedOpCodes.length === 0) {
+            if (!hasUserChangedOpCodeFilter) {
+                return enrichedData;
+            }
+
+            return [];
+        }
+
+        return enrichedData.filter((row) => row.raw_op_code !== undefined && selectedOpCodeSet.has(row.raw_op_code));
+    }, [enrichedData, hasUserChangedOpCodeFilter, opCodeOptions.length, selectedOpCodes.length, selectedOpCodeSet]);
+
+    const filteredEnrichedComparisonData = useMemo(() => {
+        if (opCodeOptions.length === 0) {
+            return enrichedComparisonData;
+        }
+
+        if (selectedOpCodes.length === 0) {
+            if (!hasUserChangedOpCodeFilter) {
+                return enrichedComparisonData;
+            }
+
+            return enrichedComparisonData.map(() => []);
+        }
+
+        return enrichedComparisonData.map((dataset) =>
+            dataset.filter((row) => row.raw_op_code !== undefined && selectedOpCodeSet.has(row.raw_op_code)),
+        );
+    }, [
+        enrichedComparisonData,
+        hasUserChangedOpCodeFilter,
+        opCodeOptions.length,
+        selectedOpCodes.length,
+        selectedOpCodeSet,
+    ]);
     const enrichedStackedData = useMemo(() => (stackedData ? enrichStackedRowData(stackedData) : []), [stackedData]);
     const enrichedComparisonStackedData = useMemo(
         () => comparisonStackedData?.map((dataset) => enrichStackedRowData(dataset)) || [],
@@ -143,6 +176,7 @@ export default function Performance() {
     }, [comparisonReportList, setSelectedRange, perfRange]);
 
     useEffect(() => {
+        setHasUserChangedOpCodeFilter(false);
         setSelectedOpCodes(opCodeOptions);
     }, [opCodeOptions]);
 
@@ -229,12 +263,12 @@ export default function Performance() {
                                         <PerfChartFilter
                                             opCodeOptions={opCodeOptions}
                                             selectedOpCodes={selectedOpCodes}
-                                            updateOpCodes={setSelectedOpCodes}
+                                            updateOpCodes={setSelectedOpCodesFromUser}
                                         />
 
                                         <PerfCharts
                                             filteredPerfData={filteredEnrichedData}
-                                            comparisonData={filteredEnrichedComparisonData || []}
+                                            comparisonData={filteredEnrichedComparisonData}
                                             selectedOpCodes={selectedOpCodes}
                                         />
                                     </div>

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -102,6 +102,24 @@ export default function Performance() {
         () => comparisonPerfData?.map((dataset) => enrichRowData(dataset, opIdsMap)) || [],
         [comparisonPerfData, opIdsMap],
     );
+
+    const filteredEnrichedData = useMemo(
+        () =>
+            selectedOpCodes.length > 0
+                ? enrichedData.filter((row) => selectedOpCodes.some((selected) => selected.opCode === row.raw_op_code))
+                : enrichedData,
+        [enrichedData, selectedOpCodes],
+    );
+
+    const filteredEnrichedComparisonData = useMemo(
+        () =>
+            selectedOpCodes.length > 0
+                ? enrichedComparisonData.map((dataset) =>
+                      dataset.filter((row) => selectedOpCodes.some((selected) => selected.opCode === row.raw_op_code)),
+                  )
+                : enrichedComparisonData,
+        [enrichedComparisonData, selectedOpCodes],
+    );
     const enrichedStackedData = useMemo(() => (stackedData ? enrichStackedRowData(stackedData) : []), [stackedData]);
     const enrichedComparisonStackedData = useMemo(
         () => comparisonStackedData?.map((dataset) => enrichStackedRowData(dataset)) || [],
@@ -215,8 +233,8 @@ export default function Performance() {
                                         />
 
                                         <PerfCharts
-                                            filteredPerfData={enrichedData}
-                                            comparisonData={enrichedComparisonData || []}
+                                            filteredPerfData={filteredEnrichedData}
+                                            comparisonData={filteredEnrichedComparisonData || []}
                                             selectedOpCodes={selectedOpCodes}
                                         />
                                     </div>


### PR DESCRIPTION
Restores op code filtering on the relevant charts.

Not sure when this was removed ❓ 

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1378.