### PR TITLE
Ensure operation and tensor list filters are reset when changing reports

### DIFF
--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -37,7 +37,6 @@ import {
     normaliseReportFolder,
 } from '../../functions/validateReportFolder';
 import { TEST_IDS } from '../../definitions/TestIds';
-import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
 
 const ICON_MAP: Record<ConnectionTestStates, IconName> = {
     [ConnectionTestStates.IDLE]: IconNames.DOT,
@@ -91,7 +90,6 @@ const LocalFolderOptions: FC = () => {
     } = useLocalConnection();
     const { data: perfFolderList } = usePerfFolderList();
     const { data: reportFolderList } = useReportFolderList();
-    const { resetListStates } = useRestoreScrollPosition();
 
     const [profilerFolder, setProfilerFolder] = useState<ConnectionStatus | undefined>();
     const [isUploadingReport, setIsUploadingReport] = useState(false);
@@ -220,7 +218,6 @@ const LocalFolderOptions: FC = () => {
         createToastNotification('Active memory report', folder.reportName ?? '', ToastType.SUCCESS);
         setActiveProfilerReport(folder);
         setProfilerReportLocation(ReportLocation.LOCAL);
-        resetListStates();
     };
 
     const handleDeleteProfiler = async (folder: ReportFolder) => {

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -27,13 +27,11 @@ import RemoteFolderSelector from './RemoteFolderSelector';
 import RemoteSyncButton from './RemoteSyncButton';
 import { updateInstance } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
-import useRestoreScrollPosition from '../../hooks/useRestoreScrollPosition';
 
 const RemoteSyncConfigurator: FC = () => {
     const remote = useRemoteConnection();
     const queryClient = useQueryClient();
     const disableRemoteSync = !!getServerConfig()?.SERVER_MODE;
-    const { resetListStates } = useRestoreScrollPosition();
 
     const [profilerReportLocation, setProfilerReportLocation] = useAtom(profilerReportLocationAtom);
     const [performanceReportLocation, setPerformanceReportLocation] = useAtom(performanceReportLocationAtom);
@@ -85,8 +83,6 @@ const RemoteSyncConfigurator: FC = () => {
             await updateInstance({
                 active_report: activeReport,
             });
-
-            resetListStates();
         }
     };
 

--- a/src/hooks/useRestoreInstance.tsx
+++ b/src/hooks/useRestoreInstance.tsx
@@ -2,8 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useEffect, useState } from 'react';
-import { useSetAtom } from 'jotai';
+import { useEffect, useRef, useState } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
 import {
     activeNpeOpTraceAtom,
     activePerformanceReportAtom,
@@ -15,17 +15,23 @@ import { useInstance, useReportFolderList } from './useAPI';
 import useRemoteConnection from './useRemote';
 import { ReportLocation } from '../definitions/Reports';
 import type { RemoteFolder } from '../definitions/RemoteConnection';
+import { useResetMemoryListStates } from './useRestoreScrollPosition';
 
 const useRestoreInstance = () => {
     const { data: instance, isLoading } = useInstance();
     const remote = useRemoteConnection();
     const { data: reports } = useReportFolderList();
+    const { resetMemoryListStates } = useResetMemoryListStates();
+
+    const [hasRestoredInstance, setHasRestoredInstance] = useState<boolean>(false);
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
     const setActiveProfilerReport = useSetAtom(activeProfilerReportAtom);
     const setActivePerformanceReport = useSetAtom(activePerformanceReportAtom);
     const setActiveNpe = useSetAtom(activeNpeOpTraceAtom);
     const setProfilerReportLocation = useSetAtom(profilerReportLocationAtom);
     const setPerformanceReportLocation = useSetAtom(performanceReportLocationAtom);
-    const [hasRestoredInstance, setHasRestoredInstance] = useState<boolean>(false);
+
+    const previousProfilerPathRef = useRef<string | null | undefined>(undefined);
 
     useEffect(() => {
         if (!instance || reports === null || hasRestoredInstance) {
@@ -42,7 +48,7 @@ const useRestoreInstance = () => {
             : profilerReportPath;
         const perfReportPath = instance?.active_report?.performance_name || null;
 
-        const activeProfilerReport = profilerReportPath
+        const restoredProfilerReport = profilerReportPath
             ? {
                   path: profilerReportPath,
                   reportName: profilerReportName ?? profilerReportPath,
@@ -58,7 +64,7 @@ const useRestoreInstance = () => {
         const activePerfLocation = instance?.active_report?.performance_location ?? null;
 
         const activeReports = {
-            profiler: activeProfilerReport,
+            profiler: restoredProfilerReport,
             profilerLocation: activeProfilerLocation,
             performance: activePerfReport,
             performanceLocation: activePerfLocation,
@@ -88,6 +94,25 @@ const useRestoreInstance = () => {
         reports,
         remote.persistentState,
     ]);
+
+    useEffect(() => {
+        if (!hasRestoredInstance) {
+            return;
+        }
+
+        const nextProfilerPath = activeProfilerReport?.path ?? null;
+
+        // Baseline the first observed value after restore to avoid false resets during hydration.
+        if (previousProfilerPathRef.current === undefined) {
+            previousProfilerPathRef.current = nextProfilerPath;
+            return;
+        }
+
+        if (previousProfilerPathRef.current !== nextProfilerPath) {
+            resetMemoryListStates();
+            previousProfilerPathRef.current = nextProfilerPath;
+        }
+    }, [activeProfilerReport?.path, hasRestoredInstance, resetMemoryListStates]);
 
     return {
         instance,

--- a/src/hooks/useRestoreScrollPosition.tsx
+++ b/src/hooks/useRestoreScrollPosition.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback } from 'react';
 import {
     listStatesAtom,
@@ -21,9 +21,8 @@ import {
 import { ListStates, ScrollLocations, VirtualListState } from '../definitions/VirtualLists';
 import { SortingOptions } from '../definitions/SortingOptions';
 
-const useRestoreScrollPosition = (key?: ScrollLocations) => {
-    const [listStates, setListStates] = useAtom(listStatesAtom);
-
+export const useResetMemoryListStates = () => {
+    const setListStates = useSetAtom(listStatesAtom);
     // Operation List
     const setOperationListFilter = useSetAtom(operationListFilterAtom);
     const setSelectedDeviceOperations = useSetAtom(selectedDeviceOperationsAtom);
@@ -38,6 +37,53 @@ const useRestoreScrollPosition = (key?: ScrollLocations) => {
     const setShowLateDeallocatedTensors = useSetAtom(showLateDeallocatedTensorsAtom);
     const setShouldSortBySize = useSetAtom(shouldSortBySizeAtom);
     const setShouldCollapseAllTensors = useSetAtom(shouldCollapseAllTensorsAtom);
+
+    const resetOperationList = useCallback(() => {
+        setOperationListFilter('');
+        setSelectedDeviceOperations(new Set());
+        setShouldSortByID(SortingOptions.ASCENDING);
+        setShouldSortDuration(SortingOptions.OFF);
+        setShouldCollapseAllOperations(false);
+    }, [
+        setOperationListFilter,
+        setSelectedDeviceOperations,
+        setShouldSortByID,
+        setShouldSortDuration,
+        setShouldCollapseAllOperations,
+    ]);
+
+    const resetTensorList = useCallback(() => {
+        setTensorListFilter('');
+        setTensorBufferTypeFilters([]);
+        setShowHighConsumerTensors(false);
+        setShowLateDeallocatedTensors(false);
+        setShouldSortBySize(SortingOptions.OFF);
+        setShouldCollapseAllTensors(false);
+    }, [
+        setTensorListFilter,
+        setTensorBufferTypeFilters,
+        setShowHighConsumerTensors,
+        setShowLateDeallocatedTensors,
+        setShouldSortBySize,
+        setShouldCollapseAllTensors,
+    ]);
+
+    const resetMemoryListStates = useCallback(() => {
+        setListStates(null);
+
+        resetOperationList();
+        resetTensorList();
+    }, [setListStates, resetOperationList, resetTensorList]);
+
+    return {
+        resetMemoryListStates,
+    };
+};
+
+const useRestoreScrollPosition = (key?: ScrollLocations) => {
+    const listStates = useAtomValue(listStatesAtom);
+    const setListStates = useSetAtom(listStatesAtom);
+    const { resetMemoryListStates } = useResetMemoryListStates();
 
     const updateListState = useCallback(
         (state: Partial<VirtualListState>) => {
@@ -72,47 +118,10 @@ const useRestoreScrollPosition = (key?: ScrollLocations) => {
         return listStates?.[key] || null;
     }, [key, listStates]);
 
-    const resetOperationList = useCallback(() => {
-        setOperationListFilter('');
-        setSelectedDeviceOperations(new Set());
-        setShouldSortByID(SortingOptions.ASCENDING);
-        setShouldSortDuration(SortingOptions.OFF);
-        setShouldCollapseAllOperations(false);
-    }, [
-        setOperationListFilter,
-        setSelectedDeviceOperations,
-        setShouldSortByID,
-        setShouldSortDuration,
-        setShouldCollapseAllOperations,
-    ]);
-
-    const resetTensorList = useCallback(() => {
-        setTensorListFilter('');
-        setTensorBufferTypeFilters([]);
-        setShowHighConsumerTensors(false);
-        setShowLateDeallocatedTensors(false);
-        setShouldSortBySize(SortingOptions.OFF);
-        setShouldCollapseAllTensors(false);
-    }, [
-        setTensorListFilter,
-        setTensorBufferTypeFilters,
-        setShowHighConsumerTensors,
-        setShowLateDeallocatedTensors,
-        setShouldSortBySize,
-        setShouldCollapseAllTensors,
-    ]);
-
-    const resetListStates = useCallback(() => {
-        setListStates(null);
-
-        resetOperationList();
-        resetTensorList();
-    }, [setListStates, resetOperationList, resetTensorList]);
-
     return {
         getListState,
         updateListState,
-        resetListStates,
+        resetMemoryListStates,
     };
 };
 

--- a/tests/useRestoreInstance.spec.tsx
+++ b/tests/useRestoreInstance.spec.tsx
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { useSetAtom } from 'jotai';
+import { TestProviders } from './helpers/TestProviders';
+import useRestoreInstance from '../src/hooks/useRestoreInstance';
+import { activeProfilerReportAtom } from '../src/store/app';
+
+const mockResetMemoryListStates = vi.fn();
+
+const { mockUseInstance, mockUseReportFolderList } = vi.hoisted(() => ({
+    mockUseInstance: vi.fn(),
+    mockUseReportFolderList: vi.fn(),
+}));
+
+vi.mock('../src/hooks/useAPI', () => ({
+    useInstance: () => mockUseInstance(),
+    useReportFolderList: () => mockUseReportFolderList(),
+}));
+
+vi.mock('../src/hooks/useRemote', () => ({
+    default: () => ({
+        persistentState: {
+            selectedConnection: null,
+            getSavedReportFolders: () => [],
+        },
+    }),
+}));
+
+vi.mock('../src/hooks/useRestoreScrollPosition', async () => {
+    const actual = await import('../src/hooks/useRestoreScrollPosition');
+    return {
+        ...actual,
+        useResetMemoryListStates: () => ({
+            resetMemoryListStates: mockResetMemoryListStates,
+        }),
+    };
+});
+
+const HookHarness = () => {
+    const { hasRestoredInstance } = useRestoreInstance();
+    return <div>{hasRestoredInstance ? 'restored' : 'pending'}</div>;
+};
+
+const SetProfilerReportButton = ({ path }: { path: string }) => {
+    const setActiveProfilerReport = useSetAtom(activeProfilerReportAtom);
+
+    return (
+        <button
+            onClick={() =>
+                setActiveProfilerReport({
+                    path,
+                    reportName: path,
+                })
+            }
+            type='button'
+        >
+            set-profiler-report
+        </button>
+    );
+};
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseReportFolderList.mockReturnValue({ data: [] });
+    mockUseInstance.mockReturnValue({
+        data: {
+            active_report: {
+                profiler_name: null,
+                profiler_location: null,
+                performance_name: null,
+                performance_location: null,
+                npe_name: null,
+            },
+            remote_profiler_folder: null,
+        },
+        isLoading: false,
+    });
+});
+
+it('does not reset memory list state during initial instance hydration', async () => {
+    render(
+        <TestProviders>
+            <HookHarness />
+        </TestProviders>,
+    );
+
+    await waitFor(() => {
+        expect(mockResetMemoryListStates).not.toHaveBeenCalled();
+    });
+});
+
+it('resets memory list state on first report change after null baseline', async () => {
+    render(
+        <TestProviders>
+            <HookHarness />
+            <SetProfilerReportButton path='reports/new-report' />
+        </TestProviders>,
+    );
+
+    await waitFor(() => {
+        expect(screen.getByText('restored')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'set-profiler-report' }));
+
+    await waitFor(() => {
+        expect(mockResetMemoryListStates).toHaveBeenCalledTimes(1);
+    });
+});
+
+it('does not reset when report path remains unchanged', async () => {
+    mockUseInstance.mockReturnValue({
+        data: {
+            active_report: {
+                profiler_name: 'reports/current-report',
+                profiler_location: null,
+                performance_name: null,
+                performance_location: null,
+                npe_name: null,
+            },
+            remote_profiler_folder: null,
+        },
+        isLoading: false,
+    });
+
+    render(
+        <TestProviders>
+            <HookHarness />
+            <SetProfilerReportButton path='reports/current-report' />
+        </TestProviders>,
+    );
+
+    await waitFor(() => {
+        expect(screen.getByText('restored')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'set-profiler-report' }));
+
+    await waitFor(() => {
+        expect(mockResetMemoryListStates).toHaveBeenCalledTimes(0);
+    });
+});

--- a/tests/useRestoreInstance.spec.tsx
+++ b/tests/useRestoreInstance.spec.tsx
@@ -91,8 +91,10 @@ it('does not reset memory list state during initial instance hydration', async (
     );
 
     await waitFor(() => {
-        expect(mockResetMemoryListStates).not.toHaveBeenCalled();
+        expect(screen.getByText('restored')).toBeTruthy();
     });
+
+    expect(mockResetMemoryListStates).toHaveBeenCalledTimes(0);
 });
 
 it('resets memory list state on first report change after null baseline', async () => {


### PR DESCRIPTION
Fixes an issue of Operation/Tensor list filters not being reset when changing active reports in a certain way.

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1360.