### PR TITLE
Chore/Update tt-perf-report version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic==2.12.5",
     "python-dotenv==1.0.1",
     "PyYAML==6.0.2",
-    "tt-perf-report==1.2.2",
+    "tt-perf-report==1.2.3",
     "uvicorn==0.30.1",
     "zstd==1.5.7.0"
 ]


### PR DESCRIPTION
There are some changes to utilization calculations in the latest version which are related to DeepSeek, so updating our version.

https://github.com/tenstorrent/tt-perf-report/pull/54