### PR TITLE
Add selectable connected-op header in info panel

### DIFF
--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -231,7 +231,7 @@ const OperationGraph: React.FC<{
                     currentOpIdRef.current = nodeId;
                 } catch (e) {
                     // eslint-disable-next-line no-console
-                    console.error('Error selecting node', e);
+                    console.warn('Error selecting node', e);
                 }
             }
         },

--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -239,6 +239,14 @@ const OperationGraph: React.FC<{
         [scale],
     );
 
+    const selectConnectedNode = useCallback(
+        (nodeId: number) => {
+            focusOnNode(nodeId);
+            colorHighlightIO(nodeId);
+        },
+        [focusOnNode, colorHighlightIO],
+    );
+
     const updateScale = useCallback(
         (newScale: number) => {
             const limitedScale = Math.min(newScale, 3);
@@ -555,6 +563,7 @@ const OperationGraph: React.FC<{
                     operationNamesById={operationNamesById}
                     currentOperationId={currentOperationId}
                     onNavigate={navigate}
+                    onSelectConnectedNode={selectConnectedNode}
                 />
             )}
             {isLoading && (
@@ -605,6 +614,7 @@ const TensorDetailsComponent: React.FC<{ tensor: Tensor }> = ({ tensor }) => {
 type ConnectedOpGroup = {
     key: string;
     label: string;
+    opId: number | null;
     tensors: Tensor[];
 };
 
@@ -626,7 +636,7 @@ const groupTensorsByConnectedOp = (
         if (!ids.length) {
             const key = direction === 'input' ? 'external-input' : 'external-output';
             const label = direction === 'input' ? 'External input' : 'Unconsumed output';
-            const group = groups.get(key) ?? { key, label, tensors: [] };
+            const group = groups.get(key) ?? { key, label, opId: null, tensors: [] };
             group.tensors.push(tensor);
             groups.set(key, group);
             return;
@@ -636,7 +646,7 @@ const groupTensorsByConnectedOp = (
             const key = String(opId);
             const name = operationNamesById.get(opId) ?? names[index] ?? '';
             const label = `${opId} ${name}`.trim();
-            const group = groups.get(key) ?? { key, label, tensors: [] };
+            const group = groups.get(key) ?? { key, label, opId, tensors: [] };
             group.tensors.push(tensor);
             groups.set(key, group);
         });
@@ -645,12 +655,38 @@ const groupTensorsByConnectedOp = (
     return Array.from(groups.values());
 };
 
+const ConnectedOpHeader: React.FC<{
+    group: ConnectedOpGroup;
+    onSelect: (opId: number) => void;
+}> = ({ group, onSelect }) => {
+    return (
+        <div className='connected-op-header'>
+            <h2 className='connected-op-name'>{group.label}</h2>
+            {group.opId !== null && (
+                <Tooltip
+                    placement={PopoverPosition.RIGHT}
+                    content={`Select operation ${group.opId}`}
+                >
+                    <Button
+                        className='connected-op-select'
+                        icon={IconNames.LOCATE}
+                        variant={ButtonVariant.MINIMAL}
+                        onClick={() => onSelect(group.opId as number)}
+                        aria-label={`Select operation ${group.opId}`}
+                    />
+                </Tooltip>
+            )}
+        </div>
+    );
+};
+
 const OperationGraphInfoComponent: React.FC<{
     currentOperationId: number;
     operationList: OperationList;
     operationNamesById: Map<number, string>;
     onNavigate: NavigateFunction;
-}> = ({ currentOperationId, operationList, operationNamesById, onNavigate }) => {
+    onSelectConnectedNode: (opId: number) => void;
+}> = ({ currentOperationId, operationList, operationNamesById, onNavigate, onSelectConnectedNode }) => {
     const operation = operationList.find((op) => op.id === currentOperationId);
 
     const inputGroups = useMemo(
@@ -688,7 +724,10 @@ const OperationGraphInfoComponent: React.FC<{
                         className='connected-op'
                         key={`input-op-${currentOperationId}-${group.key}`}
                     >
-                        <h2 className='connected-op-name'>{group.label}</h2>
+                        <ConnectedOpHeader
+                            group={group}
+                            onSelect={onSelectConnectedNode}
+                        />
                         {group.tensors.map((tensor, index) => (
                             <TensorDetailsComponent
                                 tensor={tensor}
@@ -705,7 +744,10 @@ const OperationGraphInfoComponent: React.FC<{
                         className='connected-op'
                         key={`output-op-${currentOperationId}-${group.key}`}
                     >
-                        <h2 className='connected-op-name'>{group.label}</h2>
+                        <ConnectedOpHeader
+                            group={group}
+                            onSelect={onSelectConnectedNode}
+                        />
                         {group.tensors.map((tensor, index) => (
                             <TensorDetailsComponent
                                 tensor={tensor}

--- a/src/scss/components/OperationGraphComponent.scss
+++ b/src/scss/components/OperationGraphComponent.scss
@@ -101,10 +101,22 @@
                 flex-direction: column;
                 gap: 10px;
 
+                .connected-op-header {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                }
+
                 .connected-op-name {
                     margin: 0;
                     font-size: 14px;
                     font-weight: 600;
+                }
+
+                .connected-op-select {
+                    padding: 2px;
+                    min-height: 0;
+                    min-width: 0;
                 }
             }
 


### PR DESCRIPTION
Introduce a selectable header for connected operations in the OperationGraph info panel. Add selectConnectedNode callback (calls focusOnNode and colorHighlightIO) and pass it as onSelectConnectedNode to OperationGraphInfoComponent and downstream components. Extend ConnectedOpGroup with opId and populate it when grouping tensors. Add a new ConnectedOpHeader component that shows the op label and a locate button (with Tooltip) to focus the operation in the graph. Update styles in OperationGraphComponent.scss for the header and select button. Files changed: src/components/OperationGraphComponent.tsx, src/scss/components/OperationGraphComponent.scss.

<img width="1687" height="1117" alt="image" src="https://github.com/user-attachments/assets/4f6d4ae1-89d9-41d5-8648-6664341cfd48" />

closes #1455
