### PR TITLE
Fix/Unsanitised highlighted text

### DIFF
--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -33,9 +33,11 @@ const HighlightedText: React.FC<HighlightedTextProps> = ({ text, filter, classNa
         <span
             title={text}
             className={classNames('highlighted-text', className)}
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: `${before}<mark>${match}</mark>${after}` }}
-        />
+        >
+            {before}
+            <mark>{match}</mark>
+            {after}
+        </span>
     );
 };
 

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -277,6 +277,7 @@ function StackTrace({
                     <div className='code-wrapper'>
                         <code
                             className={`language-${language} code-output`}
+                            // HTML tags are escaped by hljs
                             // eslint-disable-next-line react/no-danger
                             dangerouslySetInnerHTML={{ __html: stackTraceWithHighlights }}
                         />
@@ -285,6 +286,7 @@ function StackTrace({
                     <div className='code-wrapper'>
                         <code
                             className={`language-${language} code-output`}
+                            // HTML tags are escaped by hljs
                             // eslint-disable-next-line react/no-danger
                             dangerouslySetInnerHTML={{
                                 __html: getStackTracePreview(stackTraceWithHighlights),
@@ -379,6 +381,7 @@ function StackTrace({
                                 <p className='stack-trace-path monospace'>{displaySourcePath}</p>
                                 <code
                                     className={`language-${language} code-output`}
+                                    // HTML tags are escaped by hljs
                                     // eslint-disable-next-line react/no-danger
                                     dangerouslySetInnerHTML={{
                                         __html: fileWithHighlights,

--- a/src/components/report-selection/RemoteConnectionSelector.tsx
+++ b/src/components/report-selection/RemoteConnectionSelector.tsx
@@ -9,6 +9,7 @@ import { ItemRendererProps, Select } from '@blueprintjs/select';
 import RemoteConnectionDialog from './RemoteConnectionDialog';
 import { RemoteConnection } from '../../definitions/RemoteConnection';
 import { isEqual } from '../../functions/math';
+import HighlightedText from '../HighlightedText';
 
 interface RemoteConnectionSelectorProps {
     connectionList: RemoteConnection[];
@@ -140,7 +141,7 @@ type RenderRemoteConnectionProps<T> = (
 
 const renderRemoteConnection: RenderRemoteConnectionProps<RemoteConnection> = (
     connection,
-    { handleClick, modifiers },
+    { handleClick, modifiers, query },
     selectedConnection,
 ) => {
     if (!modifiers.matchesPredicate) {
@@ -153,7 +154,12 @@ const renderRemoteConnection: RenderRemoteConnectionProps<RemoteConnection> = (
             disabled={modifiers.disabled}
             key={formatConnectionString(connection)}
             onClick={handleClick}
-            text={formatConnectionString(connection)}
+            text={
+                <HighlightedText
+                    text={formatConnectionString(connection)}
+                    filter={query}
+                />
+            }
         />
     );
 };


### PR DESCRIPTION
Removes `dangerouslySetInnerHTML` from `HighlightedText`, and add the component to the remote connection selector where it was missing. Also adds some comments to explain HTML sanitation.

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1394.