### PR TITLE
Feature/Allow empty remote folders

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -11,7 +11,7 @@ from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
     AuthenticationFailedException,
-    NoProjectsException,
+    NoReportsException,
     NoValidConnectionsError,
     RemoteConnectionException,
     RemoteFileReadException,
@@ -87,11 +87,12 @@ def remote_exception_handler(func):
                 status=ConnectionTestStates.FAILED,
                 message=f"Unable to open path: {str(err)}",
             )
-        except NoProjectsException as err:
-            current_app.logger.error(f"No projects: {str(err)}")
+        except NoReportsException as err:
+            current_app.logger.warning(f"No reports: {str(err)}")
             raise RemoteConnectionException(
-                status=ConnectionTestStates.FAILED,
-                message=f"No remote projects found: {str(err)}",
+                status=err.status,
+                message=f"No remote reports found: {str(err)}",
+                detail=getattr(err, "detail", None),
             )
         except NoValidConnectionsError as err:
             current_app.logger.warning(

--- a/backend/ttnn_visualizer/enums.py
+++ b/backend/ttnn_visualizer/enums.py
@@ -10,3 +10,4 @@ class ConnectionTestStates(enum.Enum):
     PROGRESS = 1
     FAILED = 2
     OK = 3
+    WARNING = 4

--- a/backend/ttnn_visualizer/exceptions.py
+++ b/backend/ttnn_visualizer/exceptions.py
@@ -31,6 +31,8 @@ class RemoteConnectionException(Exception):
         # Default behavior
         if self.status == ConnectionTestStates.FAILED:
             return HTTPStatus.INTERNAL_SERVER_ERROR
+        if self.status == ConnectionTestStates.WARNING:
+            return HTTPStatus.OK
         if self.status == ConnectionTestStates.OK:
             return HTTPStatus.OK
 
@@ -52,7 +54,7 @@ class AuthenticationFailedException(RemoteConnectionException):
         )
 
 
-class NoProjectsException(RemoteConnectionException):
+class NoReportsException(RemoteConnectionException):
     pass
 
 

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -17,7 +17,7 @@ from ttnn_visualizer.decorators import remote_exception_handler
 from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
-    NoProjectsException,
+    NoReportsException,
     NoValidConnectionsError,
     RemoteConnectionException,
     SSHException,
@@ -546,18 +546,14 @@ def check_remote_path_for_reports(remote_connection):
 
     errors = []
     if not remote_profiler_paths and remote_connection.profilerPath:
-        errors.append(
-            f"No matching profiler projects found: {remote_connection.profilerPath}"
-        )
+        errors.append(f"Profiler folder path: {remote_connection.profilerPath}")
     if not remote_performance_paths and remote_connection.performancePath:
-        errors.append(
-            f"No matching performance projects found: {remote_connection.performancePath}"
-        )
+        errors.append(f"Performance folder path: {remote_connection.performancePath}")
 
     if errors:
