### PR TITLE
Add lifetime to tensor API responses

### DIFF
--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -106,6 +106,17 @@ class ProducersConsumers(SerializeableDataclass):
 
 
 @dataclasses.dataclass
+class TensorLifetime(SerializeableDataclass):
+    producer_operation_id: Optional[int] = None
+    last_use_operation_id: Optional[int] = None
+    deallocate_operation_id: Optional[int] = None
+    producer_source_file: Optional[str] = None
+    producer_source_line: Optional[int] = None
+    last_use_source_file: Optional[str] = None
+    last_use_source_line: Optional[int] = None
+
+
+@dataclasses.dataclass
 class Tensor(SerializeableDataclass):
     tensor_id: int
     shape: str
@@ -117,6 +128,7 @@ class Tensor(SerializeableDataclass):
     buffer_type: BufferType
     device_addresses: list[int]
     size: Optional[int] = None
+    lifetime: Optional[TensorLifetime] = None
     rank: int = 0
 
     def __post_init__(self):

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -23,6 +23,7 @@ from ttnn_visualizer.models import (
     StackTrace,
     Tensor,
     TensorComparisonRecord,
+    TensorLifetime,
 )
 
 
@@ -300,6 +301,7 @@ class DatabaseQueries:
         rank_on_tensors = "rank" in tensor_columns
 
         device_tensors_exists = self._check_table_exists("device_tensors")
+        tensor_lifetime_exists = self._check_table_exists("tensor_lifetime")
         dt_rank = device_tensors_exists and "rank" in self._get_table_columns(
             "device_tensors"
         )
@@ -343,6 +345,31 @@ class DatabaseQueries:
         else:
             select_parts.append("NULL AS device_tensors_data")
 
+        if tensor_lifetime_exists:
+            select_parts.extend(
+                [
+                    "tl.producer_operation_id",
+                    "tl.last_use_operation_id",
+                    "tl.deallocate_operation_id",
+                    "tl.producer_source_file",
+                    "tl.producer_source_line",
+                    "tl.last_use_source_file",
+                    "tl.last_use_source_line",
+                ]
+            )
+        else:
+            select_parts.extend(
+                [
+                    "NULL AS producer_operation_id",
+                    "NULL AS last_use_operation_id",
+                    "NULL AS deallocate_operation_id",
+                    "NULL AS producer_source_file",
+                    "NULL AS producer_source_line",
+                    "NULL AS last_use_source_file",
+                    "NULL AS last_use_source_line",
+                ]
+            )
+
         select_sql = ",\n                        ".join(select_parts)
 
         group_by = "t.tensor_id"
@@ -353,6 +380,10 @@ class DatabaseQueries:
             join_lines = []
             if device_tensors_exists:
                 join_lines.append(f"LEFT JOIN device_tensors dt ON {dt_join}")
+            if tensor_lifetime_exists:
+                join_lines.append(
+                    "LEFT JOIN tensor_lifetime tl ON tl.tensor_id = t.tensor_id"
+                )
             join_sql = (
                 "\n                    " + "\n                    ".join(join_lines)
                 if join_lines
@@ -372,6 +403,10 @@ class DatabaseQueries:
             ]
             if device_tensors_exists:
                 join_lines.append(f"LEFT JOIN device_tensors dt ON {dt_join}")
+            if tensor_lifetime_exists:
+                join_lines.append(
+                    "LEFT JOIN tensor_lifetime tl ON tl.tensor_id = t.tensor_id"
+                )
             join_sql = "\n                    " + "\n                    ".join(
                 join_lines
             )
@@ -410,6 +445,32 @@ class DatabaseQueries:
             size = row[i]
             i += 1
             device_tensors_data = row[i]
+            i += 1
+
+            # Lifetime columns are always present in the SELECT (either real or NULL).
+            (
+                producer_operation_id,
+                last_use_operation_id,
+                deallocate_operation_id,
+                producer_source_file,
+                producer_source_line,
+                last_use_source_file,
+                last_use_source_line,
+            ) = row[i : i + 7]
+
+            # Only build a TensorLifetime object when the row actually joined
+            # (i.e., the table exists and at least one column has a value).
+            lifetime: Optional[TensorLifetime] = None
+            if tensor_lifetime_exists:
+                lifetime = TensorLifetime(
+                    producer_operation_id=producer_operation_id,
+                    last_use_operation_id=last_use_operation_id,
+                    deallocate_operation_id=deallocate_operation_id,
+                    producer_source_file=producer_source_file,
+                    producer_source_line=producer_source_line,
+                    last_use_source_file=last_use_source_file,
+                    last_use_source_line=last_use_source_line,
+                )
 
             device_addresses: List[Any] = []
 
@@ -441,6 +502,7 @@ class DatabaseQueries:
                 row[7],
                 device_addresses,
                 size=size,
+                lifetime=lifetime,
                 rank=rank_val,
             )
 

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -458,10 +458,22 @@ class DatabaseQueries:
                 last_use_source_line,
             ) = row[i : i + 7]
 
-            # Only build a TensorLifetime object when the row actually joined
-            # (i.e., the table exists and at least one column has a value).
+            # Only build a TensorLifetime object when the LEFT JOIN produced at
+            # least one non-NULL value, i.e. this tensor has a lifetime row.
+            # An all-NULL result means the table exists but has no entry for
+            # this tensor_id, so we keep lifetime=None to avoid sending empty
+            # objects for every unmatched tensor in large responses.
             lifetime: Optional[TensorLifetime] = None
