### PR TITLE
Use device L1 size in L1 small marker

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -80,12 +80,21 @@ const OperationGraph: React.FC<{
         return ids;
     }, [edges]);
 
-    if (currentOperationId !== null && !connectedNodeIds.has(currentOperationId)) {
-        const val = connectedNodeIds.values().next().value;
-
-        focusNodeId = val;
-        setCurrentOperationId(val);
+    if (currentOperationId !== null && connectedNodeIds.size > 0 && !connectedNodeIds.has(currentOperationId)) {
+        focusNodeId = connectedNodeIds.values().next().value ?? focusNodeId;
     }
+
+    useEffect(() => {
+        if (connectedNodeIds.size === 0) {
+            return;
+        }
+        if (currentOperationId !== null && !connectedNodeIds.has(currentOperationId)) {
+            const fallbackId = connectedNodeIds.values().next().value;
+            if (fallbackId !== undefined && fallbackId !== currentOperationId) {
+                setCurrentOperationId(fallbackId);
+            }
+        }
+    }, [connectedNodeIds, currentOperationId]);
 
     const nodes = useMemo(
         () =>

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -258,11 +258,11 @@ export const useGetUniqueDeviceOperationsList = (): string[] => {
  */
 export const useGetL1SmallMarker = (): number => {
     const { data: buffers } = useGetAllBuffers(BufferType.L1_SMALL);
-
+    const l1Size = useGetL1Size();
     return useMemo(() => {
         const addresses = buffers?.map((buffer) => {
             return buffer.address;
-        }) || [L1_DEFAULT_MEMORY_SIZE];
+        }) || [l1Size ?? L1_DEFAULT_MEMORY_SIZE];
 
         let min = Infinity;
         for (let i = 0; i < addresses.length; i++) {
@@ -270,8 +270,8 @@ export const useGetL1SmallMarker = (): number => {
                 min = addresses[i];
             }
         }
-        return min === Infinity ? L1_DEFAULT_MEMORY_SIZE : min;
-    }, [buffers]);
+        return min === Infinity ? (l1Size ?? L1_DEFAULT_MEMORY_SIZE) : min;
+    }, [buffers, l1Size]);
 };
 
 /**
@@ -283,6 +283,17 @@ export const useGetL1StartMarker = (): number => {
     return useMemo(() => {
         if (devices && devices.length > 0) {
             return devices[0].address_at_first_l1_cb_buffer;
+        }
+        return 0;
+    }, [devices]);
+};
+
+export const useGetL1Size = (): number => {
+    const { data: devices } = useDevices();
+
+    return useMemo(() => {
+        if (devices && devices.length > 0) {
+            return devices[0].worker_l1_size;
         }
         return 0;
     }, [devices]);


### PR DESCRIPTION
closes #1408 
Add useGetL1Size hook to read worker_l1_size from devices and use it as the fallback/default for useGetL1SmallMarker. Replace hardcoded L1_DEFAULT_MEMORY_SIZE fallbacks with l1Size ?? L1_DEFAULT_MEMORY_SIZE, and include l1Size in the useMemo dependencies to ensure correct recalculation. 