### PR TITLE
Further optimise buffer summary

### DIFF
--- a/src/components/buffer-summary/BufferSummaryPlotControls.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotControls.tsx
@@ -6,6 +6,7 @@ import { Switch } from '@blueprintjs/core';
 import { useAtom, useAtomValue } from 'jotai';
 import GlobalSwitch from '../GlobalSwitch';
 import {
+    isBufferZoomAvailableAtom,
     renderMemoryLayoutAtom,
     selectedBufferSummaryTabAtom,
     showBufferSummaryZoomedAtom,
@@ -22,6 +23,7 @@ const BufferSummaryPlotControls = () => {
     const [showHex, setShowHex] = useAtom(showHexAtom);
     const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
     const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);
+    const isZoomAvailable = useAtomValue(isBufferZoomAvailableAtom);
     const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
 
     return (
@@ -29,9 +31,8 @@ const BufferSummaryPlotControls = () => {
             <Switch
                 label='Buffer zoom'
                 checked={isZoomedIn}
-                onChange={() => {
-                    setIsZoomedIn(!isZoomedIn);
-                }}
+                disabled={!isZoomAvailable}
+                onChange={() => setIsZoomedIn(!isZoomedIn)}
             />
 
             {selectedTabId === TAB_IDS.L1 ? (

--- a/src/components/buffer-summary/BufferSummaryPlotControls.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotControls.tsx
@@ -6,7 +6,6 @@ import { Switch } from '@blueprintjs/core';
 import { useAtom, useAtomValue } from 'jotai';
 import GlobalSwitch from '../GlobalSwitch';
 import {
-    isBufferZoomAvailableAtom,
     renderMemoryLayoutAtom,
     selectedBufferSummaryTabAtom,
     showBufferSummaryZoomedAtom,
@@ -23,7 +22,6 @@ const BufferSummaryPlotControls = () => {
     const [showHex, setShowHex] = useAtom(showHexAtom);
     const [isZoomedIn, setIsZoomedIn] = useAtom(showBufferSummaryZoomedAtom);
     const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);
-    const isZoomAvailable = useAtomValue(isBufferZoomAvailableAtom);
     const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
 
     return (
@@ -31,7 +29,6 @@ const BufferSummaryPlotControls = () => {
             <Switch
                 label='Buffer zoom'
                 checked={isZoomedIn}
-                disabled={!isZoomAvailable}
                 onChange={() => setIsZoomedIn(!isZoomedIn)}
             />
 

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -2,8 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import {
     BufferSummaryAxisConfiguration,
@@ -45,13 +45,12 @@ function BufferSummaryPlotRenderer({
     tensorListByOperation,
 }: BufferSummaryPlotRendererProps) {
     const showDeallocationReport = useAtomValue(showDeallocationReportAtom);
-    const renderMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
+    const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
 
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
-    const navigate = useNavigate();
     const l1StartMarker = useGetL1StartMarker();
     const l1SmallMarker = useGetL1SmallMarker();
 
@@ -81,27 +80,50 @@ function BufferSummaryPlotRenderer({
         return [minAddress, maxAddress];
     }, [uniqueBuffersByOperationList, memorySize]);
 
-    const memoryRegionsMarkers = showMemoryRegions
-        ? [
-              { color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker, label: MarkerTypeLabel.L1_SMALL },
-              { color: L1_START_MARKER_COLOR, address: l1StartMarker, label: MarkerTypeLabel.L1_START },
-          ]
-        : [];
+    const operationFileIdentifierById = useMemo(
+        () => new Map(operations?.map((operation) => [operation.id, operation.operationFileIdentifier]) ?? []),
+        [operations],
+    );
+    const memoryRegionsMarkers = useMemo(
+        () =>
+            showMemoryRegions
+                ? [
+                      { color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker, label: MarkerTypeLabel.L1_SMALL },
+                      { color: L1_START_MARKER_COLOR, address: l1StartMarker, label: MarkerTypeLabel.L1_START },
+                  ]
+                : [],
+        [showMemoryRegions, l1SmallMarker, l1StartMarker],
+    );
     const zoomedMemorySizeStart = zoomedMemorySize[0] || 0;
     const zoomedMemorySizeEnd = zoomedMemorySize[1] || memorySize;
     const memoryPadding = (zoomedMemorySizeEnd - zoomedMemorySizeStart) * MEMORY_ZOOM_PADDING_RATIO;
-
-    const handleNavigateToOperation = (event: React.MouseEvent<HTMLAnchorElement>, path: string) => {
-        event.preventDefault();
-        navigate(path);
-    };
+    const getTensorDeallocationReport = useCallback(
+        (operationId: number) =>
+            showDeallocationReport
+                ? nonDeallocatedTensorsByOperationId.get(operationId) || EMPTY_TENSOR_DEALLOCATION_REPORT
+                : EMPTY_TENSOR_DEALLOCATION_REPORT,
+        [showDeallocationReport, nonDeallocatedTensorsByOperationId],
+    );
+    const getOperationTooltipContent = useCallback(
+        (operation: BuffersByOperation) =>
+            `${operation.id} ${operation.name} (${operationFileIdentifierById.get(operation.id)})`,
+        [operationFileIdentifierById],
+    );
+    const renderOperationLink = useCallback(
+        (operation: BuffersByOperation) => (
+            <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
+                {operation.id}&nbsp;{operation.name}
+            </Link>
+        ),
+        [],
+    );
 
     return uniqueBuffersByOperationList && !isLoadingDevices && tensorListByOperation ? (
         <BufferSummaryVirtualizedList
             operations={uniqueBuffersByOperationList}
             tensorListByOperation={tensorListByOperation}
             isZoomedIn={isZoomedIn}
-            showMemoryLayout={renderMemoryLayout}
+            showMemoryLayout={showMemoryLayout}
             scrollLocation={ScrollLocations.BUFFER_SUMMARY}
             memorySize={memorySize}
             zoomStart={zoomedMemorySizeStart}
@@ -109,22 +131,9 @@ function BufferSummaryPlotRenderer({
             memoryPadding={memoryPadding}
             axisConfiguration={BufferSummaryAxisConfiguration}
             markers={memoryRegionsMarkers}
-            getTensorDeallocationReport={(operationId) =>
-                showDeallocationReport
-                    ? nonDeallocatedTensorsByOperationId.get(operationId) || EMPTY_TENSOR_DEALLOCATION_REPORT
-                    : EMPTY_TENSOR_DEALLOCATION_REPORT
-            }
-            getOperationTooltipContent={(operation) =>
-                `${operation.id} ${operation.name} (${operations?.find((op) => op.id === operation.id)?.operationFileIdentifier})`
-            }
-            renderOperationLink={(operation) => (
-                <a
-                    href={`${ROUTES.OPERATIONS}/${operation.id}`}
-                    onClick={(event) => handleNavigateToOperation(event, `${ROUTES.OPERATIONS}/${operation.id}`)}
-                >
-                    {operation.id}&nbsp;{operation.name}
-                </a>
-            )}
+            getTensorDeallocationReport={getTensorDeallocationReport}
+            getOperationTooltipContent={getOperationTooltipContent}
+            renderOperationLink={renderOperationLink}
         />
     ) : (
         <LoadingSpinner />

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -2,9 +2,9 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import {
     BufferSummaryAxisConfiguration,
     L1_SMALL_MARKER_COLOR,
@@ -20,6 +20,7 @@ import {
 import LoadingSpinner from '../LoadingSpinner';
 import ROUTES from '../../definitions/Routes';
 import {
+    isBufferZoomAvailableAtom,
     renderMemoryLayoutAtom,
     showBufferSummaryZoomedAtom,
     showDeallocationReportAtom,
@@ -48,6 +49,7 @@ function BufferSummaryPlotRenderer({
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
+    const setZoomAvailable = useSetAtom(isBufferZoomAvailableAtom);
 
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
@@ -117,6 +119,11 @@ function BufferSummaryPlotRenderer({
         ),
         [],
     );
+
+    // L1 always has zoom available
+    useEffect(() => {
+        setZoomAvailable(true);
+    }, [setZoomAvailable]);
 
     return uniqueBuffersByOperationList && !isLoadingDevices && tensorListByOperation ? (
         <BufferSummaryVirtualizedList

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -2,9 +2,9 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import {
     BufferSummaryAxisConfiguration,
     L1_SMALL_MARKER_COLOR,
@@ -20,7 +20,6 @@ import {
 import LoadingSpinner from '../LoadingSpinner';
 import ROUTES from '../../definitions/Routes';
 import {
-    isBufferZoomAvailableAtom,
     renderMemoryLayoutAtom,
     showBufferSummaryZoomedAtom,
     showDeallocationReportAtom,
@@ -49,7 +48,6 @@ function BufferSummaryPlotRenderer({
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryRegions = useAtomValue(showMemoryRegionsAtom);
-    const setZoomAvailable = useSetAtom(isBufferZoomAvailableAtom);
 
     const { data: devices, isLoading: isLoadingDevices } = useDevices();
     const { data: operations } = useOperationsList();
@@ -119,11 +117,6 @@ function BufferSummaryPlotRenderer({
         ),
         [],
     );
-
-    // L1 always has zoom available
-    useEffect(() => {
-        setZoomAvailable(true);
-    }, [setZoomAvailable]);
 
     return uniqueBuffersByOperationList && !isLoadingDevices && tensorListByOperation ? (
         <BufferSummaryVirtualizedList

--- a/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRenderer.tsx
@@ -31,6 +31,7 @@ import { BuffersByOperation, MarkerTypeLabel } from '../../model/APIData';
 import { DEFAULT_DEVICE_ID } from '../../definitions/Devices';
 import { TensorDeallocationReport, TensorsByOperationByAddress } from '../../model/BufferSummary';
 import { MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
+import { getBufferAddressZoomRange, memoryZoomPaddingForRange } from '../../functions/bufferSummary';
 import BufferSummaryVirtualizedList from './BufferSummaryVirtualizedList';
 
 const EMPTY_TENSOR_DEALLOCATION_REPORT: TensorDeallocationReport[] = [];
@@ -62,23 +63,10 @@ function BufferSummaryPlotRenderer({
         [devices, isLoadingDevices],
     );
 
-    const zoomedMemorySize = useMemo(() => {
-        let minAddress = Number.POSITIVE_INFINITY;
-        let maxAddress = Number.NEGATIVE_INFINITY;
-
-        uniqueBuffersByOperationList.forEach((operation) => {
-            operation.buffers.forEach((buffer) => {
-                minAddress = Math.min(minAddress, buffer.address);
-                maxAddress = Math.max(maxAddress, buffer.address + buffer.size);
-            });
-        });
-
-        if (!Number.isFinite(minAddress) || !Number.isFinite(maxAddress)) {
-            return [0, memorySize];
-        }
-
-        return [minAddress, maxAddress];
-    }, [uniqueBuffersByOperationList, memorySize]);
+    const [zoomedMemorySizeStart, zoomedMemorySizeEnd] = useMemo(
+        () => getBufferAddressZoomRange(uniqueBuffersByOperationList, memorySize),
+        [uniqueBuffersByOperationList, memorySize],
+    );
 
     const operationFileIdentifierById = useMemo(
         () => new Map(operations?.map((operation) => [operation.id, operation.operationFileIdentifier]) ?? []),
@@ -94,9 +82,11 @@ function BufferSummaryPlotRenderer({
                 : [],
         [showMemoryRegions, l1SmallMarker, l1StartMarker],
     );
-    const zoomedMemorySizeStart = zoomedMemorySize[0] || 0;
-    const zoomedMemorySizeEnd = zoomedMemorySize[1] || memorySize;
-    const memoryPadding = (zoomedMemorySizeEnd - zoomedMemorySizeStart) * MEMORY_ZOOM_PADDING_RATIO;
+    const memoryPadding = useMemo(
+        () => memoryZoomPaddingForRange(zoomedMemorySizeStart, zoomedMemorySizeEnd, MEMORY_ZOOM_PADDING_RATIO),
+        [zoomedMemorySizeStart, zoomedMemorySizeEnd],
+    );
+
     const getTensorDeallocationReport = useCallback(
         (operationId: number) =>
             showDeallocationReport
@@ -104,11 +94,13 @@ function BufferSummaryPlotRenderer({
                 : EMPTY_TENSOR_DEALLOCATION_REPORT,
         [showDeallocationReport, nonDeallocatedTensorsByOperationId],
     );
+
     const getOperationTooltipContent = useCallback(
         (operation: BuffersByOperation) =>
             `${operation.id} ${operation.name} (${operationFileIdentifierById.get(operation.id)})`,
         [operationFileIdentifierById],
     );
+
     const renderOperationLink = useCallback(
         (operation: BuffersByOperation) => (
             <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -13,7 +13,7 @@ import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
 import { ScrollLocations } from '../../definitions/VirtualLists';
 import { BuffersByOperation } from '../../model/APIData';
 import { TensorsByOperationByAddress } from '../../model/BufferSummary';
-import { MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
+import { MAX_DRAM_BUFFERS_FOR_GAP_SPLIT, MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
 import BufferSummaryVirtualizedList from './BufferSummaryVirtualizedList';
 
 const MEMORY_SIZE = DRAM_MEMORY_SIZE;
@@ -40,11 +40,17 @@ function BufferSummaryPlotRendererDRAM({
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
 
     const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
-        if (isZoomedIn) {
-            return getSplitBuffers(uniqueBuffersByOperationList);
+        if (!isZoomedIn) {
+            return [uniqueBuffersByOperationList];
         }
 
-        return [uniqueBuffersByOperationList];
+        const totalBuffers = countBuffersAcrossOperations(uniqueBuffersByOperationList);
+
+        if (totalBuffers > MAX_DRAM_BUFFERS_FOR_GAP_SPLIT) {
+            return [uniqueBuffersByOperationList];
+        }
+
+        return getSplitBuffers(uniqueBuffersByOperationList);
     }, [uniqueBuffersByOperationList, isZoomedIn]);
 
     const zoomedMemoryOption = useMemo(() => {
@@ -102,6 +108,14 @@ function BufferSummaryPlotRendererDRAM({
     ) : (
         <LoadingSpinner />
     );
+}
+
+function countBuffersAcrossOperations(operations: BuffersByOperation[]): number {
+    let count = 0;
+    for (const op of operations) {
+        count += op.buffers.length;
+    }
+    return count;
 }
 
 function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import { BufferSummaryAxisConfiguration } from '../../definitions/PlotConfigurations';
@@ -17,6 +17,15 @@ import { MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
 import BufferSummaryVirtualizedList from './BufferSummaryVirtualizedList';
 
 const MEMORY_SIZE = DRAM_MEMORY_SIZE;
+const SPLIT_THRESHOLD_RATIO = 2;
+
+type FlattenedBuffer = {
+    address: number;
+    size: number;
+    opId: number;
+    opName: string;
+    buffer: BuffersByOperation['buffers'][number];
+};
 
 interface BufferSummaryPlotRendererDRAMProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
@@ -38,25 +47,41 @@ function BufferSummaryPlotRendererDRAM({
         return [uniqueBuffersByOperationList];
     }, [uniqueBuffersByOperationList, isZoomedIn]);
 
-    const zoomedMemoryOptions = useMemo(
-        () =>
-            segmentedChartData
-                .map((segment) => {
-                    if (segment.length > 1) {
-                        const buffers = segment.flatMap((op) => op.buffers);
-                        const zoomStart = buffers[0].address;
-                        const zoomEnd = buffers[buffers.length - 1].address + buffers[buffers.length - 1].size;
+    const zoomedMemoryOption = useMemo(() => {
+        const segment = segmentedChartData.find((segmentedOperations) => segmentedOperations.length > 1);
 
-                        return {
-                            start: zoomStart,
-                            end: zoomEnd,
-                            padding: (zoomEnd - zoomStart) * MEMORY_ZOOM_PADDING_RATIO,
-                        };
-                    }
-                    return null;
-                })
-                .filter((elt) => elt !== null),
-        [segmentedChartData],
+        if (!segment) {
+            return null;
+        }
+
+        const firstBuffer = segment[0]?.buffers[0];
+        const lastOperationBuffers = segment[segment.length - 1]?.buffers;
+        const lastBuffer = lastOperationBuffers?.[lastOperationBuffers.length - 1];
+
+        if (!firstBuffer || !lastBuffer) {
+            return null;
+        }
+
+        const zoomStart = firstBuffer.address;
+        const zoomEnd = lastBuffer.address + lastBuffer.size;
+
+        return {
+            start: zoomStart,
+            end: zoomEnd,
+            padding: (zoomEnd - zoomStart) * MEMORY_ZOOM_PADDING_RATIO,
+        };
+    }, [segmentedChartData]);
+    const getOperationTooltipContent = useCallback(
+        (operation: BuffersByOperation) => `${operation.id} ${operation.name}`,
+        [],
+    );
+    const renderOperationLink = useCallback(
+        (operation: BuffersByOperation) => (
+            <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
+                {operation.id}&nbsp;{operation.name}
+            </Link>
+        ),
+        [],
     );
 
     return uniqueBuffersByOperationList && tensorListByOperation ? (
@@ -67,28 +92,34 @@ function BufferSummaryPlotRendererDRAM({
             showMemoryLayout={showMemoryLayout}
             scrollLocation={ScrollLocations.BUFFER_SUMMARY_DRAM}
             memorySize={MEMORY_SIZE}
-            zoomStart={zoomedMemoryOptions[0]?.start ?? 0}
-            zoomEnd={zoomedMemoryOptions[0]?.end ?? MEMORY_SIZE}
-            memoryPadding={zoomedMemoryOptions[0]?.padding ?? 0}
+            zoomStart={zoomedMemoryOption?.start ?? 0}
+            zoomEnd={zoomedMemoryOption?.end ?? MEMORY_SIZE}
+            memoryPadding={zoomedMemoryOption?.padding ?? 0}
             axisConfiguration={BufferSummaryAxisConfiguration}
-            getOperationTooltipContent={(operation) => `${operation.id} ${operation.name}`}
-            renderOperationLink={(operation) => (
-                <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
-                    {operation.id}&nbsp;{operation.name}
-                </Link>
-            )}
+            getOperationTooltipContent={getOperationTooltipContent}
+            renderOperationLink={renderOperationLink}
         />
     ) : (
         <LoadingSpinner />
     );
 }
 
-const SPLIT_THRESHOLD_RATIO = 2;
-
 function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {
-    const buffers = data
-        .flatMap((op) => op.buffers.map((buffer) => ({ ...buffer, opName: op.name, opId: op.id })))
-        .sort((a, b) => a.address - b.address);
+    const buffers: FlattenedBuffer[] = [];
+
+    data.forEach((operation) => {
+        operation.buffers.forEach((buffer) => {
+            buffers.push({
+                address: buffer.address,
+                size: buffer.size,
+                opId: operation.id,
+                opName: operation.name,
+                buffer,
+            });
+        });
+    });
+
+    buffers.sort((a, b) => a.address - b.address);
 
     const lastDataPoint = buffers.at(-1);
     const splitThreshold = lastDataPoint ? (lastDataPoint.address + lastDataPoint.size) / SPLIT_THRESHOLD_RATIO : 0;
@@ -115,12 +146,11 @@ function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {
     return result.map((buffersGroup) => {
         const operationsMap = new Map<number, BuffersByOperation>();
 
-        buffersGroup.forEach((buffer) => {
-            const { opId, opName, ...originalBuffer } = buffer;
-            if (!operationsMap.has(opId)) {
-                operationsMap.set(opId, { id: opId, name: opName, buffers: [] });
+        buffersGroup.forEach((entry) => {
+            if (!operationsMap.has(entry.opId)) {
+                operationsMap.set(entry.opId, { id: entry.opId, name: entry.opName, buffers: [] });
             }
-            operationsMap.get(opId)!.buffers.push(originalBuffer);
+            operationsMap.get(entry.opId)!.buffers.push(entry.buffer);
         });
 
         return Array.from(operationsMap.values());

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -2,13 +2,13 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { BufferSummaryAxisConfiguration } from '../../definitions/PlotConfigurations';
 import LoadingSpinner from '../LoadingSpinner';
 import ROUTES from '../../definitions/Routes';
-import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../../store/app';
+import { isBufferZoomAvailableAtom, renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../../store/app';
 import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
 import { ScrollLocations } from '../../definitions/VirtualLists';
 import { BuffersByOperation } from '../../model/APIData';
@@ -38,22 +38,39 @@ function BufferSummaryPlotRendererDRAM({
 }: BufferSummaryPlotRendererDRAMProps) {
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
+    const setZoomAvailable = useSetAtom(isBufferZoomAvailableAtom);
 
-    const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
-        if (!isZoomedIn) {
-            return [uniqueBuffersByOperationList];
-        }
-
+    const dramGapSplit = useMemo(() => {
         const totalBuffers = countBuffersAcrossOperations(uniqueBuffersByOperationList);
 
         if (totalBuffers > MAX_DRAM_BUFFERS_FOR_GAP_SPLIT) {
+            return { zoomAvailability: false, splitSegments: null as BuffersByOperation[][] | null };
+        }
+
+        const splitSegments = getSplitBuffers(uniqueBuffersByOperationList);
+
+        return {
+            zoomAvailability: splitSegments.some((segment) => segment.length > 1),
+            splitSegments,
+        };
+    }, [uniqueBuffersByOperationList]);
+
+    const { zoomAvailability, splitSegments } = dramGapSplit;
+    const shouldApplyZoom = isZoomedIn && zoomAvailability;
+
+    const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
+        if (!shouldApplyZoom || !splitSegments) {
             return [uniqueBuffersByOperationList];
         }
 
-        return getSplitBuffers(uniqueBuffersByOperationList);
-    }, [uniqueBuffersByOperationList, isZoomedIn]);
+        return splitSegments;
+    }, [uniqueBuffersByOperationList, shouldApplyZoom, splitSegments]);
 
     const zoomedMemoryOption = useMemo(() => {
+        if (!shouldApplyZoom) {
+            return null;
+        }
+
         const segment = segmentedChartData.find((segmentedOperations) => segmentedOperations.length > 1);
 
         if (!segment) {
@@ -76,7 +93,7 @@ function BufferSummaryPlotRendererDRAM({
             end: zoomEnd,
             padding: (zoomEnd - zoomStart) * MEMORY_ZOOM_PADDING_RATIO,
         };
-    }, [segmentedChartData]);
+    }, [segmentedChartData, shouldApplyZoom]);
     const getOperationTooltipContent = useCallback(
         (operation: BuffersByOperation) => `${operation.id} ${operation.name}`,
         [],
@@ -90,11 +107,15 @@ function BufferSummaryPlotRendererDRAM({
         [],
     );
 
+    useEffect(() => {
+        setZoomAvailable(zoomAvailability);
+    }, [zoomAvailability, setZoomAvailable]);
+
     return uniqueBuffersByOperationList && tensorListByOperation ? (
         <BufferSummaryVirtualizedList
             operations={segmentedChartData[0] || []}
             tensorListByOperation={tensorListByOperation}
-            isZoomedIn={isZoomedIn}
+            isZoomedIn={shouldApplyZoom}
             showMemoryLayout={showMemoryLayout}
             scrollLocation={ScrollLocations.BUFFER_SUMMARY_DRAM}
             memorySize={MEMORY_SIZE}

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -2,13 +2,13 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { BufferSummaryAxisConfiguration } from '../../definitions/PlotConfigurations';
 import LoadingSpinner from '../LoadingSpinner';
 import ROUTES from '../../definitions/Routes';
-import { isBufferZoomAvailableAtom, renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../../store/app';
+import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../../store/app';
 import { DRAM_MEMORY_SIZE } from '../../definitions/DRAMMemorySize';
 import { ScrollLocations } from '../../definitions/VirtualLists';
 import { BuffersByOperation } from '../../model/APIData';
@@ -38,47 +38,50 @@ function BufferSummaryPlotRendererDRAM({
 }: BufferSummaryPlotRendererDRAMProps) {
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
-    const setZoomAvailable = useSetAtom(isBufferZoomAvailableAtom);
 
-    const dramGapSplit = useMemo(() => {
-        const totalBuffers = countBuffersAcrossOperations(uniqueBuffersByOperationList);
-
-        if (totalBuffers > MAX_DRAM_BUFFERS_FOR_GAP_SPLIT) {
-            return { zoomAvailability: false, splitSegments: null as BuffersByOperation[][] | null };
-        }
-
-        const splitSegments = getSplitBuffers(uniqueBuffersByOperationList);
-
-        return {
-            zoomAvailability: splitSegments.some((segment) => segment.length > 1),
-            splitSegments,
-        };
-    }, [uniqueBuffersByOperationList]);
-
-    const { zoomAvailability, splitSegments } = dramGapSplit;
-    const shouldApplyZoom = isZoomedIn && zoomAvailability;
-
-    const segmentedChartData: BuffersByOperation[][] = useMemo(() => {
-        if (!shouldApplyZoom || !splitSegments) {
+    const segmentedChartData: BuffersByOperation[][] | null = useMemo(() => {
+        // Skip splitting when not zoomed in
+        if (!isZoomedIn) {
             return [uniqueBuffersByOperationList];
         }
 
-        return splitSegments;
-    }, [uniqueBuffersByOperationList, shouldApplyZoom, splitSegments]);
+        const totalBuffers = countBuffersAcrossOperations(uniqueBuffersByOperationList);
+
+        // Skip splitting when the total number of buffers exceeds the maximum threshold
+        if (totalBuffers > MAX_DRAM_BUFFERS_FOR_GAP_SPLIT) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `BufferSummaryPlotRendererDRAM: Total buffers (${totalBuffers}) exceed the maximum threshold for gap splitting. Rendering without splitting to avoid performance issues.`,
+            );
+            return [uniqueBuffersByOperationList];
+        }
+
+        return getSplitBuffers(uniqueBuffersByOperationList);
+    }, [isZoomedIn, uniqueBuffersByOperationList]);
+
+    const multiOpZoomSegment = useMemo(() => {
+        if (!isZoomedIn) {
+            return null;
+        }
+
+        return segmentedChartData.find((segmentedOperations) => segmentedOperations.length > 1) ?? null;
+    }, [segmentedChartData, isZoomedIn]);
+
+    const operationsForList = useMemo(() => {
+        if (!isZoomedIn) {
+            return segmentedChartData[0] ?? [];
+        }
+
+        return multiOpZoomSegment ?? segmentedChartData[0] ?? [];
+    }, [isZoomedIn, segmentedChartData, multiOpZoomSegment]);
 
     const zoomedMemoryOption = useMemo(() => {
-        if (!shouldApplyZoom) {
+        if (!isZoomedIn || !multiOpZoomSegment) {
             return null;
         }
 
-        const segment = segmentedChartData.find((segmentedOperations) => segmentedOperations.length > 1);
-
-        if (!segment) {
-            return null;
-        }
-
-        const firstBuffer = segment[0]?.buffers[0];
-        const lastOperationBuffers = segment[segment.length - 1]?.buffers;
+        const firstBuffer = multiOpZoomSegment[0]?.buffers[0];
+        const lastOperationBuffers = multiOpZoomSegment[multiOpZoomSegment.length - 1]?.buffers;
         const lastBuffer = lastOperationBuffers?.[lastOperationBuffers.length - 1];
 
         if (!firstBuffer || !lastBuffer) {
@@ -93,11 +96,13 @@ function BufferSummaryPlotRendererDRAM({
             end: zoomEnd,
             padding: (zoomEnd - zoomStart) * MEMORY_ZOOM_PADDING_RATIO,
         };
-    }, [segmentedChartData, shouldApplyZoom]);
+    }, [multiOpZoomSegment, isZoomedIn]);
+
     const getOperationTooltipContent = useCallback(
         (operation: BuffersByOperation) => `${operation.id} ${operation.name}`,
         [],
     );
+
     const renderOperationLink = useCallback(
         (operation: BuffersByOperation) => (
             <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
@@ -107,15 +112,11 @@ function BufferSummaryPlotRendererDRAM({
         [],
     );
 
-    useEffect(() => {
-        setZoomAvailable(zoomAvailability);
-    }, [zoomAvailability, setZoomAvailable]);
-
     return uniqueBuffersByOperationList && tensorListByOperation ? (
         <BufferSummaryVirtualizedList
-            operations={segmentedChartData[0] || []}
+            operations={operationsForList}
             tensorListByOperation={tensorListByOperation}
-            isZoomedIn={shouldApplyZoom}
+            isZoomedIn={isZoomedIn}
             showMemoryLayout={showMemoryLayout}
             scrollLocation={ScrollLocations.BUFFER_SUMMARY_DRAM}
             memorySize={MEMORY_SIZE}
@@ -129,14 +130,6 @@ function BufferSummaryPlotRendererDRAM({
     ) : (
         <LoadingSpinner />
     );
-}
-
-function countBuffersAcrossOperations(operations: BuffersByOperation[]): number {
-    let count = 0;
-    for (const op of operations) {
-        count += op.buffers.length;
-    }
-    return count;
 }
 
 function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {
@@ -190,6 +183,14 @@ function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {
 
         return Array.from(operationsMap.values());
     });
+}
+
+function countBuffersAcrossOperations(operations: BuffersByOperation[]): number {
+    let count = 0;
+    for (const op of operations) {
+        count += op.buffers.length;
+    }
+    return count;
 }
 
 export default BufferSummaryPlotRendererDRAM;

--- a/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
+++ b/src/components/buffer-summary/BufferSummaryPlotRendererDRAM.tsx
@@ -14,18 +14,15 @@ import { ScrollLocations } from '../../definitions/VirtualLists';
 import { BuffersByOperation } from '../../model/APIData';
 import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 import { MAX_DRAM_BUFFERS_FOR_GAP_SPLIT, MEMORY_ZOOM_PADDING_RATIO } from '../../definitions/BufferSummary';
+import {
+    countBuffersAcrossOperations,
+    getBufferAddressBounds,
+    getSplitBuffers,
+    memoryZoomPaddingForRange,
+} from '../../functions/bufferSummary';
 import BufferSummaryVirtualizedList from './BufferSummaryVirtualizedList';
 
 const MEMORY_SIZE = DRAM_MEMORY_SIZE;
-const SPLIT_THRESHOLD_RATIO = 2;
-
-type FlattenedBuffer = {
-    address: number;
-    size: number;
-    opId: number;
-    opName: string;
-    buffer: BuffersByOperation['buffers'][number];
-};
 
 interface BufferSummaryPlotRendererDRAMProps {
     uniqueBuffersByOperationList: BuffersByOperation[];
@@ -39,24 +36,22 @@ function BufferSummaryPlotRendererDRAM({
     const isZoomedIn = useAtomValue(showBufferSummaryZoomedAtom);
     const showMemoryLayout = useAtomValue(renderMemoryLayoutAtom);
 
-    const segmentedChartData: BuffersByOperation[][] | null = useMemo(() => {
-        // Skip splitting when not zoomed in
+    const segmentedChartData = useMemo(() => {
         if (!isZoomedIn) {
             return [uniqueBuffersByOperationList];
         }
 
         const totalBuffers = countBuffersAcrossOperations(uniqueBuffersByOperationList);
 
-        // Skip splitting when the total number of buffers exceeds the maximum threshold
         if (totalBuffers > MAX_DRAM_BUFFERS_FOR_GAP_SPLIT) {
             // eslint-disable-next-line no-console
-            console.warn(
-                `BufferSummaryPlotRendererDRAM: Total buffers (${totalBuffers}) exceed the maximum threshold for gap splitting. Rendering without splitting to avoid performance issues.`,
-            );
+            console.warn(`Total buffers (${totalBuffers}) exceed the maximum threshold, rendering without splitting.`);
             return [uniqueBuffersByOperationList];
         }
 
-        return getSplitBuffers(uniqueBuffersByOperationList);
+        const splitSegments = getSplitBuffers(uniqueBuffersByOperationList);
+
+        return splitSegments;
     }, [isZoomedIn, uniqueBuffersByOperationList]);
 
     const multiOpZoomSegment = useMemo(() => {
@@ -65,38 +60,38 @@ function BufferSummaryPlotRendererDRAM({
         }
 
         return segmentedChartData.find((segmentedOperations) => segmentedOperations.length > 1) ?? null;
-    }, [segmentedChartData, isZoomedIn]);
+    }, [isZoomedIn, segmentedChartData]);
+
+    const shouldApplyZoom = Boolean(multiOpZoomSegment);
 
     const operationsForList = useMemo(() => {
         if (!isZoomedIn) {
             return segmentedChartData[0] ?? [];
         }
 
-        return multiOpZoomSegment ?? segmentedChartData[0] ?? [];
-    }, [isZoomedIn, segmentedChartData, multiOpZoomSegment]);
+        if (multiOpZoomSegment) {
+            return multiOpZoomSegment;
+        }
+
+        return uniqueBuffersByOperationList;
+    }, [isZoomedIn, segmentedChartData, multiOpZoomSegment, uniqueBuffersByOperationList]);
 
     const zoomedMemoryOption = useMemo(() => {
-        if (!isZoomedIn || !multiOpZoomSegment) {
+        if (!shouldApplyZoom || !operationsForList.length) {
             return null;
         }
 
-        const firstBuffer = multiOpZoomSegment[0]?.buffers[0];
-        const lastOperationBuffers = multiOpZoomSegment[multiOpZoomSegment.length - 1]?.buffers;
-        const lastBuffer = lastOperationBuffers?.[lastOperationBuffers.length - 1];
-
-        if (!firstBuffer || !lastBuffer) {
+        const bounds = getBufferAddressBounds(operationsForList);
+        if (!bounds) {
             return null;
         }
-
-        const zoomStart = firstBuffer.address;
-        const zoomEnd = lastBuffer.address + lastBuffer.size;
 
         return {
-            start: zoomStart,
-            end: zoomEnd,
-            padding: (zoomEnd - zoomStart) * MEMORY_ZOOM_PADDING_RATIO,
+            start: bounds.start,
+            end: bounds.end,
+            padding: memoryZoomPaddingForRange(bounds.start, bounds.end, MEMORY_ZOOM_PADDING_RATIO),
         };
-    }, [multiOpZoomSegment, isZoomedIn]);
+    }, [operationsForList, shouldApplyZoom]);
 
     const getOperationTooltipContent = useCallback(
         (operation: BuffersByOperation) => `${operation.id} ${operation.name}`,
@@ -116,7 +111,7 @@ function BufferSummaryPlotRendererDRAM({
         <BufferSummaryVirtualizedList
             operations={operationsForList}
             tensorListByOperation={tensorListByOperation}
-            isZoomedIn={isZoomedIn}
+            isZoomedIn={shouldApplyZoom}
             showMemoryLayout={showMemoryLayout}
             scrollLocation={ScrollLocations.BUFFER_SUMMARY_DRAM}
             memorySize={MEMORY_SIZE}
@@ -130,67 +125,6 @@ function BufferSummaryPlotRendererDRAM({
     ) : (
         <LoadingSpinner />
     );
-}
-
-function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {
-    const buffers: FlattenedBuffer[] = [];
-
-    data.forEach((operation) => {
-        operation.buffers.forEach((buffer) => {
-            buffers.push({
-                address: buffer.address,
-                size: buffer.size,
-                opId: operation.id,
-                opName: operation.name,
-                buffer,
-            });
-        });
-    });
-
-    buffers.sort((a, b) => a.address - b.address);
-
-    const lastDataPoint = buffers.at(-1);
-    const splitThreshold = lastDataPoint ? (lastDataPoint.address + lastDataPoint.size) / SPLIT_THRESHOLD_RATIO : 0;
-
-    const result = [];
-    let currentArray = [];
-
-    for (let i = 0; i < buffers.length; i++) {
-        const thisPosition = buffers[i].address;
-        const lastPosition = buffers[i - 1]?.address ?? 0;
-
-        if (thisPosition - lastPosition > splitThreshold) {
-            result.push(currentArray);
-            currentArray = [];
-        }
-
-        currentArray.push(buffers[i]);
-    }
-
-    if (currentArray.length > 0) {
-        result.push(currentArray);
-    }
-
-    return result.map((buffersGroup) => {
-        const operationsMap = new Map<number, BuffersByOperation>();
-
-        buffersGroup.forEach((entry) => {
-            if (!operationsMap.has(entry.opId)) {
-                operationsMap.set(entry.opId, { id: entry.opId, name: entry.opName, buffers: [] });
-            }
-            operationsMap.get(entry.opId)!.buffers.push(entry.buffer);
-        });
-
-        return Array.from(operationsMap.values());
-    });
-}
-
-function countBuffersAcrossOperations(operations: BuffersByOperation[]): number {
-    let count = 0;
-    for (const op of operations) {
-        count += op.buffers.length;
-    }
-    return count;
 }
 
 export default BufferSummaryPlotRendererDRAM;

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -27,6 +27,7 @@ interface BufferSummaryRowProps {
     showMemoryLayout?: boolean;
     className?: string;
     tensorDeallocationReport?: TensorDeallocationReport[];
+    isScrolling?: boolean;
 }
 
 const SCALE = 100;
@@ -45,6 +46,7 @@ const BufferSummaryRow = ({
     className = '',
     tensorDeallocationReport = EMPTY_TENSOR_DEALLOCATION_REPORT,
     showMemoryLayout,
+    isScrolling = false,
 }: BufferSummaryRowProps) => {
     const [tooltip, setTooltip] = useState<{ x: number; y: number; text: React.JSX.Element } | null>(null);
     const showHex = useAtomValue(showHexAtom);
@@ -129,7 +131,12 @@ const BufferSummaryRow = ({
     };
 
     const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
+        if (isScrolling) {
+            return;
+        }
+
         const { interactiveBuffer, scaleX, canvas } = findBufferForInteraction(event);
+
         if (interactiveBuffer) {
             canvas.style.cursor = 'pointer';
             const x = interactiveBuffer.position / scaleX;

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -33,25 +33,33 @@ const SCALE = 100;
 const CANVAS_WIDTH = 1200;
 const CANVAS_HEIGHT = 20;
 const TARGET_SCALE = (CANVAS_WIDTH / SCALE) * 100;
+const EMPTY_TENSOR_LIST = new Map<number, Tensor>();
+const EMPTY_TENSOR_DEALLOCATION_REPORT: TensorDeallocationReport[] = [];
 
 const BufferSummaryRow = ({
     buffers,
     memoryStart,
     memoryEnd,
     memoryPadding,
-    tensorList = new Map(),
+    tensorList = EMPTY_TENSOR_LIST,
     className = '',
-    tensorDeallocationReport = [],
+    tensorDeallocationReport = EMPTY_TENSOR_DEALLOCATION_REPORT,
     showMemoryLayout,
 }: BufferSummaryRowProps) => {
     const [tooltip, setTooltip] = useState<{ x: number; y: number; text: React.JSX.Element } | null>(null);
     const showHex = useAtomValue(showHexAtom);
 
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const hoveredBufferAddressRef = useRef<number | null>(null);
     const { selectedTensorId, selectedAddress, resetToasts, updateBufferFocus } = useBufferFocus();
 
     const computedMemorySize = memoryEnd - memoryStart;
     const computedPadding = (memoryPadding / computedMemorySize) * SCALE;
+
+    const deallocationReportByAddress = useMemo(
+        () => new Map(tensorDeallocationReport.map((report) => [report.address, report])),
+        [tensorDeallocationReport],
+    );
 
     const interactivityList = useMemo(() => {
         return buffers.map((buffer) => {
@@ -63,7 +71,7 @@ const BufferSummaryRow = ({
             let notDeallocated = false;
             let consumerOperationId = -1;
             let consumerName = '';
-            const result = tensorDeallocationReport?.find((report) => report.address === buffer.address);
+            const result = deallocationReportByAddress.get(buffer.address);
             if (result !== undefined) {
                 notDeallocated = true;
                 consumerOperationId = result.lastConsumerOperationId;
@@ -81,7 +89,7 @@ const BufferSummaryRow = ({
                 consumerName,
             };
         });
-    }, [buffers, computedMemorySize, memoryStart, tensorList, tensorDeallocationReport]);
+    }, [buffers, computedMemorySize, memoryStart, tensorList, deallocationReportByAddress]);
 
     const findBufferForInteraction = (event: React.MouseEvent<HTMLCanvasElement>) => {
         const canvas = canvasRef.current;
@@ -125,8 +133,15 @@ const BufferSummaryRow = ({
         if (interactiveBuffer) {
             canvas.style.cursor = 'pointer';
             const x = interactiveBuffer.position / scaleX;
-            const { color } = interactiveBuffer;
+            const hoveredAddress = interactiveBuffer.buffer.address;
 
+            if (hoveredBufferAddressRef.current === hoveredAddress) {
+                return;
+            }
+
+            hoveredBufferAddressRef.current = hoveredAddress;
+
+            const { color } = interactiveBuffer;
             const tensorId = interactiveBuffer.tensor ? `Tensor ${interactiveBuffer.tensor.id}` : '';
             const tensor = interactiveBuffer.notDeallocated ? (
                 <>
@@ -173,11 +188,13 @@ const BufferSummaryRow = ({
         } else {
             // eslint-disable-next-line no-unused-expressions, @typescript-eslint/no-unused-expressions
             canvasRef.current && (canvasRef.current.style.cursor = 'default');
+            hoveredBufferAddressRef.current = null;
             setTooltip(null);
         }
     };
 
     const handleMouseLeave = () => {
+        hoveredBufferAddressRef.current = null;
         setTooltip(null);
     };
 
@@ -296,4 +313,4 @@ function getWarningPattern(ctx: CanvasRenderingContext2D, position: number, size
     ctx.strokeRect(position, 1, size, CANVAS_HEIGHT - 2);
 }
 
-export default BufferSummaryRow;
+export default React.memo(BufferSummaryRow);

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -52,7 +52,7 @@ const BufferSummaryRow = ({
     const showHex = useAtomValue(showHexAtom);
 
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const hoveredBufferAddressRef = useRef<number | null>(null);
+    const tooltipCacheKeyRef = useRef<string | null>(null);
     const { selectedTensorId, selectedAddress, resetToasts, updateBufferFocus } = useBufferFocus();
 
     const computedMemorySize = memoryEnd - memoryStart;
@@ -141,12 +141,18 @@ const BufferSummaryRow = ({
             canvas.style.cursor = 'pointer';
             const x = interactiveBuffer.position / scaleX;
             const hoveredAddress = interactiveBuffer.buffer.address;
+            const deallocationKey = interactiveBuffer.notDeallocated
+                ? `${interactiveBuffer.consumerOperationId}:${interactiveBuffer.consumerName}`
+                : '0';
+            const tooltipCacheKey = [hoveredAddress, showHex, interactiveBuffer.tensor?.id ?? '', deallocationKey].join(
+                '\0',
+            );
 
-            if (hoveredBufferAddressRef.current === hoveredAddress) {
+            if (tooltipCacheKeyRef.current === tooltipCacheKey) {
                 return;
             }
 
-            hoveredBufferAddressRef.current = hoveredAddress;
+            tooltipCacheKeyRef.current = tooltipCacheKey;
 
             const { color } = interactiveBuffer;
             const tensorId = interactiveBuffer.tensor ? `Tensor ${interactiveBuffer.tensor.id}` : '';
@@ -195,13 +201,13 @@ const BufferSummaryRow = ({
         } else {
             // eslint-disable-next-line no-unused-expressions, @typescript-eslint/no-unused-expressions
             canvasRef.current && (canvasRef.current.style.cursor = 'default');
-            hoveredBufferAddressRef.current = null;
+            tooltipCacheKeyRef.current = null;
             setTooltip(null);
         }
     };
 
     const handleMouseLeave = () => {
-        hoveredBufferAddressRef.current = null;
+        tooltipCacheKeyRef.current = null;
         setTooltip(null);
     };
 

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -2,14 +2,13 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { RefObject, useMemo } from 'react';
+import { RefObject } from 'react';
 import { useAtomValue } from 'jotai';
 import { Callout, Intent } from '@blueprintjs/core';
 import BufferSummaryPlotRenderer from './BufferSummaryPlotRenderer';
 import BufferSummaryTable from './BufferSummaryTable';
 import { SECTION_IDS, TAB_IDS } from '../../definitions/BufferSummary';
 import BufferSummaryPlotRendererDRAM from './BufferSummaryPlotRendererDRAM';
-import { Buffer } from '../../model/APIData';
 import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../../store/app';
 import { BufferType } from '../../model/BufferType';
 import { useBuffers, useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
@@ -25,30 +24,9 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
     const activePerformanceReport = useAtomValue(activeProfilerReportAtom);
     const selectedBufferType = selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM;
 
-    const tensorListByOperation = useCreateTensorsByOperationByIdList(selectedBufferType);
+    const { tensorListByOperation, uniqueBuffersByOperationList } =
+        useCreateTensorsByOperationByIdList(selectedBufferType);
     const { data: buffersByOperation, error: buffersError } = useBuffers(selectedBufferType, true);
-
-    const uniqueBuffersByOperationList = useMemo(
-        () =>
-            buffersByOperation?.map((operation) => {
-                const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
-                operation.buffers.forEach((buffer) => {
-                    const { address, size } = buffer;
-                    if (address) {
-                        const existingBuffer = uniqueBuffers.get(address);
-                        if (!existingBuffer || size > existingBuffer.size) {
-                            uniqueBuffers.set(address, buffer);
-                        }
-                    }
-                });
-
-                return {
-                    ...operation,
-                    buffers: Array.from(uniqueBuffers.values()),
-                };
-            }),
-        [buffersByOperation],
-    );
 
     if (buffersError) {
         return (
@@ -94,6 +72,7 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
                 <BufferSummaryTable
                     buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
                     tensorListByOperation={tensorListByOperation}
+                    uniqueBuffersByOperationList={uniqueBuffersByOperationList}
                 />
             </div>
         </>

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -6,7 +6,6 @@ import { RefObject } from 'react';
 import { useAtomValue } from 'jotai';
 import { Callout, Intent } from '@blueprintjs/core';
 import BufferSummaryPlotRenderer from './BufferSummaryPlotRenderer';
-import BufferSummaryTable from './BufferSummaryTable';
 import { SECTION_IDS, TAB_IDS } from '../../definitions/BufferSummary';
 import BufferSummaryPlotRendererDRAM from './BufferSummaryPlotRendererDRAM';
 import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../../store/app';
@@ -69,11 +68,11 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
                 ref={tableRef}
                 id={SECTION_IDS.TABLE}
             >
-                <BufferSummaryTable
+                {/* <BufferSummaryTable
                     buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
                     tensorListByOperation={tensorListByOperation}
                     uniqueBuffersByOperationList={uniqueBuffersByOperationList}
-                />
+                /> */}
             </div>
         </>
     ) : (

--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -12,6 +12,7 @@ import { activeProfilerReportAtom, selectedBufferSummaryTabAtom } from '../../st
 import { BufferType } from '../../model/BufferType';
 import { useBuffers, useCreateTensorsByOperationByIdList } from '../../hooks/useAPI';
 import LoadingSpinner from '../LoadingSpinner';
+import BufferSummaryTable from './BufferSummaryTable';
 
 interface BufferSummaryTabProps {
     plotRef: RefObject<HTMLHeadingElement>;
@@ -68,11 +69,11 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
                 ref={tableRef}
                 id={SECTION_IDS.TABLE}
             >
-                {/* <BufferSummaryTable
+                <BufferSummaryTable
                     buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
                     tensorListByOperation={tensorListByOperation}
                     uniqueBuffersByOperationList={uniqueBuffersByOperationList}
-                /> */}
+                />
             </div>
         </>
     ) : (

--- a/src/components/buffer-summary/BufferSummaryTable.tsx
+++ b/src/components/buffer-summary/BufferSummaryTable.tsx
@@ -28,6 +28,8 @@ import { TensorsByOperationByAddress } from '../../model/BufferSummary';
 interface BufferSummaryTableProps {
     buffersByOperation: BuffersByOperation[];
     tensorListByOperation: TensorsByOperationByAddress;
+    /** When set, skips a second address-dedupe pass (same list as the plot hook). */
+    uniqueBuffersByOperationList?: BuffersByOperation[];
 }
 
 interface SummaryTableBuffer extends BufferData {
@@ -39,7 +41,11 @@ interface SummaryTableBuffer extends BufferData {
     shape?: string;
 }
 
-function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: BufferSummaryTableProps) {
+function BufferSummaryTable({
+    buffersByOperation,
+    tensorListByOperation,
+    uniqueBuffersByOperationList: uniqueBuffersFromParent,
+}: BufferSummaryTableProps) {
     const [userSelectedRows, setUserSelectedRows] = useState<number[]>([]);
     const [showOnlySelected, setShowOnlySelected] = useState(false);
     const [mergedByDevice, setMergedByDevice] = useState(true);
@@ -65,8 +71,11 @@ function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: Buffe
         return allDeviceIds.size > 1;
     }, [buffersByOperation]);
 
-    // TODO: move this to a hook. eventually
     const uniqueBuffersByOperationList = useMemo(() => {
+        if (uniqueBuffersFromParent) {
+            return uniqueBuffersFromParent;
+        }
+
         return buffersByOperation.map((operation) => {
             const uniqueBuffers: Map<number, Buffer> = new Map<number, Buffer>();
             operation.buffers.forEach((buffer) => {
@@ -75,7 +84,6 @@ function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: Buffe
                     const existingBuffer = uniqueBuffers.get(address);
                     if (!existingBuffer || size > existingBuffer.size) {
                         uniqueBuffers.set(address, buffer);
-                        // TODO: add device list to buffer for rendering maybe
                     }
                 }
             });
@@ -84,7 +92,7 @@ function BufferSummaryTable({ buffersByOperation, tensorListByOperation }: Buffe
                 buffers: Array.from(uniqueBuffers.values()),
             };
         });
-    }, [buffersByOperation]);
+    }, [buffersByOperation, uniqueBuffersFromParent]);
 
     const listOfBuffers = useMemo(() => {
         const targetList = mergedByDevice ? uniqueBuffersByOperationList : buffersByOperation;

--- a/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
+++ b/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
@@ -86,6 +86,7 @@ function BufferSummaryVirtualizedList({
 
     const virtualItems = virtualizer.getVirtualItems();
     const virtualHeight = virtualizer.getTotalSize() - TOTAL_SHADE_HEIGHT;
+    const isVirtualizerScrolling = virtualizer.isScrolling;
     const rowMemoryStart = isZoomedIn ? zoomStart : 0;
     const rowMemoryEnd = isZoomedIn ? zoomEnd : memorySize;
     const plotMemorySize = isZoomedIn ? zoomEnd : memorySize;
@@ -97,11 +98,21 @@ function BufferSummaryVirtualizedList({
     // Store latest values in refs for unmount cleanup
     const scrollOffsetRef = useRef(virtualizer.scrollOffset);
     const measurementsCacheRef = useRef(virtualizer.measurementsCache);
+    const scrollShadeAnimationRef = useRef<number | null>(null);
 
     const handleUserScrolling = useCallback(() => {
-        if (scrollElementRef.current) {
-            updateScrollShade(scrollElementRef.current);
+        if (!scrollElementRef.current || scrollShadeAnimationRef.current !== null) {
+            return;
         }
+
+        // Avoid state churn on every scroll event callback.
+        scrollShadeAnimationRef.current = window.requestAnimationFrame(() => {
+            scrollShadeAnimationRef.current = null;
+
+            if (scrollElementRef.current) {
+                updateScrollShade(scrollElementRef.current);
+            }
+        });
     }, [updateScrollShade]);
 
     // Keep stored refs updated
@@ -112,6 +123,15 @@ function BufferSummaryVirtualizedList({
     useEffect(() => {
         measurementsCacheRef.current = virtualizer.measurementsCache;
     }, [virtualizer.measurementsCache]);
+
+    useEffect(
+        () => () => {
+            if (scrollShadeAnimationRef.current !== null) {
+                window.cancelAnimationFrame(scrollShadeAnimationRef.current);
+            }
+        },
+        [],
+    );
 
     // Update stored list state on unmount
     useEffect(() => {
@@ -179,14 +199,19 @@ function BufferSummaryVirtualizedList({
                                         tensorList={tensorListByOperation.get(operation.id)}
                                         tensorDeallocationReport={getTensorDeallocationReport(operation.id)}
                                         showMemoryLayout={showMemoryLayout}
+                                        isScrolling={isVirtualizerScrolling}
                                     />
 
-                                    <Tooltip
-                                        content={getOperationTooltipContent(operation)}
-                                        className='y-axis-tick'
-                                    >
-                                        {renderOperationLink(operation)}
-                                    </Tooltip>
+                                    {isVirtualizerScrolling ? (
+                                        <span className='y-axis-tick'>{renderOperationLink(operation)}</span>
+                                    ) : (
+                                        <Tooltip
+                                            content={getOperationTooltipContent(operation)}
+                                            className='y-axis-tick'
+                                        >
+                                            {renderOperationLink(operation)}
+                                        </Tooltip>
+                                    )}
                                 </div>
                             ) : null;
                         })}

--- a/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
+++ b/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
@@ -86,6 +86,13 @@ function BufferSummaryVirtualizedList({
 
     const virtualItems = virtualizer.getVirtualItems();
     const virtualHeight = virtualizer.getTotalSize() - TOTAL_SHADE_HEIGHT;
+    const rowMemoryStart = isZoomedIn ? zoomStart : 0;
+    const rowMemoryEnd = isZoomedIn ? zoomEnd : memorySize;
+    const plotMemorySize = isZoomedIn ? zoomEnd : memorySize;
+    const plotZoomRange = useMemo<[number, number]>(
+        () => (isZoomedIn ? [zoomStart - memoryPadding, zoomEnd + memoryPadding] : [0, memorySize]),
+        [isZoomedIn, zoomStart, zoomEnd, memoryPadding, memorySize],
+    );
 
     // Store latest values in refs for unmount cleanup
     const scrollOffsetRef = useRef(virtualizer.scrollOffset);
@@ -127,8 +134,8 @@ function BufferSummaryVirtualizedList({
                     className='buffer-summary-plot'
                     chartDataList={CHART_DATA}
                     isZoomedIn={isZoomedIn}
-                    memorySize={isZoomedIn ? zoomEnd : memorySize}
-                    plotZoomRange={isZoomedIn ? [zoomStart - memoryPadding, zoomEnd + memoryPadding] : [0, memorySize]}
+                    memorySize={plotMemorySize}
+                    plotZoomRange={plotZoomRange}
                     configuration={axisConfiguration}
                     markers={markers}
                 />
@@ -166,8 +173,8 @@ function BufferSummaryVirtualizedList({
                                 >
                                     <BufferSummaryRow
                                         buffers={operation.buffers}
-                                        memoryStart={isZoomedIn ? zoomStart : 0}
-                                        memoryEnd={isZoomedIn ? zoomEnd : memorySize}
+                                        memoryStart={rowMemoryStart}
+                                        memoryEnd={rowMemoryEnd}
                                         memoryPadding={memoryPadding}
                                         tensorList={tensorListByOperation.get(operation.id)}
                                         tensorDeallocationReport={getTensorDeallocationReport(operation.id)}

--- a/src/definitions/BufferSummary.ts
+++ b/src/definitions/BufferSummary.ts
@@ -104,6 +104,9 @@ export const OPERATION_EL_HEIGHT = 28; // Height in px of each list item (includ
 export const TOTAL_SHADE_HEIGHT = 20; // Combined height in px of 'scroll-shade' pseudo elements
 export const MEMORY_ZOOM_PADDING_RATIO = 0.01;
 
+/** Above this total buffer count, DRAM zoom "gap split" is skipped to avoid flattening and sorting all buffers. */
+export const MAX_DRAM_BUFFERS_FOR_GAP_SPLIT = 200_000;
+
 export const CHART_DATA: Partial<PlotData>[][] = [
     [
         {

--- a/src/functions/bufferSummary.ts
+++ b/src/functions/bufferSummary.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { BuffersByOperation } from '../model/APIData';
+
+type FlattenedBuffer = {
+    address: number;
+    size: number;
+    opId: number;
+    opName: string;
+    buffer: BuffersByOperation['buffers'][number];
+};
+
+const DRAM_GAP_SPLIT_THRESHOLD_RATIO = 2;
+
+/** Min/max address extent for all buffers (operation list order is irrelevant). */
+export function getBufferAddressBounds(operations: BuffersByOperation[]): { start: number; end: number } | null {
+    let minAddress = Number.POSITIVE_INFINITY;
+    let maxAddress = Number.NEGATIVE_INFINITY;
+
+    for (const operation of operations) {
+        for (const buffer of operation.buffers) {
+            minAddress = Math.min(minAddress, buffer.address);
+            maxAddress = Math.max(maxAddress, buffer.address + buffer.size);
+        }
+    }
+
+    if (!Number.isFinite(minAddress) || !Number.isFinite(maxAddress)) {
+        return null;
+    }
+
+    return { start: minAddress, end: maxAddress };
+}
+
+/** Address window for zoom; falls back to `[0, fullMemorySize]` when there are no buffers. */
+export function getBufferAddressZoomRange(operations: BuffersByOperation[], fullMemorySize: number): [number, number] {
+    const bounds = getBufferAddressBounds(operations);
+    if (!bounds) {
+        return [0, fullMemorySize];
+    }
+    return [bounds.start, bounds.end];
+}
+
+export function memoryZoomPaddingForRange(start: number, end: number, paddingRatio: number): number {
+    return (end - start) * paddingRatio;
+}
+
+export function countBuffersAcrossOperations(operations: BuffersByOperation[]): number {
+    let count = 0;
+
+    for (const op of operations) {
+        count += op.buffers.length;
+    }
+
+    return count;
+}
+
+/** Split operations into address-space clusters (DRAM gap split). */
+export function getSplitBuffers(data: BuffersByOperation[]): BuffersByOperation[][] {
+    const buffers: FlattenedBuffer[] = [];
+
+    data.forEach((operation) => {
+        operation.buffers.forEach((buffer) => {
+            buffers.push({
+                address: buffer.address,
+                size: buffer.size,
+                opId: operation.id,
+                opName: operation.name,
+                buffer,
+            });
+        });
+    });
+
+    buffers.sort((a, b) => a.address - b.address);
+
+    const lastDataPoint = buffers.at(-1);
+    const splitThreshold = lastDataPoint
+        ? (lastDataPoint.address + lastDataPoint.size) / DRAM_GAP_SPLIT_THRESHOLD_RATIO
+        : 0;
+
+    const result: FlattenedBuffer[][] = [];
+    let currentArray: FlattenedBuffer[] = [];
+
+    for (let i = 0; i < buffers.length; i++) {
+        const thisPosition = buffers[i].address;
+        const lastPosition = buffers[i - 1]?.address ?? 0;
+
+        if (thisPosition - lastPosition > splitThreshold) {
+            result.push(currentArray);
+            currentArray = [];
+        }
+
+        currentArray.push(buffers[i]);
+    }
+
+    if (currentArray.length > 0) {
+        result.push(currentArray);
+    }
+
+    return result.map((buffersGroup) => {
+        const operationsMap = new Map<number, BuffersByOperation>();
+
+        buffersGroup.forEach((entry) => {
+            if (!operationsMap.has(entry.opId)) {
+                operationsMap.set(entry.opId, { id: entry.opId, name: entry.opName, buffers: [] });
+            }
+            operationsMap.get(entry.opId)!.buffers.push(entry.buffer);
+        });
+
+        return Array.from(operationsMap.values());
+    });
+}

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1084,7 +1084,7 @@ export const usePerfFolderList = () => {
 };
 
 export const useCreateTensorsByOperationByIdList = (bufferType: BufferType = BufferType.L1) => {
-    const { data: buffersByOperation } = useBuffers(bufferType);
+    const { data: buffersByOperation } = useBuffers(bufferType, true);
     const { data: operations } = useOperationsList();
 
     const uniqueBuffersByOperationList = useMemo(() => {
@@ -1169,11 +1169,14 @@ export const useCreateTensorsByOperationByIdList = (bufferType: BufferType = Buf
         return result;
     }, [buffersByOperation, operations, uniqueBuffersByOperationList]);
 
-    return tensorsByOperationByAddress;
+    return {
+        tensorListByOperation: tensorsByOperationByAddress,
+        uniqueBuffersByOperationList,
+    };
 };
 
 export const useGetTensorDeallocationReportByOperation = () => {
-    const tensorListByOperation = useCreateTensorsByOperationByIdList();
+    const { tensorListByOperation } = useCreateTensorsByOperationByIdList();
     const { data: operations } = useOperationsList();
 
     const operationsById = useMemo(() => {

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -68,6 +68,7 @@ export const shouldSortBySizeAtom = atom<SortingOptions>(SortingOptions.OFF);
 // Buffers route
 export const selectedBufferSummaryTabAtom = atom<TAB_IDS>(TAB_IDS.L1);
 export const showBufferSummaryZoomedAtom = atomWithStorage('showBufferSummary', false);
+export const isBufferZoomAvailableAtom = atom(true);
 
 // Performance route
 export const comparisonPerformanceReportListAtom = atom<string[] | null>(null);

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -68,7 +68,6 @@ export const shouldSortBySizeAtom = atom<SortingOptions>(SortingOptions.OFF);
 // Buffers route
 export const selectedBufferSummaryTabAtom = atom<TAB_IDS>(TAB_IDS.L1);
 export const showBufferSummaryZoomedAtom = atomWithStorage('showBufferSummary', false);
-export const isBufferZoomAvailableAtom = atom(true);
 
 // Performance route
 export const comparisonPerformanceReportListAtom = atom<string[] | null>(null);

--- a/tests/BufferSummaryPlotRendererDRAM.overThreshold.spec.tsx
+++ b/tests/BufferSummaryPlotRendererDRAM.overThreshold.spec.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * Isolated module graph: mock MAX_DRAM_BUFFERS_FOR_GAP_SPLIT without affecting
+ * BufferSummaryPlotRendererDRAM.spec.tsx (Vitest hoists vi.mock per file).
+ */
+
+import { cleanup, render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../src/store/app';
+import { BufferType } from '../src/model/BufferType';
+import { MEMORY_ZOOM_PADDING_RATIO } from '../src/definitions/BufferSummary';
+import BufferSummaryPlotRendererDRAM from '../src/components/buffer-summary/BufferSummaryPlotRendererDRAM';
+import { TestProviders } from './helpers/TestProviders';
+
+vi.mock('../src/definitions/BufferSummary', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../src/definitions/BufferSummary')>();
+    return {
+        ...actual,
+        MAX_DRAM_BUFFERS_FOR_GAP_SPLIT: 2,
+    };
+});
+
+const bufferSummaryVirtualizedListMock = vi.fn();
+
+vi.mock('../src/components/buffer-summary/BufferSummaryVirtualizedList', () => ({
+    default: (props: unknown) => {
+        bufferSummaryVirtualizedListMock(props);
+        return <div data-testid='buffer-summary-virtualized-list' />;
+    },
+}));
+
+const baseTensorMap = new Map<number, Map<number, never>>();
+
+const opA = {
+    id: 1,
+    name: 'op-a',
+    buffers: [{ address: 100, size: 50, device_id: 0, buffer_type: BufferType.DRAM }],
+};
+
+const opB = {
+    id: 2,
+    name: 'op-b',
+    buffers: [{ address: 7000, size: 100, device_id: 0, buffer_type: BufferType.DRAM }],
+};
+
+const opC = {
+    id: 3,
+    name: 'op-c',
+    buffers: [{ address: 7300, size: 200, device_id: 0, buffer_type: BufferType.DRAM }],
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+});
+
+describe('BufferSummaryPlotRendererDRAM (over MAX_DRAM_BUFFERS_FOR_GAP_SPLIT)', () => {
+    it('skips gap splitting and keeps the full operation list for zoom', () => {
+        render(
+            <TestProviders
+                initialAtomValues={[
+                    [showBufferSummaryZoomedAtom, true],
+                    [renderMemoryLayoutAtom, false],
+                ]}
+            >
+                <BufferSummaryPlotRendererDRAM
+                    uniqueBuffersByOperationList={[opA, opB, opC]}
+                    tensorListByOperation={baseTensorMap}
+                />
+            </TestProviders>,
+        );
+
+        const props = bufferSummaryVirtualizedListMock.mock.calls[0][0] as {
+            operations: unknown;
+            isZoomedIn: boolean;
+            zoomStart: number;
+            zoomEnd: number;
+            memoryPadding: number;
+        };
+
+        expect(props.operations).toEqual([opA, opB, opC]);
+        expect(props.isZoomedIn).toBe(true);
+        expect(props.zoomStart).toBe(100);
+        expect(props.zoomEnd).toBe(7500);
+        expect(props.memoryPadding).toBe((7500 - 100) * MEMORY_ZOOM_PADDING_RATIO);
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalled();
+    });
+});

--- a/tests/BufferSummaryPlotRendererDRAM.spec.tsx
+++ b/tests/BufferSummaryPlotRendererDRAM.spec.tsx
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderMemoryLayoutAtom, showBufferSummaryZoomedAtom } from '../src/store/app';
+import { BufferType } from '../src/model/BufferType';
+import { MEMORY_ZOOM_PADDING_RATIO } from '../src/definitions/BufferSummary';
+import { DRAM_MEMORY_SIZE } from '../src/definitions/DRAMMemorySize';
+import BufferSummaryPlotRendererDRAM from '../src/components/buffer-summary/BufferSummaryPlotRendererDRAM';
+import { TestProviders } from './helpers/TestProviders';
+
+const bufferSummaryVirtualizedListMock = vi.fn();
+
+vi.mock('../src/components/buffer-summary/BufferSummaryVirtualizedList', () => ({
+    default: (props: unknown) => {
+        bufferSummaryVirtualizedListMock(props);
+        return <div data-testid='buffer-summary-virtualized-list' />;
+    },
+}));
+
+const baseTensorMap = new Map<number, Map<number, never>>();
+
+const opA = {
+    id: 1,
+    name: 'op-a',
+    buffers: [{ address: 100, size: 50, device_id: 0, buffer_type: BufferType.DRAM }],
+};
+
+const opB = {
+    id: 2,
+    name: 'op-b',
+    buffers: [{ address: 7000, size: 100, device_id: 0, buffer_type: BufferType.DRAM }],
+};
+
+const opC = {
+    id: 3,
+    name: 'op-c',
+    buffers: [{ address: 7300, size: 200, device_id: 0, buffer_type: BufferType.DRAM }],
+};
+
+function renderDRAMRenderer(uniqueBuffersByOperationList: (typeof opA)[]) {
+    return render(
+        <TestProviders
+            initialAtomValues={[
+                [showBufferSummaryZoomedAtom, true],
+                [renderMemoryLayoutAtom, false],
+            ]}
+        >
+            <BufferSummaryPlotRendererDRAM
+                uniqueBuffersByOperationList={uniqueBuffersByOperationList}
+                tensorListByOperation={baseTensorMap}
+            />
+        </TestProviders>,
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe('BufferSummaryPlotRendererDRAM', () => {
+    it('uses the first multi-operation segment for zoom bounds', () => {
+        renderDRAMRenderer([opA, opB, opC]);
+
+        const props = bufferSummaryVirtualizedListMock.mock.calls[0][0];
+        expect(props.zoomStart).toBe(7000);
+        expect(props.zoomEnd).toBe(7500);
+        expect(props.memoryPadding).toBe((7500 - 7000) * MEMORY_ZOOM_PADDING_RATIO);
+    });
+
+    it('falls back to full DRAM range when no valid zoom segment exists', () => {
+        renderDRAMRenderer([opA, opB]);
+
+        const props = bufferSummaryVirtualizedListMock.mock.calls[0][0];
+        expect(props.zoomStart).toBe(0);
+        expect(props.zoomEnd).toBe(DRAM_MEMORY_SIZE);
+        expect(props.memoryPadding).toBe(0);
+    });
+
+    it('passes through the original operation list when not zoomed in', () => {
+        render(
+            <TestProviders
+                initialAtomValues={[
+                    [showBufferSummaryZoomedAtom, false],
+                    [renderMemoryLayoutAtom, true],
+                ]}
+            >
+                <BufferSummaryPlotRendererDRAM
+                    uniqueBuffersByOperationList={[opA, opB, opC]}
+                    tensorListByOperation={baseTensorMap}
+                />
+            </TestProviders>,
+        );
+
+        const props = bufferSummaryVirtualizedListMock.mock.calls[0][0];
+        expect(props.isZoomedIn).toBe(false);
+        expect(props.operations).toEqual([opA, opB, opC]);
+    });
+});

--- a/tests/BufferSummaryPlotRendererDRAM.spec.tsx
+++ b/tests/BufferSummaryPlotRendererDRAM.spec.tsx
@@ -77,6 +77,7 @@ describe('BufferSummaryPlotRendererDRAM', () => {
         renderDRAMRenderer([opA, opB]);
 
         const props = bufferSummaryVirtualizedListMock.mock.calls[0][0];
+        expect(props.isZoomedIn).toBe(false);
         expect(props.zoomStart).toBe(0);
         expect(props.zoomEnd).toBe(DRAM_MEMORY_SIZE);
         expect(props.memoryPadding).toBe(0);

--- a/tests/BufferSummaryPlotRendererDRAM.spec.tsx
+++ b/tests/BufferSummaryPlotRendererDRAM.spec.tsx
@@ -11,6 +11,7 @@ import { MEMORY_ZOOM_PADDING_RATIO } from '../src/definitions/BufferSummary';
 import { DRAM_MEMORY_SIZE } from '../src/definitions/DRAMMemorySize';
 import BufferSummaryPlotRendererDRAM from '../src/components/buffer-summary/BufferSummaryPlotRendererDRAM';
 import { TestProviders } from './helpers/TestProviders';
+import { getBufferAddressBounds } from '../src/functions/bufferSummary';
 
 const bufferSummaryVirtualizedListMock = vi.fn();
 
@@ -62,6 +63,23 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
+
+describe('getBufferAddressBounds', () => {
+    it('uses min/max address over all buffers, not operation list order', () => {
+        const opHighFirst = {
+            id: 1,
+            name: 'op-high-first',
+            buffers: [{ address: 7000, size: 100, device_id: 0, buffer_type: BufferType.DRAM }],
+        };
+        const opLowSecond = {
+            id: 2,
+            name: 'op-low-second',
+            buffers: [{ address: 100, size: 50, device_id: 0, buffer_type: BufferType.DRAM }],
+        };
+
+        expect(getBufferAddressBounds([opHighFirst, opLowSecond])).toEqual({ start: 100, end: 7100 });
+    });
+});
 
 describe('BufferSummaryPlotRendererDRAM', () => {
     it('uses the first multi-operation segment for zoom bounds', () => {

--- a/tests/BufferSummaryPlotRendererDRAM.spec.tsx
+++ b/tests/BufferSummaryPlotRendererDRAM.spec.tsx
@@ -68,6 +68,7 @@ describe('BufferSummaryPlotRendererDRAM', () => {
         renderDRAMRenderer([opA, opB, opC]);
 
         const props = bufferSummaryVirtualizedListMock.mock.calls[0][0];
+        expect(props.operations).toEqual([opB, opC]);
         expect(props.zoomStart).toBe(7000);
         expect(props.zoomEnd).toBe(7500);
         expect(props.memoryPadding).toBe((7500 - 7000) * MEMORY_ZOOM_PADDING_RATIO);

--- a/tests/BufferSummaryVirtualizedList.spec.tsx
+++ b/tests/BufferSummaryVirtualizedList.spec.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BufferType } from '../src/model/BufferType';
+import BufferSummaryVirtualizedList from '../src/components/buffer-summary/BufferSummaryVirtualizedList';
+import { ScrollLocations } from '../src/definitions/VirtualLists';
+import { BufferSummaryAxisConfiguration } from '../src/definitions/PlotConfigurations';
+
+const memoryPlotRendererMock = vi.fn();
+const bufferSummaryRowMock = vi.fn();
+const virtualizerFactoryMock = vi.fn();
+const restoreScrollPositionHookMock = vi.fn();
+const scrollShadeHookMock = vi.fn();
+const bufferNavigationHookMock = vi.fn();
+
+vi.mock('@tanstack/react-virtual', () => ({
+    useVirtualizer: (options: unknown) => virtualizerFactoryMock(options),
+}));
+
+vi.mock('../src/hooks/useRestoreScrollPosition', () => ({
+    default: (...args: unknown[]) => restoreScrollPositionHookMock(...args),
+}));
+
+vi.mock('../src/hooks/useScrollShade', () => ({
+    default: () => scrollShadeHookMock(),
+}));
+
+vi.mock('../src/hooks/useBufferNavigation', () => ({
+    default: (...args: unknown[]) => bufferNavigationHookMock(...args),
+}));
+
+vi.mock('../src/components/operation-details/MemoryPlotRenderer', () => ({
+    default: (props: unknown) => {
+        memoryPlotRendererMock(props);
+        return <div data-testid='memory-plot-renderer' />;
+    },
+}));
+
+vi.mock('../src/components/buffer-summary/BufferSummaryRow', () => ({
+    default: (props: unknown) => {
+        bufferSummaryRowMock(props);
+        return <div data-testid='buffer-summary-row' />;
+    },
+}));
+
+vi.mock('../src/components/buffer-summary/BufferSummaryPlotControls', () => ({
+    default: () => <div data-testid='buffer-summary-controls' />,
+}));
+
+vi.mock('@blueprintjs/core', async () => {
+    const original = await vi.importActual('@blueprintjs/core');
+    return {
+        ...original,
+        Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    };
+});
+
+const updateListStateMock = vi.fn();
+const updateScrollShadeMock = vi.fn();
+
+const operations = [
+    {
+        id: 1,
+        name: 'op-1',
+        buffers: [{ address: 100, size: 16, device_id: 0, buffer_type: BufferType.L1 }],
+    },
+    {
+        id: 2,
+        name: 'op-2',
+        buffers: [{ address: 200, size: 32, device_id: 0, buffer_type: BufferType.L1 }],
+    },
+];
+
+const tensorListByOperation = new Map<number, Map<number, never>>();
+
+function renderVirtualizedList(isZoomedIn: boolean) {
+    return render(
+        <BufferSummaryVirtualizedList
+            operations={operations}
+            tensorListByOperation={tensorListByOperation}
+            isZoomedIn={isZoomedIn}
+            showMemoryLayout={false}
+            scrollLocation={ScrollLocations.BUFFER_SUMMARY}
+            memorySize={1024}
+            zoomStart={100}
+            zoomEnd={200}
+            memoryPadding={10}
+            axisConfiguration={BufferSummaryAxisConfiguration}
+            getOperationTooltipContent={(operation) => operation.name}
+            renderOperationLink={(operation) => <span>{operation.name}</span>}
+        />,
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+
+    restoreScrollPositionHookMock.mockReturnValue({
+        getListState: () => ({ scrollOffset: 24, measurementsCache: [{ index: 0 }] }),
+        updateListState: updateListStateMock,
+    });
+
+    scrollShadeHookMock.mockReturnValue({
+        hasScrolledFromTop: false,
+        hasScrolledToBottom: false,
+        updateScrollShade: updateScrollShadeMock,
+        shadeClasses: { top: 'top-shade', bottom: 'bottom-shade' },
+    });
+
+    virtualizerFactoryMock.mockReturnValue({
+        getVirtualItems: () => [{ index: 0, key: 'row-0', start: 0 }],
+        getTotalSize: () => 140,
+        scrollOffset: 42,
+        measurementsCache: [{ index: 0, start: 0, end: 70, size: 70 }],
+    });
+});
+
+afterEach(cleanup);
+
+describe('BufferSummaryVirtualizedList', () => {
+    it('renders non-zoomed memory bounds to plot and rows', () => {
+        renderVirtualizedList(false);
+
+        const plotProps = memoryPlotRendererMock.mock.calls[0][0];
+        expect(plotProps.memorySize).toBe(1024);
+        expect(plotProps.plotZoomRange).toEqual([0, 1024]);
+
+        const rowProps = bufferSummaryRowMock.mock.calls[0][0];
+        expect(rowProps.memoryStart).toBe(0);
+        expect(rowProps.memoryEnd).toBe(1024);
+    });
+
+    it('renders zoomed memory bounds and padded plot range', () => {
+        renderVirtualizedList(true);
+
+        const plotProps = memoryPlotRendererMock.mock.calls[0][0];
+        expect(plotProps.memorySize).toBe(200);
+        expect(plotProps.plotZoomRange).toEqual([90, 210]);
+
+        const rowProps = bufferSummaryRowMock.mock.calls[0][0];
+        expect(rowProps.memoryStart).toBe(100);
+        expect(rowProps.memoryEnd).toBe(200);
+    });
+
+    it('persists virtual list state on unmount', async () => {
+        const { unmount } = renderVirtualizedList(false);
+        unmount();
+
+        await waitFor(() => {
+            expect(updateListStateMock).toHaveBeenCalledWith({
+                scrollOffset: 42,
+                measurementsCache: [{ index: 0, start: 0, end: 70, size: 70 }],
+            });
+        });
+    });
+
+    it('applies bottom shade when virtualized rows are partial', () => {
+        const { container } = renderVirtualizedList(false);
+        const scrollableElement = container.querySelector('.scrollable-element');
+
+        expect(scrollableElement).toHaveClass('bottom-shade');
+    });
+});


### PR DESCRIPTION
These changes collectively make the buffer summary components more robust, maintainable, and performant.

**Summary**
* Refactored `BufferSummaryRow` to use `React.memo` for memoization, preventing unnecessary re-renders. Added an `isScrolling` prop to disable tooltips and interactions while scrolling, improving UI responsiveness. Tooltip lookup for tensor deallocation is now optimized using a memoized map.
* In `BufferSummaryVirtualizedList`, introduced a scroll animation frame throttle to reduce state churn during scrolling, passed the `isScrolling` flag to child rows, and conditionally disables tooltips while scrolling for smoother performance.
* Replaced ad-hoc inline functions for operation links and tooltips with memoized callbacks in both `BufferSummaryPlotRenderer` and `BufferSummaryPlotRendererDRAM`, ensuring consistent rendering and improved performance. Switched from anchor tags and navigation handlers to `Link` components from `react-router-dom` for navigation. 
* Improved buffer segmentation logic in `BufferSummaryPlotRendererDRAM` by introducing a `FlattenedBuffer` type and refactoring the `getSplitBuffers` function for clearer and more robust grouping of buffers by operation. 
* Spliting buffer data is skipped for DRAM when there are more than 200,000 buffers
* Buffer zoom logic has been improved.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1435.