### PR TITLE
Feature/Optimise buffer summary

### DIFF
--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -2,10 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import classNames from 'classnames';
-import { Tooltip } from '@blueprintjs/core';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import {
@@ -20,12 +17,8 @@ import {
     useGetTensorDeallocationReportByOperation,
     useOperationsList,
 } from '../../hooks/useAPI';
-import MemoryPlotRenderer from '../operation-details/MemoryPlotRenderer';
 import LoadingSpinner from '../LoadingSpinner';
-import BufferSummaryRow from './BufferSummaryRow';
-import 'styles/components/BufferSummaryPlot.scss';
 import ROUTES from '../../definitions/Routes';
-import isValidNumber from '../../functions/isValidNumber';
 import {
     renderMemoryLayoutAtom,
     showBufferSummaryZoomedAtom,
@@ -34,19 +27,13 @@ import {
 } from '../../store/app';
 import { L1_DEFAULT_MEMORY_SIZE } from '../../definitions/L1MemorySize';
 import { ScrollLocations } from '../../definitions/VirtualLists';
-import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
-import useScrollShade from '../../hooks/useScrollShade';
-
 import { BuffersByOperation, MarkerTypeLabel } from '../../model/APIData';
-import useBufferNavigation from '../../hooks/useBufferNavigation';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
-import BufferSummaryPlotControls from './BufferSummaryPlotControls';
-import { TensorsByOperationByAddress } from '../../model/BufferSummary';
+import { TensorDeallocationReport, TensorsByOperationByAddress } from '../../model/BufferSummary';
+import { MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
+import BufferSummaryVirtualizedList from './BufferSummaryVirtualizedList';
 
-const PLACEHOLDER_ARRAY_SIZE = 50;
-const OPERATION_EL_HEIGHT = 25; // Height in px of each list item (including padding/margin)
-const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
-const MEMORY_ZOOM_PADDING_RATIO = 0.01;
+const EMPTY_TENSOR_DEALLOCATION_REPORT: TensorDeallocationReport[] = [];
 
 interface BufferSummaryPlotRendererProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
@@ -65,46 +52,8 @@ function BufferSummaryPlotRenderer({
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
     const navigate = useNavigate();
-    const scrollElementRef = useRef<HTMLDivElement>(null);
     const l1StartMarker = useGetL1StartMarker();
     const l1SmallMarker = useGetL1SmallMarker();
-    const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY);
-    const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
-
-    const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
-        useMemo(() => getListState(), [getListState]) ?? {};
-
-    // Disabling warning because it's a known limitation of Tanstack Virtual
-    // eslint-disable-next-line react-hooks/incompatible-library
-    const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
-        estimateSize: () => OPERATION_EL_HEIGHT,
-        getScrollElement: () => scrollElementRef.current,
-        overscan: 10,
-        initialMeasurementsCache: restoredMeasurementsCache,
-        count: uniqueBuffersByOperationList?.length || PLACEHOLDER_ARRAY_SIZE,
-        initialOffset: restoredOffset || 0,
-    });
-
-    useBufferNavigation({
-        buffersByOperation: uniqueBuffersByOperationList,
-        tensorListByOperation,
-        virtualizer,
-    });
-
-    const virtualItems = virtualizer.getVirtualItems();
-    const virtualHeight = virtualizer.getTotalSize() - TOTAL_SHADE_HEIGHT;
-
-    // Store latest values in refs for unmount cleanup
-    const scrollOffsetRef = useRef(virtualizer.scrollOffset);
-    const measurementsCacheRef = useRef(virtualizer.measurementsCache);
-
-    const numberOfOperations = useMemo(
-        () =>
-            uniqueBuffersByOperationList && uniqueBuffersByOperationList.length >= 0
-                ? uniqueBuffersByOperationList.length
-                : PLACEHOLDER_ARRAY_SIZE,
-        [uniqueBuffersByOperationList],
-    );
 
     const { lateDeallocationsByOperation: nonDeallocatedTensorsByOperationId } =
         useGetTensorDeallocationReportByOperation();
@@ -115,19 +64,15 @@ function BufferSummaryPlotRenderer({
     );
 
     const zoomedMemorySize = useMemo(() => {
-        let minValue: undefined | number;
-        let maxValue: undefined | number;
-
-        uniqueBuffersByOperationList?.forEach((operation) =>
-            operation.buffers.forEach((buffer) => {
-                minValue = isValidNumber(minValue) ? Math.min(minValue, buffer.address) : buffer.address;
-                maxValue = isValidNumber(maxValue)
-                    ? Math.max(maxValue, buffer.address + buffer.size)
-                    : buffer.address + buffer.size;
-            }),
+        const addresses = uniqueBuffersByOperationList.flatMap((operation) =>
+            operation.buffers.flatMap((buffer) => [buffer.address, buffer.address + buffer.size]),
         );
 
-        return minValue && maxValue ? [minValue, maxValue] : [0, memorySize];
+        if (addresses.length === 0) {
+            return [0, memorySize];
+        }
+
+        return [Math.min(...addresses), Math.max(...addresses)];
     }, [uniqueBuffersByOperationList, memorySize]);
 
     const memoryRegionsMarkers = showMemoryRegions
@@ -140,134 +85,41 @@ function BufferSummaryPlotRenderer({
     const zoomedMemorySizeEnd = zoomedMemorySize[1] || memorySize;
     const memoryPadding = (zoomedMemorySizeEnd - zoomedMemorySizeStart) * MEMORY_ZOOM_PADDING_RATIO;
 
-    const handleUserScrolling = useCallback(() => {
-        if (scrollElementRef.current) {
-            updateScrollShade(scrollElementRef.current);
-        }
-    }, [updateScrollShade]);
-
     const handleNavigateToOperation = (event: React.MouseEvent<HTMLAnchorElement>, path: string) => {
         event.preventDefault();
         navigate(path);
     };
 
-    // Keep stored refs updated
-    useEffect(() => {
-        scrollOffsetRef.current = virtualizer.scrollOffset;
-    }, [virtualizer.scrollOffset]);
-
-    useEffect(() => {
-        measurementsCacheRef.current = virtualizer.measurementsCache;
-    }, [virtualizer.measurementsCache]);
-
-    // Update stored list state on unmount
-    useEffect(() => {
-        return () => {
-            updateListState({
-                scrollOffset: scrollOffsetRef.current || 0,
-                measurementsCache: measurementsCacheRef.current,
-            });
-        };
-    }, [updateListState, uniqueBuffersByOperationList]);
-
     return uniqueBuffersByOperationList && !isLoadingDevices && tensorListByOperation ? (
-        <div className='buffer-summary-chart'>
-            <BufferSummaryPlotControls />
-
-            <p className='x-axis-label'>Memory Address</p>
-
-            <div className='chart-position'>
-                <MemoryPlotRenderer
-                    className='buffer-summary-plot'
-                    chartDataList={[
-                        [
-                            {
-                                x: [0],
-                                y: [1],
-                                type: 'bar',
-                                width: [0],
-                                marker: {
-                                    color: 'transparent',
-                                },
-                            },
-                        ],
-                    ]}
-                    isZoomedIn={isZoomedIn}
-                    memorySize={isZoomedIn ? zoomedMemorySizeEnd : memorySize}
-                    plotZoomRange={
-                        isZoomedIn
-                            ? [zoomedMemorySizeStart - memoryPadding, zoomedMemorySizeEnd + memoryPadding]
-                            : [0, memorySize]
-                    }
-                    configuration={BufferSummaryAxisConfiguration}
-                    markers={memoryRegionsMarkers}
-                />
-            </div>
-
-            <div
-                className={classNames('scrollable-element', {
-                    [shadeClasses.top]: hasScrolledFromTop,
-                    [shadeClasses.bottom]: !hasScrolledToBottom && numberOfOperations > virtualItems.length,
-                })}
-                onScroll={handleUserScrolling}
-                ref={scrollElementRef}
-            >
-                <div
-                    style={{
-                        // Div is sized to the maximum required to render all list items minus our shade element heights
-                        height: virtualHeight,
-                    }}
+        <BufferSummaryVirtualizedList
+            operations={uniqueBuffersByOperationList}
+            tensorListByOperation={tensorListByOperation}
+            isZoomedIn={isZoomedIn}
+            showMemoryLayout={renderMemoryLayout}
+            scrollLocation={ScrollLocations.BUFFER_SUMMARY}
+            memorySize={memorySize}
+            zoomStart={zoomedMemorySizeStart}
+            zoomEnd={zoomedMemorySizeEnd}
+            memoryPadding={memoryPadding}
+            axisConfiguration={BufferSummaryAxisConfiguration}
+            markers={memoryRegionsMarkers}
+            getTensorDeallocationReport={(operationId) =>
+                showDeallocationReport
+                    ? nonDeallocatedTensorsByOperationId.get(operationId) || EMPTY_TENSOR_DEALLOCATION_REPORT
+                    : EMPTY_TENSOR_DEALLOCATION_REPORT
+            }
+            getOperationTooltipContent={(operation) =>
+                `${operation.id} ${operation.name} (${operations?.find((op) => op.id === operation.id)?.operationFileIdentifier})`
+            }
+            renderOperationLink={(operation) => (
+                <a
+                    href={`${ROUTES.OPERATIONS}/${operation.id}`}
+                    onClick={(event) => handleNavigateToOperation(event, `${ROUTES.OPERATIONS}/${operation.id}`)}
                 >
-                    <div
-                        className='list-container'
-                        style={{
-                            // Tracks scroll position
-                            transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
-                        }}
-                    >
-                        {virtualItems.map((virtualRow) => {
-                            const operation = uniqueBuffersByOperationList[virtualRow.index];
-
-                            return operation ? (
-                                <div
-                                    className='buffer-summary-plot-container'
-                                    key={virtualRow.key}
-                                    data-index={virtualRow.index}
-                                >
-                                    <BufferSummaryRow
-                                        buffers={operation.buffers}
-                                        memoryStart={isZoomedIn ? zoomedMemorySizeStart : 0}
-                                        memoryEnd={isZoomedIn ? zoomedMemorySizeEnd : memorySize}
-                                        memoryPadding={memoryPadding}
-                                        tensorList={tensorListByOperation.get(operation.id)}
-                                        tensorDeallocationReport={
-                                            showDeallocationReport
-                                                ? nonDeallocatedTensorsByOperationId.get(operation.id) || []
-                                                : []
-                                        }
-                                        showMemoryLayout={renderMemoryLayout}
-                                    />
-
-                                    <Tooltip
-                                        content={`${operation.id} ${operation.name} (${operations?.find((op) => op.id === operation.id)?.operationFileIdentifier})`}
-                                        className='y-axis-tick'
-                                    >
-                                        <a
-                                            href={`${ROUTES.OPERATIONS}/${operation.id}`}
-                                            onClick={(event) =>
-                                                handleNavigateToOperation(event, `${ROUTES.OPERATIONS}/${operation.id}`)
-                                            }
-                                        >
-                                            {operation.id}&nbsp;{operation.name}
-                                        </a>
-                                    </Tooltip>
-                                </div>
-                            ) : null;
-                        })}
-                    </div>
-                </div>
-            </div>
-        </div>
+                    {operation.id}&nbsp;{operation.name}
+                </a>
+            )}
+        />
     ) : (
         <LoadingSpinner />
     );

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
 import { Tooltip } from '@blueprintjs/core';
@@ -61,7 +61,6 @@ function BufferSummaryPlotRenderer({
     const renderMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
-    const [activeRow, setActiveRow] = useState<number | null>(null);
 
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
@@ -80,7 +79,7 @@ function BufferSummaryPlotRenderer({
     const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
         estimateSize: () => OPERATION_EL_HEIGHT,
         getScrollElement: () => scrollElementRef.current,
-        overscan: 20,
+        overscan: 10,
         initialMeasurementsCache: restoredMeasurementsCache,
         count: uniqueBuffersByOperationList?.length || PLACEHOLDER_ARRAY_SIZE,
         initialOffset: restoredOffset || 0,
@@ -234,12 +233,8 @@ function BufferSummaryPlotRenderer({
                                     className='buffer-summary-plot-container'
                                     key={virtualRow.key}
                                     data-index={virtualRow.index}
-                                    ref={virtualizer.measureElement}
-                                    onMouseEnter={() => setActiveRow(operation.id)}
-                                    onMouseLeave={() => setActiveRow(null)}
                                 >
                                     <BufferSummaryRow
-                                        className={classNames({ 'is-active': operation.id === activeRow })}
                                         buffers={operation.buffers}
                                         memoryStart={isZoomedIn ? zoomedMemorySizeStart : 0}
                                         memoryEnd={isZoomedIn ? zoomedMemorySizeEnd : memorySize}

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -44,8 +44,8 @@ import BufferSummaryPlotControls from './BufferSummaryPlotControls';
 import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
-const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
-const TOTAL_SHADE_HEIGHT = 20; // Total height in px of 'scroll-shade' pseudo elements
+const OPERATION_EL_HEIGHT = 25; // Height in px of each list item (including padding/margin)
+const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
 const MEMORY_ZOOM_PADDING_RATIO = 0.01;
 
 interface BufferSummaryPlotRendererProps {

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -64,15 +64,21 @@ function BufferSummaryPlotRenderer({
     );
 
     const zoomedMemorySize = useMemo(() => {
-        const addresses = uniqueBuffersByOperationList.flatMap((operation) =>
-            operation.buffers.flatMap((buffer) => [buffer.address, buffer.address + buffer.size]),
-        );
+        let minAddress = Number.POSITIVE_INFINITY;
+        let maxAddress = Number.NEGATIVE_INFINITY;
 
-        if (addresses.length === 0) {
+        uniqueBuffersByOperationList.forEach((operation) => {
+            operation.buffers.forEach((buffer) => {
+                minAddress = Math.min(minAddress, buffer.address);
+                maxAddress = Math.max(maxAddress, buffer.address + buffer.size);
+            });
+        });
+
+        if (!Number.isFinite(minAddress) || !Number.isFinite(maxAddress)) {
             return [0, memorySize];
         }
 
-        return [Math.min(...addresses), Math.max(...addresses)];
+        return [minAddress, maxAddress];
     }, [uniqueBuffersByOperationList, memorySize]);
 
     const memoryRegionsMarkers = showMemoryRegions

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
 import { Tooltip } from '@blueprintjs/core';
@@ -55,7 +55,6 @@ function BufferSummaryPlotRendererDRAM({
     uniqueBuffersByOperationList,
     tensorListByOperation,
 }: BufferSummaryPlotRendererDRAMProps) {
-    const [activeRow, setActiveRow] = useState<number | null>(null);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
 
@@ -108,7 +107,7 @@ function BufferSummaryPlotRendererDRAM({
     const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
         estimateSize: () => OPERATION_EL_HEIGHT,
         getScrollElement: () => scrollElementRef.current,
-        overscan: 20,
+        overscan: 10,
         initialMeasurementsCache: restoredMeasurementsCache,
         count: segmentedChartData[0]?.length || PLACEHOLDER_ARRAY_SIZE,
         initialOffset: restoredOffset || 0,
@@ -210,12 +209,8 @@ function BufferSummaryPlotRendererDRAM({
                                             className='buffer-summary-plot-container'
                                             key={virtualRow.key}
                                             data-index={virtualRow.index}
-                                            ref={virtualizer.measureElement}
-                                            onMouseEnter={() => setActiveRow(operation.id)}
-                                            onMouseLeave={() => setActiveRow(null)}
                                         >
                                             <BufferSummaryRow
-                                                className={classNames({ 'is-active': operation.id === activeRow })}
                                                 buffers={operation.buffers}
                                                 // operationId={operation.id}
                                                 memoryStart={isZoomedIn ? (zoomedMemoryOptions[index]?.start ?? 0) : 0}

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -27,8 +27,8 @@ import BufferSummaryPlotControls from './BufferSummaryPlotControls';
 import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
-const OPERATION_EL_HEIGHT = 20; // Height in px of each list item
-const TOTAL_SHADE_HEIGHT = 20; // Height in px of 'scroll-shade' pseudo elements
+const OPERATION_EL_HEIGHT = 25; // Height in px of each list item (including padding/margin)
+const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
 const MEMORY_ZOOM_PADDING_RATIO = 0.01;
 const MEMORY_SIZE = DRAM_MEMORY_SIZE;
 

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -2,49 +2,21 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import classNames from 'classnames';
-import { Tooltip } from '@blueprintjs/core';
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import { PlotData } from 'plotly.js';
 import { BufferSummaryAxisConfiguration } from '../../definitions/PlotConfigurations';
-import MemoryPlotRenderer from '../operation-details/MemoryPlotRenderer';
 import LoadingSpinner from '../LoadingSpinner';
-import BufferSummaryRow from './BufferSummaryRow';
-import 'styles/components/BufferSummaryPlot.scss';
 import ROUTES from '../../definitions/Routes';
 import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../../store/app';
 import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
 import { ScrollLocations } from '../../definitions/VirtualLists';
-import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
-import useScrollShade from '../../hooks/useScrollShade';
-
 import { BuffersByOperation } from '../../model/APIData';
-import useBufferNavigation from '../../hooks/useBufferNavigation';
-import BufferSummaryPlotControls from './BufferSummaryPlotControls';
 import { TensorsByOperationByAddress } from '../../model/BufferSummary';
+import { MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
+import BufferSummaryVirtualizedList from './BufferSummaryVirtualizedList';
 
-const PLACEHOLDER_ARRAY_SIZE = 50;
-const OPERATION_EL_HEIGHT = 25; // Height in px of each list item (including padding/margin)
-const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
-const MEMORY_ZOOM_PADDING_RATIO = 0.01;
 const MEMORY_SIZE = DRAM_MEMORY_SIZE;
-
-const CHART_DATA: Partial<PlotData>[][] = [
-    [
-        {
-            x: [0],
-            y: [1],
-            type: 'bar',
-            width: [0],
-            marker: {
-                color: 'transparent',
-            },
-        },
-    ],
-];
 
 interface BufferSummaryPlotRendererDRAMProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
@@ -58,10 +30,6 @@ function BufferSummaryPlotRendererDRAM({
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
 
-    const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.BUFFER_SUMMARY_DRAM);
-    const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
-    const scrollElementRef = useRef(null);
-
     const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
         if (isZoomedIn) {
             return getSplitBuffers(uniqueBuffersByOperationList);
@@ -69,14 +37,6 @@ function BufferSummaryPlotRendererDRAM({
 
         return [uniqueBuffersByOperationList];
     }, [uniqueBuffersByOperationList, isZoomedIn]);
-
-    const numberOfOperations = useMemo(
-        () =>
-            segmentedChartData[0] && segmentedChartData[0].length >= 0
-                ? segmentedChartData[0].length
-                : PLACEHOLDER_ARRAY_SIZE,
-        [segmentedChartData],
-    );
 
     const zoomedMemoryOptions = useMemo(
         () =>
@@ -99,148 +59,25 @@ function BufferSummaryPlotRendererDRAM({
         [segmentedChartData],
     );
 
-    const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
-        useMemo(() => getListState(), [getListState]) ?? {};
-
-    // Disabling warning because it's a known limitation of Tanstack Virtual
-    // eslint-disable-next-line react-hooks/incompatible-library
-    const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
-        estimateSize: () => OPERATION_EL_HEIGHT,
-        getScrollElement: () => scrollElementRef.current,
-        overscan: 10,
-        initialMeasurementsCache: restoredMeasurementsCache,
-        count: segmentedChartData[0]?.length || PLACEHOLDER_ARRAY_SIZE,
-        initialOffset: restoredOffset || 0,
-    });
-
-    const virtualItems = virtualizer.getVirtualItems();
-    const virtualHeight = virtualizer.getTotalSize() - TOTAL_SHADE_HEIGHT;
-
-    // Store latest values in refs for unmount cleanup
-    const scrollOffsetRef = useRef(virtualizer.scrollOffset);
-    const measurementsCacheRef = useRef(virtualizer.measurementsCache);
-
-    const handleUserScrolling = useCallback(() => {
-        if (scrollElementRef.current) {
-            updateScrollShade(scrollElementRef.current);
-        }
-    }, [updateScrollShade]);
-
-    useBufferNavigation({
-        buffersByOperation: segmentedChartData[0],
-        tensorListByOperation,
-        virtualizer,
-    });
-
-    // Keep stored refs updated
-    useEffect(() => {
-        scrollOffsetRef.current = virtualizer.scrollOffset;
-    }, [virtualizer.scrollOffset]);
-
-    useEffect(() => {
-        measurementsCacheRef.current = virtualizer.measurementsCache;
-    }, [virtualizer.measurementsCache]);
-
-    // Update stored list state on unmount
-    useEffect(() => {
-        return () => {
-            updateListState({
-                scrollOffset: scrollOffsetRef.current || 0,
-                measurementsCache: measurementsCacheRef.current,
-            });
-        };
-    }, [updateListState, uniqueBuffersByOperationList]);
-
     return uniqueBuffersByOperationList && tensorListByOperation ? (
-        <div className='buffer-summary-chart'>
-            <BufferSummaryPlotControls />
-
-            <p className='x-axis-label'>Memory Address</p>
-
-            {segmentedChartData.slice(0, 1).map((segment, index) => (
-                <Fragment key={`${segment[index]?.name}-${index}`}>
-                    <div className='chart-position'>
-                        <MemoryPlotRenderer
-                            className='buffer-summary-plot'
-                            chartDataList={CHART_DATA}
-                            isZoomedIn={isZoomedIn}
-                            memorySize={isZoomedIn ? (zoomedMemoryOptions[index]?.end ?? MEMORY_SIZE) : MEMORY_SIZE}
-                            plotZoomRange={
-                                isZoomedIn
-                                    ? [
-                                          (zoomedMemoryOptions[index]?.start ?? 0) -
-                                              (zoomedMemoryOptions[index]?.padding ?? 0),
-
-                                          (zoomedMemoryOptions[index]?.end ?? MEMORY_SIZE) +
-                                              (zoomedMemoryOptions[index]?.padding ?? 0),
-                                      ]
-                                    : [0, MEMORY_SIZE]
-                            }
-                            configuration={BufferSummaryAxisConfiguration}
-                        />
-                    </div>
-
-                    <div
-                        className={classNames('scrollable-element', {
-                            [shadeClasses.top]: hasScrolledFromTop,
-                            [shadeClasses.bottom]: !hasScrolledToBottom && numberOfOperations > virtualItems.length,
-                        })}
-                        onScroll={handleUserScrolling}
-                        ref={scrollElementRef}
-                    >
-                        <div
-                            style={{
-                                // Div is sized to the maximum required to render all list items minus our shade element heights
-                                height: virtualHeight,
-                            }}
-                        >
-                            <div
-                                className='list-container'
-                                style={{
-                                    // Tracks scroll position
-                                    transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
-                                }}
-                            >
-                                {virtualItems.map((virtualRow) => {
-                                    const operation = segment[virtualRow.index];
-
-                                    return operation ? (
-                                        <div
-                                            className='buffer-summary-plot-container'
-                                            key={virtualRow.key}
-                                            data-index={virtualRow.index}
-                                        >
-                                            <BufferSummaryRow
-                                                buffers={operation.buffers}
-                                                // operationId={operation.id}
-                                                memoryStart={isZoomedIn ? (zoomedMemoryOptions[index]?.start ?? 0) : 0}
-                                                memoryEnd={
-                                                    isZoomedIn
-                                                        ? (zoomedMemoryOptions[index]?.end ?? MEMORY_SIZE)
-                                                        : MEMORY_SIZE
-                                                }
-                                                memoryPadding={zoomedMemoryOptions[index]?.padding ?? 0}
-                                                tensorList={tensorListByOperation.get(operation.id)}
-                                                showMemoryLayout={showMemoryLayout}
-                                            />
-
-                                            <Tooltip
-                                                content={`${operation.id} ${operation.name}`}
-                                                className='y-axis-tick'
-                                            >
-                                                <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
-                                                    {operation.id}&nbsp;{operation.name}
-                                                </Link>
-                                            </Tooltip>
-                                        </div>
-                                    ) : null;
-                                })}
-                            </div>
-                        </div>
-                    </div>
-                </Fragment>
-            ))}
-        </div>
+        <BufferSummaryVirtualizedList
+            operations={segmentedChartData[0] || []}
+            tensorListByOperation={tensorListByOperation}
+            isZoomedIn={isZoomedIn}
+            showMemoryLayout={showMemoryLayout}
+            scrollLocation={ScrollLocations.BUFFER_SUMMARY_DRAM}
+            memorySize={MEMORY_SIZE}
+            zoomStart={zoomedMemoryOptions[0]?.start ?? 0}
+            zoomEnd={zoomedMemoryOptions[0]?.end ?? MEMORY_SIZE}
+            memoryPadding={zoomedMemoryOptions[0]?.padding ?? 0}
+            axisConfiguration={BufferSummaryAxisConfiguration}
+            getOperationTooltipContent={(operation) => `${operation.id} ${operation.name}`}
+            renderOperationLink={(operation) => (
+                <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
+                    {operation.id}&nbsp;{operation.name}
+                </Link>
+            )}
+        />
     ) : (
         <LoadingSpinner />
     );

--- a/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
+++ b/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
@@ -17,12 +17,7 @@ import { BuffersByOperation } from '../../model/APIData';
 import useBufferNavigation from '../../hooks/useBufferNavigation';
 import BufferSummaryPlotControls from './BufferSummaryPlotControls';
 import { TensorDeallocationReport, TensorsByOperationByAddress } from '../../model/BufferSummary';
-import {
-    CHART_DATA,
-    OPERATION_EL_HEIGHT,
-    PLACEHOLDER_ARRAY_SIZE,
-    TOTAL_SHADE_HEIGHT,
-} from '../../definitions/BufferSummary';
+import { CHART_DATA, OPERATION_EL_HEIGHT, TOTAL_SHADE_HEIGHT } from '../../definitions/BufferSummary';
 
 interface BufferSummaryVirtualizedListProps {
     operations: BuffersByOperation[];
@@ -74,7 +69,7 @@ function BufferSummaryVirtualizedList({
         getScrollElement: () => scrollElementRef.current,
         overscan: 10,
         initialMeasurementsCache: restoredMeasurementsCache,
-        count: operations.length || PLACEHOLDER_ARRAY_SIZE,
+        count: operations.length,
         initialOffset: restoredOffset || 0,
     });
 

--- a/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
+++ b/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
@@ -41,6 +41,9 @@ interface BufferSummaryVirtualizedListProps {
     renderOperationLink: (operation: BuffersByOperation) => React.ReactNode;
 }
 
+const EMPTY_TENSOR_DEALLOCATION_REPORT: TensorDeallocationReport[] = [];
+const DEFAULT_GET_TENSOR_DEALLOCATION_REPORT = () => EMPTY_TENSOR_DEALLOCATION_REPORT;
+
 function BufferSummaryVirtualizedList({
     operations,
     tensorListByOperation,
@@ -53,7 +56,7 @@ function BufferSummaryVirtualizedList({
     memoryPadding,
     axisConfiguration,
     markers,
-    getTensorDeallocationReport = () => [],
+    getTensorDeallocationReport = DEFAULT_GET_TENSOR_DEALLOCATION_REPORT,
     getOperationTooltipContent,
     renderOperationLink,
 }: BufferSummaryVirtualizedListProps) {

--- a/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
+++ b/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import classNames from 'classnames';
+import { Tooltip } from '@blueprintjs/core';
+import { PlotConfiguration, PlotMarker } from '../../definitions/PlotConfigurations';
+import MemoryPlotRenderer from '../operation-details/MemoryPlotRenderer';
+import BufferSummaryRow from './BufferSummaryRow';
+import 'styles/components/BufferSummaryPlot.scss';
+import { ScrollLocations } from '../../definitions/VirtualLists';
+import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
+import useScrollShade from '../../hooks/useScrollShade';
+import { BuffersByOperation } from '../../model/APIData';
+import useBufferNavigation from '../../hooks/useBufferNavigation';
+import BufferSummaryPlotControls from './BufferSummaryPlotControls';
+import { TensorDeallocationReport, TensorsByOperationByAddress } from '../../model/BufferSummary';
+import {
+    CHART_DATA,
+    OPERATION_EL_HEIGHT,
+    PLACEHOLDER_ARRAY_SIZE,
+    TOTAL_SHADE_HEIGHT,
+} from '../../definitions/BufferSummary';
+
+interface BufferSummaryVirtualizedListProps {
+    operations: BuffersByOperation[];
+    tensorListByOperation: TensorsByOperationByAddress;
+    isZoomedIn: boolean;
+    showMemoryLayout: boolean;
+    scrollLocation: ScrollLocations;
+    memorySize: number;
+    zoomStart: number;
+    zoomEnd: number;
+    memoryPadding: number;
+    axisConfiguration: PlotConfiguration;
+    markers?: PlotMarker[];
+    getTensorDeallocationReport?: (operationId: number) => TensorDeallocationReport[];
+    getOperationTooltipContent: (operation: BuffersByOperation) => string;
+    renderOperationLink: (operation: BuffersByOperation) => React.ReactNode;
+}
+
+function BufferSummaryVirtualizedList({
+    operations,
+    tensorListByOperation,
+    isZoomedIn,
+    showMemoryLayout,
+    scrollLocation,
+    memorySize,
+    zoomStart,
+    zoomEnd,
+    memoryPadding,
+    axisConfiguration,
+    markers,
+    getTensorDeallocationReport = () => [],
+    getOperationTooltipContent,
+    renderOperationLink,
+}: BufferSummaryVirtualizedListProps) {
+    const { getListState, updateListState } = useRestoreScrollPosition(scrollLocation);
+    const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, shadeClasses } = useScrollShade();
+    const scrollElementRef = useRef<HTMLDivElement>(null);
+
+    const { scrollOffset: restoredOffset, measurementsCache: restoredMeasurementsCache } =
+        useMemo(() => getListState(), [getListState]) ?? {};
+
+    // Disabling warning because it's a known limitation of Tanstack Virtual
+    // eslint-disable-next-line react-hooks/incompatible-library
+    const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
+        estimateSize: () => OPERATION_EL_HEIGHT,
+        getScrollElement: () => scrollElementRef.current,
+        overscan: 10,
+        initialMeasurementsCache: restoredMeasurementsCache,
+        count: operations.length || PLACEHOLDER_ARRAY_SIZE,
+        initialOffset: restoredOffset || 0,
+    });
+
+    useBufferNavigation({
+        buffersByOperation: operations,
+        tensorListByOperation,
+        virtualizer,
+    });
+
+    const virtualItems = virtualizer.getVirtualItems();
+    const virtualHeight = virtualizer.getTotalSize() - TOTAL_SHADE_HEIGHT;
+
+    // Store latest values in refs for unmount cleanup
+    const scrollOffsetRef = useRef(virtualizer.scrollOffset);
+    const measurementsCacheRef = useRef(virtualizer.measurementsCache);
+
+    const handleUserScrolling = useCallback(() => {
+        if (scrollElementRef.current) {
+            updateScrollShade(scrollElementRef.current);
+        }
+    }, [updateScrollShade]);
+
+    // Keep stored refs updated
+    useEffect(() => {
+        scrollOffsetRef.current = virtualizer.scrollOffset;
+    }, [virtualizer.scrollOffset]);
+
+    useEffect(() => {
+        measurementsCacheRef.current = virtualizer.measurementsCache;
+    }, [virtualizer.measurementsCache]);
+
+    // Update stored list state on unmount
+    useEffect(() => {
+        return () => {
+            updateListState({
+                scrollOffset: scrollOffsetRef.current || 0,
+                measurementsCache: measurementsCacheRef.current,
+            });
+        };
+    }, [operations, updateListState]);
+
+    return (
+        <div className='buffer-summary-chart'>
+            <BufferSummaryPlotControls />
+
+            <p className='x-axis-label'>Memory Address</p>
+
+            <div className='chart-position'>
+                <MemoryPlotRenderer
+                    className='buffer-summary-plot'
+                    chartDataList={CHART_DATA}
+                    isZoomedIn={isZoomedIn}
+                    memorySize={isZoomedIn ? zoomEnd : memorySize}
+                    plotZoomRange={isZoomedIn ? [zoomStart - memoryPadding, zoomEnd + memoryPadding] : [0, memorySize]}
+                    configuration={axisConfiguration}
+                    markers={markers}
+                />
+            </div>
+
+            <div
+                className={classNames('scrollable-element', {
+                    [shadeClasses.top]: hasScrolledFromTop,
+                    [shadeClasses.bottom]: !hasScrolledToBottom && operations.length > virtualItems.length,
+                })}
+                onScroll={handleUserScrolling}
+                ref={scrollElementRef}
+            >
+                <div
+                    style={{
+                        // Div is sized to the maximum required to render all list items minus our shade element heights
+                        height: virtualHeight,
+                    }}
+                >
+                    <div
+                        className='list-container'
+                        style={{
+                            // Tracks scroll position
+                            transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
+                        }}
+                    >
+                        {virtualItems.map((virtualRow) => {
+                            const operation = operations[virtualRow.index];
+
+                            return operation ? (
+                                <div
+                                    className='buffer-summary-plot-container'
+                                    key={virtualRow.key}
+                                    data-index={virtualRow.index}
+                                >
+                                    <BufferSummaryRow
+                                        buffers={operation.buffers}
+                                        memoryStart={isZoomedIn ? zoomStart : 0}
+                                        memoryEnd={isZoomedIn ? zoomEnd : memorySize}
+                                        memoryPadding={memoryPadding}
+                                        tensorList={tensorListByOperation.get(operation.id)}
+                                        tensorDeallocationReport={getTensorDeallocationReport(operation.id)}
+                                        showMemoryLayout={showMemoryLayout}
+                                    />
+
+                                    <Tooltip
+                                        content={getOperationTooltipContent(operation)}
+                                        className='y-axis-tick'
+                                    >
+                                        {renderOperationLink(operation)}
+                                    </Tooltip>
+                                </div>
+                            ) : null;
+                        })}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default BufferSummaryVirtualizedList;

--- a/src/definitions/BufferSummary.ts
+++ b/src/definitions/BufferSummary.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { PlotData } from 'plotly.js';
+
 export enum SECTION_IDS {
     PLOT = 'plot',
     TABLE = 'table',
@@ -97,3 +99,22 @@ export const Columns: ColumnDefinition[] = [
 ];
 
 export type BufferTableFilters = Record<ColumnKeys, string>;
+
+export const PLACEHOLDER_ARRAY_SIZE = 50;
+export const OPERATION_EL_HEIGHT = 28; // Height in px of each list item (including padding/margin)
+export const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
+export const MEMORY_ZOOM_PADDING_RATIO = 0.01;
+
+export const CHART_DATA: Partial<PlotData>[][] = [
+    [
+        {
+            x: [0],
+            y: [1],
+            type: 'bar',
+            width: [0],
+            marker: {
+                color: 'transparent',
+            },
+        },
+    ],
+];

--- a/src/definitions/BufferSummary.ts
+++ b/src/definitions/BufferSummary.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { PlotData } from 'plotly.js';
+import type { PlotData } from 'plotly.js';
 
 export enum SECTION_IDS {
     PLOT = 'plot',

--- a/src/definitions/BufferSummary.ts
+++ b/src/definitions/BufferSummary.ts
@@ -100,7 +100,6 @@ export const Columns: ColumnDefinition[] = [
 
 export type BufferTableFilters = Record<ColumnKeys, string>;
 
-export const PLACEHOLDER_ARRAY_SIZE = 50;
 export const OPERATION_EL_HEIGHT = 28; // Height in px of each list item (including padding/margin)
 export const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
 export const MEMORY_ZOOM_PADDING_RATIO = 0.01;

--- a/src/scss/components/BufferSummaryPlot.scss
+++ b/src/scss/components/BufferSummaryPlot.scss
@@ -37,7 +37,8 @@ $height-offset: 15px;
     .buffer-summary-plot-container {
         display: grid;
         grid-template-columns: 1fr $label-width;
-        padding-bottom: 5px;
+        padding-top: 3px;
+        padding-bottom: 3px;
 
         &:hover {
             background-color: rgb(0 0 0 / 10%);

--- a/src/scss/components/BufferSummaryPlot.scss
+++ b/src/scss/components/BufferSummaryPlot.scss
@@ -40,7 +40,8 @@ $height-offset: 15px;
         padding-top: 3px;
         padding-bottom: 3px;
 
-        &:hover {
+        &:hover,
+        &:focus-within {
             background-color: rgb(0 0 0 / 10%);
         }
 

--- a/src/scss/components/BufferSummaryPlot.scss
+++ b/src/scss/components/BufferSummaryPlot.scss
@@ -39,6 +39,10 @@ $height-offset: 15px;
         grid-template-columns: 1fr $label-width;
         padding-bottom: 5px;
 
+        &:hover {
+            background-color: rgb(0 0 0 / 10%);
+        }
+
         .y-axis-tick {
             padding-left: $label-margin;
             margin-bottom: 0;

--- a/src/scss/components/BufferSummaryRow.scss
+++ b/src/scss/components/BufferSummaryRow.scss
@@ -9,10 +9,6 @@
     position: relative;
     overflow: hidden; // Prevents the buffer data from overflowing the row when a buffer is questionably large
 
-    &:hover {
-        background-color: rgb(0 0 0 / 10%);
-    }
-
     .buffer-data {
         height: 100%;
         position: absolute;

--- a/src/scss/components/BufferSummaryRow.scss
+++ b/src/scss/components/BufferSummaryRow.scss
@@ -9,7 +9,7 @@
     position: relative;
     overflow: hidden; // Prevents the buffer data from overflowing the row when a buffer is questionably large
 
-    &.is-active {
+    &:hover {
         background-color: rgb(0 0 0 / 10%);
     }
 


### PR DESCRIPTION
Replaces a state with a CSS only effect, reduces overscan to limit the number of additional rows in browser memory and removes unnecessary `virtualizer.measureElement` usages.

Related to https://github.com/tenstorrent/ttnn-visualizer/issues/1435.