### PR TITLE
Allow buffer summary table scroll to always be visible

### DIFF
--- a/src/scss/components/BufferSummaryTable.scss
+++ b/src/scss/components/BufferSummaryTable.scss
@@ -16,6 +16,11 @@
     max-width: 1200px;
     overflow-y: auto;
 
+    // Allows scrollbar to be visible from the top and not hidden by the table header
+    .bp6-table-quadrant.bp6-table-quadrant-top {
+        background-color: transparent;
+    }
+
     .aside-container {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
Scroll position was hidden under the header especially if you had a large dataset. My solution was to remove a background colour from the header. 

The Blueprint Table puts the scroll there unfortunately and not aligned with the table body contents.

**After**
<img width="1280" height="764" alt="Screenshot 2026-05-04 at 15 43 00" src="https://github.com/user-attachments/assets/d4b3096d-10d8-4aad-b649-7100dd81b4e3" />
