### PR TITLE
Update lefthand menu title to include trademark symbol

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -52,7 +52,7 @@ function Layout() {
                                 alt='tenstorrent'
                                 src='https://docs.tenstorrent.com/tt-tm-assets/Logo/Standard%20Lockup/svg/tt_logo_color-orange-whitetext.svg'
                             />
-                            <span className='visualizer-title'>TT-NN Visualizer</span>
+                            <span className='visualizer-title'>TT-NN&trade; Visualizer</span>
                         </h1>
                     </Link>
 


### PR DESCRIPTION
This was a request from Legal to add "TM" next to "TT-NN" in the lefthand menu title (as it appears in large text, above the search bar)