-            if tensor_lifetime_exists:
+            lifetime_values = (
+                producer_operation_id,
+                last_use_operation_id,
+                deallocate_operation_id,
+                producer_source_file,
+                producer_source_line,
+                last_use_source_file,
+                last_use_source_line,
+            )
+            if tensor_lifetime_exists and any(v is not None for v in lifetime_values):
                 lifetime = TensorLifetime(
                     producer_operation_id=producer_operation_id,
                     last_use_operation_id=last_use_operation_id,

--- a/backend/ttnn_visualizer/tests/conftest.py
+++ b/backend/ttnn_visualizer/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from ttnn_visualizer.app import create_app
 from ttnn_visualizer.extensions import db
 from ttnn_visualizer.models import InstanceTable
+from ttnn_visualizer.tests.report_schemas import SCHEMA_V2
 
 
 @pytest.fixture
@@ -51,13 +52,13 @@ def make_report(app):
 
     Yields an inner function::
 
-        instance_id = make_report(schema_sql, inserts_sql="")
+        instance_id = make_report(inserts_sql="", schema_sql=SCHEMA_V2)
 
-    *schema_sql* should contain the ``CREATE TABLE`` statements for the schema
-    version under test.  *inserts_sql* is an optional second script with the
-    ``INSERT`` statements for that test's data.  The two scripts are executed
-    separately so that schema constants can be reused across tests while only
-    the data varies.
+    *inserts_sql* is an optional script with the ``INSERT`` statements for
+    that test's data.  *schema_sql* defaults to ``SCHEMA_V2`` (the current
+    baseline schema) and can be overridden to test backwards compatibility with
+    older schema versions.  Both arguments are optional so a bare
+    ``make_report()`` call produces an empty database with the default schema.
 
     The inner function registers the database as a profiler instance and
     returns the ``instance_id`` string to pass as ``?instanceId=`` in API
@@ -66,7 +67,7 @@ def make_report(app):
     paths = []
     counter = [0]
 
-    def _make(schema_sql, inserts_sql=""):
+    def _make(inserts_sql="", schema_sql=SCHEMA_V2):
         counter[0] += 1
         instance_id = f"pytest-make-report-{counter[0]}"
 

--- a/backend/ttnn_visualizer/tests/conftest.py
+++ b/backend/ttnn_visualizer/tests/conftest.py
@@ -7,12 +7,14 @@ Pytest fixtures for API tests.
 """
 
 import shutil
+import sqlite3
 import tempfile
 from pathlib import Path
 
 import pytest
 from ttnn_visualizer.app import create_app
 from ttnn_visualizer.extensions import db
+from ttnn_visualizer.models import InstanceTable
 
 
 @pytest.fixture
@@ -41,3 +43,61 @@ def app():
 def client(app):
     """Flask test client for API requests (GET, POST, etc.)."""
     return app.test_client()
+
+
+@pytest.fixture
+def make_report(app):
+    """Fixture that creates a temporary SQLite report database.
+
+    Yields an inner function::
+
+        instance_id = make_report(schema_sql, inserts_sql="")
+
+    *schema_sql* should contain the ``CREATE TABLE`` statements for the schema
+    version under test.  *inserts_sql* is an optional second script with the
+    ``INSERT`` statements for that test's data.  The two scripts are executed
+    separately so that schema constants can be reused across tests while only
+    the data varies.
+
+    The inner function registers the database as a profiler instance and
+    returns the ``instance_id`` string to pass as ``?instanceId=`` in API
+    requests.  All temporary files are removed automatically after the test.
+    """
+    paths = []
+    counter = [0]
+
+    def _make(schema_sql, inserts_sql=""):
+        counter[0] += 1
+        instance_id = f"pytest-make-report-{counter[0]}"
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+            path = f.name
+        paths.append(path)
+
+        conn = sqlite3.connect(path)
+        conn.executescript(schema_sql)
+        if inserts_sql:
+            conn.executescript(inserts_sql)
+        conn.commit()
+        conn.close()
+
+        with app.app_context():
+            existing = InstanceTable.query.filter_by(instance_id=instance_id).first()
+            if existing:
+                db.session.delete(existing)
+                db.session.commit()
+            db.session.add(
+                InstanceTable(
+                    instance_id=instance_id,
+                    active_report={},
+                    profiler_path=path,
+                )
+            )
+            db.session.commit()
+
+        return instance_id
+
+    yield _make
+
+    for path in paths:
+        Path(path).unlink(missing_ok=True)

--- a/backend/ttnn_visualizer/tests/report_schemas.py
+++ b/backend/ttnn_visualizer/tests/report_schemas.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+SQL DDL constants representing historical TTNN report database schema versions.
+
+Import these into tests to build SQLite fixture databases via the
+``make_report`` fixture defined in conftest.py.  Each constant is a complete
+set of ``CREATE TABLE`` statements — no data rows — so test data can be
+supplied independently through the ``inserts_sql`` argument.
+"""
+
+SCHEMA_V2 = """
+CREATE TABLE devices (
+    device_id int,
+    num_y_cores int,
+    num_x_cores int,
+    num_y_compute_cores int,
+    num_x_compute_cores int,
+    worker_l1_size int,
+    l1_num_banks int,
+    l1_bank_size int,
+    address_at_first_l1_bank int,
+    address_at_first_l1_cb_buffer int,
+    num_banks_per_storage_core int,
+    num_compute_cores int,
+    num_storage_cores int,
+    total_l1_memory int,
+    total_l1_for_tensors int,
+    total_l1_for_interleaved_buffers int,
+    total_l1_for_sharded_buffers int,
+    cb_limit int
+);
+CREATE TABLE operations (
+    operation_id int UNIQUE,
+    name text,
+    duration float
+);
+CREATE TABLE operation_arguments (
+    operation_id int,
+    name text,
+    value text
+);
+CREATE TABLE tensors (
+    tensor_id int UNIQUE,
+    shape text,
+    dtype text,
+    layout text,
+    memory_config text,
+    device_id int,
+    address int,
+    buffer_type int
+);
+CREATE TABLE device_tensors (
+    tensor_id int,
+    device_id int,
+    address int
+);
+CREATE TABLE buffers (
+    operation_id int,
+    device_id int,
+    address int,
+    max_size_per_bank int,
+    buffer_type int,
+    buffer_layout int
+);
+CREATE TABLE captured_graph (
+    operation_id int,
+    captured_graph text
+);
+CREATE TABLE nodes (
+    operation_id int,
+    unique_id int,
+    node_operation_id int,
+    name text
+);
+CREATE TABLE edges (
+    operation_id int,
+    source_unique_id int,
+    sink_unique_id int,
+    source_output_index int,
+    sink_input_index int,
+    key int
+);
+CREATE TABLE report_metadata (
+    key text UNIQUE,
+    value text
+);
+CREATE TABLE errors (
+    operation_id int,
+    operation_name text,
+    error_type text,
+    error_message text,
+    stack_trace text,
+    timestamp text
+);
+CREATE TABLE stack_traces (
+    operation_id int,
+    stack_trace text
+);
+CREATE TABLE input_tensors (
+    operation_id int,
+    input_index int,
+    tensor_id int
+);
+CREATE TABLE output_tensors (
+    operation_id int,
+    output_index int,
+    tensor_id int
+);
+CREATE TABLE local_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE global_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE buffer_pages (
+    operation_id int,
+    device_id int,
+    address int,
+    core_y int,
+    core_x int,
+    bank_id int,
+    page_index int,
+    page_address int,
+    page_size int,
+    buffer_type int
+);
+"""
+
+SCHEMA_V2_WITH_LIFETIME = (
+    SCHEMA_V2
+    + """
+CREATE TABLE tensor_lifetime (
+    tensor_id int UNIQUE,
+    producer_operation_id int,
+    last_use_operation_id int,
+    deallocate_operation_id int,
+    producer_source_file text,
+    producer_source_line int,
+    last_use_source_file text,
+    last_use_source_line int
+);
+"""
+)

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -126,6 +126,7 @@ class TestSerializers(unittest.TestCase):
                         "buffer_type": 0,
                         "device_addresses": [25],
                         "size": None,
