### PR TITLE
Fix checking for config paths when reports are deleted

### DIFF
--- a/backend/ttnn_visualizer/tests/test_utils.py
+++ b/backend/ttnn_visualizer/tests/test_utils.py
@@ -538,3 +538,15 @@ def test_read_profiler_config_api_payload_single_file(tmp_path):
     payload, err = read_profiler_config_api_payload(tmp_path, logical_rank=99)
     assert err is None
     assert payload == {"report_name": "x"}
+
+
+def test_pick_profiler_config_paths_missing_directory(tmp_path):
+    missing = tmp_path / "deleted_report"
+    assert pick_profiler_config_paths(missing) == []
+
+
+def test_read_profiler_config_api_payload_missing_directory(tmp_path):
+    missing = tmp_path / "deleted_report"
+    payload, err = read_profiler_config_api_payload(missing)
+    assert payload is None
+    assert err is None

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -77,6 +77,8 @@ def pick_profiler_config_paths(report_dir: Path) -> List[Path]:
     """
     Prefer config.json when present; otherwise use consistent config_*_of_*.json files.
     """
+    if not report_dir.is_dir():
+        return []
     single = report_dir / PROFILER_CONFIG_BASENAME
     if single.is_file():
         return [single]
@@ -121,6 +123,8 @@ def read_profiler_config_api_payload(
     respond with an empty object); otherwise ``rank_out_of_range``,
     ``missing_rank_file``, or ``parse_error``.
     """
+    if not report_dir.is_dir():
+        return None, None
     single = report_dir / PROFILER_CONFIG_BASENAME
     if single.is_file():
         try:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -793,6 +793,8 @@ def get_profiler_data_list(instance: Instance):
 
     for dir_name in directory_names:
         dir_path = Path(path) / dir_name
+        if not dir_path.is_dir():
+            continue
         files = list(dir_path.glob("**/*"))
         report_name = None
         if pick_profiler_config_paths(dir_path):


### PR DESCRIPTION
This fixes a bug that was caused by looking for whether `config.json` or `config_x_of_y.json` style naming is used, on reports that were deleted from the reports directory.

Closes #1463