### PR TITLE
Bump flask socketio to 5.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 dependencies = [
     "build",
     "Flask-Cors==6.0.0",
-    "flask-socketio==5.4.1",
+    "flask-socketio==5.6.1",
     "flask-sqlalchemy==3.1.1",
     "Flask-Static-Digest==0.4.1",
     "Flask==3.1.3",


### PR DESCRIPTION
The attribute error was due to a version bump in the dependencies. Bumping flask-socketio to the latest version, 5.6.1, resolves the `AttributeError`.

[Closes #1432]