+                        "lifetime": None,
                     }
                 ],
                 "outputs": [
@@ -148,6 +149,7 @@ class TestSerializers(unittest.TestCase):
                         "buffer_type": 0,
                         "device_addresses": [25],
                         "size": None,
+                        "lifetime": None,
                     }
                 ],
                 "error": None,
@@ -341,6 +343,7 @@ class TestSerializers(unittest.TestCase):
                     "buffer_type": 0,
                     "device_addresses": [25],
                     "size": None,
+                    "lifetime": None,
                 }
             ]
         }
@@ -366,6 +369,7 @@ class TestSerializers(unittest.TestCase):
                     "buffer_type": 0,
                     "device_addresses": [25],
                     "size": None,
+                    "lifetime": None,
                 }
             ]
         }
@@ -450,6 +454,7 @@ class TestSerializers(unittest.TestCase):
                     "shape": "shape1",
                     "device_addresses": [200, 300],
                     "size": None,
+                    "lifetime": None,
                     "rank": 0,
                 }
             ],
@@ -474,6 +479,7 @@ class TestSerializers(unittest.TestCase):
                     "shape": "shape1",
                     "device_addresses": [200, 300],
                     "size": None,
+                    "lifetime": None,
                     "rank": 0,
                 }
             ],
@@ -596,6 +602,7 @@ class TestSerializers(unittest.TestCase):
                 "producers": [2],
                 "device_addresses": [500, 1500],
                 "size": None,
+                "lifetime": None,
                 "rank": 0,
             },
             {
@@ -615,6 +622,7 @@ class TestSerializers(unittest.TestCase):
                 "producers": [],
                 "device_addresses": [2000, 2500],
                 "size": None,
+                "lifetime": None,
                 "rank": 0,
             },
         ]

--- a/backend/ttnn_visualizer/tests/views/test_tensors.py
+++ b/backend/ttnn_visualizer/tests/views/test_tensors.py
@@ -185,11 +185,10 @@ def test_tensors_list_with_full_lifetime(app, client):
         # tensor_id must not appear inside the nested lifetime object.
         assert "tensor_id" not in t10["lifetime"]
 
-        # Tensor 20 has no lifetime row — should still be a dict (table exists)
-        # but all values are None.
+        # Tensor 20 has no lifetime row — lifetime must be null even though the
+        # table exists, to avoid sending empty objects in large responses.
         t20 = tensor_map[20]
-        assert t20["lifetime"] is not None
-        assert all(v is None for v in t20["lifetime"].values())
+        assert t20["lifetime"] is None
     finally:
         Path(path).unlink(missing_ok=True)
 
@@ -218,10 +217,9 @@ def test_tensors_list_partial_lifetime_fields_are_nullable(app, client):
         assert t20["lifetime"]["last_use_source_file"] is None
         assert t20["lifetime"]["last_use_source_line"] is None
 
-        # Tensor 10 has no lifetime row at all — all fields should be None.
+        # Tensor 10 has no lifetime row at all — lifetime must be null.
         t10 = tensor_map[10]
-        assert t10["lifetime"] is not None
-        assert all(v is None for v in t10["lifetime"].values())
+        assert t10["lifetime"] is None
     finally:
         Path(path).unlink(missing_ok=True)
 

--- a/backend/ttnn_visualizer/tests/views/test_tensors.py
+++ b/backend/ttnn_visualizer/tests/views/test_tensors.py
@@ -6,19 +6,13 @@
 API tests for tensor endpoints, including optional tensor_lifetime support.
 """
 
-import sqlite3
-import tempfile
 from http import HTTPStatus
-from pathlib import Path
 
-import pytest
-from ttnn_visualizer.extensions import db
-from ttnn_visualizer.models import InstanceTable
+# ---------------------------------------------------------------------------
+# Schema versions
+# ---------------------------------------------------------------------------
 
-INSTANCE_ID = "pytest-tensors"
-
-# Schema without tensor_lifetime — simulates older report databases.
-_LEGACY_SCHEMA_SQL = """
+_SCHEMA_BASE = """
 CREATE TABLE operations (operation_id int UNIQUE, name text, duration float);
 CREATE TABLE tensors (
     tensor_id int UNIQUE,
@@ -53,6 +47,29 @@ CREATE TABLE global_tensor_comparison_records (
     desired_pcc float,
     actual_pcc float
 );
+"""
+
+_SCHEMA_WITH_LIFETIME = (
+    _SCHEMA_BASE
+    + """
+CREATE TABLE tensor_lifetime (
+    tensor_id int UNIQUE,
+    producer_operation_id int,
+    last_use_operation_id int,
+    deallocate_operation_id int,
+    producer_source_file text,
+    producer_source_line int,
+    last_use_source_file text,
+    last_use_source_line int
+);
+"""
+)
+
+# ---------------------------------------------------------------------------
+# Shared inserts
+# ---------------------------------------------------------------------------
+
+_BASE_INSERTS = """
 INSERT INTO operations VALUES (1, 'op_a', 1.0);
 INSERT INTO tensors VALUES (10, '(2, 4)', 'bfloat16', 'TILE', '{}', 0, 200, 0);
 INSERT INTO tensors VALUES (20, '(1,)', 'float32', 'ROW_MAJOR', '{}', 0, 300, 0);
@@ -62,166 +79,94 @@ INSERT INTO buffers VALUES (1, 0, 200, 512, 0);
 INSERT INTO buffers VALUES (1, 0, 300, 256, 0);
 """
 
