### PR TITLE
Feature/L1 memory zoom behaviour

### DIFF
--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Button, ButtonGroup, ButtonVariant, Intent, Label, RangeSlider, Size, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom } from 'jotai';
@@ -43,9 +43,15 @@ import { StackTraceLanguage } from '../../definitions/StackTrace';
 import { L1_DEFAULT_MEMORY_SIZE } from '../../definitions/L1MemorySize';
 import MemoryPlotRenderer from './MemoryPlotRenderer';
 import { getMemoryAddress } from '../../functions/math';
+import useL1ZoomRange from '../../hooks/useL1ZoomRange';
 
 interface OperationDetailsProps {
     operationId: number;
+}
+
+interface ZoomMemoryChunk {
+    address: number;
+    size: number;
 }
 
 const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationId }) => {
@@ -65,14 +71,9 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
     const [isL1Active, setIsL1Active] = useState(true);
     const [isDramActive, setIsDramActive] = useState(false);
 
-    const [zoomRangeStart, setZoomRangeStart] = useState(0);
-    const [zoomRangeEnd, setZoomRangeEnd] = useState(0);
-
     const { data: operations } = useOperationsList();
     const l1start = useGetL1StartMarker();
     const l1end = useGetL1SmallMarker();
-
-    const didInitZoomRange = useRef(false);
 
     const {
         operationDetails: { data: operationDetails, isLoading, status },
@@ -87,26 +88,44 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
 
     const operation = operations?.find((op) => op.id === operationId);
     const { lateDeallocationsByOperation } = useGetTensorDeallocationReportByOperation();
+    const hasRequiredData =
+        !isLoading && !isPrevLoading && !!operationDetails && !!previousOperationDetails && !!operations;
+
     let details: OperationDetails | null = null;
+    let previousDetails: OperationDetails | null = null;
+    let memorySizeL1 = L1_DEFAULT_MEMORY_SIZE;
+    let memory: ZoomMemoryChunk[] = [];
 
-    useEffect(() => {
-        if (didInitZoomRange.current) {
-            return;
-        }
-        if (!isLoading && !isPrevLoading && operationDetails && previousOperationDetails && details !== null) {
-            const { plotZoomRangeStart, plotZoomRangeEnd } = calculatePlotZoomRange();
-            setZoomRangeStart(plotZoomRangeStart);
-            setZoomRangeEnd(plotZoomRangeEnd);
-            didInitZoomRange.current = true;
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [details, isLoading, isPrevLoading, operationDetails, previousOperationDetails]);
+    if (hasRequiredData) {
+        const deallocationReport = lateDeallocationsByOperation.get(operation?.id || -1) || [];
+        details = new OperationDetails(
+            operationDetails,
+            operations,
+            deallocationReport,
+            { l1start, l1end },
+            {
+                renderPattern: renderMemoryLayoutPattern,
+                lateDeallocation: showDeallocationReport,
+                showHex,
+            },
+        );
 
-    useEffect(() => {
-        didInitZoomRange.current = false;
-    }, [operationId]);
+        previousDetails = new OperationDetails(previousOperationDetails, operations, [], {
+            l1start,
+            l1end,
+        });
 
-    if (isLoading || isPrevLoading || !operationDetails || !previousOperationDetails || !operations) {
+        memorySizeL1 = details.memorySizeL1;
+        memory = details.memoryData().memory;
+    }
+
+    const { plotZoomRangeStart, plotZoomRangeEnd, zoomRangeStart, zoomRangeEnd, handleSetZoomRange } = useL1ZoomRange({
+        operationId,
+        memorySizeL1,
+        memory,
+    });
+
+    if (!hasRequiredData || !details || !previousDetails) {
         return (
             <>
                 <OperationDetailsNavigation
@@ -117,51 +136,8 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
             </>
         );
     }
-    const deallocationReport = lateDeallocationsByOperation.get(operation?.id || -1) || [];
-    details = new OperationDetails(
-        operationDetails,
-        operations,
-        deallocationReport,
-        { l1start, l1end },
-        {
-            renderPattern: renderMemoryLayoutPattern,
-            lateDeallocation: showDeallocationReport,
-            showHex,
-        },
-    );
-
-    const previousDetails: OperationDetails | null = new OperationDetails(previousOperationDetails, operations, [], {
-        l1start,
-        l1end,
-    });
-
     const l1Small = details.memoryData(BufferType.L1_SMALL);
-
-    const { memory, cbChartDataByOperation } = details.memoryData();
-    const { memory: previousMemory } = previousDetails.memoryData();
-
-    const { memorySizeL1 } = details;
-
-    const calculatePlotZoomRange = () => {
-        let plotZoomRangeStart = Math.min(
-            memory[0]?.address || memorySizeL1,
-            previousMemory[0]?.address || memorySizeL1,
-        );
-        let plotZoomRangeEnd = Math.max(
-            memory.length > 0 ? memory[memory.length - 1].address + memory[memory.length - 1].size : 0,
-            previousMemory.length > 0
-                ? previousMemory[previousMemory.length - 1].address + previousMemory[previousMemory.length - 1].size
-                : 0,
-        );
-
-        if (plotZoomRangeEnd < plotZoomRangeStart) {
-            plotZoomRangeStart = 0;
-            plotZoomRangeEnd = memorySizeL1;
-        }
-        return { plotZoomRangeStart, plotZoomRangeEnd };
-    };
-
-    const { plotZoomRangeStart, plotZoomRangeEnd } = calculatePlotZoomRange();
+    const { cbChartDataByOperation } = details.memoryData();
 
     const onDramDeltaClick = (event: Readonly<PlotMouseEventCustom>): void => {
         const { address, tensor } = event.points[0].data.memoryData;
@@ -387,8 +363,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                             icon={IconNames.RESET}
                                             intent={Intent.WARNING}
                                             onClick={() => {
-                                                setZoomRangeStart(plotZoomRangeStart);
-                                                setZoomRangeEnd(plotZoomRangeEnd);
+                                                handleSetZoomRange(plotZoomRangeStart, plotZoomRangeEnd);
                                             }}
                                         />
                                         {!zoomedInViewMainMemory && '(Requires buffer zoom to be enabled)'}
@@ -416,8 +391,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                             labelRenderer={(value) => getMemoryAddress(value, showHex)}
                                             value={[zoomRangeStart, zoomRangeEnd]}
                                             onChange={(value: number[]) => {
-                                                setZoomRangeStart(value[0]);
-                                                setZoomRangeEnd(value[1]);
+                                                handleSetZoomRange(value[0], value[1]);
                                             }}
                                             className='memory-zoom-range'
                                         />

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -88,7 +88,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
 
     const operation = operations?.find((op) => op.id === operationId);
     const { lateDeallocationsByOperation } = useGetTensorDeallocationReportByOperation();
-    const hasRequiredData =
+    const hasOperationDetails =
         !isLoading && !isPrevLoading && !!operationDetails && !!previousOperationDetails && !!operations;
 
     let details: OperationDetails | null = null;
@@ -96,7 +96,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
     let memorySizeL1 = L1_DEFAULT_MEMORY_SIZE;
     let memory: ZoomMemoryChunk[] = [];
 
-    if (hasRequiredData) {
+    if (hasOperationDetails) {
         const deallocationReport = lateDeallocationsByOperation.get(operation?.id || -1) || [];
         details = new OperationDetails(
             operationDetails,
@@ -127,7 +127,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
         },
     );
 
-    if (!hasRequiredData || !details || !previousDetails) {
+    if (!hasOperationDetails || !details || !previousDetails) {
         return (
             <>
                 <OperationDetailsNavigation

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -93,11 +93,13 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
 
     let details: OperationDetails | null = null;
     let previousDetails: OperationDetails | null = null;
+    let l1MemoryData: ReturnType<OperationDetails['memoryData']> | null = null;
     let memorySizeL1 = L1_DEFAULT_MEMORY_SIZE;
     let memory: ZoomMemoryChunk[] = [];
 
     if (hasOperationDetails) {
         const deallocationReport = lateDeallocationsByOperation.get(operation?.id || -1) || [];
+
         details = new OperationDetails(
             operationDetails,
             operations,
@@ -115,8 +117,9 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
             l1end,
         });
 
+        l1MemoryData = details.memoryData();
         memorySizeL1 = details.memorySizeL1;
-        memory = details.memoryData().memory;
+        memory = l1MemoryData.memory;
     }
 
     const { plotZoomRangeMin, plotZoomRangeMax, zoomRangeStart, zoomRangeEnd, handleSetZoomRange } = useMemoryZoomRange(
@@ -127,7 +130,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
         },
     );
 
-    if (!hasOperationDetails || !details || !previousDetails) {
+    if (!hasOperationDetails || !details || !previousDetails || !l1MemoryData) {
         return (
             <>
                 <OperationDetailsNavigation
@@ -139,7 +142,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
         );
     }
     const l1Small = details.memoryData(BufferType.L1_SMALL);
-    const { cbChartDataByOperation } = details.memoryData();
+    const { cbChartDataByOperation, chartData } = l1MemoryData;
 
     const onDramDeltaClick = (event: Readonly<PlotMouseEventCustom>): void => {
         const { address, tensor } = event.points[0].data.memoryData;
@@ -172,8 +175,6 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
 
     const inputOutputList = details.inputs.concat(details.outputs);
     const inputOutputAddressList: string = inputOutputList.map((tensor) => tensor.address).join(',');
-    const { chartData } = details.memoryData();
-
     return (
         <>
             <OperationDetailsNavigation

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -43,7 +43,7 @@ import { StackTraceLanguage } from '../../definitions/StackTrace';
 import { L1_DEFAULT_MEMORY_SIZE } from '../../definitions/L1MemorySize';
 import MemoryPlotRenderer from './MemoryPlotRenderer';
 import { getMemoryAddress } from '../../functions/math';
-import useL1ZoomRange from '../../hooks/useL1ZoomRange';
+import useMemoryZoomRange from '../../hooks/useMemoryZoomRange';
 
 interface OperationDetailsProps {
     operationId: number;
@@ -119,11 +119,13 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
         memory = details.memoryData().memory;
     }
 
-    const { plotZoomRangeMin, plotZoomRangeMax, zoomRangeStart, zoomRangeEnd, handleSetZoomRange } = useL1ZoomRange({
-        operationId,
-        memorySizeL1,
-        memory,
-    });
+    const { plotZoomRangeMin, plotZoomRangeMax, zoomRangeStart, zoomRangeEnd, handleSetZoomRange } = useMemoryZoomRange(
+        {
+            operationId,
+            memorySizeL1,
+            memory,
+        },
+    );
 
     if (!hasRequiredData || !details || !previousDetails) {
         return (

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -119,7 +119,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
         memory = details.memoryData().memory;
     }
 
-    const { plotZoomRangeStart, plotZoomRangeEnd, zoomRangeStart, zoomRangeEnd, handleSetZoomRange } = useL1ZoomRange({
+    const { plotZoomRangeMin, plotZoomRangeMax, zoomRangeStart, zoomRangeEnd, handleSetZoomRange } = useL1ZoomRange({
         operationId,
         memorySizeL1,
         memory,
@@ -355,15 +355,15 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                             className='memory-zoom-range-reset'
                                             disabled={
                                                 !zoomedInViewMainMemory ||
-                                                (plotZoomRangeStart === zoomRangeStart &&
-                                                    plotZoomRangeEnd === zoomRangeEnd)
+                                                (plotZoomRangeMin === zoomRangeStart &&
+                                                    plotZoomRangeMax === zoomRangeEnd)
                                             }
                                             size={Size.SMALL}
                                             variant={ButtonVariant.MINIMAL}
                                             icon={IconNames.RESET}
                                             intent={Intent.WARNING}
                                             onClick={() => {
-                                                handleSetZoomRange(plotZoomRangeStart, plotZoomRangeEnd);
+                                                handleSetZoomRange(plotZoomRangeMin, plotZoomRangeMax);
                                             }}
                                         />
                                         {!zoomedInViewMainMemory && '(Requires buffer zoom to be enabled)'}
@@ -373,7 +373,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                         className={classNames('l1-memory-renderer zoom-reference', {
                                             disabled: !zoomedInViewMainMemory,
                                         })}
-                                        plotZoomRange={[plotZoomRangeStart, plotZoomRangeEnd]}
+                                        plotZoomRange={[plotZoomRangeMin, plotZoomRangeMax]}
                                         chartDataList={[chartData]}
                                         isZoomedIn={zoomedInViewMainMemory}
                                         memorySize={memorySizeL1}
@@ -381,12 +381,12 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                     />
                                     <div className='zoom-range-wrap'>
                                         <RangeSlider
-                                            min={plotZoomRangeStart}
-                                            max={plotZoomRangeEnd}
+                                            min={plotZoomRangeMin}
+                                            max={plotZoomRangeMax}
                                             disabled={!zoomedInViewMainMemory}
                                             intent={Intent.WARNING}
                                             labelStepSize={
-                                                (plotZoomRangeEnd - plotZoomRangeStart) / 3 || L1_DEFAULT_MEMORY_SIZE
+                                                (plotZoomRangeMax - plotZoomRangeMin) / 3 || L1_DEFAULT_MEMORY_SIZE
                                             }
                                             labelRenderer={(value) => getMemoryAddress(value, showHex)}
                                             value={[zoomRangeStart, zoomRangeEnd]}

--- a/src/hooks/useL1ZoomRange.ts
+++ b/src/hooks/useL1ZoomRange.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useMemo, useState } from 'react';
+
+interface MemoryChunk {
+    address: number;
+    size: number;
+}
+
+interface UseZoomRangeProps {
+    operationId: number;
+    memorySizeL1: number;
+    memory: MemoryChunk[];
+}
+
+interface UseZoomRange {
+    plotZoomRangeStart: number;
+    plotZoomRangeEnd: number;
+    zoomRangeStart: number;
+    zoomRangeEnd: number;
+    handleSetZoomRange: (start: number, end: number) => void;
+}
+
+interface ZoomRange {
+    operationKey: symbol;
+    start: number;
+    end: number;
+}
+
+const useL1ZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeProps): UseZoomRange => {
+    const [zoomRange, setZoomRange] = useState<ZoomRange | null>(null);
+    const currentOperationKey = useMemo(() => Symbol(String(operationId)), [operationId]);
+    const canUserSetRange = zoomRange?.operationKey === currentOperationKey;
+
+    const { plotZoomRangeStart, plotZoomRangeEnd } = useMemo(() => {
+        let nextPlotZoomRangeStart = memory[0]?.address || memorySizeL1;
+        let nextPlotZoomRangeEnd =
+            memory.length > 0 ? memory[memory.length - 1].address + memory[memory.length - 1].size : 0;
+
+        if (nextPlotZoomRangeEnd < nextPlotZoomRangeStart) {
+            nextPlotZoomRangeStart = 0;
+            nextPlotZoomRangeEnd = memorySizeL1;
+        }
+
+        return {
+            plotZoomRangeStart: nextPlotZoomRangeStart,
+            plotZoomRangeEnd: nextPlotZoomRangeEnd,
+        };
+    }, [memory, memorySizeL1]);
+
+    const handleSetZoomRange = (start: number, end: number) => {
+        setZoomRange({
+            operationKey: currentOperationKey,
+            start,
+            end,
+        });
+    };
+
+    return {
+        plotZoomRangeStart,
+        plotZoomRangeEnd,
+        zoomRangeStart: canUserSetRange ? zoomRange?.start : plotZoomRangeStart,
+        zoomRangeEnd: canUserSetRange ? zoomRange?.end : plotZoomRangeEnd,
+        handleSetZoomRange,
+    };
+};
+
+export default useL1ZoomRange;

--- a/src/hooks/useL1ZoomRange.ts
+++ b/src/hooks/useL1ZoomRange.ts
@@ -16,8 +16,8 @@ interface UseZoomRangeProps {
 }
 
 interface UseZoomRange {
-    plotZoomRangeStart: number;
-    plotZoomRangeEnd: number;
+    plotZoomRangeMin: number;
+    plotZoomRangeMax: number;
     zoomRangeStart: number;
     zoomRangeEnd: number;
     handleSetZoomRange: (start: number, end: number) => void;
@@ -32,21 +32,21 @@ interface ZoomRange {
 const useL1ZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeProps): UseZoomRange => {
     const [zoomRange, setZoomRange] = useState<ZoomRange | null>(null);
     const currentOperationKey = useMemo(() => Symbol(String(operationId)), [operationId]);
-    const canUserSetRange = zoomRange?.operationKey === currentOperationKey;
+    const isCurrentOperation = zoomRange?.operationKey === currentOperationKey;
 
-    const { plotZoomRangeStart, plotZoomRangeEnd } = useMemo(() => {
-        let nextPlotZoomRangeStart = memory[0]?.address || memorySizeL1;
-        let nextPlotZoomRangeEnd =
+    const { plotZoomRangeMin, plotZoomRangeMax } = useMemo(() => {
+        let updatedPlotZoomRangeMin = memory[0]?.address || memorySizeL1;
+        let updatedPlotZoomRangeMax =
             memory.length > 0 ? memory[memory.length - 1].address + memory[memory.length - 1].size : 0;
 
-        if (nextPlotZoomRangeEnd < nextPlotZoomRangeStart) {
-            nextPlotZoomRangeStart = 0;
-            nextPlotZoomRangeEnd = memorySizeL1;
+        if (updatedPlotZoomRangeMax < updatedPlotZoomRangeMin) {
+            updatedPlotZoomRangeMin = 0;
+            updatedPlotZoomRangeMax = memorySizeL1;
         }
 
         return {
-            plotZoomRangeStart: nextPlotZoomRangeStart,
-            plotZoomRangeEnd: nextPlotZoomRangeEnd,
+            plotZoomRangeMin: updatedPlotZoomRangeMin,
+            plotZoomRangeMax: updatedPlotZoomRangeMax,
         };
     }, [memory, memorySizeL1]);
 
@@ -59,10 +59,10 @@ const useL1ZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeProps
     };
 
     return {
-        plotZoomRangeStart,
-        plotZoomRangeEnd,
-        zoomRangeStart: canUserSetRange ? zoomRange?.start : plotZoomRangeStart,
-        zoomRangeEnd: canUserSetRange ? zoomRange?.end : plotZoomRangeEnd,
+        plotZoomRangeMin,
+        plotZoomRangeMax,
+        zoomRangeStart: isCurrentOperation ? zoomRange?.start : plotZoomRangeMin,
+        zoomRangeEnd: isCurrentOperation ? zoomRange?.end : plotZoomRangeMax,
         handleSetZoomRange,
     };
 };

--- a/src/hooks/useMemoryZoomRange.ts
+++ b/src/hooks/useMemoryZoomRange.ts
@@ -35,7 +35,7 @@ const useMemoryZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeP
     const isCurrentOperation = zoomRange?.operationKey === currentOperationKey;
 
     const { plotZoomRangeMin, plotZoomRangeMax } = useMemo(() => {
-        let updatedPlotZoomRangeMin = memory[0]?.address || memorySizeL1;
+        let updatedPlotZoomRangeMin = memory[0]?.address ?? memorySizeL1;
         let updatedPlotZoomRangeMax =
             memory.length > 0 ? memory[memory.length - 1].address + memory[memory.length - 1].size : 0;
 
@@ -58,11 +58,13 @@ const useMemoryZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeP
         });
     };
 
+    const selectedZoomRange = isCurrentOperation && zoomRange !== null ? zoomRange : null;
+
     return {
         plotZoomRangeMin,
         plotZoomRangeMax,
-        zoomRangeStart: isCurrentOperation ? zoomRange?.start : plotZoomRangeMin,
-        zoomRangeEnd: isCurrentOperation ? zoomRange?.end : plotZoomRangeMax,
+        zoomRangeStart: selectedZoomRange ? selectedZoomRange.start : plotZoomRangeMin,
+        zoomRangeEnd: selectedZoomRange ? selectedZoomRange.end : plotZoomRangeMax,
         handleSetZoomRange,
     };
 };

--- a/src/hooks/useMemoryZoomRange.ts
+++ b/src/hooks/useMemoryZoomRange.ts
@@ -29,7 +29,7 @@ interface ZoomRange {
     end: number;
 }
 
-const useL1ZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeProps): UseZoomRange => {
+const useMemoryZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeProps): UseZoomRange => {
     const [zoomRange, setZoomRange] = useState<ZoomRange | null>(null);
     const currentOperationKey = useMemo(() => Symbol(String(operationId)), [operationId]);
     const isCurrentOperation = zoomRange?.operationKey === currentOperationKey;
@@ -67,4 +67,4 @@ const useL1ZoomRange = ({ operationId, memorySizeL1, memory }: UseZoomRangeProps
     };
 };
 
-export default useL1ZoomRange;
+export default useMemoryZoomRange;


### PR DESCRIPTION
Moved logic to a hook and ensured range is reset to the operation memory size on initial load.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1424.