-        raise NoProjectsException(
+        raise NoReportsException(
             message="; ".join(errors),
-            status=ConnectionTestStates.FAILED,
+            status=ConnectionTestStates.WARNING,
         )
 
     return True
@@ -684,14 +680,15 @@ def get_remote_performance_folders(
             remote_connection, remote_connection.performancePath, [TEST_PROFILER_FILE]
         )
     else:
-        error = "Performance path is not configured for this connection"
-        logger.error(error)
-        raise NoProjectsException(status=ConnectionTestStates.FAILED, message=error)
+        logger.info("No performance path configured for this connection")
+        return []
 
     if not performance_paths:
-        error = f"Performance path: {remote_connection.performancePath}"
-        logger.info(error)
-        raise NoProjectsException(status=ConnectionTestStates.FAILED, message=error)
+        logger.info(
+            "No performance reports found under path: %s",
+            remote_connection.performancePath,
+        )
+        return []
 
     remote_folder_data = []
     for path in performance_paths:
@@ -714,14 +711,15 @@ def get_remote_profiler_folders(
             remote_connection, remote_connection.profilerPath, [TEST_DB_FILE]
         )
     else:
-        error = f"No profiler reports found at {remote_connection.profilerPath}"
-        logger.info(error)
-        raise NoProjectsException(status=ConnectionTestStates.FAILED, message=error)
+        logger.info("No profiler path configured for this connection")
+        return []
 
     if not profiler_paths:
-        error = f"Profiler path: {remote_connection.profilerPath}"
-        logger.info(error)
-        raise NoProjectsException(status=ConnectionTestStates.FAILED, message=error)
+        logger.info(
+            "No profiler reports found under path: %s",
+            remote_connection.profilerPath,
+        )
+        return []
 
     remote_folder_data = []
     for path in profiler_paths:

--- a/backend/ttnn_visualizer/tests/views/test_remote_folders.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_folders.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from http import HTTPStatus
+from pathlib import Path
+from unittest.mock import patch
+
+from ttnn_visualizer.models import RemoteReportFolder
+
+
+def _remote_connection_payload():
+    return {
+        "name": "test-remote",
+        "username": "tester",
+        "host": "remote.example.com",
+        "port": 22,
+        "profilerPath": "/remote/profiler/reports",
+        "performancePath": "/remote/performance/reports",
+    }
+
+
+def test_remote_profiler_returns_204_when_no_reports(client):
+    with patch("ttnn_visualizer.views.get_remote_profiler_folders", return_value=[]):
+        response = client.post(
+            "/api/remote/profiler", json=_remote_connection_payload()
+        )
+
+    assert response.status_code == HTTPStatus.NO_CONTENT
+    assert response.data == b""
+
+
+def test_remote_profiler_returns_json_when_reports_exist(app, client):
+    app.config["REMOTE_DATA_DIRECTORY"] = Path(app.config["REMOTE_DATA_DIRECTORY"])
+
+    folders = [
+        RemoteReportFolder(
+            reportName="resnet50",
+            remotePath="/remote/profiler/reports/resnet50",
+            lastModified=100,
+        )
+    ]
+
+    with (
+        patch(
+            "ttnn_visualizer.views.get_remote_profiler_folders", return_value=folders
+        ),
+        patch("ttnn_visualizer.views.read_last_synced_file", return_value=123),
+    ):
+        response = client.post(
+            "/api/remote/profiler", json=_remote_connection_payload()
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["reportName"] == "resnet50"
+    assert data[0]["remotePath"] == "/remote/profiler/reports/resnet50"
+    assert data[0]["lastModified"] == 100
+    assert data[0]["lastSynced"] == 123
+
+
+def test_remote_performance_returns_204_when_no_reports(client):
+    with patch("ttnn_visualizer.views.get_remote_performance_folders", return_value=[]):
+        response = client.post(
+            "/api/remote/performance", json=_remote_connection_payload()
+        )
+
+    assert response.status_code == HTTPStatus.NO_CONTENT
+    assert response.data == b""
+
+
+def test_remote_performance_returns_json_when_reports_exist(app, client):
+    app.config["REMOTE_DATA_DIRECTORY"] = Path(app.config["REMOTE_DATA_DIRECTORY"])
+
+    folders = [
+        RemoteReportFolder(
+            reportName="bert",
+            remotePath="/remote/performance/reports/bert",
+            lastModified=200,
+        )
+    ]
+
+    with (
+        patch(
+            "ttnn_visualizer.views.get_remote_performance_folders", return_value=folders
+        ),
+        patch("ttnn_visualizer.views.read_last_synced_file", return_value=456),
+    ):
+        response = client.post(
+            "/api/remote/performance", json=_remote_connection_payload()
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["reportName"] == "bert"
+    assert data[0]["remotePath"] == "/remote/performance/reports/bert"
+    assert data[0]["lastModified"] == 200
+    assert data[0]["lastSynced"] == 456

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1490,7 +1490,6 @@ def test_remote_folder():
         test_ssh_connection(connection)
         add_status(ConnectionTestStates.OK.value, "SSH connection established")
     except AuthenticationFailedException as e:
-        # Return 422 for authentication failures
         add_status(
             ConnectionTestStates.FAILED.value, e.message, getattr(e, "detail", None)
         )

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1376,6 +1376,8 @@ def get_remote_folders_profiler():
         remote_folders: List[RemoteReportFolder] = get_remote_profiler_folders(
             connection
         )
+        if not remote_folders:
+            return Response(status=HTTPStatus.NO_CONTENT)
 
         for rf in remote_folders:
             directory_name = Path(rf.remotePath).name
@@ -1414,6 +1416,8 @@ def get_remote_folders_performance():
         remote_performance_folders: List[RemoteReportFolder] = (
             get_remote_performance_folders(connection)
         )
+        if not remote_performance_folders:
+            return Response(status=HTTPStatus.NO_CONTENT)
 
         for rf in remote_performance_folders:
             performance_name = Path(rf.remotePath).name

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1510,7 +1510,7 @@ def test_remote_folder():
 
     def has_failures():
         return any(
-            status.status != ConnectionTestStates.OK.value for status in statuses
+            status.status == ConnectionTestStates.FAILED.value for status in statuses
         )
 
     # Test SSH Connection
@@ -1524,9 +1524,7 @@ def test_remote_folder():
         )
         return jsonify([status.model_dump() for status in statuses]), e.http_status
     except RemoteConnectionException as e:
-        add_status(
-            ConnectionTestStates.FAILED.value, e.message, getattr(e, "detail", None)
-        )
+        add_status(e.status.value, e.message, getattr(e, "detail", None))
 
     # Test Directory Configuration
     if not has_failures() and connection.profilerPath:
@@ -1539,9 +1537,7 @@ def test_remote_folder():
             )
             return jsonify([status.model_dump() for status in statuses]), e.http_status
         except RemoteConnectionException as e:
-            add_status(
-                ConnectionTestStates.FAILED.value, e.message, getattr(e, "detail", None)
-            )
+            add_status(e.status.value, e.message, getattr(e, "detail", None))
 
     # Test Directory Configuration (perf)
     if not has_failures() and connection.performancePath:
@@ -1554,9 +1550,7 @@ def test_remote_folder():
             )
             return jsonify([status.model_dump() for status in statuses]), e.http_status
         except RemoteConnectionException as e:
-            add_status(
-                ConnectionTestStates.FAILED.value, e.message, getattr(e, "detail", None)
-            )
+            add_status(e.status.value, e.message, getattr(e, "detail", None))
 
     # Check for Project Configurations
     if not has_failures():
@@ -1568,9 +1562,7 @@ def test_remote_folder():
             )
             return jsonify([status.model_dump() for status in statuses]), e.http_status
         except RemoteConnectionException as e:
-            add_status(
-                ConnectionTestStates.FAILED.value, e.message, getattr(e, "detail", None)
-            )
+            add_status(e.status.value, e.message, getattr(e, "detail", None))
 
     return Response(
         orjson.dumps([status.model_dump() for status in statuses]),

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -421,13 +421,8 @@ def errors_list(instance: Instance):
         if rejected is not None:
             return rejected
         if not db._check_table_exists("errors"):
-            return (
-                jsonify(
-                    {
-                        "error": "Error records table does not exist in this report database."
-                    }
-                ),
-                HTTPStatus.UNPROCESSABLE_ENTITY,
+            return response_unprocessable_entity(
+                message="Error records table does not exist in this report database."
             )
 
         error_records = list(
@@ -447,13 +442,8 @@ def errors_list(instance: Instance):
 def report_metadata(instance: Instance):
     with DatabaseQueries(instance) as db:
         if not db._check_table_exists("report_metadata"):
-            return (
-                jsonify(
-                    {
-                        "error": "Report metadata table does not exist in this report database."
-                    }
-                ),
-                HTTPStatus.UNPROCESSABLE_ENTITY,
+            return response_unprocessable_entity(
+                message="Report metadata table does not exist in this report database."
             )
         rows = db.query_report_metadata()
         payload = {row[0]: row[1] for row in rows}
@@ -1555,19 +1545,19 @@ def read_remote_folder(instance: Instance):
     remote_connection = instance.remote_connection
 
     if check_path_only:
-        available = False
+        is_available = False
 
         if remote_connection:
             try:
                 ssh_client = SSHClient(remote_connection)
-                available = check_stack_source_remote(ssh_client, file_path)
+                is_available = check_stack_source_remote(ssh_client, file_path)
             except RemoteConnectionException:
                 return jsonify({"available": False})
         else:
             if not current_app.config.get("SERVER_MODE"):
-                available = check_stack_source_local(file_path)
+                is_available = check_stack_source_local(file_path)
 
-        return jsonify({"available": available})
+        return jsonify({"available": is_available})
 
     if remote_connection:
         try:

--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -17,6 +17,7 @@ const ICON_MAP: Record<ConnectionTestStates, IconName> = {
     [ConnectionTestStates.PROGRESS]: IconNames.DOT,
     [ConnectionTestStates.FAILED]: IconNames.CROSS,
     [ConnectionTestStates.OK]: IconNames.TICK,
+    [ConnectionTestStates.WARNING]: IconNames.WARNING_SIGN,
 };
 
 const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
@@ -24,6 +25,7 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
     [ConnectionTestStates.PROGRESS]: Intent.WARNING,
     [ConnectionTestStates.FAILED]: Intent.DANGER,
     [ConnectionTestStates.OK]: Intent.SUCCESS,
+    [ConnectionTestStates.WARNING]: Intent.WARNING,
 };
 
 const NPEFileLoader: React.FC = () => {

--- a/src/components/report-selection/ConnectionTestMessage.tsx
+++ b/src/components/report-selection/ConnectionTestMessage.tsx
@@ -14,6 +14,7 @@ const ICON_MAP: Record<ConnectionTestStates, IconName> = {
     [ConnectionTestStates.PROGRESS]: IconNames.DOT,
     [ConnectionTestStates.FAILED]: IconNames.CROSS,
     [ConnectionTestStates.OK]: IconNames.TICK,
+    [ConnectionTestStates.WARNING]: IconNames.WARNING_SIGN,
 };
 
 const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
@@ -21,6 +22,7 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
     [ConnectionTestStates.PROGRESS]: Intent.WARNING,
     [ConnectionTestStates.FAILED]: Intent.DANGER,
     [ConnectionTestStates.OK]: Intent.SUCCESS,
+    [ConnectionTestStates.WARNING]: Intent.WARNING,
 };
 
 function ConnectionTestMessage({ status, message, detail }: ConnectionTestMessageProps) {
@@ -29,7 +31,7 @@ function ConnectionTestMessage({ status, message, detail }: ConnectionTestMessag
             <Icon
                 className='connection-status-icon'
                 icon={ICON_MAP[status]}
-                size={20}
+                size={18}
                 intent={INTENT_MAP[status]}
             />
 

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -43,6 +43,7 @@ const ICON_MAP: Record<ConnectionTestStates, IconName> = {
     [ConnectionTestStates.PROGRESS]: IconNames.DOT,
     [ConnectionTestStates.FAILED]: IconNames.CROSS,
     [ConnectionTestStates.OK]: IconNames.TICK,
+    [ConnectionTestStates.WARNING]: IconNames.WARNING_SIGN,
 };
 
 const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
@@ -50,6 +51,7 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
     [ConnectionTestStates.PROGRESS]: Intent.WARNING,
     [ConnectionTestStates.FAILED]: Intent.DANGER,
     [ConnectionTestStates.OK]: Intent.SUCCESS,
+    [ConnectionTestStates.WARNING]: Intent.WARNING,
 };
 
 const connectionOkStatus: ConnectionStatus = {

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -57,7 +57,10 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
     const [isTestingConnection, setIsTestingconnection] = useState(false);
 
     const isValidConnection =
-        connectionTests.length > 0 && connectionTests.every((status) => status.status === ConnectionTestStates.OK);
+        connectionTests.length > 0 &&
+        connectionTests.every(
+            ({ status }) => status === ConnectionTestStates.OK || status === ConnectionTestStates.WARNING,
+        );
 
     const testConnectionStatus = async () => {
         setIsTestingconnection(true);
@@ -243,7 +246,7 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
                 minimal
                 actions={
                     <Tooltip
-                        content='Ensure connection passes all tests'
+                        content='Resolve any failed checks before saving'
                         disabled={isValidConnection}
                     >
                         <Button

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -31,6 +31,27 @@ import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
 
 const GENERIC_ERROR_MESSAGE = 'An unknown error occurred.';
 
+const getAxiosErrorMessage = (err: unknown): string => {
+    if (!axios.isAxiosError(err)) {
+        return GENERIC_ERROR_MESSAGE;
+    }
+
+    const responseData = err.response?.data;
+    if (typeof responseData === 'string' && responseData.trim().length > 0) {
+        return responseData;
+    }
+
+    if (responseData && typeof responseData === 'object' && 'message' in responseData) {
+        const { message } = responseData;
+
+        if (typeof message === 'string' && message.trim().length > 0) {
+            return message;
+        }
+    }
+
+    return err.message || GENERIC_ERROR_MESSAGE;
+};
+
 const RemoteSyncConfigurator: FC = () => {
     const remote = useRemoteConnection();
     const queryClient = useQueryClient();
@@ -359,27 +380,45 @@ const RemoteSyncConfigurator: FC = () => {
                             setIsFetching(true);
 
                             if (remote.persistentState.selectedConnection) {
-                                const [fetchedReportFolders, fetchedPerformanceFolders] = await Promise.all([
+                                const [reportFolders, performanceFolders] = await Promise.allSettled([
                                     remote.persistentState.selectedConnection.profilerPath
                                         ? remote.listReportFolders(remote.persistentState.selectedConnection)
-                                        : [],
+                                        : Promise.resolve([]),
                                     remote.persistentState.selectedConnection.performancePath
                                         ? remote.listPerformanceFolders(remote.persistentState.selectedConnection)
-                                        : [],
+                                        : Promise.resolve([]),
                                 ]);
 
-                                updateSavedReportFolders(
-                                    remote.persistentState.selectedConnection,
-                                    fetchedReportFolders,
-                                );
+                                const fetchErrors: string[] = [];
 
-                                updateSavedPerformanceFolders(
-                                    remote.persistentState.selectedConnection,
-                                    fetchedPerformanceFolders,
-                                );
+                                if (reportFolders.status === 'fulfilled') {
+                                    updateSavedReportFolders(
+                                        remote.persistentState.selectedConnection,
+                                        reportFolders.value,
+                                    );
+                                } else {
+                                    fetchErrors.push(getAxiosErrorMessage(reportFolders.reason));
+                                }
+
+                                if (performanceFolders.status === 'fulfilled') {
+                                    updateSavedPerformanceFolders(
+                                        remote.persistentState.selectedConnection,
+                                        performanceFolders.value,
+                                    );
+                                } else {
+                                    fetchErrors.push(getAxiosErrorMessage(performanceFolders.reason));
+                                }
+
+                                if (fetchErrors.length > 0) {
+                                    createToastNotification(
+                                        'Folder list sync error',
+                                        fetchErrors.join('; '),
+                                        ToastType.ERROR,
+                                    );
+                                }
                             }
                         } catch (err: unknown) {
-                            const message = axios.isAxiosError(err) ? err.response?.data : GENERIC_ERROR_MESSAGE;
+                            const message = getAxiosErrorMessage(err);
 
                             createToastNotification('Folder list sync error', message, ToastType.ERROR);
                         } finally {

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -7,7 +7,6 @@ import { FC, useEffect, useMemo, useState } from 'react';
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
-import axios from 'axios';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
@@ -29,29 +28,6 @@ import RemoteSyncButton from './RemoteSyncButton';
 import { updateInstance } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
 import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
-
-const GENERIC_ERROR_MESSAGE = 'An unknown error occurred.';
-
-const getAxiosErrorMessage = (err: unknown): string => {
-    if (!axios.isAxiosError(err)) {
-        return GENERIC_ERROR_MESSAGE;
-    }
-
-    const responseData = err.response?.data;
-    if (typeof responseData === 'string' && responseData.trim().length > 0) {
-        return responseData;
-    }
-
-    if (responseData && typeof responseData === 'object' && 'message' in responseData) {
-        const { message } = responseData;
-
-        if (typeof message === 'string' && message.trim().length > 0) {
-            return message;
-        }
-    }
-
-    return err.message || GENERIC_ERROR_MESSAGE;
-};
 
 const RemoteSyncConfigurator: FC = () => {
     const remote = useRemoteConnection();
@@ -394,7 +370,7 @@ const RemoteSyncConfigurator: FC = () => {
                                         reportFolders.value,
                                     );
                                 } else {
-                                    fetchErrors.push(getAxiosErrorMessage(reportFolders.reason));
+                                    fetchErrors.push(getResponseError(reportFolders.reason));
                                 }
 
                                 if (performanceFolders.status === 'fulfilled') {
@@ -403,7 +379,7 @@ const RemoteSyncConfigurator: FC = () => {
                                         performanceFolders.value,
                                     );
                                 } else {
-                                    fetchErrors.push(getAxiosErrorMessage(performanceFolders.reason));
+                                    fetchErrors.push(getResponseError(performanceFolders.reason));
                                 }
 
                                 if (fetchErrors.length > 0) {
@@ -415,11 +391,7 @@ const RemoteSyncConfigurator: FC = () => {
                                 }
                             }
                         } catch (err: unknown) {
-                            createToastNotification(
-                                'Folder list sync error',
-                                getAxiosErrorMessage(err),
-                                ToastType.ERROR,
-                            );
+                            createToastNotification('Folder list sync error', getResponseError(err), ToastType.ERROR);
                         } finally {
                             setIsFetching(false);
                         }

--- a/src/definitions/ConnectionStatus.ts
+++ b/src/definitions/ConnectionStatus.ts
@@ -7,6 +7,7 @@ export enum ConnectionTestStates {
     PROGRESS,
     FAILED,
     OK,
+    WARNING,
 }
 
 export interface ConnectionStatus {

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import axios from 'axios';
+import axios, { HttpStatusCode } from 'axios';
 import { useCallback } from 'react';
 import { ConnectionTestStates } from '../definitions/ConnectionStatus';
 import { MountRemoteFolder, RemoteConnection, RemoteFolder } from '../definitions/RemoteConnection';
@@ -49,6 +49,11 @@ const useRemoteConnection = () => {
         }
 
         const response = await axiosInstance.post<RemoteFolder[]>(`${Endpoints.REMOTE}/profiler`, connection);
+
+        if (response.status === HttpStatusCode.NoContent) {
+            return [];
+        }
+
         const reportFolders = Array.isArray(response.data) ? response.data : [];
 
         return reportFolders.map(normaliseReportFolder) as RemoteFolder[];
@@ -64,6 +69,11 @@ const useRemoteConnection = () => {
         }
 
         const response = await axiosInstance.post<RemoteFolder[]>(`${Endpoints.REMOTE}/performance`, connection);
+
+        if (response.status === HttpStatusCode.NoContent) {
+            return [];
+        }
+
         const performanceFolders = Array.isArray(response.data) ? response.data : [];
 
         return performanceFolders;

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -49,8 +49,9 @@ const useRemoteConnection = () => {
         }
 
         const response = await axiosInstance.post<RemoteFolder[]>(`${Endpoints.REMOTE}/profiler`, connection);
+        const reportFolders = Array.isArray(response.data) ? response.data : [];
 
-        return response.data.map(normaliseReportFolder) as RemoteFolder[];
+        return reportFolders.map(normaliseReportFolder) as RemoteFolder[];
     };
 
     const listPerformanceFolders = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
@@ -63,8 +64,9 @@ const useRemoteConnection = () => {
         }
 
         const response = await axiosInstance.post<RemoteFolder[]>(`${Endpoints.REMOTE}/performance`, connection);
+        const performanceFolders = Array.isArray(response.data) ? response.data : [];
 
-        return response.data;
+        return performanceFolders;
     };
 
     const syncRemoteFolder = async (

--- a/src/scss/components/ConnectionTestMessage.scss
+++ b/src/scss/components/ConnectionTestMessage.scss
@@ -6,7 +6,7 @@
 
 .connection-test-message {
     display: inline-flex;
-    gap: 2px;
+    gap: 6px;
     flex-basis: 100%;
 
     &:last-of-type {


### PR DESCRIPTION
This PR allows you to set empty folders as paths for remote machines even if they are empty or don't have valid reports in them, it will now display a warning.

The main benefit of this is setting up a remote connection which has no generated reports, but will do.

<img width="1262" height="884" alt="Screenshot 2026-04-20 at 16 23 51" src="https://github.com/user-attachments/assets/65dbdb93-ced8-49f3-96e8-dc3abdf3bc09" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1371.