-# Schema with tensor_lifetime, all fields populated for tensor 10.
-_LIFETIME_SCHEMA_SQL = (
-    _LEGACY_SCHEMA_SQL
-    + """
-CREATE TABLE tensor_lifetime (
-    tensor_id int UNIQUE,
-    producer_operation_id int,
-    last_use_operation_id int,
-    deallocate_operation_id int,
-    producer_source_file text,
-    producer_source_line int,
-    last_use_source_file text,
-    last_use_source_line int
-);
-INSERT INTO tensor_lifetime VALUES (
-    10,
-    1,
-    3,
-    5,
-    'model.py',
-    42,
-    'train.py',
-    99
-);
+# All lifetime fields populated for tensor 10.
+_FULL_LIFETIME_INSERT = """
+INSERT INTO tensor_lifetime VALUES (10, 1, 3, 5, 'model.py', 42, 'train.py', 99);
 """
-)
 
-# Schema with tensor_lifetime, but some fields are NULL for tensor 20.
-_PARTIAL_LIFETIME_SQL = (
-    _LEGACY_SCHEMA_SQL
-    + """
-CREATE TABLE tensor_lifetime (
-    tensor_id int UNIQUE,
-    producer_operation_id int,
-    last_use_operation_id int,
-    deallocate_operation_id int,
-    producer_source_file text,
-    producer_source_line int,
-    last_use_source_file text,
-    last_use_source_line int
-);
+# Only producer_operation_id set for tensor 20; every other field is NULL.
+_PARTIAL_LIFETIME_INSERT = """
 INSERT INTO tensor_lifetime VALUES (20, 1, NULL, NULL, NULL, NULL, NULL, NULL);
 """
-)
-
-
-def _write_db(path: str, sql: str) -> None:
-    conn = sqlite3.connect(path)
-    conn.executescript(sql)
-    conn.commit()
-    conn.close()
-
-
-def _register_instance(app, sqlite_path: str, instance_id: str = INSTANCE_ID) -> None:
-    with app.app_context():
-        existing = InstanceTable.query.filter_by(instance_id=instance_id).first()
-        if existing:
-            db.session.delete(existing)
-            db.session.commit()
-        row = InstanceTable(
-            instance_id=instance_id,
-            active_report={},
-            profiler_path=sqlite_path,
-        )
-        db.session.add(row)
-        db.session.commit()
-
 
 # ---------------------------------------------------------------------------
 # /api/tensors — list endpoint
 # ---------------------------------------------------------------------------
 
 
-def test_tensors_list_no_lifetime_table_returns_null_lifetime(app, client):
+def test_tensors_list_no_lifetime_table_returns_null_lifetime(client, make_report):
     """Older databases without tensor_lifetime should return lifetime: null."""
-    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
-    try:
-        _write_db(path, _LEGACY_SCHEMA_SQL)
-        _register_instance(app, path)
+    instance_id = make_report(_SCHEMA_BASE, _BASE_INSERTS)
 
