### PR TITLE
Feature/Stacked host ops availability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic==2.12.5",
     "python-dotenv==1.2.2",
     "PyYAML==6.0.2",
-    "tt-perf-report==1.2.3",
+    "tt-perf-report==1.2.4",
     "uvicorn==0.30.1",
     "zstd==1.5.7.0"
 ]

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -419,8 +419,6 @@ const PerformanceReport: FC<PerformanceReportProps> = ({
                                 onChange={() => setHideHostOps(!hideHostOps)}
                                 checked={hideHostOps}
                                 className='option-switch'
-                                // Host Ops are missing when not grouped by memory is disabled - https://github.com/tenstorrent/ttnn-visualizer/issues/1268
-                                disabled={!isGroupedByMemory && isStackedView}
                             />
 
                             <Switch


### PR DESCRIPTION
Upgraded the `tt-perf-report` dependency to 1.2.4 and removed restrictions on toggling host ops in the stacked report.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1268.