### PR TITLE
Feature/Avoid performance filter wrapping

### DIFF
--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -465,10 +465,10 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                     )}
                 </div>
 
-                <div className='option-row'>
+                <div className='filters-container'>
                     <FormGroup
                         subLabel='Filters'
-                        className='form-group'
+                        className='form-group option-row'
                     >
                         <ButtonGroup className='select-group'>
                             <SearchField
@@ -485,98 +485,98 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                                 updateHandler={setActiveRawOpCodeFilterList}
                             />
                         </ButtonGroup>
-
-                        {!isStackedView && (
-                            <>
-                                <ButtonGroup className='select-group'>
-                                    <MultiSelectField<TypedPerfTableRow, 'buffer_type'>
-                                        keyName='buffer_type'
-                                        options={processedRows || []}
-                                        labelFormatter={(value: BufferType | null) =>
-                                            value !== null ? BufferTypeLabel[value] : 'No value'
-                                        }
-                                        placeholder='Select Buffer Type...'
-                                        values={activeBufferTypeFilterList}
-                                        updateHandler={setActiveBufferTypeFilterList}
-                                    />
-
-                                    <MultiSelectField<TypedPerfTableRow, 'layout'>
-                                        keyName='layout'
-                                        options={processedRows || []}
-                                        labelFormatter={(value: DeviceOperationLayoutTypes | null) =>
-                                            value !== null ? value : 'No value'
-                                        }
-                                        placeholder='Select Layout...'
-                                        values={activeLayoutFilterList}
-                                        updateHandler={setActiveLayoutFilterList}
-                                    />
-
-                                    <MultiSelectField<TypedPerfTableRow, 'math_fidelity'>
-                                        keyName='math_fidelity'
-                                        options={processedRows || []}
-                                        placeholder='Select Math Fidelity...'
-                                        values={activeMathFilterList}
-                                        updateHandler={setActiveMathFilterList}
-                                        disabled={isStackedView}
-                                    />
-                                </ButtonGroup>
-
-                                <ButtonGroup className='switch-group'>
-                                    <Switch
-                                        label='Matmul optimization analysis'
-                                        onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
-                                        checked={provideMatmulAdvice}
-                                        className='option-switch'
-                                        disabled={isStackedView}
-                                    />
-
-                                    <Switch
-                                        label='Highlight high dispatch ops'
-                                        onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
-                                        checked={hiliteHighDispatch}
-                                        className='option-switch'
-                                        disabled={isStackedView}
-                                    />
-
-                                    <Tooltip
-                                        content='Tries to match up operations between the performance reports'
-                                        position={Position.TOP}
-                                    >
-                                        <Switch
-                                            label='Normalise data'
-                                            disabled={!activeComparisonReportList || isStackedView}
-                                            onChange={() => setUseNormalisedData(!useNormalisedData)}
-                                            checked={useNormalisedData}
-                                            className='option-switch'
-                                        />
-                                    </Tooltip>
-                                </ButtonGroup>
-                            </>
-                        )}
-
-                        {activeComparisonReportList && useNormalisedData && (
-                            <Tooltip
-                                content='Highlights rows where ops have been added or are missing after normalising the data'
-                                position={Position.TOP}
-                            >
-                                <Switch
-                                    label='Highlight row differences'
-                                    onChange={() => setHighlightRows(!highlightRows)}
-                                    disabled={!activeComparisonReportList || !useNormalisedData || isStackedView}
-                                    checked={highlightRows}
-                                    className='option-switch'
-                                />
-                            </Tooltip>
-                        )}
-
-                        {/* May keep this or remove it - undecided as yet */}
-                        {/* <Switch
-                            label='Show Hash Column'
-                            onChange={() => setShowHashColumn(!showHashColumn)}
-                            checked={showHashColumn}
-                            className='option-switch'
-                        /> */}
                     </FormGroup>
