### PR TITLE
Use styles/ alias for component SCSS imports

### DIFF
--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonVariant, Collapse, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import React from 'react';
 import { JSX } from 'react/jsx-runtime';
-import '../scss/components/Collapsible.scss';
+import 'styles/components/Collapsible.scss';
 import classNames from 'classnames';
 
 interface CollapsibleProps {

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Icon, IconName, Intent, TagProps } from '@blueprintjs/core';
 import HighlightedText from './HighlightedText';
-import '../scss/components/ListItem.scss';
+import 'styles/components/ListItem.scss';
 import MemoryTag from './MemoryTag';
 
 interface ListItemProps {

--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -13,7 +13,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { NavigateFunction, useNavigate } from 'react-router';
 import tinycolor from 'tinycolor2';
 import { OperationDescription, Tensor } from '../model/APIData';
-import '../scss/components/OperationGraphComponent.scss';
+import 'styles/components/OperationGraphComponent.scss';
 import LoadingSpinner from './LoadingSpinner';
 import MemoryConfigRow from './MemoryConfigRow';
 import { ShardSpec } from '../functions/parseMemoryConfig';

--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router';
 import { useArchitecture, useGetClusterDescription } from '../../hooks/useAPI';
 import { stringToArchitecture } from '../../definitions/DeviceArchitecture';
 
-import '../../scss/components/ClusterView.scss';
+import 'styles/components/ClusterView.scss';
 import {
     CLUSTER_COORDS,
     CLUSTER_ETH_POSITION,

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { useAtomValue } from 'jotai';
 import { BufferType } from '../../model/BufferType';
 import { useBufferPages, useDevices } from '../../hooks/useAPI';
-import '../../scss/components/TensorVisualizationComponent.scss';
+import 'styles/components/TensorVisualizationComponent.scss';
 import { BufferPage, Tensor } from '../../model/APIData';
 import SVGBufferRenderer from './SVGBufferRenderer';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';


### PR DESCRIPTION
## Summary
- Replaced relative `../scss/...` imports in the five components called out in #1495 with the shared `styles/` path alias (matching Vite and `tsconfig`).

Closes #1495.

## Test plan
- [x] CI ESLint/Stylelint pass
- [x] Quick UI smoke: collapsible list rows, operation graph, cluster view, tensor visualization still styled

Made with [Cursor](https://cursor.com)