-        response = client.get("/api/tensors", query_string={"instanceId": INSTANCE_ID})
-        assert response.status_code == HTTPStatus.OK
+    response = client.get("/api/tensors", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.OK
 
-        data = response.get_json()
-        assert isinstance(data, list)
-        assert len(data) == 2
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 2
 
-        for tensor in data:
-            assert "lifetime" in tensor
-            assert tensor["lifetime"] is None
-    finally:
-        Path(path).unlink(missing_ok=True)
+    for tensor in data:
+        assert "lifetime" in tensor
+        assert tensor["lifetime"] is None
 
 
-def test_tensors_list_with_full_lifetime(app, client):
+def test_tensors_list_with_full_lifetime(client, make_report):
     """Tensors with a tensor_lifetime row should include a populated lifetime object."""
-    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
-    try:
-        _write_db(path, _LIFETIME_SCHEMA_SQL)
-        _register_instance(app, path)
+    instance_id = make_report(
+        _SCHEMA_WITH_LIFETIME, _BASE_INSERTS + _FULL_LIFETIME_INSERT
+    )
 
-        response = client.get("/api/tensors", query_string={"instanceId": INSTANCE_ID})
-        assert response.status_code == HTTPStatus.OK
+    response = client.get("/api/tensors", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.OK
 
-        data = response.get_json()
-        tensor_map = {t["id"]: t for t in data}
+    data = response.get_json()
+    tensor_map = {t["id"]: t for t in data}
 
-        # Tensor 10 has a full lifetime row.
-        t10 = tensor_map[10]
-        assert t10["lifetime"] is not None
-        assert t10["lifetime"]["producer_operation_id"] == 1
-        assert t10["lifetime"]["last_use_operation_id"] == 3
-        assert t10["lifetime"]["deallocate_operation_id"] == 5
-        assert t10["lifetime"]["producer_source_file"] == "model.py"
-        assert t10["lifetime"]["producer_source_line"] == 42
-        assert t10["lifetime"]["last_use_source_file"] == "train.py"
-        assert t10["lifetime"]["last_use_source_line"] == 99
+    # Tensor 10 has a full lifetime row.
+    t10 = tensor_map[10]
+    assert t10["lifetime"] is not None
+    assert t10["lifetime"]["producer_operation_id"] == 1
+    assert t10["lifetime"]["last_use_operation_id"] == 3
+    assert t10["lifetime"]["deallocate_operation_id"] == 5
+    assert t10["lifetime"]["producer_source_file"] == "model.py"
+    assert t10["lifetime"]["producer_source_line"] == 42
+    assert t10["lifetime"]["last_use_source_file"] == "train.py"
+    assert t10["lifetime"]["last_use_source_line"] == 99
 
-        # tensor_id must not appear inside the nested lifetime object.
-        assert "tensor_id" not in t10["lifetime"]
+    # tensor_id must not appear inside the nested lifetime object.
+    assert "tensor_id" not in t10["lifetime"]
 
-        # Tensor 20 has no lifetime row — lifetime must be null even though the
-        # table exists, to avoid sending empty objects in large responses.
-        t20 = tensor_map[20]
-        assert t20["lifetime"] is None
-    finally:
-        Path(path).unlink(missing_ok=True)
+    # Tensor 20 has no lifetime row — lifetime must be null even though the
+    # table exists, to avoid sending empty objects in large responses.
+    t20 = tensor_map[20]
+    assert t20["lifetime"] is None
 
 
-def test_tensors_list_partial_lifetime_fields_are_nullable(app, client):
+def test_tensors_list_partial_lifetime_fields_are_nullable(client, make_report):
     """A tensor_lifetime row with some NULL fields is serialised with None values."""
-    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
-    try:
-        _write_db(path, _PARTIAL_LIFETIME_SQL)
-        _register_instance(app, path)
+    instance_id = make_report(
+        _SCHEMA_WITH_LIFETIME, _BASE_INSERTS + _PARTIAL_LIFETIME_INSERT
+    )
 
-        response = client.get("/api/tensors", query_string={"instanceId": INSTANCE_ID})
-        assert response.status_code == HTTPStatus.OK
+    response = client.get("/api/tensors", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.OK
 
-        data = response.get_json()
-        tensor_map = {t["id"]: t for t in data}
+    data = response.get_json()
+    tensor_map = {t["id"]: t for t in data}
 
-        t20 = tensor_map[20]
-        assert t20["lifetime"] is not None
-        assert t20["lifetime"]["producer_operation_id"] == 1
-        assert t20["lifetime"]["last_use_operation_id"] is None
-        assert t20["lifetime"]["deallocate_operation_id"] is None
-        assert t20["lifetime"]["producer_source_file"] is None
-        assert t20["lifetime"]["producer_source_line"] is None
-        assert t20["lifetime"]["last_use_source_file"] is None
-        assert t20["lifetime"]["last_use_source_line"] is None
+    t20 = tensor_map[20]
+    assert t20["lifetime"] is not None
+    assert t20["lifetime"]["producer_operation_id"] == 1
+    assert t20["lifetime"]["last_use_operation_id"] is None
+    assert t20["lifetime"]["deallocate_operation_id"] is None
+    assert t20["lifetime"]["producer_source_file"] is None
+    assert t20["lifetime"]["producer_source_line"] is None
+    assert t20["lifetime"]["last_use_source_file"] is None
+    assert t20["lifetime"]["last_use_source_line"] is None
 
-        # Tensor 10 has no lifetime row at all — lifetime must be null.
-        t10 = tensor_map[10]
-        assert t10["lifetime"] is None
-    finally:
-        Path(path).unlink(missing_ok=True)
+    # Tensor 10 has no lifetime row at all — lifetime must be null.
+    t10 = tensor_map[10]
+    assert t10["lifetime"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -229,67 +174,45 @@ def test_tensors_list_partial_lifetime_fields_are_nullable(app, client):
 # ---------------------------------------------------------------------------
 
 
-def test_tensor_detail_no_lifetime_table(app, client):
+def test_tensor_detail_no_lifetime_table(client, make_report):
     """Detail endpoint returns lifetime: null when table is absent."""
-    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
-    try:
-        _write_db(path, _LEGACY_SCHEMA_SQL)
-        _register_instance(app, path)
+    instance_id = make_report(_SCHEMA_BASE, _BASE_INSERTS)
 
-        response = client.get(
-            "/api/tensors/10", query_string={"instanceId": INSTANCE_ID}
-        )
-        assert response.status_code == HTTPStatus.OK
+    response = client.get("/api/tensors/10", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.OK
 
-        data = response.get_json()
-        assert data["tensor_id"] == 10
-        assert "lifetime" in data
-        assert data["lifetime"] is None
-    finally:
-        Path(path).unlink(missing_ok=True)
+    data = response.get_json()
+    assert data["tensor_id"] == 10
+    assert "lifetime" in data
+    assert data["lifetime"] is None
 
 
-def test_tensor_detail_with_lifetime(app, client):
+def test_tensor_detail_with_lifetime(client, make_report):
     """Detail endpoint includes a populated lifetime object when the table exists."""
-    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
-    try:
-        _write_db(path, _LIFETIME_SCHEMA_SQL)
-        _register_instance(app, path)
+    instance_id = make_report(
+        _SCHEMA_WITH_LIFETIME, _BASE_INSERTS + _FULL_LIFETIME_INSERT
+    )
 
-        response = client.get(
-            "/api/tensors/10", query_string={"instanceId": INSTANCE_ID}
-        )
-        assert response.status_code == HTTPStatus.OK
+    response = client.get("/api/tensors/10", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.OK
 
-        data = response.get_json()
-        assert data["tensor_id"] == 10
-        lifetime = data["lifetime"]
-        assert lifetime is not None
-        assert lifetime["producer_operation_id"] == 1
-        assert lifetime["last_use_operation_id"] == 3
-        assert lifetime["deallocate_operation_id"] == 5
-        assert lifetime["producer_source_file"] == "model.py"
-        assert lifetime["producer_source_line"] == 42
-        assert lifetime["last_use_source_file"] == "train.py"
-        assert lifetime["last_use_source_line"] == 99
-        assert "tensor_id" not in lifetime
-    finally:
-        Path(path).unlink(missing_ok=True)
+    data = response.get_json()
+    assert data["tensor_id"] == 10
+    lifetime = data["lifetime"]
+    assert lifetime is not None
+    assert lifetime["producer_operation_id"] == 1
+    assert lifetime["last_use_operation_id"] == 3
+    assert lifetime["deallocate_operation_id"] == 5
+    assert lifetime["producer_source_file"] == "model.py"
+    assert lifetime["producer_source_line"] == 42
+    assert lifetime["last_use_source_file"] == "train.py"
+    assert lifetime["last_use_source_line"] == 99
+    assert "tensor_id" not in lifetime
 
 
-def test_tensor_detail_not_found(app, client):
+def test_tensor_detail_not_found(client, make_report):
     """Requesting a non-existent tensor returns 404."""
-    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
-        path = f.name
-    try:
-        _write_db(path, _LEGACY_SCHEMA_SQL)
-        _register_instance(app, path)
+    instance_id = make_report(_SCHEMA_BASE, _BASE_INSERTS)
 
-        response = client.get(
-            "/api/tensors/9999", query_string={"instanceId": INSTANCE_ID}
-        )
-        assert response.status_code == HTTPStatus.NOT_FOUND
-    finally:
-        Path(path).unlink(missing_ok=True)
+    response = client.get("/api/tensors/9999", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.NOT_FOUND

--- a/backend/ttnn_visualizer/tests/views/test_tensors.py
+++ b/backend/ttnn_visualizer/tests/views/test_tensors.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+API tests for tensor endpoints, including optional tensor_lifetime support.
+"""
+
+import sqlite3
+import tempfile
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+from ttnn_visualizer.extensions import db
+from ttnn_visualizer.models import InstanceTable
+
+INSTANCE_ID = "pytest-tensors"
+
+# Schema without tensor_lifetime — simulates older report databases.
+_LEGACY_SCHEMA_SQL = """
+CREATE TABLE operations (operation_id int UNIQUE, name text, duration float);
+CREATE TABLE tensors (
+    tensor_id int UNIQUE,
+    shape text,
+    dtype text,
+    layout text,
+    memory_config text,
+    device_id int,
+    address int,
+    buffer_type int
+);
+CREATE TABLE input_tensors (operation_id int, input_index int, tensor_id int);
+CREATE TABLE output_tensors (operation_id int, output_index int, tensor_id int);
+CREATE TABLE buffers (
+    operation_id int,
+    device_id int,
+    address int,
+    max_size_per_bank int,
+    buffer_type int
+);
+CREATE TABLE local_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE global_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+INSERT INTO operations VALUES (1, 'op_a', 1.0);
+INSERT INTO tensors VALUES (10, '(2, 4)', 'bfloat16', 'TILE', '{}', 0, 200, 0);
+INSERT INTO tensors VALUES (20, '(1,)', 'float32', 'ROW_MAJOR', '{}', 0, 300, 0);
+INSERT INTO output_tensors VALUES (1, 0, 10);
+INSERT INTO input_tensors VALUES (1, 0, 20);
+INSERT INTO buffers VALUES (1, 0, 200, 512, 0);
+INSERT INTO buffers VALUES (1, 0, 300, 256, 0);
+"""
+
+# Schema with tensor_lifetime, all fields populated for tensor 10.
+_LIFETIME_SCHEMA_SQL = (
+    _LEGACY_SCHEMA_SQL
+    + """
+CREATE TABLE tensor_lifetime (
+    tensor_id int UNIQUE,
+    producer_operation_id int,
+    last_use_operation_id int,
+    deallocate_operation_id int,
+    producer_source_file text,
+    producer_source_line int,
+    last_use_source_file text,
+    last_use_source_line int
+);
+INSERT INTO tensor_lifetime VALUES (
+    10,
+    1,
+    3,
+    5,
+    'model.py',
+    42,
+    'train.py',
+    99
+);
+"""
+)
+
+# Schema with tensor_lifetime, but some fields are NULL for tensor 20.
+_PARTIAL_LIFETIME_SQL = (
+    _LEGACY_SCHEMA_SQL
+    + """
+CREATE TABLE tensor_lifetime (
+    tensor_id int UNIQUE,
+    producer_operation_id int,
+    last_use_operation_id int,
+    deallocate_operation_id int,
+    producer_source_file text,
+    producer_source_line int,
+    last_use_source_file text,
+    last_use_source_line int
+);
+INSERT INTO tensor_lifetime VALUES (20, 1, NULL, NULL, NULL, NULL, NULL, NULL);
+"""
+)
+
+
+def _write_db(path: str, sql: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(sql)
+    conn.commit()
+    conn.close()
+
+
+def _register_instance(app, sqlite_path: str, instance_id: str = INSTANCE_ID) -> None:
+    with app.app_context():
+        existing = InstanceTable.query.filter_by(instance_id=instance_id).first()
+        if existing:
+            db.session.delete(existing)
+            db.session.commit()
+        row = InstanceTable(
+            instance_id=instance_id,
+            active_report={},
+            profiler_path=sqlite_path,
+        )
+        db.session.add(row)
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# /api/tensors — list endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_tensors_list_no_lifetime_table_returns_null_lifetime(app, client):
+    """Older databases without tensor_lifetime should return lifetime: null."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_db(path, _LEGACY_SCHEMA_SQL)
+        _register_instance(app, path)
+
+        response = client.get("/api/tensors", query_string={"instanceId": INSTANCE_ID})
+        assert response.status_code == HTTPStatus.OK
+
+        data = response.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+        for tensor in data:
+            assert "lifetime" in tensor
+            assert tensor["lifetime"] is None
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_tensors_list_with_full_lifetime(app, client):
+    """Tensors with a tensor_lifetime row should include a populated lifetime object."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_db(path, _LIFETIME_SCHEMA_SQL)
+        _register_instance(app, path)
+
+        response = client.get("/api/tensors", query_string={"instanceId": INSTANCE_ID})
+        assert response.status_code == HTTPStatus.OK
+
+        data = response.get_json()
+        tensor_map = {t["id"]: t for t in data}
+
+        # Tensor 10 has a full lifetime row.
+        t10 = tensor_map[10]
+        assert t10["lifetime"] is not None
+        assert t10["lifetime"]["producer_operation_id"] == 1
+        assert t10["lifetime"]["last_use_operation_id"] == 3
+        assert t10["lifetime"]["deallocate_operation_id"] == 5
+        assert t10["lifetime"]["producer_source_file"] == "model.py"
+        assert t10["lifetime"]["producer_source_line"] == 42
+        assert t10["lifetime"]["last_use_source_file"] == "train.py"
+        assert t10["lifetime"]["last_use_source_line"] == 99
+
+        # tensor_id must not appear inside the nested lifetime object.
+        assert "tensor_id" not in t10["lifetime"]
+
+        # Tensor 20 has no lifetime row — should still be a dict (table exists)
+        # but all values are None.
+        t20 = tensor_map[20]
+        assert t20["lifetime"] is not None
+        assert all(v is None for v in t20["lifetime"].values())
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_tensors_list_partial_lifetime_fields_are_nullable(app, client):
+    """A tensor_lifetime row with some NULL fields is serialised with None values."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_db(path, _PARTIAL_LIFETIME_SQL)
+        _register_instance(app, path)
+
+        response = client.get("/api/tensors", query_string={"instanceId": INSTANCE_ID})
+        assert response.status_code == HTTPStatus.OK
+
+        data = response.get_json()
+        tensor_map = {t["id"]: t for t in data}
+
+        t20 = tensor_map[20]
+        assert t20["lifetime"] is not None
+        assert t20["lifetime"]["producer_operation_id"] == 1
+        assert t20["lifetime"]["last_use_operation_id"] is None
+        assert t20["lifetime"]["deallocate_operation_id"] is None
+        assert t20["lifetime"]["producer_source_file"] is None
+        assert t20["lifetime"]["producer_source_line"] is None
+        assert t20["lifetime"]["last_use_source_file"] is None
+        assert t20["lifetime"]["last_use_source_line"] is None
+
+        # Tensor 10 has no lifetime row at all — all fields should be None.
+        t10 = tensor_map[10]
+        assert t10["lifetime"] is not None
+        assert all(v is None for v in t10["lifetime"].values())
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# /api/tensors/<tensor_id> — detail endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_detail_no_lifetime_table(app, client):
+    """Detail endpoint returns lifetime: null when table is absent."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_db(path, _LEGACY_SCHEMA_SQL)
+        _register_instance(app, path)
+
+        response = client.get(
+            "/api/tensors/10", query_string={"instanceId": INSTANCE_ID}
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        data = response.get_json()
+        assert data["tensor_id"] == 10
+        assert "lifetime" in data
+        assert data["lifetime"] is None
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_tensor_detail_with_lifetime(app, client):
+    """Detail endpoint includes a populated lifetime object when the table exists."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_db(path, _LIFETIME_SCHEMA_SQL)
+        _register_instance(app, path)
+
+        response = client.get(
+            "/api/tensors/10", query_string={"instanceId": INSTANCE_ID}
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        data = response.get_json()
+        assert data["tensor_id"] == 10
+        lifetime = data["lifetime"]
+        assert lifetime is not None
+        assert lifetime["producer_operation_id"] == 1
+        assert lifetime["last_use_operation_id"] == 3
+        assert lifetime["deallocate_operation_id"] == 5
+        assert lifetime["producer_source_file"] == "model.py"
+        assert lifetime["producer_source_line"] == 42
+        assert lifetime["last_use_source_file"] == "train.py"
+        assert lifetime["last_use_source_line"] == 99
+        assert "tensor_id" not in lifetime
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_tensor_detail_not_found(app, client):
+    """Requesting a non-existent tensor returns 404."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_db(path, _LEGACY_SCHEMA_SQL)
+        _register_instance(app, path)
+
+        response = client.get(
+            "/api/tensors/9999", query_string={"instanceId": INSTANCE_ID}
+        )
+        assert response.status_code == HTTPStatus.NOT_FOUND
+    finally:
+        Path(path).unlink(missing_ok=True)

--- a/backend/ttnn_visualizer/tests/views/test_tensors.py
+++ b/backend/ttnn_visualizer/tests/views/test_tensors.py
@@ -3,67 +3,12 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 """
-API tests for tensor endpoints, including optional tensor_lifetime support.
+API tests for tensor endpoints.
 """
 
 from http import HTTPStatus
 
-# ---------------------------------------------------------------------------
-# Schema versions
-# ---------------------------------------------------------------------------
-
-_SCHEMA_BASE = """
-CREATE TABLE operations (operation_id int UNIQUE, name text, duration float);
-CREATE TABLE tensors (
-    tensor_id int UNIQUE,
-    shape text,
-    dtype text,
-    layout text,
-    memory_config text,
-    device_id int,
-    address int,
-    buffer_type int
-);
-CREATE TABLE input_tensors (operation_id int, input_index int, tensor_id int);
-CREATE TABLE output_tensors (operation_id int, output_index int, tensor_id int);
-CREATE TABLE buffers (
-    operation_id int,
-    device_id int,
-    address int,
-    max_size_per_bank int,
-    buffer_type int
-);
-CREATE TABLE local_tensor_comparison_records (
-    tensor_id int,
-    golden_tensor_id int,
-    matches int,
-    desired_pcc float,
-    actual_pcc float
-);
-CREATE TABLE global_tensor_comparison_records (
-    tensor_id int,
-    golden_tensor_id int,
-    matches int,
-    desired_pcc float,
-    actual_pcc float
-);
-"""
-
-_SCHEMA_WITH_LIFETIME = (
-    _SCHEMA_BASE
-    + """
-CREATE TABLE tensor_lifetime (
-    tensor_id int UNIQUE,
-    producer_operation_id int,
-    last_use_operation_id int,
-    deallocate_operation_id int,
-    producer_source_file text,
-    producer_source_line int,
-    last_use_source_file text,
-    last_use_source_line int
-);
-"""
-)
+from ttnn_visualizer.tests.report_schemas import SCHEMA_V2, SCHEMA_V2_WITH_LIFETIME
 
 # ---------------------------------------------------------------------------
 # Shared inserts
@@ -75,8 +20,8 @@ INSERT INTO tensors VALUES (10, '(2, 4)', 'bfloat16', 'TILE', '{}', 0, 200, 0);
 INSERT INTO tensors VALUES (20, '(1,)', 'float32', 'ROW_MAJOR', '{}', 0, 300, 0);
 INSERT INTO output_tensors VALUES (1, 0, 10);
 INSERT INTO input_tensors VALUES (1, 0, 20);
-INSERT INTO buffers VALUES (1, 0, 200, 512, 0);
-INSERT INTO buffers VALUES (1, 0, 300, 256, 0);
+INSERT INTO buffers VALUES (1, 0, 200, 512, 0, NULL);
+INSERT INTO buffers VALUES (1, 0, 300, 256, 0, NULL);
 """
 
 # All lifetime fields populated for tensor 10.
@@ -96,7 +41,7 @@ INSERT INTO tensor_lifetime VALUES (20, 1, NULL, NULL, NULL, NULL, NULL, NULL);
 
 def test_tensors_list_no_lifetime_table_returns_null_lifetime(client, make_report):
     """Older databases without tensor_lifetime should return lifetime: null."""
-    instance_id = make_report(_SCHEMA_BASE, _BASE_INSERTS)
+    instance_id = make_report(_BASE_INSERTS, SCHEMA_V2)
 
     response = client.get("/api/tensors", query_string={"instanceId": instance_id})
     assert response.status_code == HTTPStatus.OK
@@ -113,7 +58,7 @@ def test_tensors_list_no_lifetime_table_returns_null_lifetime(client, make_repor
 def test_tensors_list_with_full_lifetime(client, make_report):
     """Tensors with a tensor_lifetime row should include a populated lifetime object."""
     instance_id = make_report(
-        _SCHEMA_WITH_LIFETIME, _BASE_INSERTS + _FULL_LIFETIME_INSERT
+        _BASE_INSERTS + _FULL_LIFETIME_INSERT, SCHEMA_V2_WITH_LIFETIME
     )
 
     response = client.get("/api/tensors", query_string={"instanceId": instance_id})
@@ -145,7 +90,7 @@ def test_tensors_list_with_full_lifetime(client, make_report):
 def test_tensors_list_partial_lifetime_fields_are_nullable(client, make_report):
     """A tensor_lifetime row with some NULL fields is serialised with None values."""
     instance_id = make_report(
-        _SCHEMA_WITH_LIFETIME, _BASE_INSERTS + _PARTIAL_LIFETIME_INSERT
+        _BASE_INSERTS + _PARTIAL_LIFETIME_INSERT, SCHEMA_V2_WITH_LIFETIME
     )
 
     response = client.get("/api/tensors", query_string={"instanceId": instance_id})
@@ -176,7 +121,7 @@ def test_tensors_list_partial_lifetime_fields_are_nullable(client, make_report):
 
 def test_tensor_detail_no_lifetime_table(client, make_report):
     """Detail endpoint returns lifetime: null when table is absent."""
-    instance_id = make_report(_SCHEMA_BASE, _BASE_INSERTS)
+    instance_id = make_report(_BASE_INSERTS, SCHEMA_V2)
 
     response = client.get("/api/tensors/10", query_string={"instanceId": instance_id})
     assert response.status_code == HTTPStatus.OK
@@ -190,7 +135,7 @@ def test_tensor_detail_no_lifetime_table(client, make_report):
 def test_tensor_detail_with_lifetime(client, make_report):
     """Detail endpoint includes a populated lifetime object when the table exists."""
     instance_id = make_report(
-        _SCHEMA_WITH_LIFETIME, _BASE_INSERTS + _FULL_LIFETIME_INSERT
+        _BASE_INSERTS + _FULL_LIFETIME_INSERT, SCHEMA_V2_WITH_LIFETIME
     )
 
     response = client.get("/api/tensors/10", query_string={"instanceId": instance_id})
@@ -212,7 +157,7 @@ def test_tensor_detail_with_lifetime(client, make_report):
 
 def test_tensor_detail_not_found(client, make_report):
     """Requesting a non-existent tensor returns 404."""
-    instance_id = make_report(_SCHEMA_BASE, _BASE_INSERTS)
+    instance_id = make_report(_BASE_INSERTS)
 
     response = client.get("/api/tensors/9999", query_string={"instanceId": instance_id})
     assert response.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
This PR modifies the `/api/tensors` responses to include a new `lifetime` property. It will contain the tensor lifetime data being added on the TTNN side:

https://github.com/tenstorrent/tt-metal/pull/42907/

For legacy reports that do not contain the `tensor_lifetime` table, the value in the API response will be null. Likewise, it will also be null if there is no `tensor_lifetime` record for the given tensor. This is to not add unnecessary data to the responses, in particular when dealing with very large reports.

When any lifetime value is present, the whole nested object will be return in the API response. It looks like this:

```
"lifetime": {
  "producer_operation_id": 1,
  "last_use_operation_id": 1,
  "deallocate_operation_id": null,
  "producer_source_file": "/localdev/smountenay/tt-metal/models/demos/vision/classification/resnet50/ttnn_resnet/tt/ttnn_functional_resnet50.py",
  "producer_source_line": 425,
  "last_use_source_file": "/localdev/smountenay/tt-metal/models/demos/vision/classification/resnet50/ttnn_resnet/tt/ttnn_functional_resnet50.py",
  "last_use_source_line": 425
},
```

Each individual value may or may not be present. It depends on whether it was able to be detected by analyzing the graph capture JSON file, and whether the user has `enable_detailed_tensor_report` enabled or not on the TTNN side.

I have also introduced a new way of making reports in unit tests, with a `make_report` fixture.

[Closes #1427]