+
+                    {!isStackedView && (
+                        <FormGroup className='option-row'>
+                            <ButtonGroup className='select-group'>
+                                <MultiSelectField<TypedPerfTableRow, 'buffer_type'>
+                                    keyName='buffer_type'
+                                    options={processedRows || []}
+                                    labelFormatter={(value: BufferType | null) =>
+                                        value !== null ? BufferTypeLabel[value] : 'No value'
+                                    }
+                                    placeholder='Select Buffer Type...'
+                                    values={activeBufferTypeFilterList}
+                                    updateHandler={setActiveBufferTypeFilterList}
+                                />
+
+                                <MultiSelectField<TypedPerfTableRow, 'layout'>
+                                    keyName='layout'
+                                    options={processedRows || []}
+                                    labelFormatter={(value: DeviceOperationLayoutTypes | null) =>
+                                        value !== null ? value : 'No value'
+                                    }
+                                    placeholder='Select Layout...'
+                                    values={activeLayoutFilterList}
+                                    updateHandler={setActiveLayoutFilterList}
+                                />
+
+                                <MultiSelectField<TypedPerfTableRow, 'math_fidelity'>
+                                    keyName='math_fidelity'
+                                    options={processedRows || []}
+                                    placeholder='Select Math Fidelity...'
+                                    values={activeMathFilterList}
+                                    updateHandler={setActiveMathFilterList}
+                                    disabled={isStackedView}
+                                />
+                            </ButtonGroup>
+
+                            <ButtonGroup className='switch-group'>
+                                <Switch
+                                    label='Matmul optimization analysis'
+                                    onChange={() => setProvideMatmulAdvice(!provideMatmulAdvice)}
+                                    checked={provideMatmulAdvice}
+                                    className='option-switch'
+                                    disabled={isStackedView}
+                                />
+
+                                <Switch
+                                    label='Highlight high dispatch ops'
+                                    onChange={() => setHiliteHighDispatch(!hiliteHighDispatch)}
+                                    checked={hiliteHighDispatch}
+                                    className='option-switch'
+                                    disabled={isStackedView}
+                                />
+
+                                <Tooltip
+                                    content='Tries to match up operations between the performance reports'
+                                    position={Position.TOP}
+                                >
+                                    <Switch
+                                        label='Normalise data'
+                                        disabled={!activeComparisonReportList || isStackedView}
+                                        onChange={() => setUseNormalisedData(!useNormalisedData)}
+                                        checked={useNormalisedData}
+                                        className='option-switch'
+                                    />
+                                </Tooltip>
+                            </ButtonGroup>
+                        </FormGroup>
+                    )}
+
+                    {activeComparisonReportList && useNormalisedData && (
+                        <Tooltip
+                            content='Highlights rows where ops have been added or are missing after normalising the data'
+                            position={Position.TOP}
+                        >
+                            <Switch
+                                label='Highlight row differences'
+                                onChange={() => setHighlightRows(!highlightRows)}
+                                disabled={!activeComparisonReportList || !useNormalisedData || isStackedView}
+                                checked={highlightRows}
+                                className='option-switch'
+                            />
+                        </Tooltip>
+                    )}
+
+                    {/* May keep this or remove it - undecided as yet */}
+                    {/* <Switch
+                        label='Show Hash Column'
+                        onChange={() => setShowHashColumn(!showHashColumn)}
+                        checked={showHashColumn}
+                        className='option-switch'
+                    /> */}
                 </div>
 
                 <Tabs

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -17,7 +17,7 @@ $header-footer-border: 2px solid colours.$tt-grey-5;
     overflow: auto;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 12px;
 
     .report-tabs {
         > .bp6-tab-list {
@@ -59,6 +59,12 @@ $header-footer-border: 2px solid colours.$tt-grey-5;
         margin-bottom: 0;
     }
 
+    .filters-container {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+    }
+
     .option-row {
         display: flex;
         flex-wrap: nowrap;
@@ -72,6 +78,7 @@ $header-footer-border: 2px solid colours.$tt-grey-5;
         }
 
         .select-group {
+            align-items: flex-start;
             column-gap: 5px;
             margin-right: 10px;
         }


### PR DESCRIPTION
Adds a containing div and another row to manage the expanding filter size better.

**No filter**
<img width="1262" height="884" alt="Screenshot 2026-04-21 at 11 03 28" src="https://github.com/user-attachments/assets/e680ddd2-c0a0-431a-bf78-5d101b8af714" />

**With filters**
<img width="1262" height="884" alt="Screenshot 2026-04-21 at 11 03 36" src="https://github.com/user-attachments/assets/9ef492d6-8d8e-4b75-a716-d21d1f9ec1dc" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1417.