### PR TITLE
Fix/Memory zoom range resetting

### DIFF
--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -97,6 +97,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
             const { plotZoomRangeStart, plotZoomRangeEnd } = calculatePlotZoomRange();
             setZoomRangeStart(plotZoomRangeStart);
             setZoomRangeEnd(plotZoomRangeEnd);
+            didInitZoomRange.current = true;
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [details, isLoading, isPrevLoading, operationDetails, previousOperationDetails]);


### PR DESCRIPTION
Couldn't use this control as it would reset to the original value on mouseUp.

<img width="526" height="128" alt="Screenshot 2026-04-22 at 13 54 16" src="https://github.com/user-attachments/assets/ace45322-c617-4eff-a066-8e24b7a6d9a4" />
