### PR TITLE
Dim legend and input/outputs when out of bounds of user zoom

### DIFF
--- a/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
+++ b/src/components/buffer-summary/BufferSummaryVirtualizedList.tsx
@@ -149,7 +149,7 @@ function BufferSummaryVirtualizedList({
                     className='buffer-summary-plot'
                     chartDataList={CHART_DATA}
                     isZoomedIn={isZoomedIn}
-                    memorySize={plotMemorySize}
+                    memoryZoomEnd={plotMemorySize}
                     plotZoomRange={plotZoomRange}
                     configuration={axisConfiguration}
                     markers={markers}

--- a/src/components/operation-details/DRAMPlots.tsx
+++ b/src/components/operation-details/DRAMPlots.tsx
@@ -118,7 +118,7 @@ function DRAMPlots({
                                 plotZoomRange={[dramNonContinuousPlotZoomRangeStart, dramNonContinuousPlotZoomRangeEnd]}
                                 chartDataList={[chartData]}
                                 isZoomedIn
-                                memorySize={DRAM_MEMORY_SIZE}
+                                memoryZoomEnd={DRAM_MEMORY_SIZE}
                                 onBufferClick={onDramBufferClick}
                                 configuration={{
                                     ...DRAMRenderConfiguration,
@@ -139,7 +139,7 @@ function DRAMPlots({
                         plotZoomRange={[dramPlotZoomRangeStart, dramPlotZoomRangeEnd]}
                         chartDataList={[previousDramData]}
                         isZoomedIn={zoomedInViewMainMemory}
-                        memorySize={DRAM_MEMORY_SIZE}
+                        memoryZoomEnd={DRAM_MEMORY_SIZE}
                         configuration={DRAMRenderConfiguration}
                     />
                 )}
@@ -168,7 +168,7 @@ function DRAMPlots({
                                 plotZoomRange={[dramNonContinuousPlotZoomRangeStart, dramNonContinuousPlotZoomRangeEnd]}
                                 chartDataList={[chartData]}
                                 isZoomedIn
-                                memorySize={DRAM_MEMORY_SIZE}
+                                memoryZoomEnd={DRAM_MEMORY_SIZE}
                                 onBufferClick={onDramBufferClick}
                                 configuration={{
                                     ...DRAMRenderConfiguration,
@@ -188,7 +188,7 @@ function DRAMPlots({
                         plotZoomRange={[dramPlotZoomRangeStart, dramPlotZoomRangeEnd]}
                         chartDataList={[dramData]}
                         isZoomedIn={zoomedInViewMainMemory}
-                        memorySize={DRAM_MEMORY_SIZE}
+                        memoryZoomEnd={DRAM_MEMORY_SIZE}
                         onBufferClick={onDramBufferClick}
                         configuration={DRAMRenderConfiguration}
                     />
@@ -219,7 +219,7 @@ function DRAMPlots({
                                 plotZoomRange={[dramNonContinuousPlotZoomRangeStart, dramNonContinuousPlotZoomRangeEnd]}
                                 chartDataList={[chartData]}
                                 isZoomedIn
-                                memorySize={DRAM_MEMORY_SIZE}
+                                memoryZoomEnd={DRAM_MEMORY_SIZE}
                                 onBufferClick={onDramDeltaClick}
                                 configuration={{
                                     ...DRAMRenderConfiguration,
@@ -240,7 +240,7 @@ function DRAMPlots({
                         plotZoomRange={[dramPlotZoomRangeStart, dramPlotZoomRangeEnd]}
                         chartDataList={[dramHasntChanged ? EMPTY_CHART : dramData]}
                         isZoomedIn={zoomedInViewMainMemory}
-                        memorySize={DRAM_MEMORY_SIZE}
+                        memoryZoomEnd={DRAM_MEMORY_SIZE}
                         onBufferClick={onDramBufferClick}
                         configuration={DRAMRenderConfiguration}
                     />

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -169,7 +169,7 @@ function L1Plots({
                 plotZoomRange={[zoomRangeStart - MEMORY_PADDING_L1, zoomRangeEnd + MEMORY_PADDING_L1]}
                 chartDataList={[previousChartData]}
                 isZoomedIn={zoomedInViewMainMemory}
-                memorySize={memorySizeL1}
+                memoryZoomEnd={memorySizeL1}
                 configuration={L1RenderConfiguration}
                 markers={memoryRegionsMarkers}
             />
@@ -182,7 +182,7 @@ function L1Plots({
                 isZoomedIn={zoomedInViewMainMemory}
                 plotZoomRange={[zoomRangeStart - MEMORY_PADDING_L1, zoomRangeEnd + MEMORY_PADDING_L1]}
                 chartDataList={[cbChartData, chartData, l1SmallMemory.length > 0 ? l1SmallCondensedChart : []]}
-                memorySize={memorySizeL1}
+                memoryZoomEnd={memorySizeL1}
                 onBufferClick={onBufferClick}
                 configuration={L1RenderConfiguration}
                 markers={memoryRegionsMarkers}
@@ -213,7 +213,7 @@ function L1Plots({
                                         zoomRangeEnd + MEMORY_PADDING_L1,
                                     ]}
                                     isZoomedIn={zoomedInViewMainMemory}
-                                    memorySize={memorySizeL1}
+                                    memoryZoomEnd={memorySizeL1}
                                     configuration={BufferRenderConfiguration}
                                     onBufferClick={onBufferClick}
                                     markers={memoryRegionsMarkers}
@@ -236,7 +236,7 @@ function L1Plots({
                         l1SmallZoomEnd + MEMORY_PADDING_L1_SMALL,
                     ]}
                     chartDataList={[l1SmallChartData]}
-                    memorySize={memorySizeL1} // Not used as we're always zoomed in
+                    memoryZoomEnd={memorySizeL1} // Not used as we're always zoomed in
                     configuration={L1SmallRenderConfiguration}
                     onBufferClick={() => {}}
                 />
@@ -271,7 +271,7 @@ function L1Plots({
                                 chartDataList={[plotData]}
                                 plotZoomRange={[cbZoomStart - MEMORY_PADDING_CB, cbZoomEnd + MEMORY_PADDING_CB]}
                                 isZoomedIn={zoomedInViewCBMemory}
-                                memorySize={memorySizeL1}
+                                memoryZoomEnd={memorySizeL1}
                                 configuration={CBRenderConfiguration}
                                 onBufferClick={onBufferClick}
                                 markers={[{ color: L1_SMALL_MARKER_COLOR, address: l1SmallMarker }]}

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -7,7 +7,7 @@ import { useAtomValue } from 'jotai';
 import { IconNames } from '@blueprintjs/icons';
 import { Icon, Intent, Switch } from '@blueprintjs/core';
 import { Fragment } from 'react/jsx-runtime';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import MemoryPlotRenderer from './MemoryPlotRenderer';
 import { OperationDetails } from '../../model/OperationDetails';
 import { MemoryLegendElement } from './MemoryLegendElement';
@@ -125,6 +125,10 @@ function L1Plots({
 
     const zoomRangeStart = plotZoomRangeStart; // Math.min(plotZoomRangeStart, bufferZoomRangeStart);
     const zoomRangeEnd = plotZoomRangeEnd; // Math.max(plotZoomRangeEnd, bufferZoomRangeEnd);
+    const userL1ZoomRange = useMemo(
+        () => (zoomedInViewMainMemory ? ([plotZoomRangeStart, plotZoomRangeEnd] as [number, number]) : undefined),
+        [zoomedInViewMainMemory, plotZoomRangeStart, plotZoomRangeEnd],
+    );
 
     const memoryRegionsMarkers = showMemoryRegions
         ? [
@@ -298,6 +302,7 @@ function L1Plots({
                         selectedTensorAddress={null}
                         operationDetails={operationDetails}
                         onLegendClick={onLegendClick}
+                        userL1ZoomRange={userL1ZoomRange}
                     />
                 )}
                 {showCircularBuffer &&
@@ -310,6 +315,7 @@ function L1Plots({
                             operationDetails={operationDetails}
                             onLegendClick={onLegendClick}
                             colorVariance={chunk.colorVariance}
+                            userL1ZoomRange={userL1ZoomRange}
                         />
                     ))}
 
@@ -325,6 +331,7 @@ function L1Plots({
                                 selectedTensorAddress={selectedAddress}
                                 operationDetails={operationDetails}
                                 onLegendClick={onLegendClick}
+                                userL1ZoomRange={userL1ZoomRange}
                             />
                         ) : (
                             <MemoryLegendElement
@@ -334,6 +341,7 @@ function L1Plots({
                                 selectedTensorAddress={selectedAddress}
                                 operationDetails={operationDetails}
                                 onLegendClick={onLegendClick}
+                                userL1ZoomRange={userL1ZoomRange}
                             />
                         );
                     })}
@@ -349,6 +357,7 @@ function L1Plots({
                         selectedTensorAddress={null}
                         operationDetails={operationDetails}
                         onLegendClick={onLegendClick}
+                        userL1ZoomRange={userL1ZoomRange}
                     />
                 )}
             </div>

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -91,10 +91,12 @@ export const MemoryLegendElement: React.FC<{
     const isMatchingBufferColour = memorySquare.backgroundColor === selectedBufferColour;
     // L1_START / L1_SMALL are axis markers
     const isLegendMarker = chunk.markerType === MarkerType.L1_SMALL || chunk.markerType === MarkerType.L1_START;
+    const chunkSize = chunk.size ?? 0;
     const isOutOfL1ZoomRange =
         !isLegendMarker &&
         !Number.isNaN(chunk.address) &&
-        isAddressRangeOutOfL1Zoom(chunk.address, chunk.address + Math.max(chunk.size, 0), userL1ZoomRange);
+        chunkSize > 0 &&
+        isAddressRangeOutOfL1Zoom(chunk.address, chunk.address + chunkSize, userL1ZoomRange);
 
     return (
         <Component

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -16,6 +16,7 @@ import 'styles/components/MemoryLegendElement.scss';
 import { L1_SMALL_MARKER_COLOR, L1_START_MARKER_COLOR } from '../../definitions/PlotConfigurations';
 import { selectedBufferColourAtom, showHexAtom } from '../../store/app';
 import { StringBufferType, StringBufferTypeLabel } from '../../model/BufferType';
+import { isAddressRangeOutOfL1Zoom } from '../../functions/isAddressRangeVisibleInL1Zoom';
 
 export const MemoryLegendElement: React.FC<{
     chunk: FragmentationEntry;
@@ -30,6 +31,7 @@ export const MemoryLegendElement: React.FC<{
     isGroupHeader?: boolean;
     className?: string;
     numCores?: number;
+    userL1ZoomRange?: [number, number];
 }> = ({
     // no wrap eslint
     chunk,
@@ -43,6 +45,7 @@ export const MemoryLegendElement: React.FC<{
     isMultiDeviceBuffer = false,
     className,
     numCores,
+    userL1ZoomRange,
 }) => {
     const showHex = useAtomValue(showHexAtom);
     const selectedBufferColour = useAtomValue(selectedBufferColourAtom);
@@ -86,6 +89,12 @@ export const MemoryLegendElement: React.FC<{
     };
 
     const isMatchingBufferColour = memorySquare.backgroundColor === selectedBufferColour;
+    // L1_START / L1_SMALL are axis markers
+    const isLegendMarker = chunk.markerType === MarkerType.L1_SMALL || chunk.markerType === MarkerType.L1_START;
+    const isOutOfL1ZoomRange =
+        !isLegendMarker &&
+        !Number.isNaN(chunk.address) &&
+        isAddressRangeOutOfL1Zoom(chunk.address, chunk.address + Math.max(chunk.size, 0), userL1ZoomRange);
 
     return (
         <Component
@@ -99,9 +108,10 @@ export const MemoryLegendElement: React.FC<{
                         chunk.markerType !== MarkerType.L1_START,
                     active: selectedTensorAddress === chunk.address && isMatchingBufferColour,
                     dimmed:
-                        selectedBufferColour !== null &&
-                        selectedTensorAddress !== null &&
-                        (selectedTensorAddress !== chunk.address || !isMatchingBufferColour),
+                        isOutOfL1ZoomRange ||
+                        (selectedBufferColour !== null &&
+                            selectedTensorAddress !== null &&
+                            (selectedTensorAddress !== chunk.address || !isMatchingBufferColour)),
                     'extra-info': bufferType || layout,
                 },
                 className,

--- a/src/components/operation-details/MemoryLegendGroup.tsx
+++ b/src/components/operation-details/MemoryLegendGroup.tsx
@@ -16,6 +16,7 @@ export const MemoryLegendGroup: React.FC<{
     selectedTensorAddress: number | null;
     operationDetails: OperationDetails;
     onLegendClick: (selectedTensorAddress: number, tensorId?: number, colorVariance?: number) => void;
+    userL1ZoomRange?: [number, number];
 }> = ({
     // no wrap eslint
     group,
@@ -23,6 +24,7 @@ export const MemoryLegendGroup: React.FC<{
     selectedTensorAddress,
     operationDetails,
     onLegendClick,
+    userL1ZoomRange,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -37,6 +39,7 @@ export const MemoryLegendGroup: React.FC<{
                     operationDetails={operationDetails}
                     onLegendClick={onLegendClick}
                     isGroupHeader
+                    userL1ZoomRange={userL1ZoomRange}
                 />
 
                 <strong>x{group.length}</strong>
@@ -67,6 +70,7 @@ export const MemoryLegendGroup: React.FC<{
                             operationDetails={operationDetails}
                             onLegendClick={onLegendClick}
                             isMultiDeviceBuffer
+                            userL1ZoomRange={userL1ZoomRange}
                         />
                     ))}
                 </div>

--- a/src/components/operation-details/MemoryPlotRenderer.tsx
+++ b/src/components/operation-details/MemoryPlotRenderer.tsx
@@ -14,7 +14,7 @@ import { getMemoryAddress } from '../../functions/math';
 export interface MemoryPlotRendererProps {
     chartDataList: Partial<PlotData>[][];
     isZoomedIn: boolean;
-    memorySize: number;
+    memoryZoomEnd: number;
     title?: string;
     onBufferClick?: (event: Readonly<PlotMouseEventCustom>) => void;
     plotZoomRange?: [start: number, end: number];
@@ -27,7 +27,7 @@ export interface MemoryPlotRendererProps {
 const MemoryPlotRenderer: React.FC<MemoryPlotRendererProps> = ({
     chartDataList,
     isZoomedIn,
-    memorySize,
+    memoryZoomEnd,
     className = '',
     title,
     onBufferClick,
@@ -42,7 +42,7 @@ const MemoryPlotRenderer: React.FC<MemoryPlotRendererProps> = ({
     const selectedAddress = useAtomValue(selectedAddressAtom);
     const [hoveredPoint, setHoveredPoint] = useState<number | null>(null);
 
-    const range = isZoomedIn ? plotZoomRange : [0, memorySize];
+    const range = isZoomedIn ? plotZoomRange : [0, memoryZoomEnd];
     // If we need more flexibility on the tickformat front, we can expand this to accept a prop instead of defaulting to the below (hex or decimal)
     const tickFormat = showHex ? { tickformat: 'x', tickprefix: '0x' } : { tickformat: 'd' };
 

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -379,7 +379,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                         plotZoomRange={[plotZoomRangeMin, plotZoomRangeMax]}
                                         chartDataList={[chartData]}
                                         isZoomedIn={zoomedInViewMainMemory}
-                                        memorySize={memorySizeL1}
+                                        memoryZoomEnd={memorySizeL1}
                                         configuration={L1RenderZoomoutConfiguration}
                                     />
                                     <div className='zoom-range-wrap'>

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -331,7 +331,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                             operationId={operationId}
                                             address={inputOutputAddressList}
                                             bufferType={BufferType.L1}
-                                            zoomRange={[zoomRangeStart, zoomRangeEnd]}
+                                            plotZoomRange={[zoomRangeStart, zoomRangeEnd]}
                                             isOpen={tensixIOVisualisationOpen}
                                             onClose={() => setTensixIOVisualisationOpen(false)}
                                             tensorByAddress={details.tensorListByAddress}
@@ -342,7 +342,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                                             title={`${operationId} ${operation.name}  (${operation.operationFileIdentifier})  detailed memory report`}
                                             operationId={operationId}
                                             bufferType={BufferType.L1}
-                                            zoomRange={[zoomRangeStart, zoomRangeEnd]}
+                                            plotZoomRange={[zoomRangeStart, zoomRangeEnd]}
                                             isOpen={tensixFullVisualisationOpen}
                                             onClose={() => setTensixFullVisualisationOpen(false)}
                                             tensorByAddress={details.tensorListByAddress}
@@ -436,6 +436,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                             operationDetails={details}
                             plotZoomRangeStart={zoomRangeStart}
                             plotZoomRangeEnd={zoomRangeEnd}
+                            zoomedInViewMainMemory={zoomedInViewMainMemory}
                             onTensorClick={onTensorClick}
                         />
 

--- a/src/components/operation-details/TensorDetailsComponent.tsx
+++ b/src/components/operation-details/TensorDetailsComponent.tsx
@@ -22,19 +22,22 @@ import GoldenTensorComparisonIndicator from '../GoldenTensorComparisonIndicator'
 import MemoryTag from '../MemoryTag';
 import useBufferFocus from '../../hooks/useBufferFocus';
 import { showHexAtom } from '../../store/app';
+import { isAddressRangeOutOfL1Zoom } from '../../functions/isAddressRangeVisibleInL1Zoom';
 
 export interface TensorDetailsComponentProps {
     tensor: Tensor;
     onTensorClick: (address?: number, tensorId?: number) => void;
     operationId: number;
-    zoomRange: [number, number];
+    plotZoomRange: [number, number];
+    userL1ZoomRange?: [number, number];
 }
 
 const TensorDetailsComponent: React.FC<TensorDetailsComponentProps> = ({
     tensor,
     onTensorClick,
     operationId,
-    zoomRange,
+    plotZoomRange,
+    userL1ZoomRange,
 }) => {
     const [overlayOpen, setOverlayOpen] = useState(false);
     const useHex = useAtomValue(showHexAtom);
@@ -43,6 +46,10 @@ const TensorDetailsComponent: React.FC<TensorDetailsComponentProps> = ({
     const { data: operations } = useOperationsList();
     const nextAllocationOperationId = operations ? getNextAllocationOperation(tensor, operations)?.id : null;
     const { selectedTensorId } = useBufferFocus();
+    const isTensorOutOfL1ZoomRange =
+        tensor.buffer_type === BufferType.L1 &&
+        tensor.address !== null &&
+        isAddressRangeOutOfL1Zoom(tensor.address, tensor.address + Math.max(tensor.size ?? 0, 0), userL1ZoomRange);
 
     const shardSpec = tensor.memory_config?.shard_spec;
 
@@ -50,7 +57,7 @@ const TensorDetailsComponent: React.FC<TensorDetailsComponentProps> = ({
         <div
             className={classNames('tensor-item', {
                 active: tensor.id === selectedTensorId,
-                dimmed: selectedTensorId !== null && tensor.id !== selectedTensorId,
+                dimmed: isTensorOutOfL1ZoomRange || (selectedTensorId !== null && tensor.id !== selectedTensorId),
             })}
         >
             <div className='tensor-header'>
@@ -105,7 +112,7 @@ const TensorDetailsComponent: React.FC<TensorDetailsComponentProps> = ({
                         bufferType={tensor.buffer_type}
                         isOpen={overlayOpen}
                         onClose={() => setOverlayOpen(false)}
-                        zoomRange={zoomRange}
+                        plotZoomRange={plotZoomRange}
                         tensorId={tensor.id}
                     />
                 )}

--- a/src/components/operation-details/TensorDetailsList.tsx
+++ b/src/components/operation-details/TensorDetailsList.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { useMemo } from 'react';
 import TensorDetailsComponent from './TensorDetailsComponent';
 import { OperationDetails } from '../../model/OperationDetails';
 import 'styles/components/TensorDetailsList.scss';
@@ -10,6 +11,7 @@ interface TensorDetailsProps {
     operationDetails: OperationDetails;
     plotZoomRangeStart: number;
     plotZoomRangeEnd: number;
+    zoomedInViewMainMemory: boolean;
     onTensorClick: (address?: number, tensorId?: number) => void;
 }
 
@@ -17,9 +19,18 @@ function TensorDetailsList({
     operationDetails,
     plotZoomRangeStart,
     plotZoomRangeEnd,
+    zoomedInViewMainMemory,
     onTensorClick,
 }: TensorDetailsProps) {
     const { id, inputs, outputs } = operationDetails;
+    const plotZoomRange = useMemo(
+        () => [plotZoomRangeStart, plotZoomRangeEnd] as [number, number],
+        [plotZoomRangeStart, plotZoomRangeEnd],
+    );
+    const userL1ZoomRange = useMemo(
+        () => (zoomedInViewMainMemory ? plotZoomRange : undefined),
+        [zoomedInViewMainMemory, plotZoomRange],
+    );
 
     return (
         <div className='tensor-list'>
@@ -32,7 +43,8 @@ function TensorDetailsList({
                         key={`${tensor.id}-${index}`}
                         onTensorClick={onTensorClick}
                         operationId={id}
-                        zoomRange={[plotZoomRangeStart, plotZoomRangeEnd]}
+                        plotZoomRange={plotZoomRange}
+                        userL1ZoomRange={userL1ZoomRange}
                     />
                 ))}
             </div>
@@ -46,7 +58,8 @@ function TensorDetailsList({
                         key={`${tensor.id}-${index}`}
                         onTensorClick={onTensorClick}
                         operationId={id}
-                        zoomRange={[plotZoomRangeStart, plotZoomRangeEnd]}
+                        plotZoomRange={plotZoomRange}
+                        userL1ZoomRange={userL1ZoomRange}
                     />
                 ))}
             </div>

--- a/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
+++ b/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
@@ -9,17 +9,17 @@ import { pageDataToChunkArray } from '../../functions/getChartData';
 interface SVGBufferRendererProps {
     height: number;
     data: BufferPage[];
-    memorySize: number;
     memoryStart: number;
+    memoryEnd: number;
 }
 
 const SVGBufferRenderer: React.FC<SVGBufferRendererProps> = ({
     height,
     data,
-    memorySize,
     memoryStart,
+    memoryEnd,
 }: SVGBufferRendererProps) => {
-    const memoryRange = memorySize - memoryStart;
+    const memoryRange = memoryEnd - memoryStart;
     const mergedRange = pageDataToChunkArray(data);
 
     return (

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -76,8 +76,7 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
     const width = devices[0].num_x_cores;
     const height = devices[0].num_y_cores;
 
-    const memStart = plotZoomRange[0];
-    const memSize = plotZoomRange[1];
+    const [memStart, memEnd] = plotZoomRange;
     const tensixSize = 120;
     const tensixHeight = tensixSize / 3;
 
@@ -170,8 +169,8 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
                                     <SVGBufferRenderer
                                         height={tensixHeight}
                                         data={buffersByBankId[matchIndex]}
-                                        memorySize={memSize}
                                         memoryStart={memStart}
+                                        memoryEnd={memEnd}
                                     />
                                 </button>
                             ) : (
@@ -207,9 +206,9 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
                                 }`}
                                 className='detailed-l1-memory-renderer l1-memory-renderer'
                                 isZoomedIn
-                                plotZoomRange={[memStart, memSize]}
+                                plotZoomRange={[memStart, memEnd]}
                                 chartDataList={[chartData]}
-                                memorySize={memSize}
+                                memoryZoomEnd={memEnd}
                                 onBufferClick={() => {}}
                                 configuration={{
                                     ...L1RenderConfiguration,

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -29,22 +29,9 @@ export interface TensorVisualisationComponentProps {
     onClose: () => void;
     tensorByAddress?: Map<number, Tensor>;
     tensorId?: number;
-    zoomRange: [number, number];
+    plotZoomRange: [number, number];
 }
 
-/**
- * @description Component for visualising buffer pagination data on tensix grid
- * @param title popup title
- * @param operationId
- * @param address buffer address or comma separated list of addresses
- * @param bufferType buffer type (always L1 as there is no other page data)
- * @param isOpen
- * @param onClose close callback
- * @param tensorByAddress optional historical lookup map
- * @param tensorId optionally used in the absence of tensorByAddress
- * @param zoomRange range of memory to display
- * @constructor
- */
 const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> = ({
     title,
     operationId,
@@ -53,7 +40,7 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
     isOpen,
     onClose,
     tensorByAddress,
-    zoomRange,
+    plotZoomRange,
     tensorId,
 }) => {
     const { data } = useBufferPages(operationId, address, bufferType);
@@ -89,8 +76,8 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
     const width = devices[0].num_x_cores;
     const height = devices[0].num_y_cores;
 
-    const memStart = zoomRange[0];
-    const memSize = zoomRange[1];
+    const memStart = plotZoomRange[0];
+    const memSize = plotZoomRange[1];
     const tensixSize = 120;
     const tensixHeight = tensixSize / 3;
 

--- a/src/functions/isAddressRangeVisibleInL1Zoom.ts
+++ b/src/functions/isAddressRangeVisibleInL1Zoom.ts
@@ -3,9 +3,10 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 /**
- * Half-open [rangeStart, rangeEnd) overlap with the L1 zoom window [zoomStart, zoomEnd].
- * Matches fragmentation gaps in OperationDetails (gap end equals the next allocation address).
- * Plotly clips the x-axis to the same slider endpoints; bar/gap visibility uses this rule.
+ * Half-open allocation [rangeStart, rangeEnd) vs inclusive zoom [zoomStart, zoomEnd].
+ * Gap end equals the next allocation address (OperationDetails fragmentation).
+ * Zoom low bound is exclusive (rangeEnd > zoomStart); high bound is inclusive (rangeStart <= zoomEnd)
+ * so gaps that start on the slider max address are not dimmed.
  */
 export function isAddressRangeVisibleInL1Zoom(
     rangeStart: number,
@@ -18,7 +19,7 @@ export function isAddressRangeVisibleInL1Zoom(
         return false;
     }
 
-    return rangeEnd > l1ZoomStart && rangeStart < l1ZoomEnd;
+    return rangeEnd > l1ZoomStart && rangeStart <= l1ZoomEnd;
 }
 
 export function isAddressRangeOutOfL1Zoom(

--- a/src/functions/isAddressRangeVisibleInL1Zoom.ts
+++ b/src/functions/isAddressRangeVisibleInL1Zoom.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * Half-open [rangeStart, rangeEnd) overlap with the L1 zoom window [zoomStart, zoomEnd].
+ * Matches fragmentation gaps in OperationDetails (gap end equals the next allocation address).
+ * Plotly clips the x-axis to the same slider endpoints; bar/gap visibility uses this rule.
+ */
+export function isAddressRangeVisibleInL1Zoom(
+    rangeStart: number,
+    rangeEnd: number,
+    l1ZoomRange: [number, number],
+): boolean {
+    const [l1ZoomStart, l1ZoomEnd] = l1ZoomRange;
+
+    if (Number.isNaN(rangeStart) || Number.isNaN(rangeEnd) || rangeEnd <= rangeStart) {
+        return false;
+    }
+
+    return rangeEnd > l1ZoomStart && rangeStart < l1ZoomEnd;
+}
+
+export function isAddressRangeOutOfL1Zoom(
+    rangeStart: number,
+    rangeEnd: number,
+    l1ZoomRange?: [number, number],
+): boolean {
+    if (l1ZoomRange === undefined) {
+        return false;
+    }
+
+    return !isAddressRangeVisibleInL1Zoom(rangeStart, rangeEnd, l1ZoomRange);
+}

--- a/tests/BufferSummaryVirtualizedList.spec.tsx
+++ b/tests/BufferSummaryVirtualizedList.spec.tsx
@@ -127,7 +127,7 @@ describe('BufferSummaryVirtualizedList', () => {
         renderVirtualizedList(false);
 
         const plotProps = memoryPlotRendererMock.mock.calls[0][0];
-        expect(plotProps.memorySize).toBe(1024);
+        expect(plotProps.memoryZoomEnd).toBe(1024);
         expect(plotProps.plotZoomRange).toEqual([0, 1024]);
 
         const rowProps = bufferSummaryRowMock.mock.calls[0][0];
@@ -139,7 +139,7 @@ describe('BufferSummaryVirtualizedList', () => {
         renderVirtualizedList(true);
 
         const plotProps = memoryPlotRendererMock.mock.calls[0][0];
-        expect(plotProps.memorySize).toBe(200);
+        expect(plotProps.memoryZoomEnd).toBe(200);
         expect(plotProps.plotZoomRange).toEqual([90, 210]);
 
         const rowProps = bufferSummaryRowMock.mock.calls[0][0];

--- a/tests/isAddressRangeVisibleInL1Zoom.spec.ts
+++ b/tests/isAddressRangeVisibleInL1Zoom.spec.ts
@@ -24,13 +24,17 @@ test('isAddressRangeVisibleInL1Zoom treats empty above zoom as outside', () => {
     expect(isAddressRangeOutOfL1Zoom(0x20000, 0x30000, ZOOM)).toBe(true);
 });
 
-test('isAddressRangeVisibleInL1Zoom does not count boundary touch as overlap', () => {
+test('isAddressRangeVisibleInL1Zoom does not count gap ending at zoom start as overlap', () => {
     expect(isAddressRangeVisibleInL1Zoom(0x5000, 0x10000, ZOOM)).toBe(false);
-    expect(isAddressRangeVisibleInL1Zoom(0x15000, 0x20000, ZOOM)).toBe(false);
 });
 
-test('isAddressRangeVisibleInL1Zoom treats fully contained range as visible', () => {
+test('isAddressRangeVisibleInL1Zoom counts gap starting at zoom end as overlap', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0x15000, 0x20000, ZOOM)).toBe(true);
+});
+
+test('isAddressRangeVisibleInL1Zoom treats empty fully inside zoom as visible', () => {
     expect(isAddressRangeVisibleInL1Zoom(0x11000, 0x14000, ZOOM)).toBe(true);
+    expect(isAddressRangeOutOfL1Zoom(0x11000, 0x14000, ZOOM)).toBe(false);
 });
 
 test('isAddressRangeOutOfL1Zoom returns false when zoom range is undefined', () => {

--- a/tests/isAddressRangeVisibleInL1Zoom.spec.ts
+++ b/tests/isAddressRangeVisibleInL1Zoom.spec.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { expect, test } from 'vitest';
+import {
+    isAddressRangeOutOfL1Zoom,
+    isAddressRangeVisibleInL1Zoom,
+} from '../src/functions/isAddressRangeVisibleInL1Zoom';
+
+const ZOOM: [number, number] = [0x10000, 0x15000];
+
+test('isAddressRangeVisibleInL1Zoom detects partial overlap', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0x5000, 0x12000, ZOOM)).toBe(true);
+});
+
+test('isAddressRangeVisibleInL1Zoom treats leading empty below zoom as outside', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0, 0x10000, ZOOM)).toBe(false);
+    expect(isAddressRangeOutOfL1Zoom(0, 0x10000, ZOOM)).toBe(true);
+});
+
+test('isAddressRangeVisibleInL1Zoom treats empty above zoom as outside', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0x20000, 0x30000, ZOOM)).toBe(false);
+    expect(isAddressRangeOutOfL1Zoom(0x20000, 0x30000, ZOOM)).toBe(true);
+});
+
+test('isAddressRangeVisibleInL1Zoom does not count boundary touch as overlap', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0x5000, 0x10000, ZOOM)).toBe(false);
+    expect(isAddressRangeVisibleInL1Zoom(0x15000, 0x20000, ZOOM)).toBe(false);
+});
+
+test('isAddressRangeVisibleInL1Zoom treats fully contained range as visible', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0x11000, 0x14000, ZOOM)).toBe(true);
+});
+
+test('isAddressRangeOutOfL1Zoom returns false when zoom range is undefined', () => {
+    expect(isAddressRangeOutOfL1Zoom(0, 0x10000, undefined)).toBe(false);
+});
+
+test('isAddressRangeOutOfL1Zoom treats NaN range as outside when zoom is active', () => {
+    expect(isAddressRangeOutOfL1Zoom(Number.NaN, Number.NaN, ZOOM)).toBe(true);
+});
+
+test('isAddressRangeVisibleInL1Zoom treats zero-size range as outside', () => {
+    expect(isAddressRangeVisibleInL1Zoom(0x11000, 0x11000, ZOOM)).toBe(false);
+    expect(isAddressRangeOutOfL1Zoom(0x11000, 0x11000, ZOOM)).toBe(true);
+});


### PR DESCRIPTION
When setting the L1 zoom range, legend items and input/output Tensors will check if they fall within that space. If not, they are dimmed.

L1 START and L1 SMALL legend markers are ignored.

**Only buffer zoom - one empty space is already out of bounds **
<img width="1232" height="875" alt="Screenshot 2026-05-19 at 11 38 35" src="https://github.com/user-attachments/assets/891e905b-59c6-4007-83d7-be65533d62f7" />

**With user zoom**
<img width="1232" height="875" alt="Screenshot 2026-05-19 at 11 38 48" src="https://github.com/user-attachments/assets/fe1aea01-96ee-4afb-9816-d9348eb17627" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/998.