### PR TITLE
Pin mypy version

### DIFF
--- a/backend/ttnn_visualizer/sockets.py
+++ b/backend/ttnn_visualizer/sockets.py
@@ -61,8 +61,8 @@ class ReportGenerated(SerializeableDataclass):
     timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
 
-# For tracking connected clients subscriber ID
-tab_clients = {}
+# For tracking connected clients subscriber ID (instance_id -> socket sid)
+tab_clients: dict[str, str] = {}
 
 # Global variables for debouncing
 debounce_timer = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ classifiers = [
 dev = [
     "black==26.3.1",
     "isort==6.0.1",
-    "mypy",
+    "mypy==2.0.0",
+    "mypy-extensions==1.0.0",
     "playwright==1.58.0",
     "pytest==9.0.3",
     "types-PyYAML==6.0.12.20240311",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dev = [
     "black==26.3.1",
     "isort==6.0.1",
     "mypy==2.0.0",
-    "mypy-extensions==1.0.0",
     "playwright==1.58.0",
     "pytest==9.0.3",
     "types-PyYAML==6.0.12.20240311",


### PR DESCRIPTION
A new version of mypy was released today, version 2.0.0. We did not have the mypy version pinned in `pyproject.toml`, and the major version change from 1.x to 2.x caused the PR lint-and-test workflow to fail.

This PR pins the version, and fixes the problem that caused the mypy check to fail with the new version.

Closes #1461 