### PR TITLE
Feature/Show app version text on server mode

### DIFF
--- a/src/components/AppVersionStatus.tsx
+++ b/src/components/AppVersionStatus.tsx
@@ -11,7 +11,7 @@ import 'styles/components/AppVersionStatus.scss';
 
 interface AppVersionStatusProps {
     appVersion: string;
-    latestAppVersion: string;
+    latestAppVersion?: string;
     isServerMode?: boolean;
 }
 

--- a/src/components/AppVersionStatus.tsx
+++ b/src/components/AppVersionStatus.tsx
@@ -13,6 +13,7 @@ interface AppVersionStatusProps {
     appVersion: string;
     latestAppVersion?: string;
     isServerMode?: boolean;
+    latestVersionCheckFailed?: boolean;
 }
 
 enum OutdatedLevel {
@@ -32,7 +33,12 @@ const OUTDATED_CLASS_MAP: Record<OutdatedLevel, string> = {
 const PYPI_SOURCE_URL = 'https://pypi.org/project/ttnn-visualizer/';
 const VERSION_ICON_SIZE = 14;
 
-function AppVersionStatus({ appVersion, latestAppVersion, isServerMode }: AppVersionStatusProps) {
+function AppVersionStatus({
+    appVersion,
+    latestAppVersion,
+    isServerMode,
+    latestVersionCheckFailed,
+}: AppVersionStatusProps) {
     const versionOutdatedLevel: OutdatedLevel = useMemo(
         () =>
             isServerMode || !latestAppVersion
@@ -50,6 +56,24 @@ function AppVersionStatus({ appVersion, latestAppVersion, isServerMode }: AppVer
             <div className='version-info'>
                 <span className='app-version'>v{appVersion}</span>
             </div>
+        );
+    }
+
+    if (latestVersionCheckFailed) {
+        return (
+            <Tooltip
+                content='Could not check for the latest version'
+                position={PopoverPosition.TOP}
+            >
+                <div className='version-info version-info--latest-check-unknown'>
+                    <Icon
+                        className='version-status-icon'
+                        icon={IconNames.ISSUE}
+                        size={VERSION_ICON_SIZE}
+                    />
+                    <span className='app-version'>v{appVersion}</span>
+                </div>
+            </Tooltip>
         );
     }
 

--- a/src/components/AppVersionStatus.tsx
+++ b/src/components/AppVersionStatus.tsx
@@ -12,6 +12,7 @@ import 'styles/components/AppVersionStatus.scss';
 interface AppVersionStatusProps {
     appVersion: string;
     latestAppVersion: string;
+    isServerMode?: boolean;
 }
 
 enum OutdatedLevel {
@@ -31,15 +32,26 @@ const OUTDATED_CLASS_MAP: Record<OutdatedLevel, string> = {
 const PYPI_SOURCE_URL = 'https://pypi.org/project/ttnn-visualizer/';
 const VERSION_ICON_SIZE = 14;
 
-function AppVersionStatus({ appVersion, latestAppVersion }: AppVersionStatusProps) {
+function AppVersionStatus({ appVersion, latestAppVersion, isServerMode }: AppVersionStatusProps) {
     const versionOutdatedLevel: OutdatedLevel = useMemo(
-        () => (latestAppVersion ? getVersionOutdatedLevel(appVersion, latestAppVersion) : OutdatedLevel.NONE),
-        [latestAppVersion, appVersion],
+        () =>
+            isServerMode || !latestAppVersion
+                ? OutdatedLevel.NONE
+                : getVersionOutdatedLevel(appVersion, latestAppVersion),
+        [isServerMode, latestAppVersion, appVersion],
     );
     const isAppOutdated = versionOutdatedLevel > OutdatedLevel.NONE;
     const versionClasses = classNames('version-info', OUTDATED_CLASS_MAP[versionOutdatedLevel], {
         'is-anchor': isAppOutdated,
     });
+
+    if (isServerMode) {
+        return (
+            <div className='version-info'>
+                <span className='app-version'>v{appVersion}</span>
+            </div>
+        );
+    }
 
     return (
         <Tooltip

--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -5,7 +5,7 @@
 import classNames from 'classnames';
 import { Button, Classes, Collapse, Icon, NumberRange, PopoverPosition, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useCallback, useEffect, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { useLocation } from 'react-router';
 import {
@@ -78,21 +78,20 @@ function FooterInfobar() {
         }
     }, [isAllowedRoute]);
 
+    const versionStatus: ReactNode = latestAppVersion ? (
+        <AppVersionStatus
+            appVersion={appVersion}
+            latestAppVersion={latestAppVersion}
+            isServerMode={isServerMode}
+        />
+    ) : (
+        <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />
+    );
+
     return (
         <footer className={classNames('app-footer', { 'is-open': sliderIsOpen })}>
             <div className='current-data'>
-                {!isServerMode ? (
-                    <div className='version-container'>
-                        {latestAppVersion ? (
-                            <AppVersionStatus
-                                appVersion={appVersion}
-                                latestAppVersion={latestAppVersion}
-                            />
-                        ) : (
-                            <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />
-                        )}
-                    </div>
-                ) : null}
+                <div className='version-container'>{versionStatus}</div>
 
                 <div className='active-reports'>
                     {!isServerMode && (

--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -41,7 +41,7 @@ function FooterInfobar() {
     const serverConfig = getServerConfig();
     const isServerMode = serverConfig.SERVER_MODE;
 
-    const latestAppVersion = useGetLatestAppVersion();
+    const { data: latestAppVersion, isPending: isLatestAppPending } = useGetLatestAppVersion();
     const appVersion = import.meta.env.APP_VERSION;
 
     const activeProfilerReportPath = activeProfilerReport?.path;
@@ -78,15 +78,24 @@ function FooterInfobar() {
         }
     }, [isAllowedRoute]);
 
-    const versionStatus: ReactNode = latestAppVersion ? (
-        <AppVersionStatus
-            appVersion={appVersion}
-            latestAppVersion={latestAppVersion}
-            isServerMode={isServerMode}
-        />
-    ) : (
-        <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />
-    );
+    let versionStatus: ReactNode;
+    if (isServerMode) {
+        versionStatus = (
+            <AppVersionStatus
+                appVersion={appVersion}
+                isServerMode
+            />
+        );
+    } else if (isLatestAppPending) {
+        versionStatus = <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />;
+    } else {
+        versionStatus = (
+            <AppVersionStatus
+                appVersion={appVersion}
+                latestAppVersion={latestAppVersion ?? undefined}
+            />
+        );
+    }
 
     return (
         <footer className={classNames('app-footer', { 'is-open': sliderIsOpen })}>

--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -38,10 +38,14 @@ function FooterInfobar() {
 
     const { data: instance } = useInstance();
     const location = useLocation();
+    const {
+        data: latestAppVersion,
+        isPending: isLatestAppPending,
+        isError: isLatestAppVersionError,
+    } = useGetLatestAppVersion();
     const serverConfig = getServerConfig();
-    const isServerMode = serverConfig.SERVER_MODE;
 
-    const { data: latestAppVersion, isPending: isLatestAppPending } = useGetLatestAppVersion();
+    const isServerMode = serverConfig.SERVER_MODE || false;
     const appVersion = import.meta.env.APP_VERSION;
 
     const activeProfilerReportPath = activeProfilerReport?.path;
@@ -72,30 +76,19 @@ function FooterInfobar() {
         return selectedRange && `Selected: ${selectedRange[0]} - ${selectedRange[1]}`;
     };
 
+    const versionStatus = getAppVersionStatus(
+        appVersion,
+        isLatestAppPending,
+        isServerMode,
+        latestAppVersion,
+        isLatestAppVersionError,
+    );
+
     useEffect(() => {
         if (!isAllowedRoute()) {
             setSliderIsOpen(false);
         }
     }, [isAllowedRoute]);
-
-    let versionStatus: ReactNode;
-    if (isServerMode) {
-        versionStatus = (
-            <AppVersionStatus
-                appVersion={appVersion}
-                isServerMode
-            />
-        );
-    } else if (isLatestAppPending) {
-        versionStatus = <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />;
-    } else {
-        versionStatus = (
-            <AppVersionStatus
-                appVersion={appVersion}
-                latestAppVersion={latestAppVersion ?? undefined}
-            />
-        );
-    }
 
     return (
         <footer className={classNames('app-footer', { 'is-open': sliderIsOpen })}>
@@ -225,6 +218,43 @@ const formatName = (str: string): string => {
     }
 
     return str;
+};
+
+const getAppVersionStatus = (
+    appVersion: string,
+    isLatestAppPending: boolean,
+    isServerMode: boolean,
+    latestAppVersion: string | null | undefined,
+    isLatestAppVersionError: boolean,
+): ReactNode => {
+    if (isServerMode) {
+        return (
+            <AppVersionStatus
+                appVersion={appVersion}
+                isServerMode
+            />
+        );
+    }
+
+    if (isLatestAppPending) {
+        return <LoadingSpinner size={LoadingSpinnerSizes.SMALL} />;
+    }
+
+    if (isLatestAppVersionError && latestAppVersion == null) {
+        return (
+            <AppVersionStatus
+                appVersion={appVersion}
+                latestVersionCheckFailed
+            />
+        );
+    }
+
+    return (
+        <AppVersionStatus
+            appVersion={appVersion}
+            latestAppVersion={latestAppVersion ?? undefined}
+        />
+    );
 };
 
 export default FooterInfobar;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -59,7 +59,6 @@ import { RemoteFolder } from '../definitions/RemoteConnection';
 import createToastNotification, { ToastType } from '../functions/createToastNotification';
 import { DEALLOCATE_OP_NAME_LIST } from '../definitions/Deallocate';
 import { processInputsOutputs } from '../functions/processMemoryAllocations';
-import getServerConfig from '../functions/getServerConfig';
 
 const EMPTY_PERF_RETURN = { report: [], stacked_report: [], signposts: [] };
 
@@ -1214,15 +1213,11 @@ const fetchLatestAppVersion = async (): Promise<string | null> => {
 };
 
 export const useGetLatestAppVersion = () => {
-    const serverConfig = getServerConfig();
-    const isServerMode = serverConfig.SERVER_MODE;
-
     const response = useQuery<string | null, AxiosError>({
         queryFn: () => fetchLatestAppVersion(),
         queryKey: ['get-latest-app-version'],
         retry: false,
         staleTime: Infinity,
-        enabled: !isServerMode, // Disable in server mode
     });
 
     return response.data;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -28,6 +28,7 @@ import {
 } from '../model/APIData';
 import { BufferType } from '../model/BufferType';
 import parseMemoryConfig, { MemoryConfig, memoryConfigPattern } from '../functions/parseMemoryConfig';
+import getServerConfig from '../functions/getServerConfig';
 import { PerfTableRow } from '../definitions/PerfTable';
 import { StackedGroupBy, StackedPerfRow } from '../definitions/StackedPerfTable';
 import { isDeviceOperation } from '../functions/filterOperations';
@@ -1213,12 +1214,13 @@ const fetchLatestAppVersion = async (): Promise<string | null> => {
 };
 
 export const useGetLatestAppVersion = () => {
-    const response = useQuery<string | null, AxiosError>({
+    const isServerMode = !!getServerConfig().SERVER_MODE;
+
+    return useQuery<string | null, AxiosError>({
         queryFn: () => fetchLatestAppVersion(),
         queryKey: ['get-latest-app-version'],
         retry: false,
         staleTime: Infinity,
+        enabled: !isServerMode,
     });
-
-    return response.data;
 };

--- a/src/scss/components/AppVersionStatus.scss
+++ b/src/scss/components/AppVersionStatus.scss
@@ -8,6 +8,7 @@ $version-up-to-date-color: #76fd92;
 $version-outdated-one-color: #ffe454;
 $version-outdated-two-color: #fb854b;
 $version-outdated-three-color: #ff7272;
+$version-unknown-color: $version-outdated-one-color;
 
 .version-info {
     display: flex;
@@ -76,6 +77,14 @@ $version-outdated-three-color: #ff7272;
 
         .version-status-icon {
             color: $version-outdated-three-color;
+        }
+    }
+
+    &--latest-check-unknown {
+        color: $version-unknown-color;
+
+        .version-status-icon {
+            color: $version-unknown-color;
         }
     }
 }

--- a/src/scss/components/AppVersionStatus.scss
+++ b/src/scss/components/AppVersionStatus.scss
@@ -80,3 +80,9 @@ $version-outdated-three-color: #ff7272;
         }
     }
 }
+
+.version-container > .app-version {
+    font-size: 12px;
+    font-weight: 500;
+    color: $version-up-to-date-color;
+}

--- a/src/scss/components/AppVersionStatus.scss
+++ b/src/scss/components/AppVersionStatus.scss
@@ -30,7 +30,6 @@ $version-outdated-three-color: #ff7272;
 
     .app-version {
         color: inherit;
-        font-weight: 500;
     }
 
     .version-status-icon {
@@ -79,10 +78,4 @@ $version-outdated-three-color: #ff7272;
             color: $version-outdated-three-color;
         }
     }
-}
-
-.version-container > .app-version {
-    font-size: 12px;
-    font-weight: 500;
-    color: $version-up-to-date-color;
 }


### PR DESCRIPTION
Adds the version number in the bottom left without any tooltips or links to upgrade. 

<img width="1281" height="885" alt="Screenshot 2026-04-08 at 16 14 00" src="https://github.com/user-attachments/assets/9140fc50-29e2-4d12-ba03-e830eff2f6ac" />

Closes https://github.com/tenstorrent/ttnn-visualizer/pull/1377.