### PR TITLE
Operation graph focused ops update inputs/outputs to track operations and corresponding edges 

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -80,6 +80,12 @@ const OperationGraph: React.FC<{
         return ids;
     }, [edges]);
 
+    const operationNamesById = useMemo(() => {
+        const map = new Map<number, string>();
+        operationList.forEach((op) => map.set(op.id, op.name));
+        return map;
+    }, [operationList]);
+
     if (currentOperationId !== null && connectedNodeIds.size > 0 && !connectedNodeIds.has(currentOperationId)) {
         focusNodeId = connectedNodeIds.values().next().value ?? focusNodeId;
     }
@@ -546,6 +552,7 @@ const OperationGraph: React.FC<{
             {currentOperationId !== null && !isLoading && (
                 <OperationGraphInfoComponent
                     operationList={operationList}
+                    operationNamesById={operationNamesById}
                     currentOperationId={currentOperationId}
                     onNavigate={navigate}
                 />
@@ -604,7 +611,7 @@ type ConnectedOpGroup = {
 const groupTensorsByConnectedOp = (
     tensors: Tensor[] | undefined,
     direction: 'input' | 'output',
-    operationList: OperationList,
+    operationNamesById: Map<number, string>,
 ): ConnectedOpGroup[] => {
     if (!tensors?.length) {
         return [];
@@ -627,8 +634,7 @@ const groupTensorsByConnectedOp = (
 
         ids.forEach((opId, index) => {
             const key = String(opId);
-            const opFromList = operationList.find((op) => op.id === opId);
-            const name = opFromList?.name ?? names[index] ?? '';
+            const name = operationNamesById.get(opId) ?? names[index] ?? '';
             const label = `${opId} ${name}`.trim();
             const group = groups.get(key) ?? { key, label, tensors: [] };
             group.tensors.push(tensor);
@@ -642,17 +648,18 @@ const groupTensorsByConnectedOp = (
 const OperationGraphInfoComponent: React.FC<{
     currentOperationId: number;
     operationList: OperationList;
+    operationNamesById: Map<number, string>;
     onNavigate: NavigateFunction;
-}> = ({ currentOperationId, operationList, onNavigate }) => {
+}> = ({ currentOperationId, operationList, operationNamesById, onNavigate }) => {
     const operation = operationList.find((op) => op.id === currentOperationId);
 
     const inputGroups = useMemo(
-        () => groupTensorsByConnectedOp(operation?.inputs, 'input', operationList),
-        [operation, operationList],
+        () => groupTensorsByConnectedOp(operation?.inputs, 'input', operationNamesById),
+        [operation, operationNamesById],
     );
     const outputGroups = useMemo(
-        () => groupTensorsByConnectedOp(operation?.outputs, 'output', operationList),
-        [operation, operationList],
+        () => groupTensorsByConnectedOp(operation?.outputs, 'output', operationNamesById),
+        [operation, operationNamesById],
     );
 
     return (

--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -137,36 +137,37 @@ const OperationGraph: React.FC<{
 
             const allEdges = edgesDataSetRef.current.get();
 
-            const inputNodeIds = new Set<IdType | undefined>();
-            const outputNodeIds = new Set<IdType | undefined>();
+            const nextInputNodeIds = new Set<IdType>();
+            const nextOutputNodeIds = new Set<IdType>();
             const inputEdgeIds = new Set<IdType | undefined>();
             const outputEdgeIds = new Set<IdType | undefined>();
 
             for (const edge of allEdges) {
-                if (edge.to === selectedNodeId) {
-                    inputNodeIds.add(edge.from);
+                if (edge.to === selectedNodeId && edge.from !== undefined) {
+                    nextInputNodeIds.add(edge.from);
                     inputEdgeIds.add(edge.id);
                 }
 
-                if (edge.from === selectedNodeId) {
-                    outputNodeIds.add(edge.to);
+                if (edge.from === selectedNodeId && edge.to !== undefined) {
+                    nextOutputNodeIds.add(edge.to);
                     outputEdgeIds.add(edge.id);
                 }
             }
+
             nodes.update(
                 allNodes.map((node) => {
                     if (node.id === selectedNodeId) {
                         return node;
                     }
 
-                    if (inputNodeIds.has(node.id)) {
+                    if (nextInputNodeIds.has(node.id)) {
                         return {
                             id: node.id,
                             color: { background: GRAPH_COLORS.inputNode },
                         };
                     }
 
-                    if (outputNodeIds.has(node.id)) {
+                    if (nextOutputNodeIds.has(node.id)) {
                         return {
                             id: node.id,
                             color: { background: GRAPH_COLORS.outputNode },
@@ -594,12 +595,66 @@ const TensorDetailsComponent: React.FC<{ tensor: Tensor }> = ({ tensor }) => {
         </div>
     );
 };
+type ConnectedOpGroup = {
+    key: string;
+    label: string;
+    tensors: Tensor[];
+};
+
+const groupTensorsByConnectedOp = (
+    tensors: Tensor[] | undefined,
+    direction: 'input' | 'output',
+    operationList: OperationList,
+): ConnectedOpGroup[] => {
+    if (!tensors?.length) {
+        return [];
+    }
+
+    const groups = new Map<string, ConnectedOpGroup>();
+
+    tensors.forEach((tensor) => {
+        const ids = direction === 'input' ? tensor.producers : tensor.consumers;
+        const names = direction === 'input' ? tensor.producerNames : tensor.consumerNames;
+
+        if (!ids.length) {
+            const key = direction === 'input' ? 'external-input' : 'external-output';
+            const label = direction === 'input' ? 'External input' : 'Unconsumed output';
+            const group = groups.get(key) ?? { key, label, tensors: [] };
+            group.tensors.push(tensor);
+            groups.set(key, group);
+            return;
+        }
+
+        ids.forEach((opId, index) => {
+            const key = String(opId);
+            const opFromList = operationList.find((op) => op.id === opId);
+            const name = opFromList?.name ?? names[index] ?? '';
+            const label = `${opId} ${name}`.trim();
+            const group = groups.get(key) ?? { key, label, tensors: [] };
+            group.tensors.push(tensor);
+            groups.set(key, group);
+        });
+    });
+
+    return Array.from(groups.values());
+};
+
 const OperationGraphInfoComponent: React.FC<{
     currentOperationId: number;
     operationList: OperationList;
     onNavigate: NavigateFunction;
 }> = ({ currentOperationId, operationList, onNavigate }) => {
     const operation = operationList.find((op) => op.id === currentOperationId);
+
+    const inputGroups = useMemo(
+        () => groupTensorsByConnectedOp(operation?.inputs, 'input', operationList),
+        [operation, operationList],
+    );
+    const outputGroups = useMemo(
+        () => groupTensorsByConnectedOp(operation?.outputs, 'output', operationList),
+        [operation, operationList],
+    );
+
     return (
         <div className='operation-graph-props'>
             <h2 className='operation-name'>
@@ -619,22 +674,38 @@ const OperationGraphInfoComponent: React.FC<{
                 Memory Details
             </Button>
 
-            <h3>Inputs:</h3>
+            <h3 className='inputs'>Inputs:</h3>
             <div className='inputs tensors'>
-                {operation?.inputs.map((tensor, index) => (
-                    <TensorDetailsComponent
-                        tensor={tensor}
-                        key={`input-${currentOperationId} ${tensor.id} ${index}`}
-                    />
+                {inputGroups.map((group) => (
+                    <div
+                        className='connected-op'
+                        key={`input-op-${currentOperationId}-${group.key}`}
+                    >
+                        <h2 className='connected-op-name'>{group.label}</h2>
+                        {group.tensors.map((tensor, index) => (
+                            <TensorDetailsComponent
+                                tensor={tensor}
+                                key={`input-${currentOperationId}-${group.key}-${tensor.id}-${index}`}
+                            />
+                        ))}
+                    </div>
                 ))}
             </div>
-            <h3>Outputs:</h3>
+            <h3 className='outputs'>Outputs:</h3>
             <div className='outputs tensors'>
-                {operation?.outputs.map((tensor, index) => (
-                    <TensorDetailsComponent
-                        tensor={tensor}
-                        key={`output-${currentOperationId} ${tensor.id} ${index}`}
-                    />
+                {outputGroups.map((group) => (
+                    <div
+                        className='connected-op'
+                        key={`output-op-${currentOperationId}-${group.key}`}
+                    >
+                        <h2 className='connected-op-name'>{group.label}</h2>
+                        {group.tensors.map((tensor, index) => (
+                            <TensorDetailsComponent
+                                tensor={tensor}
+                                key={`output-${currentOperationId}-${group.key}-${tensor.id}-${index}`}
+                            />
+                        ))}
+                    </div>
                 ))}
             </div>
         </div>

--- a/src/scss/components/OperationGraphComponent.scss
+++ b/src/scss/components/OperationGraphComponent.scss
@@ -68,6 +68,15 @@
             background-color: $tt-grey-4;
             padding: 5px;
             font-size: 16px;
+            border-left: 3px solid transparent;
+
+            &.inputs {
+                border-left-color: var(--graph-input-edge);
+            }
+
+            &.outputs {
+                border-left-color: var(--graph-output-edge);
+            }
         }
 
         .device-operation-list {
@@ -85,6 +94,18 @@
             h3 {
                 margin: 0;
                 margin-bottom: 2px;
+            }
+
+            .connected-op {
+                display: flex;
+                flex-direction: column;
+                gap: 10px;
+
+                .connected-op-name {
+                    margin: 0;
+                    font-size: 14px;
+                    font-weight: 600;
+                }
             }
 
             .tensor-details {


### PR DESCRIPTION
Refactor operation graph UI to group tensors by their producing/consuming operation and add related styling.

- Add ConnectedOpGroup type and groupTensorsByConnectedOp utility to collect tensors by connected operation (including external inputs/outputs).
- Use useMemo to compute input/output groups for the current operation and render grouped sections with clearer keys.
- Rename input/output node id sets to nextInputNodeIds/nextOutputNodeIds and guard against undefined edge endpoints when building those sets to avoid adding invalid ids.
- Update SCSS to add left border color indicators for inputs/outputs and styles for connected-op blocks.

These changes improve readability of tensor lists, stabilize keys, and prevent undefined ids in node sets.

closes #1425

<img width="1687" height="1106" alt="image" src="https://github.com/user-attachments/assets/dbdf6384-3bb3-4cf3-9538-2b2c6a68c18e" />
