### PR TITLE
Fix non connected graph rendering errors

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -80,12 +80,21 @@ const OperationGraph: React.FC<{
         return ids;
     }, [edges]);
 
-    if (currentOperationId !== null && !connectedNodeIds.has(currentOperationId)) {
-        const val = connectedNodeIds.values().next().value;
-
-        focusNodeId = val;
-        setCurrentOperationId(val);
+    if (currentOperationId !== null && connectedNodeIds.size > 0 && !connectedNodeIds.has(currentOperationId)) {
+        focusNodeId = connectedNodeIds.values().next().value ?? focusNodeId;
     }
+
+    useEffect(() => {
+        if (connectedNodeIds.size === 0) {
+            return;
+        }
+        if (currentOperationId !== null && !connectedNodeIds.has(currentOperationId)) {
+            const fallbackId = connectedNodeIds.values().next().value;
+            if (fallbackId !== undefined && fallbackId !== currentOperationId) {
+                setCurrentOperationId(fallbackId);
+            }
+        }
+    }, [connectedNodeIds, currentOperationId]);
 
     const nodes = useMemo(
         () =>


### PR DESCRIPTION
Avoid updating state during render by moving the fallback logic that sets currentOperationId into a useEffect. Add guards for empty connectedNodeIds and undefined fallback values, and use a safe fallback for focusNodeId (using ??). The effect only calls setCurrentOperationId when a valid, different fallback id exists, preventing render-time state updates and related React warnings.

closes #1407