### PR TITLE
Allow reading of stack trace content from new database table

### DIFF
--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -203,11 +203,7 @@ def middleware(app: flask.Flask):
     # CORS configuration
     origins = app.config["ALLOWED_ORIGINS"]
 
-    CORS(
-        app,
-        origins=origins,
-        expose_headers=["X-TTNN-Resolved-Source-Path"],
-    )
+    CORS(app, origins=origins)
 
     return None
 

--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -206,7 +206,7 @@ def middleware(app: flask.Flask):
     CORS(
         app,
         origins=origins,
-        expose_headers=["X-TTNN-Resolved-Source-Path", "X-TTNN-Source-Remapped"],
+        expose_headers=["X-TTNN-Resolved-Source-Path"],
     )
 
     return None

--- a/backend/ttnn_visualizer/enums.py
+++ b/backend/ttnn_visualizer/enums.py
@@ -11,3 +11,9 @@ class ConnectionTestStates(enum.Enum):
     FAILED = 2
     OK = 3
     WARNING = 4
+
+
+class StackSourceOrigin(enum.Enum):
+    DATABASE = "database"
+    PATH = "path"
+    REMAPPED = "remapped"

--- a/backend/ttnn_visualizer/enums.py
+++ b/backend/ttnn_visualizer/enums.py
@@ -13,7 +13,9 @@ class ConnectionTestStates(enum.Enum):
     WARNING = 4
 
 
-class StackSourceOrigin(enum.Enum):
+class StackSourceOrigin(str, enum.Enum):
+    """Possible ``source`` values on ``GET /api/remote/stack-trace/test`` JSON."""
+
     DATABASE = "database"
     PATH = "path"
     REMAPPED = "remapped"

--- a/backend/ttnn_visualizer/enums.py
+++ b/backend/ttnn_visualizer/enums.py
@@ -14,8 +14,6 @@ class ConnectionTestStates(enum.Enum):
 
 
 class StackSourceOrigin(str, enum.Enum):
-    """Possible ``source`` values on ``GET /api/remote/stack-trace/test`` JSON."""
-
     DATABASE = "database"
     PATH = "path"
     REMAPPED = "remapped"

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -171,8 +171,10 @@ class OperationArgument(SerializeableDataclass):
 @dataclasses.dataclass
 class SourceFile(SerializeableDataclass):
     id: int
-    path: str
-    contents: str
+    # SQLite columns are nullable: empty/NULL contents fall through to
+    # tt-metal local/SSH; a NULL path skips the exact-path lookup.
+    path: Optional[str] = None
+    contents: Optional[str] = None
 
 
 @dataclasses.dataclass

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -169,9 +169,17 @@ class OperationArgument(SerializeableDataclass):
 
 
 @dataclasses.dataclass
+class SourceFile(SerializeableDataclass):
+    id: int
+    path: str
+    contents: str
+
+
+@dataclasses.dataclass
 class StackTrace(SerializeableDataclass):
     operation_id: int
     stack_trace: str
+    source_file_id: Optional[int] = None
     rank: int = 0
 
 

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -33,6 +33,7 @@ from ttnn_visualizer.models import (
     OperationArgument,
     OutputTensor,
     ProducersConsumers,
+    SourceFile,
     StackTrace,
     Tensor,
     TensorComparisonRecord,
@@ -300,6 +301,24 @@ class DatabaseQueries:
         rows = self._query_table("stack_traces", filters, select_clause=select_clause)
         for row in rows:
             yield StackTrace(*row)
+
+    def query_source_files(
+        self, filters: Optional[Dict[str, Any]] = None
+    ) -> Generator[SourceFile, None, None]:
+        if not self._check_table_exists("source_files"):
+            return
+        select_clause = self._dataclass_select_clause("source_files", SourceFile)
+        rows = self._query_table("source_files", filters, select_clause=select_clause)
+        for row in rows:
+            yield SourceFile(*row)
+
+    def get_source_file_by_id(self, source_file_id: int) -> Optional[SourceFile]:
+        rows = list(self.query_source_files(filters={"id": source_file_id}))
+        return rows[0] if rows else None
+
+    def get_source_file_by_path(self, path: str) -> Optional[SourceFile]:
+        rows = list(self.query_source_files(filters={"path": path}))
+        return rows[0] if rows else None
 
     def query_error_records(
         self, filters: Optional[Dict[str, Any]] = None

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -320,6 +320,44 @@ class DatabaseQueries:
         rows = list(self.query_source_files(filters={"path": path}))
         return rows[0] if rows else None
 
+    def get_source_file_path_if_present(
+        self,
+        *,
+        source_file_id: Optional[int] = None,
+        file_path: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Return ``source_files.path`` for the first row whose ``contents`` is
+        non-empty, **without** loading the (potentially large) blob.
+
+        Used by availability probes (``GET /api/remote/stack-trace/test``) so the
+        cost scales with row count, not with embedded source size. ``source_file_id``
+        is preferred over ``file_path`` (mirrors ``lookup_report_source_file``).
+        """
+        if source_file_id is None and not file_path:
+            return None
+        if not self._check_table_exists("source_files"):
+            return None
+        if source_file_id is not None:
+            rows = self.query_runner.execute_query(
+                "SELECT path FROM source_files "
+                "WHERE id = ? AND contents IS NOT NULL AND length(contents) > 0 "
+                "LIMIT 1",
+                [source_file_id],
+            )
+            if rows:
+                return rows[0][0]
+        if file_path:
+            rows = self.query_runner.execute_query(
+                "SELECT path FROM source_files "
+                "WHERE path = ? AND contents IS NOT NULL AND length(contents) > 0 "
+                "LIMIT 1",
+                [file_path],
+            )
+            if rows:
+                return rows[0][0]
+        return None
+
     def query_error_records(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> Generator[ErrorRecord, None, None]:

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -107,7 +107,7 @@ def read_report_source_file(
     source_file = lookup_report_source_file(
         db, source_file_id=source_file_id, file_path=file_path
     )
-    if source_file is None:
+    if source_file is None or source_file.contents is None:
         return None
     validated_path = _validated_report_source_path(source_file.path)
     if validated_path is None:

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 def _source_file_has_contents(source_file: Optional["SourceFile"]) -> bool:
-    return source_file is not None and bool(source_file.contents)
+    return source_file is not None and source_file.contents is not None
 
 
 def lookup_report_source_file(

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Read stack-trace source file bodies from the report SQLite ``source_files`` table."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+from ttnn_visualizer.stack_trace_source import _validate_stack_trace_raw_path
+
+if TYPE_CHECKING:
+    from ttnn_visualizer.models import SourceFile
+    from ttnn_visualizer.queries import DatabaseQueries
+
+
+def _source_file_has_contents(source_file: Optional["SourceFile"]) -> bool:
+    return source_file is not None and bool(source_file.contents)
+
+
+def lookup_report_source_file(
+    db: "DatabaseQueries",
+    *,
+    source_file_id: Optional[int] = None,
+    file_path: Optional[str] = None,
+) -> Optional["SourceFile"]:
+    """
+    Resolve a ``source_files`` row by primary key or exact path match.
+
+    ``file_path`` is validated with the same rules as tt-metal stack source reads.
+    """
+    if source_file_id is not None:
+        source_file = db.get_source_file_by_id(source_file_id)
+        if _source_file_has_contents(source_file):
+            return source_file
+
+    if file_path:
+        try:
+            validated_path = _validate_stack_trace_raw_path(file_path)
+        except ValueError:
+            return None
+        source_file = db.get_source_file_by_path(validated_path)
+        if _source_file_has_contents(source_file):
+            return source_file
+
+    return None
+
+
+def report_source_file_available(
+    db: "DatabaseQueries",
+    *,
+    source_file_id: Optional[int] = None,
+    file_path: Optional[str] = None,
+) -> bool:
+    return (
+        lookup_report_source_file(
+            db, source_file_id=source_file_id, file_path=file_path
+        )
+        is not None
+    )
+
+
+def read_report_source_file(
+    db: "DatabaseQueries",
+    *,
+    source_file_id: Optional[int] = None,
+    file_path: Optional[str] = None,
+) -> Optional[Tuple[str, str]]:
+    """
+    Return ``(contents, resolved_path)`` when the report DB has a matching row.
+
+    ``resolved_path`` is ``source_files.path`` for response headers.
+    """
+    source_file = lookup_report_source_file(
+        db, source_file_id=source_file_id, file_path=file_path
+    )
+    if source_file is None:
+        return None
+    return source_file.contents, source_file.path

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -70,7 +70,8 @@ def read_report_source_file(
     """
     Return ``(contents, resolved_path)`` when the report DB has a matching row.
 
-    ``resolved_path`` is ``source_files.path`` for response headers.
+    ``resolved_path`` is ``source_files.path`` used as the resolved-path header
+    (``X-TTNN-Resolved-Source-Path``) on ``GET /api/remote/stack-trace/read``.
     """
     source_file = lookup_report_source_file(
         db, source_file_id=source_file_id, file_path=file_path

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -22,7 +22,13 @@ def _source_file_has_contents(source_file: Optional["SourceFile"]) -> bool:
 
 
 def _validated_report_source_path(path: Optional[str]) -> Optional[str]:
-    """Reject unsafe ``source_files.path`` values before HTTP headers or reads."""
+    """
+    Normalize a stack-trace path or return ``None`` if it fails validation.
+
+    Used for both untrusted query parameters (``?filePath=``) and DB-stored
+    ``source_files.path`` values so the same rules apply on the way in and on
+    the way out (e.g. before paths enter a JSON ``resolved_path`` field).
+    """
     if path is None:
         return None
     try:
@@ -40,22 +46,20 @@ def lookup_report_source_file(
     """
     Resolve a ``source_files`` row by primary key or exact path match.
 
-    The query parameter ``file_path`` is validated up-front. The row's stored
-    ``path`` is re-validated at the HTTP boundary by ``read_report_source_file``
-    and ``report_source_file_available`` so DB-supplied values cannot reach
-    response headers without passing the same rules.
+    The query parameter ``file_path`` is validated up-front via
+    ``_validated_report_source_path``. The row's stored ``path`` is re-validated
+    at the HTTP boundary (``read_report_source_file`` /
+    ``report_source_file_available``) so DB-supplied values cannot reach the
+    JSON ``resolved_path`` field without passing the same rules.
     """
     if source_file_id is not None:
         source_file = db.get_source_file_by_id(source_file_id)
         if _source_file_has_contents(source_file):
             return source_file
 
-    if file_path:
-        try:
-            validated_path = _validate_stack_trace_raw_path(file_path)
-        except ValueError:
-            return None
-        source_file = db.get_source_file_by_path(validated_path)
+    validated_file_path = _validated_report_source_path(file_path)
+    if validated_file_path is not None:
+        source_file = db.get_source_file_by_path(validated_file_path)
         if _source_file_has_contents(source_file):
             return source_file
 
@@ -74,23 +78,18 @@ def report_source_file_available(
     Avoids loading ``source_files.contents`` (which can be large) by asking the
     DB only for the stored ``path``. The same path validation that gates
     ``read_report_source_file`` applies here so unsafe stored paths report as
-    unavailable instead of being approved for a header that would later be
-    rejected.
+    unavailable instead of being approved for a read that would later fail.
     """
-    validated_file_path: Optional[str] = None
-    if file_path:
-        try:
-            validated_file_path = _validate_stack_trace_raw_path(file_path)
-        except ValueError:
-            validated_file_path = None
-    if source_file_id is None and not validated_file_path:
+    validated_file_path = _validated_report_source_path(file_path)
+    if source_file_id is None and validated_file_path is None:
         return False
     stored_path = db.get_source_file_path_if_present(
         source_file_id=source_file_id, file_path=validated_file_path
     )
-    if stored_path is None:
-        return False
-    return _validated_report_source_path(stored_path) is not None
+    return (
+        stored_path is not None
+        and _validated_report_source_path(stored_path) is not None
+    )
 
 
 def read_report_source_file(

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -16,7 +16,19 @@ if TYPE_CHECKING:
 
 
 def _source_file_has_contents(source_file: Optional["SourceFile"]) -> bool:
-    return source_file is not None and source_file.contents is not None
+    # Treat empty contents as "unavailable" so the UI falls through to
+    # tt-metal/SSH; matches test_lookup_by_id_skips_empty_contents.
+    return source_file is not None and bool(source_file.contents)
+
+
+def _validated_report_source_path(path: Optional[str]) -> Optional[str]:
+    """Reject unsafe ``source_files.path`` values before HTTP headers or reads."""
+    if path is None:
+        return None
+    try:
+        return _validate_stack_trace_raw_path(path)
+    except ValueError:
+        return None
 
 
 def lookup_report_source_file(
@@ -28,7 +40,10 @@ def lookup_report_source_file(
     """
     Resolve a ``source_files`` row by primary key or exact path match.
 
-    ``file_path`` is validated with the same rules as tt-metal stack source reads.
+    The query parameter ``file_path`` is validated up-front. The row's stored
+    ``path`` is re-validated at the HTTP boundary by ``read_report_source_file``
+    and ``report_source_file_available`` so DB-supplied values cannot reach
+    response headers without passing the same rules.
     """
     if source_file_id is not None:
         source_file = db.get_source_file_by_id(source_file_id)
@@ -53,10 +68,10 @@ def report_source_file_available(
     source_file_id: Optional[int] = None,
     file_path: Optional[str] = None,
 ) -> bool:
+    # Mirror read_report_source_file: don't claim availability for a row whose
+    # stored path can't safely become an X-TTNN-Resolved-Source-Path header.
     return (
-        lookup_report_source_file(
-            db, source_file_id=source_file_id, file_path=file_path
-        )
+        read_report_source_file(db, source_file_id=source_file_id, file_path=file_path)
         is not None
     )
 
@@ -78,4 +93,7 @@ def read_report_source_file(
     )
     if source_file is None:
         return None
-    return source_file.contents, source_file.path
+    validated_path = _validated_report_source_path(source_file.path)
+    if validated_path is None:
+        return None
+    return source_file.contents, validated_path

--- a/backend/ttnn_visualizer/report_source_file.py
+++ b/backend/ttnn_visualizer/report_source_file.py
@@ -68,12 +68,29 @@ def report_source_file_available(
     source_file_id: Optional[int] = None,
     file_path: Optional[str] = None,
 ) -> bool:
-    # Mirror read_report_source_file: don't claim availability for a row whose
-    # stored path can't safely become an X-TTNN-Resolved-Source-Path header.
-    return (
-        read_report_source_file(db, source_file_id=source_file_id, file_path=file_path)
-        is not None
+    """
+    Lightweight availability probe used by ``GET /api/remote/stack-trace/test``.
+
+    Avoids loading ``source_files.contents`` (which can be large) by asking the
+    DB only for the stored ``path``. The same path validation that gates
+    ``read_report_source_file`` applies here so unsafe stored paths report as
+    unavailable instead of being approved for a header that would later be
+    rejected.
+    """
+    validated_file_path: Optional[str] = None
+    if file_path:
+        try:
+            validated_file_path = _validate_stack_trace_raw_path(file_path)
+        except ValueError:
+            validated_file_path = None
+    if source_file_id is None and not validated_file_path:
+        return False
+    stored_path = db.get_source_file_path_if_present(
+        source_file_id=source_file_id, file_path=validated_file_path
     )
+    if stored_path is None:
+        return False
+    return _validated_report_source_path(stored_path) is not None
 
 
 def read_report_source_file(
@@ -85,8 +102,8 @@ def read_report_source_file(
     """
     Return ``(contents, resolved_path)`` when the report DB has a matching row.
 
-    ``resolved_path`` is ``source_files.path`` used as the resolved-path header
-    (``X-TTNN-Resolved-Source-Path``) on ``GET /api/remote/stack-trace/read``.
+    ``resolved_path`` is ``source_files.path`` returned in the JSON body of
+    ``GET /api/remote/stack-trace/read``.
     """
     source_file = lookup_report_source_file(
         db, source_file_id=source_file_id, file_path=file_path

--- a/backend/ttnn_visualizer/serializers.py
+++ b/backend/ttnn_visualizer/serializers.py
@@ -74,9 +74,7 @@ def serialize_operations(
         (st.operation_id, st.rank): st.stack_trace for st in stack_traces
     }
     stack_trace_source_file_ids_dict = {
-        (st.operation_id, st.rank): st.source_file_id
-        for st in stack_traces
-        if st.source_file_id is not None
+        (st.operation_id, st.rank): st.source_file_id for st in stack_traces
     }
 
     errors_dict = {}

--- a/backend/ttnn_visualizer/serializers.py
+++ b/backend/ttnn_visualizer/serializers.py
@@ -28,6 +28,15 @@ def _stack_trace_for_operation(stack_traces_by_key, operation):
     return stack_traces_by_key.get((operation.operation_id, 0))
 
 
+def _stack_trace_source_file_id_for_operation(
+    stack_trace_source_file_ids_by_key, operation
+):
+    key = (operation.operation_id, operation.rank)
+    if key in stack_trace_source_file_ids_by_key:
+        return stack_trace_source_file_ids_by_key[key]
+    return stack_trace_source_file_ids_by_key.get((operation.operation_id, 0))
+
+
 def _error_for_operation(errors_by_key, operation):
     key = (operation.operation_id, operation.rank)
     if key in errors_by_key:
@@ -64,6 +73,11 @@ def serialize_operations(
     stack_traces_dict = {
         (st.operation_id, st.rank): st.stack_trace for st in stack_traces
     }
+    stack_trace_source_file_ids_dict = {
+        (st.operation_id, st.rank): st.source_file_id
+        for st in stack_traces
+        if st.source_file_id is not None
+    }
 
     errors_dict = {}
     if error_records:
@@ -97,6 +111,9 @@ def serialize_operations(
                 **operation_data,
                 "id": id,
                 "stack_trace": _stack_trace_for_operation(stack_traces_dict, operation),
+                "stack_trace_source_file_id": _stack_trace_source_file_id_for_operation(
+                    stack_trace_source_file_ids_dict, operation
+                ),
                 "device_operations": operation_device_operations,
                 "arguments": arguments,
                 "inputs": inputs,
@@ -245,6 +262,11 @@ def serialize_operation(
         "l1_sizes": l1_sizes,
         "device_operations": device_operations_data,
         "stack_trace": stack_trace.stack_trace if stack_trace else "",
+        "stack_trace_source_file_id": (
+            stack_trace.source_file_id
+            if stack_trace and stack_trace.source_file_id is not None
+            else None
+        ),
         "buffers": buffer_list,
         "arguments": arguments_data,
         "inputs": inputs_data or [],

--- a/backend/ttnn_visualizer/stack_trace_source.py
+++ b/backend/ttnn_visualizer/stack_trace_source.py
@@ -397,33 +397,47 @@ def _remote_regular_file_exists(ssh_client: "SSHClient", posix_path: str) -> boo
         return False
 
 
+def check_stack_source_local_with_origin(raw_path: str) -> Optional[bool]:
+    """
+    Probe whether a local stack source file is readable and how it was resolved.
+
+    :return: ``None`` when the file is not available, ``False`` when matched at the
+        literal path, ``True`` when matched via a ``/tt-metal/`` remap.
+    """
+    try:
+        _, remapped = _resolve_local_stack_path(raw_path)
+        return remapped
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+
+
 def check_stack_source_local(raw_path: str) -> bool:
     """Whether _resolve_local_stack_path would succeed (including /tt-metal/ remaps)."""
-    try:
-        _resolve_local_stack_path(raw_path)
-        return True
-    except (FileNotFoundError, OSError, ValueError):
-        return False
+    return check_stack_source_local_with_origin(raw_path) is not None
 
 
-def check_stack_source_remote(ssh_client: "SSHClient", raw_path: str) -> bool:
+def check_stack_source_remote_with_origin(
+    ssh_client: "SSHClient", raw_path: str
+) -> Optional[bool]:
     """
-    Whether read_stack_source_remote would succeed: literal path or remapped under any
-    discovered tt-metal root (same roots as local).
+    Probe whether a remote stack source file is readable and how it was resolved.
+
+    Mirrors ``check_stack_source_local_with_origin``: ``None`` for unavailable,
+    ``False`` for a literal path hit, ``True`` for a ``/tt-metal/`` remap hit.
     """
     try:
         validated_path = _validate_stack_trace_raw_path(
             raw_path, require_absolute_posix=True
         )
     except ValueError:
-        return False
+        return None
 
     path_str = _normalize_remote_posix_path(validated_path)
     if _remote_regular_file_exists(ssh_client, path_str):
-        return True
+        return False
     suffix = _extract_suffix_after_tt_metal(validated_path)
     if suffix is None:
-        return False
+        return None
     roots = _remote_roots_for_raw_path(ssh_client, validated_path)
     for root_str in roots:
         try:
@@ -432,19 +446,30 @@ def check_stack_source_remote(ssh_client: "SSHClient", raw_path: str) -> bool:
             continue
         if _remote_regular_file_exists(ssh_client, remapped_str):
             return True
-    return False
+    return None
 
 
-def stack_source_response(text: str, resolved: str, remapped: bool) -> Response:
+def check_stack_source_remote(ssh_client: "SSHClient", raw_path: str) -> bool:
+    """
+    Whether read_stack_source_remote would succeed: literal path or remapped under any
+    discovered tt-metal root (same roots as local).
+    """
+    return check_stack_source_remote_with_origin(ssh_client, raw_path) is not None
+
+
+def stack_source_response(text: str, resolved: str) -> Response:
+    """
+    Plain-text body for ``GET /api/remote/stack-trace/read``.
+
+    Remap vs exact-path resolution is reported on ``GET .../stack-trace/test``
+    via the JSON ``source`` field, not on this response.
+    """
     resp = Response(
         response=text,
         status=HTTPStatus.OK,
         mimetype="text/plain; charset=utf-8",
     )
     resp.headers["X-TTNN-Resolved-Source-Path"] = resolved
-
-    if remapped:
-        resp.headers["X-TTNN-Source-Remapped"] = "true"
 
     # Source files can change underneath a stable filePath (e.g. after
     # re-syncing a remote folder), so disable caching for the GET endpoint.

--- a/backend/ttnn_visualizer/stack_trace_source.py
+++ b/backend/ttnn_visualizer/stack_trace_source.py
@@ -62,6 +62,11 @@ def _validate_stack_trace_raw_path(
         raise ValueError("Path exceeds maximum length")
     if "\x00" in s:
         raise ValueError("Path contains null byte")
+    # Reject control characters (including CR/LF) to keep DB-stored paths safe
+    # for filesystem use *and* for response headers like X-TTNN-Resolved-Source-Path
+    # (defends against header injection / smuggling, beyond what Werkzeug enforces).
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in s):
+        raise ValueError("Path contains control characters")
     if _path_parts_contain_dotdot(s):
         raise ValueError("Path must not contain '..' components")
     if require_absolute_posix and not s.startswith("/"):

--- a/backend/ttnn_visualizer/stack_trace_source.py
+++ b/backend/ttnn_visualizer/stack_trace_source.py
@@ -14,7 +14,7 @@ from http import HTTPStatus
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from flask import Response
+from flask import Response, jsonify
 from ttnn_visualizer.exceptions import RemoteFileReadException
 from ttnn_visualizer.ssh_client import SSHException
 
@@ -63,7 +63,7 @@ def _validate_stack_trace_raw_path(
     if "\x00" in s:
         raise ValueError("Path contains null byte")
     # Reject control characters (including CR/LF) to keep DB-stored paths safe
-    # for filesystem use *and* for response headers like X-TTNN-Resolved-Source-Path
+    # for filesystem use and for JSON ``resolved_path`` on stack-trace read responses
     # (defends against header injection / smuggling, beyond what Werkzeug enforces).
     if any(ord(c) < 0x20 or ord(c) == 0x7F for c in s):
         raise ValueError("Path contains control characters")
@@ -464,22 +464,14 @@ def check_stack_source_remote(ssh_client: "SSHClient", raw_path: str) -> bool:
 
 def stack_source_response(text: str, resolved: str) -> Response:
     """
-    Plain-text body for ``GET /api/remote/stack-trace/read``.
+    JSON body for ``GET /api/remote/stack-trace/read``.
 
     Remap vs exact-path resolution is reported on ``GET .../stack-trace/test``
     via the JSON ``source`` field, not on this response.
     """
-    resp = Response(
-        response=text,
-        status=HTTPStatus.OK,
-        mimetype="text/plain; charset=utf-8",
-    )
-    resp.headers["X-TTNN-Resolved-Source-Path"] = resolved
-
+    resp = jsonify({"content": text, "resolved_path": resolved})
+    resp.status_code = HTTPStatus.OK
     # Source files can change underneath a stable filePath (e.g. after
     # re-syncing a remote folder), so disable caching for the GET endpoint.
     resp.headers["Cache-Control"] = "no-store"
-    resp.headers["X-Content-Type-Options"] = "nosniff"
-    resp.headers["Content-Disposition"] = 'inline; filename="stack-source.txt"'
-
     return resp

--- a/backend/ttnn_visualizer/stack_trace_source.py
+++ b/backend/ttnn_visualizer/stack_trace_source.py
@@ -474,5 +474,7 @@ def stack_source_response(text: str, resolved: str) -> Response:
     # Source files can change underneath a stable filePath (e.g. after
     # re-syncing a remote folder), so disable caching for the GET endpoint.
     resp.headers["Cache-Control"] = "no-store"
+    resp.headers["X-Content-Type-Options"] = "nosniff"
+    resp.headers["Content-Disposition"] = 'inline; filename="stack-source.txt"'
 
     return resp

--- a/backend/ttnn_visualizer/tests/report_schemas.py
+++ b/backend/ttnn_visualizer/tests/report_schemas.py
@@ -152,9 +152,7 @@ CREATE TABLE source_files (
 )
 assert "source_file_id" in SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES
 
-SCHEMA_V2_WITH_LIFETIME = (
-    SCHEMA_V2
-    + """
+SCHEMA_V2_WITH_LIFETIME = SCHEMA_V2 + """
 CREATE TABLE tensor_lifetime (
     tensor_id int UNIQUE,
     producer_operation_id int,
@@ -166,4 +164,3 @@ CREATE TABLE tensor_lifetime (
     last_use_source_line int
 );
 """
-)

--- a/backend/ttnn_visualizer/tests/report_schemas.py
+++ b/backend/ttnn_visualizer/tests/report_schemas.py
@@ -150,8 +150,11 @@ CREATE TABLE source_files (
 );
 """
 )
+assert "source_file_id" in SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES
 
-SCHEMA_V2_WITH_LIFETIME = SCHEMA_V2 + """
+SCHEMA_V2_WITH_LIFETIME = (
+    SCHEMA_V2
+    + """
 CREATE TABLE tensor_lifetime (
     tensor_id int UNIQUE,
     producer_operation_id int,
@@ -163,3 +166,4 @@ CREATE TABLE tensor_lifetime (
     last_use_source_line int
 );
 """
+)

--- a/backend/ttnn_visualizer/tests/report_schemas.py
+++ b/backend/ttnn_visualizer/tests/report_schemas.py
@@ -7,21 +7,25 @@ SQL DDL constants representing historical TTNN report database schema versions.
 
 Import these into tests to build SQLite fixture databases via the
 ``make_report`` fixture defined in conftest.py.  Each constant is a complete
-set of ``CREATE TABLE`` statements — no data rows — so test data can be
-supplied independently through the ``inserts_sql`` argument.
+DDL block — no data rows — so test data can be supplied independently
+through the ``inserts_sql`` argument.
 
 The ``SCHEMA_V*`` constants below are verbatim ``.schema`` dumps from
 representative TTNN report databases, lightly normalised (12-space indent
-collapsed to 4-space) for readability. Each constant records its source
-report above its definition. To regenerate from a fresh representative
-report::
+collapsed to 4-space) for readability. To regenerate from a fresh
+representative report::
 
     sqlite3 path/to/db.sqlite ".schema" \\
         | sed 's/^            /    /; s/^        );/);/'
 
-Then paste the output into the corresponding triple-quoted string.
+Then paste the output into the corresponding triple-quoted string. A
+provenance comment above each constant records which TTNN feature flag
+shape produced it.
 """
 
+# Source: TTNN profiler report from before stack-trace source-file storage
+# was introduced (no ``source_files`` table; ``stack_traces`` has only
+# ``operation_id`` and ``stack_trace`` columns).
 SCHEMA_V2 = """
 CREATE TABLE devices (
     device_id int,
@@ -148,14 +152,17 @@ CREATE TABLE buffer_pages (
 );
 """
 
-# Source: representative TTNN profiler report after PR #1364 added the
-# ``source_files`` table and the ``stack_traces.source_file_id`` foreign
-# key. Dumped from
-# ``~/.ttnn-visualizer/reports/local/profiler-reports/resnet50_may08_1841/db.sqlite``.
-# Differences from ``SCHEMA_V2`` (verbatim from production): a new
-# ``source_files`` table with ``path text UNIQUE NOT NULL``, a
+# Source: TTNN profiler report after stack-trace source-file storage was
+# introduced. Verbatim differences from ``SCHEMA_V2``: a new ``source_files``
+# table with ``path text UNIQUE NOT NULL``, a
 # ``source_file_id int REFERENCES source_files(id)`` column on
 # ``stack_traces``, and an ``idx_stack_traces_source_file_id`` index.
+#
+# Note: the foreign key on ``stack_traces.source_file_id`` is structural-only
+# in test contexts. SQLite enforces foreign keys per-connection only when
+# ``PRAGMA foreign_keys = ON`` is set, which neither ``make_report`` nor
+# ``DatabaseQueries`` issues — matching production TTNN behaviour. Test data
+# may reference nonexistent ``source_files.id`` values without raising.
 SCHEMA_V2_1 = """
 CREATE TABLE devices (
     device_id int,

--- a/backend/ttnn_visualizer/tests/report_schemas.py
+++ b/backend/ttnn_visualizer/tests/report_schemas.py
@@ -9,6 +9,17 @@ Import these into tests to build SQLite fixture databases via the
 ``make_report`` fixture defined in conftest.py.  Each constant is a complete
 set of ``CREATE TABLE`` statements — no data rows — so test data can be
 supplied independently through the ``inserts_sql`` argument.
+
+The ``SCHEMA_V*`` constants below are verbatim ``.schema`` dumps from
+representative TTNN report databases, lightly normalised (12-space indent
+collapsed to 4-space) for readability. Each constant records its source
+report above its definition. To regenerate from a fresh representative
+report::
+
+    sqlite3 path/to/db.sqlite ".schema" \\
+        | sed 's/^            /    /; s/^        );/);/'
+
+Then paste the output into the corresponding triple-quoted string.
 """
 
 SCHEMA_V2 = """
@@ -137,21 +148,153 @@ CREATE TABLE buffer_pages (
 );
 """
 
-SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES = (
-    SCHEMA_V2.replace(
-        "CREATE TABLE stack_traces (\n    operation_id int,\n    stack_trace text\n);",
-        "CREATE TABLE stack_traces (\n    operation_id int,\n    stack_trace text,\n    source_file_id int\n);",
-    )
-    + """
+# Source: representative TTNN profiler report after PR #1364 added the
+# ``source_files`` table and the ``stack_traces.source_file_id`` foreign
+# key. Dumped from
+# ``~/.ttnn-visualizer/reports/local/profiler-reports/resnet50_may08_1841/db.sqlite``.
+# Differences from ``SCHEMA_V2`` (verbatim from production): a new
+# ``source_files`` table with ``path text UNIQUE NOT NULL``, a
+# ``source_file_id int REFERENCES source_files(id)`` column on
+# ``stack_traces``, and an ``idx_stack_traces_source_file_id`` index.
+SCHEMA_V2_1 = """
+CREATE TABLE devices (
+    device_id int,
+    num_y_cores int,
+    num_x_cores int,
+    num_y_compute_cores int,
+    num_x_compute_cores int,
+    worker_l1_size int,
+    l1_num_banks int,
+    l1_bank_size int,
+    address_at_first_l1_bank int,
+    address_at_first_l1_cb_buffer int,
+    num_banks_per_storage_core int,
+    num_compute_cores int,
+    num_storage_cores int,
+    total_l1_memory int,
+    total_l1_for_tensors int,
+    total_l1_for_interleaved_buffers int,
+    total_l1_for_sharded_buffers int,
+    cb_limit int
+);
+CREATE TABLE operations (
+    operation_id int UNIQUE,
+    name text,
+    duration float
+);
+CREATE TABLE operation_arguments (
+    operation_id int,
+    name text,
+    value text
+);
+CREATE TABLE tensors (
+    tensor_id int UNIQUE,
+    shape text,
+    dtype text,
+    layout text,
+    memory_config text,
+    device_id int,
+    address int,
+    buffer_type int
+);
+CREATE TABLE device_tensors (
+    tensor_id int,
+    device_id int,
+    address int
+);
+CREATE TABLE buffers (
+    operation_id int,
+    device_id int,
+    address int,
+    max_size_per_bank int,
+    buffer_type int,
+    buffer_layout int
+);
+CREATE TABLE captured_graph (
+    operation_id int,
+    captured_graph text
+);
+CREATE TABLE nodes (
+    operation_id int,
+    unique_id int,
+    node_operation_id int,
+    name text
+);
+CREATE TABLE edges (
+    operation_id int,
+    source_unique_id int,
+    sink_unique_id int,
+    source_output_index int,
+    sink_input_index int,
+    key int
+);
+CREATE TABLE report_metadata (
+    key text UNIQUE,
+    value text
+);
+CREATE TABLE errors (
+    operation_id int,
+    operation_name text,
+    error_type text,
+    error_message text,
+    stack_trace text,
+    timestamp text
+);
 CREATE TABLE source_files (
-    id int PRIMARY KEY,
-    path text,
+    id INTEGER PRIMARY KEY,
+    path text UNIQUE NOT NULL,
     contents text
 );
+CREATE TABLE stack_traces (
+    operation_id int,
+    stack_trace text,
+    source_file_id int REFERENCES source_files(id)
+);
+CREATE TABLE input_tensors (
+    operation_id int,
+    input_index int,
+    tensor_id int
+);
+CREATE TABLE output_tensors (
+    operation_id int,
+    output_index int,
+    tensor_id int
+);
+CREATE TABLE local_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE global_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE buffer_pages (
+    operation_id int,
+    device_id int,
+    address int,
+    core_y int,
+    core_x int,
+    bank_id int,
+    page_index int,
+    page_address int,
+    page_size int,
+    buffer_type int
+);
+CREATE INDEX idx_stack_traces_source_file_id ON stack_traces (source_file_id);
 """
-)
-assert "source_file_id" in SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES
 
+# Hand-derived: TTNN does not yet emit reports with the ``tensor_lifetime``
+# table in production, so this schema cannot be sourced via ``.schema``. The
+# DDL below tracks the shape proposed in PR #1430 ("Add lifetime to tensor
+# API responses"). Once a TTNN release ships ``tensor_lifetime``, regenerate
+# this constant from a real report the same way as ``SCHEMA_V2`` above and
+# fold it into a versioned ``SCHEMA_V2_2``.
 SCHEMA_V2_WITH_LIFETIME = SCHEMA_V2 + """
 CREATE TABLE tensor_lifetime (
     tensor_id int UNIQUE,

--- a/backend/ttnn_visualizer/tests/report_schemas.py
+++ b/backend/ttnn_visualizer/tests/report_schemas.py
@@ -137,6 +137,20 @@ CREATE TABLE buffer_pages (
 );
 """
 
+SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES = (
+    SCHEMA_V2.replace(
+        "CREATE TABLE stack_traces (\n    operation_id int,\n    stack_trace text\n);",
+        "CREATE TABLE stack_traces (\n    operation_id int,\n    stack_trace text,\n    source_file_id int\n);",
+    )
+    + """
+CREATE TABLE source_files (
+    id int PRIMARY KEY,
+    path text,
+    contents text
+);
+"""
+)
+
 SCHEMA_V2_WITH_LIFETIME = SCHEMA_V2 + """
 CREATE TABLE tensor_lifetime (
     tensor_id int UNIQUE,

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -308,27 +308,31 @@ class TestDatabaseQueries(unittest.TestCase):
         self.assertEqual(results[0].stack_trace, "trace_data")
 
     def test_query_source_files(self):
-        self.connection.executescript("""
+        self.connection.executescript(
+            """
             CREATE TABLE source_files (
                 id int PRIMARY KEY,
                 path text,
                 contents text
             );
             INSERT INTO source_files VALUES (1, '/a.py', 'contents');
-            """)
+            """
+        )
         results = list(self.db_queries.query_source_files())
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].contents, "contents")
 
     def test_get_source_file_by_id_and_path(self):
-        self.connection.executescript("""
+        self.connection.executescript(
+            """
             CREATE TABLE source_files (
                 id int PRIMARY KEY,
                 path text,
                 contents text
             );
             INSERT INTO source_files VALUES (5, '/b.py', 'body');
-            """)
+            """
+        )
         by_id = self.db_queries.get_source_file_by_id(5)
         self.assertIsNotNone(by_id)
         self.assertEqual(by_id.path, "/b.py")
@@ -336,11 +340,13 @@ class TestDatabaseQueries(unittest.TestCase):
         self.assertEqual(by_path.id, 5)
 
     def test_query_tensor_comparisons(self):
-        self.connection.execute("""
+        self.connection.execute(
+            """
             INSERT INTO local_tensor_comparison_records
             (tensor_id, golden_tensor_id, matches, desired_pcc, actual_pcc)
             VALUES (1, 10, 1, 0.9, 0.8)
-            """)
+            """
+        )
         results = list(
             self.db_queries.query_tensor_comparisons(local=True, filters={"matches": 1})
         )

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -364,6 +364,14 @@ class TestDatabaseQueries(unittest.TestCase):
             self.db_queries.get_source_file_path_if_present(source_file_id=999)
         )
         self.assertIsNone(self.db_queries.get_source_file_path_if_present())
+        # When source_file_id misses and file_path is also supplied, the
+        # implementation must fall through to the path branch.
+        self.assertEqual(
+            self.db_queries.get_source_file_path_if_present(
+                source_file_id=999, file_path="/has.py"
+            ),
+            "/has.py",
+        )
 
     def test_query_tensor_comparisons(self):
         self.connection.execute("""

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -307,6 +307,34 @@ class TestDatabaseQueries(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].stack_trace, "trace_data")
 
+    def test_query_source_files(self):
+        self.connection.executescript("""
+            CREATE TABLE source_files (
+                id int PRIMARY KEY,
+                path text,
+                contents text
+            );
+            INSERT INTO source_files VALUES (1, '/a.py', 'contents');
+            """)
+        results = list(self.db_queries.query_source_files())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].contents, "contents")
+
+    def test_get_source_file_by_id_and_path(self):
+        self.connection.executescript("""
+            CREATE TABLE source_files (
+                id int PRIMARY KEY,
+                path text,
+                contents text
+            );
+            INSERT INTO source_files VALUES (5, '/b.py', 'body');
+            """)
+        by_id = self.db_queries.get_source_file_by_id(5)
+        self.assertIsNotNone(by_id)
+        self.assertEqual(by_id.path, "/b.py")
+        by_path = self.db_queries.get_source_file_by_path("/b.py")
+        self.assertEqual(by_path.id, 5)
+
     def test_query_tensor_comparisons(self):
         self.connection.execute("""
             INSERT INTO local_tensor_comparison_records

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -308,31 +308,27 @@ class TestDatabaseQueries(unittest.TestCase):
         self.assertEqual(results[0].stack_trace, "trace_data")
 
     def test_query_source_files(self):
-        self.connection.executescript(
-            """
+        self.connection.executescript("""
             CREATE TABLE source_files (
                 id int PRIMARY KEY,
                 path text,
                 contents text
             );
             INSERT INTO source_files VALUES (1, '/a.py', 'contents');
-            """
-        )
+            """)
         results = list(self.db_queries.query_source_files())
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].contents, "contents")
 
     def test_get_source_file_by_id_and_path(self):
-        self.connection.executescript(
-            """
+        self.connection.executescript("""
             CREATE TABLE source_files (
                 id int PRIMARY KEY,
                 path text,
                 contents text
             );
             INSERT INTO source_files VALUES (5, '/b.py', 'body');
-            """
-        )
+            """)
         by_id = self.db_queries.get_source_file_by_id(5)
         self.assertIsNotNone(by_id)
         self.assertEqual(by_id.path, "/b.py")
@@ -340,13 +336,11 @@ class TestDatabaseQueries(unittest.TestCase):
         self.assertEqual(by_path.id, 5)
 
     def test_query_tensor_comparisons(self):
-        self.connection.execute(
-            """
+        self.connection.execute("""
             INSERT INTO local_tensor_comparison_records
             (tensor_id, golden_tensor_id, matches, desired_pcc, actual_pcc)
             VALUES (1, 10, 1, 0.9, 0.8)
-            """
-        )
+            """)
         results = list(
             self.db_queries.query_tensor_comparisons(local=True, filters={"matches": 1})
         )

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -335,6 +335,36 @@ class TestDatabaseQueries(unittest.TestCase):
         by_path = self.db_queries.get_source_file_by_path("/b.py")
         self.assertEqual(by_path.id, 5)
 
+    def test_get_source_file_path_if_present(self):
+        self.connection.executescript("""
+            CREATE TABLE source_files (
+                id int PRIMARY KEY,
+                path text,
+                contents text
+            );
+            INSERT INTO source_files VALUES (1, '/has.py', 'body');
+            INSERT INTO source_files VALUES (2, '/empty.py', '');
+            INSERT INTO source_files VALUES (3, '/null.py', NULL);
+            """)
+        self.assertEqual(
+            self.db_queries.get_source_file_path_if_present(source_file_id=1),
+            "/has.py",
+        )
+        self.assertEqual(
+            self.db_queries.get_source_file_path_if_present(file_path="/has.py"),
+            "/has.py",
+        )
+        self.assertIsNone(
+            self.db_queries.get_source_file_path_if_present(source_file_id=2)
+        )
+        self.assertIsNone(
+            self.db_queries.get_source_file_path_if_present(source_file_id=3)
+        )
+        self.assertIsNone(
+            self.db_queries.get_source_file_path_if_present(source_file_id=999)
+        )
+        self.assertIsNone(self.db_queries.get_source_file_path_if_present())
+
     def test_query_tensor_comparisons(self):
         self.connection.execute("""
             INSERT INTO local_tensor_comparison_records

--- a/backend/ttnn_visualizer/tests/test_report_schemas.py
+++ b/backend/ttnn_visualizer/tests/test_report_schemas.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Smoke tests for the historical report-schema constants.
+
+These constants are intentionally derived from real TTNN reports (see the
+module docstring in ``report_schemas.py``); the tests below ensure each one
+is valid SQLite DDL and contains the columns/tables that downstream
+production code in ``queries.py`` probes for via runtime feature detection.
+"""
+
+import sqlite3
+from typing import Set
+
+import pytest
+from ttnn_visualizer.tests.report_schemas import (
+    SCHEMA_V2,
+    SCHEMA_V2_1,
+    SCHEMA_V2_WITH_LIFETIME,
+)
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> Set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _table_names(conn: sqlite3.Connection) -> Set[str]:
+    return {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [SCHEMA_V2, SCHEMA_V2_1, SCHEMA_V2_WITH_LIFETIME],
+    ids=["v2", "v2_1", "v2_with_lifetime"],
+)
+def test_schema_loads_into_sqlite(schema):
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(schema)
+    finally:
+        conn.close()
+
+
+def test_schema_v2_1_has_source_files_and_source_file_id():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA_V2_1)
+        assert "source_files" in _table_names(conn)
+        assert "source_file_id" in _table_columns(conn, "stack_traces")
+    finally:
+        conn.close()
+
+
+def test_schema_v2_lacks_source_files_and_source_file_id():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA_V2)
+        assert "source_files" not in _table_names(conn)
+        assert "source_file_id" not in _table_columns(conn, "stack_traces")
+    finally:
+        conn.close()
+
+
+def test_schema_v2_with_lifetime_adds_tensor_lifetime():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA_V2_WITH_LIFETIME)
+        assert "tensor_lifetime" in _table_names(conn)
+    finally:
+        conn.close()

--- a/backend/ttnn_visualizer/tests/test_report_source_file.py
+++ b/backend/ttnn_visualizer/tests/test_report_source_file.py
@@ -17,8 +17,7 @@ from ttnn_visualizer.report_source_file import (
 class TestReportSourceFile(unittest.TestCase):
     def setUp(self):
         self.connection = sqlite3.connect(":memory:")
-        self.connection.executescript(
-            """
+        self.connection.executescript("""
             CREATE TABLE source_files (
                 id int PRIMARY KEY,
                 path text,
@@ -26,8 +25,7 @@ class TestReportSourceFile(unittest.TestCase):
             );
             INSERT INTO source_files VALUES (1, '/proj/model.py', 'def forward(): pass');
             INSERT INTO source_files VALUES (2, '/proj/other.py', '');
-            """
-        )
+            """)
         self.db = DatabaseQueries(connection=self.connection)
 
     def test_lookup_by_id(self):

--- a/backend/ttnn_visualizer/tests/test_report_source_file.py
+++ b/backend/ttnn_visualizer/tests/test_report_source_file.py
@@ -28,6 +28,9 @@ class TestReportSourceFile(unittest.TestCase):
             """)
         self.db = DatabaseQueries(connection=self.connection)
 
+    def tearDown(self):
+        self.connection.close()
+
     def test_lookup_by_id(self):
         row = lookup_report_source_file(self.db, source_file_id=1)
         self.assertIsInstance(row, SourceFile)

--- a/backend/ttnn_visualizer/tests/test_report_source_file.py
+++ b/backend/ttnn_visualizer/tests/test_report_source_file.py
@@ -58,10 +58,36 @@ class TestReportSourceFile(unittest.TestCase):
         result = read_report_source_file(self.db, source_file_id=1)
         self.assertEqual(result, ("def forward(): pass", "/proj/model.py"))
 
+    def test_availability_does_not_load_contents(self):
+        """
+        ``report_source_file_available`` is on the hot /test path and must not
+        fetch the (potentially large) ``contents`` blob. We assert the dedicated
+        lightweight query is used and the contents-loading lookup is bypassed.
+        """
+        contents_loaded = False
+
+        original_by_id = self.db.get_source_file_by_id
+
+        def _spy(*args, **kwargs):
+            nonlocal contents_loaded
+            contents_loaded = True
+            return original_by_id(*args, **kwargs)
+
+        self.db.get_source_file_by_id = _spy  # type: ignore[assignment]
+        try:
+            self.assertTrue(report_source_file_available(self.db, source_file_id=1))
+        finally:
+            self.db.get_source_file_by_id = original_by_id  # type: ignore[assignment]
+
+        self.assertFalse(
+            contents_loaded,
+            "availability probe must not load source_files.contents",
+        )
+
     def test_read_and_availability_reject_unsafe_db_paths(self):
         """
         DB-stored paths must pass _validate_stack_trace_raw_path before
-        becoming the X-TTNN-Resolved-Source-Path response header. lookup_*
+        becoming ``resolved_path`` in the stack-trace read JSON body. lookup_*
         may still surface the row (it's the SQL layer), but read_* and
         available_* must refuse it so HTTP callers never see it.
         """

--- a/backend/ttnn_visualizer/tests/test_report_source_file.py
+++ b/backend/ttnn_visualizer/tests/test_report_source_file.py
@@ -17,7 +17,8 @@ from ttnn_visualizer.report_source_file import (
 class TestReportSourceFile(unittest.TestCase):
     def setUp(self):
         self.connection = sqlite3.connect(":memory:")
-        self.connection.executescript("""
+        self.connection.executescript(
+            """
             CREATE TABLE source_files (
                 id int PRIMARY KEY,
                 path text,
@@ -25,7 +26,8 @@ class TestReportSourceFile(unittest.TestCase):
             );
             INSERT INTO source_files VALUES (1, '/proj/model.py', 'def forward(): pass');
             INSERT INTO source_files VALUES (2, '/proj/other.py', '');
-            """)
+            """
+        )
         self.db = DatabaseQueries(connection=self.connection)
 
     def test_lookup_by_id(self):

--- a/backend/ttnn_visualizer/tests/test_report_source_file.py
+++ b/backend/ttnn_visualizer/tests/test_report_source_file.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import sqlite3
+import unittest
+
+from ttnn_visualizer.models import SourceFile
+from ttnn_visualizer.queries import DatabaseQueries
+from ttnn_visualizer.report_source_file import (
+    lookup_report_source_file,
+    read_report_source_file,
+    report_source_file_available,
+)
+
+
+class TestReportSourceFile(unittest.TestCase):
+    def setUp(self):
+        self.connection = sqlite3.connect(":memory:")
+        self.connection.executescript("""
+            CREATE TABLE source_files (
+                id int PRIMARY KEY,
+                path text,
+                contents text
+            );
+            INSERT INTO source_files VALUES (1, '/proj/model.py', 'def forward(): pass');
+            INSERT INTO source_files VALUES (2, '/proj/other.py', '');
+            """)
+        self.db = DatabaseQueries(connection=self.connection)
+
+    def test_lookup_by_id(self):
+        row = lookup_report_source_file(self.db, source_file_id=1)
+        self.assertIsInstance(row, SourceFile)
+        self.assertEqual(row.path, "/proj/model.py")
+
+    def test_lookup_by_id_skips_empty_contents(self):
+        self.assertIsNone(lookup_report_source_file(self.db, source_file_id=2))
+
+    def test_lookup_by_path(self):
+        row = lookup_report_source_file(self.db, file_path="/proj/model.py")
+        self.assertEqual(row.id, 1)
+
+    def test_lookup_by_path_only_without_source_file_id(self):
+        row = lookup_report_source_file(
+            self.db, source_file_id=None, file_path="/proj/model.py"
+        )
+        self.assertEqual(row.contents, "def forward(): pass")
+
+    def test_read_report_source_file_by_path_only(self):
+        result = read_report_source_file(self.db, file_path="/proj/model.py")
+        self.assertEqual(result, ("def forward(): pass", "/proj/model.py"))
+
+    def test_report_source_file_available(self):
+        self.assertTrue(report_source_file_available(self.db, source_file_id=1))
+        self.assertFalse(report_source_file_available(self.db, file_path="/missing.py"))
+
+    def test_read_report_source_file(self):
+        result = read_report_source_file(self.db, source_file_id=1)
+        self.assertEqual(result, ("def forward(): pass", "/proj/model.py"))

--- a/backend/ttnn_visualizer/tests/test_report_source_file.py
+++ b/backend/ttnn_visualizer/tests/test_report_source_file.py
@@ -57,3 +57,33 @@ class TestReportSourceFile(unittest.TestCase):
     def test_read_report_source_file(self):
         result = read_report_source_file(self.db, source_file_id=1)
         self.assertEqual(result, ("def forward(): pass", "/proj/model.py"))
+
+    def test_read_and_availability_reject_unsafe_db_paths(self):
+        """
+        DB-stored paths must pass _validate_stack_trace_raw_path before
+        becoming the X-TTNN-Resolved-Source-Path response header. lookup_*
+        may still surface the row (it's the SQL layer), but read_* and
+        available_* must refuse it so HTTP callers never see it.
+        """
+        unsafe_cases = [
+            (10, "/a/../evil.py"),
+            (11, "/proj/x.py\r\nInjected: 1"),
+            (12, "/proj/inner\nhead.py"),
+            (13, "/proj/\x00.py"),
+            (14, "   "),
+        ]
+        for row_id, bad_path in unsafe_cases:
+            self.connection.execute(
+                "INSERT INTO source_files VALUES (?, ?, 'body')",
+                (row_id, bad_path),
+            )
+        self.connection.commit()
+
+        for row_id, bad_path in unsafe_cases:
+            with self.subTest(bad_path=bad_path):
+                self.assertIsNone(
+                    read_report_source_file(self.db, source_file_id=row_id)
+                )
+                self.assertFalse(
+                    report_source_file_available(self.db, source_file_id=row_id)
+                )

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -91,6 +91,7 @@ class TestSerializers(unittest.TestCase):
                 "duration": 0.5,
                 "rank": 0,
                 "stack_trace": "trace1",
+                "stack_trace_source_file_id": None,
                 "device_operations": [{"id": 1, "op_id": 1}],
                 "arguments": [
                     {
@@ -484,10 +485,48 @@ class TestSerializers(unittest.TestCase):
                 }
             ],
             "stack_trace": "trace1",
+            "stack_trace_source_file_id": None,
             "error": None,
         }
 
         self.assertEqual(orjson.loads(orjson.dumps(result)), expected)
+
+    def test_serialize_operations_with_stack_trace_source_file_id(self):
+        operations = [Operation(1, "op1", 0.5)]
+        stack_traces = [StackTrace(1, "trace text", source_file_id=42)]
+        result = serialize_operations(
+            [],
+            [],
+            operations,
+            [],
+            stack_traces,
+            [],
+            [],
+            [],
+            [],
+        )
+        self.assertEqual(result[0]["stack_trace"], "trace text")
+        self.assertEqual(result[0]["stack_trace_source_file_id"], 42)
+
+    def test_serialize_operation_with_stack_trace_source_file_id(self):
+        operation = Operation(1, "op1", 0.5)
+        stack_trace = StackTrace(1, "trace text", source_file_id=7)
+        result = serialize_operation(
+            [],
+            [],
+            operation,
+            [],
+            [],
+            stack_trace,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
+        self.assertEqual(result["stack_trace"], "trace text")
+        self.assertEqual(result["stack_trace_source_file_id"], 7)
 
     def test_serialize_buffer_pages(self):
         buffer_pages = [

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -508,6 +508,29 @@ class TestSerializers(unittest.TestCase):
         self.assertEqual(result[0]["stack_trace"], "trace text")
         self.assertEqual(result[0]["stack_trace_source_file_id"], 42)
 
+    def test_serialize_operations_null_source_file_id_does_not_fallback_to_rank_zero(
+        self,
+    ):
+        """Explicit NULL at a rank must not inherit rank-0's source_file_id."""
+        operations = [Operation(1, "op1", 0.5, rank=1)]
+        stack_traces = [
+            StackTrace(1, "trace rank 0", source_file_id=42, rank=0),
+            StackTrace(1, "trace rank 1", source_file_id=None, rank=1),
+        ]
+        result = serialize_operations(
+            [],
+            [],
+            operations,
+            [],
+            stack_traces,
+            [],
+            [],
+            [],
+            [],
+        )
+        self.assertEqual(result[0]["stack_trace"], "trace rank 1")
+        self.assertIsNone(result[0]["stack_trace_source_file_id"])
+
     def test_serialize_operation_with_stack_trace_source_file_id(self):
         operation = Operation(1, "op1", 0.5)
         stack_trace = StackTrace(1, "trace text", source_file_id=7)

--- a/backend/ttnn_visualizer/tests/test_stack_trace_source.py
+++ b/backend/ttnn_visualizer/tests/test_stack_trace_source.py
@@ -364,6 +364,12 @@ def test_validate_stack_trace_raw_path_rejects_unsafe():
         _validate_stack_trace_raw_path("/a/../b")
     with pytest.raises(ValueError, match="absolute"):
         _validate_stack_trace_raw_path("relative-only", require_absolute_posix=True)
+    # Reject mid-path control characters (including CR/LF) so DB-stored paths
+    # can't smuggle extra HTTP headers via X-TTNN-Resolved-Source-Path.
+    # Trailing whitespace is fine because strip() removes it before this check.
+    for bad in ("/a/b\r\nX-Evil: 1", "/a/inner\nhead.py", "/a/b\x1ftail"):
+        with pytest.raises(ValueError, match="control"):
+            _validate_stack_trace_raw_path(bad)
 
 
 def test_remote_roots_for_raw_path_prioritizes_preferred_user_root(monkeypatch):

--- a/backend/ttnn_visualizer/tests/test_stack_trace_source.py
+++ b/backend/ttnn_visualizer/tests/test_stack_trace_source.py
@@ -365,7 +365,7 @@ def test_validate_stack_trace_raw_path_rejects_unsafe():
     with pytest.raises(ValueError, match="absolute"):
         _validate_stack_trace_raw_path("relative-only", require_absolute_posix=True)
     # Reject mid-path control characters (including CR/LF) so DB-stored paths
-    # can't smuggle extra HTTP headers via X-TTNN-Resolved-Source-Path.
+    # are safe in JSON ``resolved_path`` on stack-trace read responses.
     # Trailing whitespace is fine because strip() removes it before this check.
     for bad in ("/a/b\r\nX-Evil: 1", "/a/inner\nhead.py", "/a/b\x1ftail"):
         with pytest.raises(ValueError, match="control"):

--- a/backend/ttnn_visualizer/tests/test_stack_trace_source.py
+++ b/backend/ttnn_visualizer/tests/test_stack_trace_source.py
@@ -17,6 +17,8 @@ from ttnn_visualizer.stack_trace_source import (
     _safe_join_under_tt_metal_root,
     _validate_stack_trace_raw_path,
     check_stack_source_local,
+    check_stack_source_local_with_origin,
+    check_stack_source_remote_with_origin,
     read_stack_source_remote,
 )
 
@@ -147,6 +149,104 @@ def test_check_stack_source_local_matches_resolve(monkeypatch, tmp_path):
 
     assert check_stack_source_local("/x/tt-metal/ttnn/probe.py") is True
     assert check_stack_source_local("/x/tt-metal/ttnn/missing.py") is False
+
+
+def test_check_stack_source_local_with_origin_literal_match(monkeypatch, tmp_path):
+    """Literal path under a discovered root returns False (no remap)."""
+    metal = tmp_path / "tt-metal"
+    (metal / "ttnn").mkdir(parents=True)
+    target = metal / "ttnn" / "literal.py"
+    target.write_text("# x", encoding="utf-8")
+    monkeypatch.setenv("TT_METAL_HOME", str(metal))
+
+    assert check_stack_source_local_with_origin(str(target)) is False
+
+
+def test_check_stack_source_local_with_origin_remapped_match(monkeypatch, tmp_path):
+    """Foreign tt-metal prefix that exists under a discovered root returns True."""
+    metal = tmp_path / "tt-metal"
+    (metal / "ttnn").mkdir(parents=True)
+    target = metal / "ttnn" / "remapped.py"
+    target.write_text("# x", encoding="utf-8")
+    monkeypatch.setenv("TT_METAL_HOME", str(metal))
+
+    assert (
+        check_stack_source_local_with_origin("/elsewhere/tt-metal/ttnn/remapped.py")
+        is True
+    )
+
+
+def test_check_stack_source_local_with_origin_missing_returns_none(
+    monkeypatch, tmp_path
+):
+    metal = tmp_path / "tt-metal"
+    metal.mkdir()
+    monkeypatch.setenv("TT_METAL_HOME", str(metal))
+
+    assert (
+        check_stack_source_local_with_origin("/elsewhere/tt-metal/ttnn/missing.py")
+        is None
+    )
+
+
+def test_check_stack_source_local_with_origin_rejects_bad_input():
+    assert check_stack_source_local_with_origin("a\x00b") is None
+    assert check_stack_source_local_with_origin("/a/../b") is None
+
+
+def test_check_stack_source_remote_with_origin_literal_hit(monkeypatch):
+    """Literal path hit on the remote returns False (no remap)."""
+    import ttnn_visualizer.stack_trace_source as sts
+
+    raw = "/home/dev/tt-metal/ttnn/literal.py"
+
+    def fake_exists(_ssh, path: str) -> bool:
+        return path == raw
+
+    monkeypatch.setattr(sts, "_remote_regular_file_exists", fake_exists)
+
+    ssh = MagicMock()
+    assert check_stack_source_remote_with_origin(ssh, raw) is False
+
+
+def test_check_stack_source_remote_with_origin_remapped_hit(monkeypatch):
+    """Hit under a discovered root after literal miss returns True."""
+    import ttnn_visualizer.stack_trace_source as sts
+
+    monkeypatch.setattr(
+        sts,
+        "_discover_tt_metal_roots_remote",
+        lambda _ssh: ["/good/tt-metal"],
+    )
+
+    def fake_exists(_ssh, path: str) -> bool:
+        return path == "/good/tt-metal/u/v.py"
+
+    monkeypatch.setattr(sts, "_remote_regular_file_exists", fake_exists)
+
+    ssh = MagicMock()
+    assert (
+        check_stack_source_remote_with_origin(ssh, "/container/tt-metal/u/v.py") is True
+    )
+
+
+def test_check_stack_source_remote_with_origin_missing_returns_none(monkeypatch):
+    import ttnn_visualizer.stack_trace_source as sts
+
+    monkeypatch.setattr(sts, "_discover_tt_metal_roots_remote", lambda _ssh: [])
+    monkeypatch.setattr(sts, "_remote_regular_file_exists", lambda _ssh, _p: False)
+
+    ssh = MagicMock()
+    assert (
+        check_stack_source_remote_with_origin(ssh, "/container/tt-metal/u/v.py") is None
+    )
+
+
+def test_check_stack_source_remote_with_origin_rejects_bad_input():
+    ssh = MagicMock()
+    # Relative path; remote helper requires absolute POSIX paths.
+    assert check_stack_source_remote_with_origin(ssh, "relative.py") is None
+    ssh.execute_command.assert_not_called()
 
 
 def test_read_stack_source_remote_remaps_after_not_found(monkeypatch):

--- a/backend/ttnn_visualizer/tests/views/test_latest_version.py
+++ b/backend/ttnn_visualizer/tests/views/test_latest_version.py
@@ -49,9 +49,7 @@ class TestLatestVersionSuccess:
                 <item><title>2.1.0</title></item>
             </channel>
         </rss>
-        """.encode(
-            "utf-8"
-        )
+        """.encode("utf-8")
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_response = MagicMock()
@@ -118,9 +116,7 @@ class TestLatestVersionFailures:
                 <item><title>Latest Update</title></item>
             </channel>
         </rss>
-        """.encode(
-            "utf-8"
-        )
+        """.encode("utf-8")
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_response = MagicMock()

--- a/backend/ttnn_visualizer/tests/views/test_latest_version.py
+++ b/backend/ttnn_visualizer/tests/views/test_latest_version.py
@@ -49,7 +49,9 @@ class TestLatestVersionSuccess:
                 <item><title>2.1.0</title></item>
             </channel>
         </rss>
-        """.encode("utf-8")
+        """.encode(
+            "utf-8"
+        )
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_response = MagicMock()
@@ -116,7 +118,9 @@ class TestLatestVersionFailures:
                 <item><title>Latest Update</title></item>
             </channel>
         </rss>
-        """.encode("utf-8")
+        """.encode(
+            "utf-8"
+        )
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_response = MagicMock()

--- a/backend/ttnn_visualizer/tests/views/test_operations_source_files.py
+++ b/backend/ttnn_visualizer/tests/views/test_operations_source_files.py
@@ -4,24 +4,28 @@
 
 from http import HTTPStatus
 
-from ttnn_visualizer.tests.report_schemas import (
-    SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
-)
-
-_OPERATIONS_FIXTURE = """
-INSERT INTO operations VALUES (1, 'op1', 0.5);
-INSERT INTO stack_traces VALUES (1, 'File "/proj/model.py", line 10, in forward', 1);
-INSERT INTO source_files VALUES (1, '/proj/model.py', 'def forward(): pass');
-INSERT INTO input_tensors VALUES (1, 0, 1);
-INSERT INTO output_tensors VALUES (1, 0, 1);
-INSERT INTO tensors VALUES (1, '[]', 'float32', 'ROW_MAJOR', '', 0, 0, 0);
-"""
+import pytest
+from ttnn_visualizer.tests.report_schemas import SCHEMA_V2_1
 
 
-def test_operations_list_stack_trace_and_source_file_id(client, make_report):
+@pytest.fixture
+def operations_inserts_sql():
+    return """
+    INSERT INTO operations VALUES (1, 'op1', 0.5);
+    INSERT INTO stack_traces VALUES (1, 'File "/proj/model.py", line 10, in forward', 1);
+    INSERT INTO source_files VALUES (1, '/proj/model.py', 'def forward(): pass');
+    INSERT INTO input_tensors VALUES (1, 0, 1);
+    INSERT INTO output_tensors VALUES (1, 0, 1);
+    INSERT INTO tensors VALUES (1, '[]', 'float32', 'ROW_MAJOR', '', 0, 0, 0);
+    """
+
+
+def test_operations_list_stack_trace_and_source_file_id(
+    client, make_report, operations_inserts_sql
+):
     instance_id = make_report(
-        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
-        inserts_sql=_OPERATIONS_FIXTURE,
+        schema_sql=SCHEMA_V2_1,
+        inserts_sql=operations_inserts_sql,
     )
     response = client.get(
         "/api/operations",

--- a/backend/ttnn_visualizer/tests/views/test_operations_source_files.py
+++ b/backend/ttnn_visualizer/tests/views/test_operations_source_files.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from http import HTTPStatus
+
+from ttnn_visualizer.tests.report_schemas import (
+    SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+)
+
+_OPERATIONS_FIXTURE = """
+INSERT INTO operations VALUES (1, 'op1', 0.5);
+INSERT INTO stack_traces VALUES (1, 'File "/proj/model.py", line 10, in forward', 1);
+INSERT INTO source_files VALUES (1, '/proj/model.py', 'def forward(): pass');
+INSERT INTO input_tensors VALUES (1, 0, 1);
+INSERT INTO output_tensors VALUES (1, 0, 1);
+INSERT INTO tensors VALUES (1, '[]', 'float32', 'ROW_MAJOR', '', 0, 0, 0);
+"""
+
+
+def test_operations_list_stack_trace_and_source_file_id(client, make_report):
+    instance_id = make_report(
+        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        inserts_sql=_OPERATIONS_FIXTURE,
+    )
+    response = client.get(
+        "/api/operations",
+        query_string={"instanceId": instance_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    operations = response.get_json()
+    assert len(operations) == 1
+    assert operations[0]["stack_trace"] == 'File "/proj/model.py", line 10, in forward'
+    assert operations[0]["stack_trace_source_file_id"] == 1

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -5,6 +5,7 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 from ttnn_visualizer.tests.report_schemas import (
     SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
 )
@@ -53,6 +54,9 @@ def test_stack_source_content_forbidden_in_server_mode_without_remote(
 def test_stack_source_content_local_read_sets_no_store(app, client, make_report):
     instance_id = make_report()
     app.config["SERVER_MODE"] = False
+    # read_stack_source_local still returns (content, resolved, remapped); the third
+    # element is unused by stack_source_response since the remap signal moved to
+    # /stack-trace/test's JSON `source` field.
     with patch(
         "ttnn_visualizer.views.read_stack_source_local",
         return_value=("print('hi')\n", "/abs/resolved.py", False),
@@ -82,24 +86,17 @@ def test_stack_source_content_rejects_missing_file_path(client, make_report):
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_stack_source_availability_from_report_db_by_path_only_in_server_mode(
-    client, make_report
+@pytest.mark.parametrize(
+    "extra_query",
+    [
+        pytest.param({"filePath": "/proj/model.py"}, id="path-only"),
+        pytest.param({"sourceFileId": 1}, id="source-file-id-only"),
+        pytest.param({"sourceFileId": 1, "filePath": "/proj/model.py"}, id="both"),
+    ],
+)
+def test_stack_source_availability_from_report_db_in_server_mode(
+    client, make_report, extra_query
 ):
-    instance_id = make_report(
-        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
-        inserts_sql="""
-        INSERT INTO source_files VALUES (3, '/proj/other.py', 'print(2)');
-        """,
-    )
-    response = client.get(
-        "/api/remote/stack-trace/test",
-        query_string={"instanceId": instance_id, "filePath": "/proj/other.py"},
-    )
-    assert response.status_code == HTTPStatus.OK
-    assert response.get_json() == {"available": True, "source": "database"}
-
-
-def test_stack_source_availability_from_report_db_in_server_mode(client, make_report):
     instance_id = make_report(
         schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
         inserts_sql="""
@@ -108,11 +105,7 @@ def test_stack_source_availability_from_report_db_in_server_mode(client, make_re
     )
     response = client.get(
         "/api/remote/stack-trace/test",
-        query_string={
-            "instanceId": instance_id,
-            "sourceFileId": 1,
-            "filePath": "/proj/model.py",
-        },
+        query_string={"instanceId": instance_id, **extra_query},
     )
     assert response.status_code == HTTPStatus.OK
     assert response.get_json() == {"available": True, "source": "database"}
@@ -150,23 +143,6 @@ def test_stack_source_read_from_report_db_in_server_mode(client, make_report):
     assert response.status_code == HTTPStatus.OK
     assert response.get_data(as_text=True) == "print(1)\n"
     assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/proj/model.py"
-
-
-def test_stack_source_availability_accepts_source_file_id_without_file_path(
-    client, make_report
-):
-    instance_id = make_report(
-        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
-        inserts_sql="""
-        INSERT INTO source_files VALUES (2, '/x.py', 'body');
-        """,
-    )
-    response = client.get(
-        "/api/remote/stack-trace/test",
-        query_string={"instanceId": instance_id, "sourceFileId": 2},
-    )
-    assert response.status_code == HTTPStatus.OK
-    assert response.get_json() == {"available": True, "source": "database"}
 
 
 def test_stack_source_availability_reports_path_origin_on_literal_match(

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -67,12 +67,10 @@ def test_stack_source_content_local_read_sets_no_store(app, client, make_report)
         )
     assert response.status_code == HTTPStatus.OK
     assert response.headers.get("Cache-Control") == "no-store"
-    assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/abs/resolved.py"
-    assert response.headers.get("X-Content-Type-Options") == "nosniff"
-    assert (
-        response.headers.get("Content-Disposition")
-        == 'inline; filename="stack-source.txt"'
-    )
+    assert response.get_json() == {
+        "content": "print('hi')\n",
+        "resolved_path": "/abs/resolved.py",
+    }
 
 
 def test_stack_source_content_requires_instance(client):
@@ -130,8 +128,10 @@ def test_stack_source_read_from_report_db_by_path_only_in_server_mode(
         query_string={"instanceId": instance_id, "filePath": "/proj/other.py"},
     )
     assert response.status_code == HTTPStatus.OK
-    assert response.get_data(as_text=True) == "print(2)\n"
-    assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/proj/other.py"
+    assert response.get_json() == {
+        "content": "print(2)\n",
+        "resolved_path": "/proj/other.py",
+    }
 
 
 def test_stack_source_read_from_report_db_in_server_mode(client, make_report):
@@ -146,8 +146,10 @@ def test_stack_source_read_from_report_db_in_server_mode(client, make_report):
         query_string={"instanceId": instance_id, "sourceFileId": 1},
     )
     assert response.status_code == HTTPStatus.OK
-    assert response.get_data(as_text=True) == "print(1)\n"
-    assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/proj/model.py"
+    assert response.get_json() == {
+        "content": "print(1)\n",
+        "resolved_path": "/proj/model.py",
+    }
 
 
 def test_stack_source_availability_reports_path_origin_on_literal_match(

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -54,9 +54,8 @@ def test_stack_source_content_forbidden_in_server_mode_without_remote(
 def test_stack_source_content_local_read_sets_no_store(app, client, make_report):
     instance_id = make_report()
     app.config["SERVER_MODE"] = False
-    # read_stack_source_local still returns (content, resolved, remapped); the third
-    # element is unused by stack_source_response since the remap signal moved to
-    # /stack-trace/test's JSON `source` field.
+    # read_stack_source_local still returns (content, resolved, remapped); remap is
+    # reported on /stack-trace/test's JSON `source` field, not on /read's JSON body.
     with patch(
         "ttnn_visualizer.views.read_stack_source_local",
         return_value=("print('hi')\n", "/abs/resolved.py", False),

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -6,9 +6,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
-from ttnn_visualizer.tests.report_schemas import (
-    SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
-)
+from ttnn_visualizer.tests.report_schemas import SCHEMA_V2_1
 
 
 def test_stack_source_availability_requires_instance(client):
@@ -100,7 +98,7 @@ def test_stack_source_availability_from_report_db_in_server_mode(
     client, make_report, extra_query
 ):
     instance_id = make_report(
-        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        schema_sql=SCHEMA_V2_1,
         inserts_sql="""
         INSERT INTO source_files VALUES (1, '/proj/model.py', 'print(1)');
         """,
@@ -117,7 +115,7 @@ def test_stack_source_read_from_report_db_by_path_only_in_server_mode(
     client, make_report
 ):
     instance_id = make_report(
-        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        schema_sql=SCHEMA_V2_1,
         inserts_sql="""
         INSERT INTO source_files VALUES (3, '/proj/other.py', 'print(2)\n');
         """,
@@ -135,7 +133,7 @@ def test_stack_source_read_from_report_db_by_path_only_in_server_mode(
 
 def test_stack_source_read_from_report_db_in_server_mode(client, make_report):
     instance_id = make_report(
-        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        schema_sql=SCHEMA_V2_1,
         inserts_sql="""
         INSERT INTO source_files VALUES (1, '/proj/model.py', 'print(1)\n');
         """,

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -5,6 +5,10 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from ttnn_visualizer.tests.report_schemas import (
+    SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+)
+
 
 def test_stack_source_availability_requires_instance(client):
     response = client.get(
@@ -31,7 +35,7 @@ def test_stack_source_availability_server_mode_without_remote_reports_unavailabl
         query_string={"instanceId": instance_id, "filePath": "/any/path"},
     )
     assert response.status_code == HTTPStatus.OK
-    assert response.get_json() == {"available": False}
+    assert response.get_json() == {"available": False, "source": None}
     assert response.headers.get("Cache-Control") == "no-store"
 
 
@@ -76,3 +80,141 @@ def test_stack_source_content_rejects_missing_file_path(client, make_report):
         query_string={"instanceId": instance_id},
     )
     assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_stack_source_availability_from_report_db_by_path_only_in_server_mode(
+    client, make_report
+):
+    instance_id = make_report(
+        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        inserts_sql="""
+        INSERT INTO source_files VALUES (3, '/proj/other.py', 'print(2)');
+        """,
+    )
+    response = client.get(
+        "/api/remote/stack-trace/test",
+        query_string={"instanceId": instance_id, "filePath": "/proj/other.py"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"available": True, "source": "database"}
+
+
+def test_stack_source_availability_from_report_db_in_server_mode(client, make_report):
+    instance_id = make_report(
+        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        inserts_sql="""
+        INSERT INTO source_files VALUES (1, '/proj/model.py', 'print(1)');
+        """,
+    )
+    response = client.get(
+        "/api/remote/stack-trace/test",
+        query_string={
+            "instanceId": instance_id,
+            "sourceFileId": 1,
+            "filePath": "/proj/model.py",
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"available": True, "source": "database"}
+
+
+def test_stack_source_read_from_report_db_by_path_only_in_server_mode(
+    client, make_report
+):
+    instance_id = make_report(
+        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        inserts_sql="""
+        INSERT INTO source_files VALUES (3, '/proj/other.py', 'print(2)\\n');
+        """,
+    )
+    response = client.get(
+        "/api/remote/stack-trace/read",
+        query_string={"instanceId": instance_id, "filePath": "/proj/other.py"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_data(as_text=True) == "print(2)\n"
+    assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/proj/other.py"
+
+
+def test_stack_source_read_from_report_db_in_server_mode(client, make_report):
+    instance_id = make_report(
+        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        inserts_sql="""
+        INSERT INTO source_files VALUES (1, '/proj/model.py', 'print(1)\\n');
+        """,
+    )
+    response = client.get(
+        "/api/remote/stack-trace/read",
+        query_string={"instanceId": instance_id, "sourceFileId": 1},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_data(as_text=True) == "print(1)\n"
+    assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/proj/model.py"
+
+
+def test_stack_source_availability_accepts_source_file_id_without_file_path(
+    client, make_report
+):
+    instance_id = make_report(
+        schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
+        inserts_sql="""
+        INSERT INTO source_files VALUES (2, '/x.py', 'body');
+        """,
+    )
+    response = client.get(
+        "/api/remote/stack-trace/test",
+        query_string={"instanceId": instance_id, "sourceFileId": 2},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"available": True, "source": "database"}
+
+
+def test_stack_source_availability_reports_path_origin_on_literal_match(
+    app, client, make_report
+):
+    instance_id = make_report()
+    app.config["SERVER_MODE"] = False
+    # Returning False from *_with_origin means the file resolved at the literal path
+    # (no /tt-metal/ remap), which the API surfaces as source="path".
+    with patch(
+        "ttnn_visualizer.views.check_stack_source_local_with_origin",
+        return_value=False,
+    ):
+        response = client.get(
+            "/api/remote/stack-trace/test",
+            query_string={"instanceId": instance_id, "filePath": "/any/path"},
+        )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"available": True, "source": "path"}
+
+
+def test_stack_source_availability_reports_remapped_origin(app, client, make_report):
+    instance_id = make_report()
+    app.config["SERVER_MODE"] = False
+    with patch(
+        "ttnn_visualizer.views.check_stack_source_local_with_origin",
+        return_value=True,
+    ):
+        response = client.get(
+            "/api/remote/stack-trace/test",
+            query_string={"instanceId": instance_id, "filePath": "/any/path"},
+        )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"available": True, "source": "remapped"}
+
+
+def test_stack_source_availability_reports_unavailable_when_origin_none(
+    app, client, make_report
+):
+    instance_id = make_report()
+    app.config["SERVER_MODE"] = False
+    with patch(
+        "ttnn_visualizer.views.check_stack_source_local_with_origin",
+        return_value=None,
+    ):
+        response = client.get(
+            "/api/remote/stack-trace/test",
+            query_string={"instanceId": instance_id, "filePath": "/any/path"},
+        )
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"available": False, "source": None}

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -68,6 +68,11 @@ def test_stack_source_content_local_read_sets_no_store(app, client, make_report)
     assert response.status_code == HTTPStatus.OK
     assert response.headers.get("Cache-Control") == "no-store"
     assert response.headers.get("X-TTNN-Resolved-Source-Path") == "/abs/resolved.py"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert (
+        response.headers.get("Content-Disposition")
+        == 'inline; filename="stack-source.txt"'
+    )
 
 
 def test_stack_source_content_requires_instance(client):

--- a/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_stack_source_routes.py
@@ -117,7 +117,7 @@ def test_stack_source_read_from_report_db_by_path_only_in_server_mode(
     instance_id = make_report(
         schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
         inserts_sql="""
-        INSERT INTO source_files VALUES (3, '/proj/other.py', 'print(2)\\n');
+        INSERT INTO source_files VALUES (3, '/proj/other.py', 'print(2)\n');
         """,
     )
     response = client.get(
@@ -133,7 +133,7 @@ def test_stack_source_read_from_report_db_in_server_mode(client, make_report):
     instance_id = make_report(
         schema_sql=SCHEMA_V2_WITH_SOURCE_FILES_STACK_TRACES,
         inserts_sql="""
-        INSERT INTO source_files VALUES (1, '/proj/model.py', 'print(1)\\n');
+        INSERT INTO source_files VALUES (1, '/proj/model.py', 'print(1)\n');
         """,
     )
     response = client.get(

--- a/backend/ttnn_visualizer/tests/views/test_report_metadata.py
+++ b/backend/ttnn_visualizer/tests/views/test_report_metadata.py
@@ -52,14 +52,12 @@ def test_report_metadata_returns_metadata_on_success(app, client):
         db_path = f.name
     try:
         conn = sqlite3.connect(db_path)
-        conn.executescript(
-            """
+        conn.executescript("""
             CREATE TABLE report_metadata (key text UNIQUE, value text);
             INSERT INTO report_metadata VALUES ('schema_version', '2');
             INSERT INTO report_metadata VALUES ('capture_timestamp_ns', '1773424287168605099');
             INSERT INTO report_metadata VALUES ('total_duration_ns', '22119664963');
-        """
-        )
+        """)
         conn.commit()
         conn.close()
 

--- a/backend/ttnn_visualizer/tests/views/test_report_metadata.py
+++ b/backend/ttnn_visualizer/tests/views/test_report_metadata.py
@@ -52,12 +52,14 @@ def test_report_metadata_returns_metadata_on_success(app, client):
         db_path = f.name
     try:
         conn = sqlite3.connect(db_path)
-        conn.executescript("""
+        conn.executescript(
+            """
             CREATE TABLE report_metadata (key text UNIQUE, value text);
             INSERT INTO report_metadata VALUES ('schema_version', '2');
             INSERT INTO report_metadata VALUES ('capture_timestamp_ns', '1773424287168605099');
             INSERT INTO report_metadata VALUES ('total_duration_ns', '22119664963');
-        """)
+        """
+        )
         conn.commit()
         conn.close()
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -243,7 +243,7 @@ def _remote_stack_source_read(
     file_path: Optional[str],
     source_file_id: Optional[int] = None,
 ):
-    """Return plain-text stack source (report DB, then local or SSH tt-metal)."""
+    """Return JSON stack source (content + resolved_path) from report DB, then local or SSH tt-metal."""
     with DatabaseQueries(instance) as db:
         report_result = read_report_source_file(
             db, source_file_id=source_file_id, file_path=file_path

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -26,7 +26,7 @@ from ttnn_visualizer.csv_queries import (
     OpsPerformanceReportQueries,
 )
 from ttnn_visualizer.decorators import local_only, with_instance
-from ttnn_visualizer.enums import ConnectionTestStates
+from ttnn_visualizer.enums import ConnectionTestStates, StackSourceOrigin
 from ttnn_visualizer.exceptions import (
     AuthenticationFailedException,
     DataFormatError,
@@ -54,6 +54,10 @@ from ttnn_visualizer.models import (
     StatusMessage,
 )
 from ttnn_visualizer.queries import DatabaseQueries
+from ttnn_visualizer.report_source_file import (
+    read_report_source_file,
+    report_source_file_available,
+)
 from ttnn_visualizer.serializers import (
     serialize_buffer,
     serialize_buffer_pages,
@@ -75,8 +79,8 @@ from ttnn_visualizer.sftp_operations import (
 )
 from ttnn_visualizer.ssh_client import SSHClient
 from ttnn_visualizer.stack_trace_source import (
-    check_stack_source_local,
-    check_stack_source_remote,
+    check_stack_source_local_with_origin,
+    check_stack_source_remote_with_origin,
     read_stack_source_local,
     read_stack_source_remote,
     stack_source_response,
@@ -104,15 +108,34 @@ logger = logging.getLogger(__name__)
 api = Blueprint("api", __name__)
 
 
-def _file_path_from_stack_source_request():
+def _stack_source_request_params():
     """
-    Parse ``?filePath=`` for stack-trace availability/content GET requests.
-    Returns ``(path, None)`` or ``(None, error_response)``.
+    Parse ``?filePath=`` and optional ``?sourceFileId=`` for stack-trace GET requests.
+
+    Returns ``(file_path, source_file_id, None)`` or ``(None, None, error_response)``.
     """
     file_path = request.args.get("filePath")
-    if not file_path or not isinstance(file_path, str):
-        return None, response_bad_request("Missing or invalid filePath")
-    return file_path, None
+    if file_path is not None and not isinstance(file_path, str):
+        return None, None, response_bad_request("Invalid filePath")
+
+    source_file_id: Optional[int] = None
+    raw_source_file_id = request.args.get("sourceFileId")
+    if raw_source_file_id is not None and raw_source_file_id != "":
+        try:
+            source_file_id = int(raw_source_file_id)
+        except (TypeError, ValueError):
+            return (
+                None,
+                None,
+                response_bad_request(
+                    "Invalid query parameter 'sourceFileId': expected an integer."
+                ),
+            )
+
+    if source_file_id is None and (not file_path or not file_path.strip()):
+        return None, None, response_bad_request("Missing or invalid filePath")
+
+    return file_path, source_file_id, None
 
 
 def _optional_rank_query_param() -> Optional[int]:
@@ -154,44 +177,87 @@ def _reject_nonzero_rank_on_legacy_db(db: DatabaseQueries, rank: Optional[int]):
     return response_unprocessable_entity(_NONZERO_RANK_UNSUPPORTED_MSG)
 
 
-def _stack_source_availability_response(is_available: bool) -> Response:
+def _stack_source_availability_response(
+    is_available: bool, source: Optional[StackSourceOrigin] = None
+) -> Response:
     # Match stack_source_response: same filePath can resolve differently after
     # re-syncing remote reports, so don't let caches serve a stale answer.
-    resp = jsonify({"available": is_available})
+    payload = {
+        "available": is_available,
+        "source": source.value if is_available and source is not None else None,
+    }
+    resp = jsonify(payload)
     resp.headers["Cache-Control"] = "no-store"
 
     return resp
 
 
-def _remote_stack_source_path_availability(instance: Instance, file_path: str):
-    """Whether stack source ``file_path`` is readable for this instance (local or SSH)."""
-    remote_connection = instance.remote_connection
-    is_available = False
+def _remote_stack_source_path_availability(
+    instance: Instance,
+    file_path: Optional[str],
+    source_file_id: Optional[int] = None,
+):
+    """Whether stack source is readable (report DB, then local or SSH tt-metal)."""
+    with DatabaseQueries(instance) as db:
+        if report_source_file_available(
+            db, source_file_id=source_file_id, file_path=file_path
+        ):
+            return _stack_source_availability_response(
+                True, source=StackSourceOrigin.DATABASE
+            )
 
+    remote_connection = instance.remote_connection
+
+    if not file_path:
+        return _stack_source_availability_response(False)
+
+    # `remapped` is None when the file is unavailable, False on a literal-path hit,
+    # and True when resolved via a /tt-metal/ remap. The /test endpoint surfaces this
+    # distinction so clients can warn only about approximate (remapped) matches.
+    remapped: Optional[bool] = None
     if remote_connection:
         try:
             ssh_client = SSHClient(remote_connection)
-            is_available = check_stack_source_remote(ssh_client, file_path)
+            remapped = check_stack_source_remote_with_origin(ssh_client, file_path)
         except RemoteConnectionException:
             return _stack_source_availability_response(False)
-    else:
-        if not current_app.config.get("SERVER_MODE"):
-            is_available = check_stack_source_local(file_path)
+    elif not current_app.config.get("SERVER_MODE"):
+        remapped = check_stack_source_local_with_origin(file_path)
 
-    return _stack_source_availability_response(is_available)
+    if remapped is None:
+        return _stack_source_availability_response(False)
+    return _stack_source_availability_response(
+        True,
+        source=StackSourceOrigin.REMAPPED if remapped else StackSourceOrigin.PATH,
+    )
 
 
-def _remote_stack_source_read(instance: Instance, file_path: str):
-    """Return plain-text stack source (or error response)."""
+def _remote_stack_source_read(
+    instance: Instance,
+    file_path: Optional[str],
+    source_file_id: Optional[int] = None,
+):
+    """Return plain-text stack source (report DB, then local or SSH tt-metal)."""
+    with DatabaseQueries(instance) as db:
+        report_result = read_report_source_file(
+            db, source_file_id=source_file_id, file_path=file_path
+        )
+        if report_result is not None:
+            content, resolved_path = report_result
+            return stack_source_response(content, resolved_path)
+
     remote_connection = instance.remote_connection
+
+    if not file_path:
+        return response_not_found("Source file not found.")
 
     if remote_connection:
         try:
             ssh_client = SSHClient(remote_connection)
-            content, resolved, remapped = read_stack_source_remote(
+            content, resolved, _remapped = read_stack_source_remote(
                 ssh_client, file_path
             )
-            return stack_source_response(content, resolved, remapped)
+            return stack_source_response(content, resolved)
         except RemoteConnectionException as e:
             return error_response(e.http_status, e.message)
         except RemoteFileReadException as e:
@@ -203,8 +269,8 @@ def _remote_stack_source_read(instance: Instance, file_path: str):
         )
 
     try:
-        content, resolved, remapped = read_stack_source_local(file_path)
-        return stack_source_response(content, resolved, remapped)
+        content, resolved, _remapped = read_stack_source_local(file_path)
+        return stack_source_response(content, resolved)
     except ValueError as e:
         return response_bad_request(str(e))
     except FileNotFoundError as e:
@@ -1662,19 +1728,19 @@ def test_remote_folder():
 @api.route("/remote/stack-trace/test", methods=["GET"])
 @with_instance
 def remote_stack_trace_test(instance: Instance):
-    file_path, err = _file_path_from_stack_source_request()
+    file_path, source_file_id, err = _stack_source_request_params()
     if err is not None:
         return err
-    return _remote_stack_source_path_availability(instance, file_path)
+    return _remote_stack_source_path_availability(instance, file_path, source_file_id)
 
 
 @api.route("/remote/stack-trace/read", methods=["GET"])
 @with_instance
 def remote_stack_trace_read(instance: Instance):
-    file_path, err = _file_path_from_stack_source_request()
+    file_path, source_file_id, err = _stack_source_request_params()
     if err is not None:
         return err
-    return _remote_stack_source_read(instance, file_path)
+    return _remote_stack_source_read(instance, file_path, source_file_id)
 
 
 @api.route("/remote/sync", methods=["POST"])

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -133,7 +133,13 @@ def _stack_source_request_params():
             )
 
     if source_file_id is None and (not file_path or not file_path.strip()):
-        return None, None, response_bad_request("Missing or invalid filePath")
+        return (
+            None,
+            None,
+            response_bad_request(
+                "Missing or invalid query: provide filePath and/or sourceFileId."
+            ),
+        )
 
     return file_path, source_file_id, None
 

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -195,6 +195,7 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                         {details.stack_trace && (
                             <StackTrace
                                 stackTrace={details.stack_trace}
+                                stackTraceSourceFileId={operationDetails?.stack_trace_source_file_id ?? null}
                                 language={StackTraceLanguage.PYTHON}
                                 isInitiallyExpanded={showFullStackTrace}
                                 onExpandChange={() => setShowFullStackTrace(!showFullStackTrace)}

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -2,22 +2,22 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import hljs from 'highlight.js/lib/core';
-import python from 'highlight.js/lib/languages/python';
-import cpp from 'highlight.js/lib/languages/cpp';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import 'highlight.js/styles/a11y-dark.css';
 import { Button, ButtonVariant, Callout, Classes, Intent, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
+import hljs from 'highlight.js/lib/core';
+import cpp from 'highlight.js/lib/languages/cpp';
+import python from 'highlight.js/lib/languages/python';
+import 'highlight.js/styles/a11y-dark.css';
 import { useAtomValue } from 'jotai';
-import { profilerReportLocationAtom } from '../../store/app';
-import useRemoteConnection from '../../hooks/useRemote';
-import Overlay from '../Overlay';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import 'styles/components/StackTrace.scss';
 import { ReportLocation } from '../../definitions/Reports';
-import { SourceFileStatus, StackTraceLanguage } from '../../definitions/StackTrace';
+import { SourceFileStatus, StackSourceOrigin, StackTraceLanguage } from '../../definitions/StackTrace';
 import getServerConfig from '../../functions/getServerConfig';
+import useRemoteConnection from '../../hooks/useRemote';
+import { profilerReportLocationAtom } from '../../store/app';
+import Overlay from '../Overlay';
 
 hljs.registerLanguage(StackTraceLanguage.PYTHON, python);
 hljs.registerLanguage(StackTraceLanguage.CPP, cpp);
@@ -28,6 +28,7 @@ const LINE_NUMBER_REGEX = /line (\d*),/m;
 interface StackTraceProps {
     title?: string;
     stackTrace: string;
+    stackTraceSourceFileId?: number | null;
     language: StackTraceLanguage;
     hideSourceButton?: boolean;
     isInline?: boolean;
@@ -41,6 +42,7 @@ interface StackTraceProps {
 function StackTrace({
     title,
     stackTrace,
+    stackTraceSourceFileId = null,
     language,
     hideSourceButton,
     isInline,
@@ -56,9 +58,9 @@ function StackTrace({
     const [isFetchingFile, setIsFetchingFile] = useState(false);
     const [fileContents, setFileContents] = useState('');
     const [errorDetails, setErrorDetails] = useState('');
-    const [sourceMatchedViaRemap, setSourceMatchedViaRemap] = useState(false);
     const [resolvedSourcePath, setResolvedSourcePath] = useState<string | null>(null);
     const [sourceFileStatus, setSourceFileStatus] = useState<SourceFileStatus>(SourceFileStatus.Unavailable);
+    const [sourceMatchedViaRemap, setSourceMatchedViaRemap] = useState(false);
     const [isViewingSourceFile, setIsViewingSourceFile] = useState(false);
     const [scrollContainerEl, setScrollContainerEl] = useState<Element | null>(null);
     const [overlayTopOffset, setOverlayTopOffset] = useState<number>(0);
@@ -109,16 +111,17 @@ function StackTrace({
     const toggleViewingFile = useCallback(() => setIsViewingSourceFile((open) => !open), [setIsViewingSourceFile]);
 
     const serverMode = !!getServerConfig()?.SERVER_MODE;
-    const canReadSource = isRemote ? !!persistentState.selectedConnection : !serverMode;
+    const hasReportSourceFileId = stackTraceSourceFileId != null;
+    const canProbeSource = !!filePath || hasReportSourceFileId;
 
     const shouldShowSourceControls = !hideSourceButton;
     const sourceTooltip = useMemo(
-        () => getSourceTooltipContents(serverMode, isRemote, filePath, canReadSource, sourceFileStatus),
-        [serverMode, isRemote, filePath, canReadSource, sourceFileStatus],
+        () => getSourceTooltipContents(serverMode, canProbeSource, sourceFileStatus),
+        [serverMode, canProbeSource, sourceFileStatus],
     );
 
     const handleReadSource = async () => {
-        if (!canReadSource || !filePath || sourceFileStatus !== SourceFileStatus.Available) {
+        if (!canProbeSource || sourceFileStatus !== SourceFileStatus.Available) {
             return;
         }
 
@@ -129,10 +132,9 @@ function StackTrace({
 
         setIsFetchingFile(true);
 
-        const { data, error, isRemapped, resolvedPath } = await readRemoteFile(filePath);
+        const { data, error, resolvedPath } = await readRemoteFile(filePath, stackTraceSourceFileId);
 
         setErrorDetails('');
-        setSourceMatchedViaRemap(!!isRemapped);
         setResolvedSourcePath(resolvedPath);
 
         if (error) {
@@ -181,8 +183,8 @@ function StackTrace({
         return path;
     }, [isRemote, persistentState, resolvedSourcePath, filePath]);
     const isCheckingStackTraceAvailability =
-        isFetchingFile || (sourceFileStatus === SourceFileStatus.Pending && !!filePath && canReadSource);
-    const isStackTraceUnavailable = !canReadSource || !filePath || sourceFileStatus !== SourceFileStatus.Available;
+        isFetchingFile || (sourceFileStatus === SourceFileStatus.Pending && canProbeSource);
+    const isStackTraceUnavailable = !canProbeSource || sourceFileStatus !== SourceFileStatus.Available;
 
     useEffect(() => {
         if (!scrollContainerEl) {
@@ -225,16 +227,17 @@ function StackTrace({
             setFileContents('');
             setErrorDetails('');
             setSourceFileStatus(SourceFileStatus.Unavailable);
-            setSourceMatchedViaRemap(false);
             setResolvedSourcePath(null);
+            setSourceMatchedViaRemap(false);
         });
-    }, [filePath, canReadSource]);
+    }, [filePath, stackTraceSourceFileId]);
 
     // Check stack trace file is available
     useEffect(() => {
-        if (!shouldShowSourceControls || !filePath || !canReadSource) {
+        if (!shouldShowSourceControls || !canProbeSource) {
             queueMicrotask(() => {
                 setSourceFileStatus(SourceFileStatus.Unavailable);
+                setSourceMatchedViaRemap(false);
             });
             return undefined;
         }
@@ -243,17 +246,20 @@ function StackTrace({
         let fetchCancelled = false;
         queueMicrotask(() => {
             setSourceFileStatus(SourceFileStatus.Pending);
+            setSourceMatchedViaRemap(false);
         });
 
         (async () => {
             try {
-                const ok = await isSourceFileAvailable(filePath, controller.signal);
+                const result = await isSourceFileAvailable(filePath, controller.signal, stackTraceSourceFileId);
                 if (!fetchCancelled) {
-                    setSourceFileStatus(ok ? SourceFileStatus.Available : SourceFileStatus.Unavailable);
+                    setSourceFileStatus(result.available ? SourceFileStatus.Available : SourceFileStatus.Unavailable);
+                    setSourceMatchedViaRemap(result.available && result.source === StackSourceOrigin.Remapped);
                 }
             } catch {
                 if (!fetchCancelled) {
                     setSourceFileStatus(SourceFileStatus.Unavailable);
+                    setSourceMatchedViaRemap(false);
                 }
             }
         })();
@@ -262,7 +268,7 @@ function StackTrace({
             fetchCancelled = true;
             controller.abort();
         };
-    }, [shouldShowSourceControls, filePath, canReadSource, isSourceFileAvailable]);
+    }, [shouldShowSourceControls, canProbeSource, filePath, stackTraceSourceFileId, isSourceFileAvailable]);
 
     return (
         <div className={classNames('stack-trace', className)}>
@@ -369,6 +375,7 @@ function StackTrace({
 
                         {fileWithHighlights && !errorDetails ? (
                             <div className='stack-trace'>
+                                <p className='stack-trace-path monospace'>{displaySourcePath}</p>
                                 {sourceMatchedViaRemap ? (
                                     <Callout
                                         className='stack-trace-source-remap-notice'
@@ -379,7 +386,6 @@ function StackTrace({
                                         or revision that produced the trace.
                                     </Callout>
                                 ) : null}
-                                <p className='stack-trace-path monospace'>{displaySourcePath}</p>
                                 <code
                                     className={`language-${language} code-output`}
                                     // HTML tags are escaped by hljs
@@ -420,28 +426,31 @@ const scrollToLineNumberInFile = () => {
     }
 };
 
+/**
+ * Source button tooltip. Intentionally generic for all ``StackSourceOrigin`` values
+ * (database, path, remapped); only availability state affects the message.
+ */
 function getSourceTooltipContents(
     serverMode: boolean,
-    isRemote: boolean,
-    filePath: string,
-    canReadSource: boolean,
+    canProbeSource: boolean,
     sourceFileStatus: SourceFileStatus,
 ): string {
-    if (serverMode && !isRemote) {
-        return 'Source viewing is not available';
-    }
-    if (!filePath) {
+    if (!canProbeSource) {
         return 'No file path found for this stack trace';
     }
-    if (!canReadSource) {
-        return isRemote ? 'Remote connection cannot be established' : 'Cannot read source file';
+
+    if (serverMode && sourceFileStatus === SourceFileStatus.Unavailable) {
+        return 'Source file is not available in this report';
     }
+
     if (sourceFileStatus === SourceFileStatus.Pending) {
         return 'Checking whether source file is available…';
     }
+
     if (sourceFileStatus === SourceFileStatus.Unavailable) {
         return 'Source file is not available';
     }
+
     return 'View source file';
 }
 

--- a/src/components/operation-details/StackTrace.tsx
+++ b/src/components/operation-details/StackTrace.tsx
@@ -14,7 +14,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import 'styles/components/StackTrace.scss';
 import { ReportLocation } from '../../definitions/Reports';
 import { SourceFileStatus, StackSourceOrigin, StackTraceLanguage } from '../../definitions/StackTrace';
-import getServerConfig from '../../functions/getServerConfig';
 import useRemoteConnection from '../../hooks/useRemote';
 import { profilerReportLocationAtom } from '../../store/app';
 import Overlay from '../Overlay';
@@ -110,14 +109,13 @@ function StackTrace({
 
     const toggleViewingFile = useCallback(() => setIsViewingSourceFile((open) => !open), [setIsViewingSourceFile]);
 
-    const serverMode = !!getServerConfig()?.SERVER_MODE;
     const hasReportSourceFileId = stackTraceSourceFileId != null;
     const canProbeSource = !!filePath || hasReportSourceFileId;
 
     const shouldShowSourceControls = !hideSourceButton;
     const sourceTooltip = useMemo(
-        () => getSourceTooltipContents(serverMode, canProbeSource, sourceFileStatus),
-        [serverMode, canProbeSource, sourceFileStatus],
+        () => getSourceTooltipContents(canProbeSource, sourceFileStatus),
+        [canProbeSource, sourceFileStatus],
     );
 
     const handleReadSource = async () => {
@@ -430,17 +428,9 @@ const scrollToLineNumberInFile = () => {
  * Source button tooltip. Intentionally generic for all ``StackSourceOrigin`` values
  * (database, path, remapped); only availability state affects the message.
  */
-function getSourceTooltipContents(
-    serverMode: boolean,
-    canProbeSource: boolean,
-    sourceFileStatus: SourceFileStatus,
-): string {
+function getSourceTooltipContents(canProbeSource: boolean, sourceFileStatus: SourceFileStatus): string {
     if (!canProbeSource) {
         return 'No file path found for this stack trace';
-    }
-
-    if (serverMode && sourceFileStatus === SourceFileStatus.Unavailable) {
-        return 'Source file is not available in this report';
     }
 
     if (sourceFileStatus === SourceFileStatus.Pending) {

--- a/src/definitions/StackTrace.ts
+++ b/src/definitions/StackTrace.ts
@@ -12,3 +12,10 @@ export enum SourceFileStatus {
     Pending = 'pending',
     Available = 'available',
 }
+
+/** Values returned by ``GET /api/remote/stack-trace/test`` in the ``source`` field. */
+export enum StackSourceOrigin {
+    Database = 'database',
+    Path = 'path',
+    Remapped = 'remapped',
+}

--- a/src/definitions/StackTrace.ts
+++ b/src/definitions/StackTrace.ts
@@ -13,7 +13,6 @@ export enum SourceFileStatus {
     Available = 'available',
 }
 
-/** Values returned by ``GET /api/remote/stack-trace/test`` in the ``source`` field. */
 export enum StackSourceOrigin {
     Database = 'database',
     Path = 'path',

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -12,12 +12,11 @@ import { normaliseReportFolder } from '../functions/validateReportFolder';
 import Endpoints from '../definitions/Endpoints';
 import { StackSourceOrigin } from '../definitions/StackTrace';
 
-export interface StackSourceAvailability {
+interface StackSourceAvailability {
     available: boolean;
     source: StackSourceOrigin | null;
 }
 
-/** JSON body from ``GET /api/remote/stack-trace/read``. */
 interface StackSourceReadResponse {
     content?: string;
     resolved_path?: string | null;

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -215,9 +215,14 @@ const useRemoteConnection = () => {
                 });
 
                 const available = data?.available === true;
+                const rawSource = data?.source;
+                const knownSource =
+                    typeof rawSource === 'string' && (Object.values(StackSourceOrigin) as string[]).includes(rawSource)
+                        ? (rawSource as StackSourceOrigin)
+                        : null;
                 return {
                     available,
-                    source: available && data?.source ? data.source : null,
+                    source: available ? knownSource : null,
                 };
             } catch {
                 return { available: false, source: null };

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -17,6 +17,12 @@ export interface StackSourceAvailability {
     source: StackSourceOrigin | null;
 }
 
+/** JSON body from ``GET /api/remote/stack-trace/read``. */
+interface StackSourceReadResponse {
+    content?: string;
+    resolved_path?: string | null;
+}
+
 const FAILED_NO_CONNECTION = {
     status: ConnectionTestStates.FAILED,
     message: 'No connection provided',
@@ -240,17 +246,17 @@ const useRemoteConnection = () => {
             if (sourceFileId != null) {
                 params.sourceFileId = sourceFileId;
             }
-            const response = await axiosInstance.get<string>(`${Endpoints.REMOTE}/stack-trace/read`, {
+            const { data } = await axiosInstance.get<StackSourceReadResponse>(`${Endpoints.REMOTE}/stack-trace/read`, {
                 params,
-                responseType: 'text',
             });
 
-            const resolvedPath = response.headers['x-ttnn-resolved-source-path'] || null;
+            const content = typeof data?.content === 'string' ? data.content : null;
+            const resolvedPath = typeof data?.resolved_path === 'string' ? data.resolved_path : null;
 
             return {
-                data: response.data,
+                data: content,
                 error: null,
-                resolvedPath: typeof resolvedPath === 'string' ? resolvedPath : null,
+                resolvedPath,
             };
         } catch (error: unknown) {
             const standardError = {

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -10,6 +10,12 @@ import axiosInstance from '../libs/axiosInstance';
 import useAppConfig from './useAppConfig';
 import { normaliseReportFolder } from '../functions/validateReportFolder';
 import Endpoints from '../definitions/Endpoints';
+import { StackSourceOrigin } from '../definitions/StackTrace';
+
+export interface StackSourceAvailability {
+    available: boolean;
+    source: StackSourceOrigin | null;
+}
 
 const FAILED_NO_CONNECTION = {
     status: ConnectionTestStates.FAILED,
@@ -186,39 +192,64 @@ const useRemoteConnection = () => {
         setAppConfig(LOCAL_STORAGE_KEY_CONNECTIONS, safeJsonStringify(connectionList, '[]'));
     };
 
-    const isSourceFileAvailable = useCallback(async (filePath: string, signal?: AbortSignal): Promise<boolean> => {
-        try {
-            const { data } = await axiosInstance.get<{ available?: boolean }>(`${Endpoints.REMOTE}/stack-trace/test`, {
-                signal,
-                params: { filePath },
-            });
+    const isSourceFileAvailable = useCallback(
+        async (
+            filePath: string,
+            signal?: AbortSignal,
+            sourceFileId?: number | null,
+        ): Promise<StackSourceAvailability> => {
+            try {
+                const params: { filePath?: string; sourceFileId?: number } = {};
+                if (filePath) {
+                    params.filePath = filePath;
+                }
+                if (sourceFileId != null) {
+                    params.sourceFileId = sourceFileId;
+                }
+                const { data } = await axiosInstance.get<{
+                    available?: boolean;
+                    source?: StackSourceOrigin | null;
+                }>(`${Endpoints.REMOTE}/stack-trace/test`, {
+                    signal,
+                    params,
+                });
 
-            return data?.available === true;
-        } catch {
-            return false;
-        }
-    }, []);
+                const available = data?.available === true;
+                return {
+                    available,
+                    source: available && data?.source ? data.source : null,
+                };
+            } catch {
+                return { available: false, source: null };
+            }
+        },
+        [],
+    );
 
-    const readRemoteFile = async (filePath: string) => {
+    const readRemoteFile = async (filePath: string, sourceFileId?: number | null) => {
         try {
+            const params: { filePath?: string; sourceFileId?: number } = {};
+            if (filePath) {
+                params.filePath = filePath;
+            }
+            if (sourceFileId != null) {
+                params.sourceFileId = sourceFileId;
+            }
             const response = await axiosInstance.get<string>(`${Endpoints.REMOTE}/stack-trace/read`, {
-                params: { filePath },
+                params,
                 responseType: 'text',
             });
 
-            const isRemapped = response.headers['x-ttnn-source-remapped'] === 'true';
             const resolvedPath = response.headers['x-ttnn-resolved-source-path'] || null;
 
             return {
                 data: response.data,
                 error: null,
-                isRemapped,
                 resolvedPath: typeof resolvedPath === 'string' ? resolvedPath : null,
             };
         } catch (error: unknown) {
             const standardError = {
                 data: null,
-                isRemapped: false,
                 resolvedPath: null,
                 error: 'An unexpected error occurred',
             };

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -22,6 +22,7 @@ export interface Operation {
     inputs: Tensor[];
     outputs: Tensor[];
     stack_trace: string;
+    stack_trace_source_file_id: number | null;
     device_operations: Node[];
     operationFileIdentifier: string;
     error: OperationError | null;
@@ -135,6 +136,7 @@ export const defaultOperation: OperationDetailsData = {
     buffersSummary: [],
     l1_sizes: [],
     stack_trace: '',
+    stack_trace_source_file_id: null,
     device_operations: [],
     operationFileIdentifier: '',
     error: null,

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -68,6 +68,50 @@ describe('useRemoteConnection - stack source GETs', () => {
         expect(availability).toEqual({ available: false, source: null });
     });
 
+    it('isSourceFileAvailable forwards sourceFileId and parses database origin', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockGet = vi.mocked(axiosInstance.default.get);
+        mockGet.mockResolvedValue({
+            data: { available: true, source: StackSourceOrigin.Database },
+        } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        const availability = await result.current.isSourceFileAvailable('', undefined, 42);
+
+        expect(availability).toEqual({ available: true, source: StackSourceOrigin.Database });
+        expect(mockGet).toHaveBeenCalledWith('/api/remote/stack-trace/test', {
+            params: { sourceFileId: 42 },
+        });
+    });
+
+    it('isSourceFileAvailable forwards both filePath and sourceFileId', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockGet = vi.mocked(axiosInstance.default.get);
+        mockGet.mockResolvedValue({
+            data: { available: true, source: StackSourceOrigin.Database },
+        } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        await result.current.isSourceFileAvailable('/proj/model.py', undefined, 1);
+
+        expect(mockGet).toHaveBeenCalledWith('/api/remote/stack-trace/test', {
+            params: { filePath: '/proj/model.py', sourceFileId: 1 },
+        });
+    });
+
+    it('isSourceFileAvailable drops unknown source values when available', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockGet = vi.mocked(axiosInstance.default.get);
+        mockGet.mockResolvedValue({
+            data: { available: true, source: 'not-a-real-origin' },
+        } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        const availability = await result.current.isSourceFileAvailable('/x');
+
+        expect(availability).toEqual({ available: true, source: null });
+    });
+
     it('readRemoteFile issues GET /api/remote/stack-trace/read and parses JSON body', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
@@ -88,6 +132,26 @@ describe('useRemoteConnection - stack source GETs', () => {
             data: 'file contents',
             error: null,
             resolvedPath: '/abs/resolved.py',
+        });
+    });
+
+    it('readRemoteFile forwards sourceFileId without filePath', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockGet = vi.mocked(axiosInstance.default.get);
+        mockGet.mockResolvedValue({
+            data: { content: 'from db', resolved_path: '/proj/model.py' },
+        } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        const out = await result.current.readRemoteFile('', 1);
+
+        expect(mockGet).toHaveBeenCalledWith('/api/remote/stack-trace/read', {
+            params: { sourceFileId: 1 },
+        });
+        expect(out).toEqual({
+            data: 'from db',
+            error: null,
+            resolvedPath: '/proj/model.py',
         });
     });
 

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -5,6 +5,7 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AxiosResponse } from 'axios';
+import { StackSourceOrigin } from '../src/definitions/StackTrace';
 import useRemoteConnection from '../src/hooks/useRemote';
 
 vi.mock('../src/libs/axiosInstance', () => ({
@@ -27,13 +28,15 @@ describe('useRemoteConnection - stack source GETs', () => {
     it('isSourceFileAvailable issues GET /api/remote/stack-trace/test with filePath query and forwards signal', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
-        mockGet.mockResolvedValue({ data: { available: true } } as AxiosResponse);
+        mockGet.mockResolvedValue({
+            data: { available: true, source: StackSourceOrigin.Path },
+        } as AxiosResponse);
 
         const { result } = renderHook(() => useRemoteConnection());
         const controller = new AbortController();
-        const available = await result.current.isSourceFileAvailable('/some/file.py', controller.signal);
+        const availability = await result.current.isSourceFileAvailable('/some/file.py', controller.signal);
 
-        expect(available).toBe(true);
+        expect(availability).toEqual({ available: true, source: StackSourceOrigin.Path });
         expect(mockGet).toHaveBeenCalledTimes(1);
         const [url, config] = mockGet.mock.calls[0];
         expect(url).toBe('/api/remote/stack-trace/test');
@@ -43,35 +46,34 @@ describe('useRemoteConnection - stack source GETs', () => {
         });
     });
 
-    it('isSourceFileAvailable returns false when the request rejects', async () => {
+    it('isSourceFileAvailable returns unavailable when the request rejects', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
         mockGet.mockRejectedValue(new Error('boom'));
 
         const { result } = renderHook(() => useRemoteConnection());
-        const available = await result.current.isSourceFileAvailable('/x');
+        const availability = await result.current.isSourceFileAvailable('/x');
 
-        expect(available).toBe(false);
+        expect(availability).toEqual({ available: false, source: null });
     });
 
-    it('isSourceFileAvailable returns false when the response shape is unexpected', async () => {
+    it('isSourceFileAvailable returns unavailable when the response shape is unexpected', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
         mockGet.mockResolvedValue({ data: { available: 'maybe' } } as AxiosResponse);
 
         const { result } = renderHook(() => useRemoteConnection());
-        const available = await result.current.isSourceFileAvailable('/x');
+        const availability = await result.current.isSourceFileAvailable('/x');
 
-        expect(available).toBe(false);
+        expect(availability).toEqual({ available: false, source: null });
     });
 
-    it('readRemoteFile issues GET /api/remote/stack-trace/read and parses X-TTNN headers', async () => {
+    it('readRemoteFile issues GET /api/remote/stack-trace/read and parses X-TTNN-Resolved-Source-Path', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
         mockGet.mockResolvedValue({
             data: 'file contents',
             headers: {
-                'x-ttnn-source-remapped': 'true',
                 'x-ttnn-resolved-source-path': '/abs/resolved.py',
             },
         } as unknown as AxiosResponse);
@@ -86,12 +88,11 @@ describe('useRemoteConnection - stack source GETs', () => {
         expect(out).toEqual({
             data: 'file contents',
             error: null,
-            isRemapped: true,
             resolvedPath: '/abs/resolved.py',
         });
     });
 
-    it('readRemoteFile reports isRemapped=false and null resolvedPath when headers are absent', async () => {
+    it('readRemoteFile reports null resolvedPath when header is absent', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
         mockGet.mockResolvedValue({
@@ -103,7 +104,6 @@ describe('useRemoteConnection - stack source GETs', () => {
         const out = await result.current.readRemoteFile('/x');
 
         expect(out.data).toBe('plain');
-        expect(out.isRemapped).toBe(false);
         expect(out.resolvedPath).toBeNull();
         expect(out.error).toBeNull();
     });
@@ -117,7 +117,6 @@ describe('useRemoteConnection - stack source GETs', () => {
         const out = await result.current.readRemoteFile('/x');
 
         expect(out.data).toBeNull();
-        expect(out.isRemapped).toBe(false);
         expect(out.resolvedPath).toBeNull();
         expect(typeof out.error).toBe('string');
     });

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -68,22 +68,21 @@ describe('useRemoteConnection - stack source GETs', () => {
         expect(availability).toEqual({ available: false, source: null });
     });
 
-    it('readRemoteFile issues GET /api/remote/stack-trace/read and parses X-TTNN-Resolved-Source-Path', async () => {
+    it('readRemoteFile issues GET /api/remote/stack-trace/read and parses JSON body', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
         mockGet.mockResolvedValue({
-            data: 'file contents',
-            headers: {
-                'x-ttnn-resolved-source-path': '/abs/resolved.py',
+            data: {
+                content: 'file contents',
+                resolved_path: '/abs/resolved.py',
             },
-        } as unknown as AxiosResponse);
+        } as AxiosResponse);
 
         const { result } = renderHook(() => useRemoteConnection());
         const out = await result.current.readRemoteFile('/some/file.py');
 
         expect(mockGet).toHaveBeenCalledWith('/api/remote/stack-trace/read', {
             params: { filePath: '/some/file.py' },
-            responseType: 'text',
         });
         expect(out).toEqual({
             data: 'file contents',
@@ -92,13 +91,12 @@ describe('useRemoteConnection - stack source GETs', () => {
         });
     });
 
-    it('readRemoteFile reports null resolvedPath when header is absent', async () => {
+    it('readRemoteFile reports null resolvedPath when JSON field is absent', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockGet = vi.mocked(axiosInstance.default.get);
         mockGet.mockResolvedValue({
-            data: 'plain',
-            headers: {},
-        } as unknown as AxiosResponse);
+            data: { content: 'plain' },
+        } as AxiosResponse);
 
         const { result } = renderHook(() => useRemoteConnection());
         const out = await result.current.readRemoteFile('/x');


### PR DESCRIPTION
Fairly big refactor of stack trace reading so this went through a number of review cycles with Cursor/Copilot.

Adds support for associating stack traces with source files stored in the report database, adds new APIs for reading and probing source file availability, and strengthens path validation for security. It also refactors how stack source file resolution and responses are handled, and adds comprehensive tests for the new database queries.

**Stack trace and source file association:**
- Added a `source_file_id` field to the `StackTrace` model and serialization logic, allowing stack traces to reference source files in the new `source_files` table. (`backend/ttnn_visualizer/models.py` [[1]](diffhunk://#diff-c22eca001a8884812b4ab8e5fce0a552cb3c82988049b63f260f5dfd6d261ba2R171-R182) `backend/ttnn_visualizer/serializers.py` [[2]](diffhunk://#diff-5119a520c2cb7046a7773a8e8e9b7eb0e90ad7c38a0fd44933e46fdeebe14c73R76-R80) [[3]](diffhunk://#diff-5119a520c2cb7046a7773a8e8e9b7eb0e90ad7c38a0fd44933e46fdeebe14c73R114-R116) [[4]](diffhunk://#diff-5119a520c2cb7046a7773a8e8e9b7eb0e90ad7c38a0fd44933e46fdeebe14c73R265-R269)
- Updated the database schema and tests to support the `source_files` table and the new association. (`backend/ttnn_visualizer/tests/report_schemas.py` [[1]](diffhunk://#diff-31d6fa340302ea3e057ceb377e157418447e03dd7080ada7b23660962702fd17R140-R154) `backend/ttnn_visualizer/tests/test_queries.py` [[2]](diffhunk://#diff-f381e9e4ae68511b0fe143e305b42fdec6873fbbc76fa35ed921b6b4fd1346edR310-R375)

**Source file database access and APIs:**
- Implemented new query methods for reading, filtering, and probing `source_files` by ID or path, including efficient availability checks that avoid loading large blobs. (`backend/ttnn_visualizer/queries.py` [backend/ttnn_visualizer/queries.pyR305-R360](diffhunk://#diff-9f005c8ebc47f036afefe9038eb10e51e5d3cded955cfc700a9d7aff6d4a2b0fR305-R360))
- Added the `report_source_file.py` module, which provides functions to resolve, validate, and read source files for stack traces, with consistent path validation for both query parameters and DB values. (`backend/ttnn_visualizer/report_source_file.py` [backend/ttnn_visualizer/report_source_file.pyR1-R115](diffhunk://#diff-7ceb3d2e294b8a3212135b15e5e5fe3ca3b3961fd7427862b296c13abe005869R1-R115))

**Stack source file path validation and security:**
- Strengthened validation of stack trace paths by rejecting control characters, improving safety for filesystem and JSON usage, and defending against header injection attacks. (`backend/ttnn_visualizer/stack_trace_source.py` [backend/ttnn_visualizer/stack_trace_source.pyR65-R69](diffhunk://#diff-9243e99bf45d1fd88bf94b01390ddf8b56658d292a876169202443f2bbfd3bdcR65-R69))

**Stack source file resolution and response refactor:**
- Refactored local and remote stack source file probing to return richer information about resolution origin (exact path vs `/tt-metal/` remap) and updated response formats to use JSON bodies instead of custom headers. (`backend/ttnn_visualizer/stack_trace_source.py` [[1]](diffhunk://#diff-9243e99bf45d1fd88bf94b01390ddf8b56658d292a876169202443f2bbfd3bdcL400-R445) [[2]](diffhunk://#diff-9243e99bf45d1fd88bf94b01390ddf8b56658d292a876169202443f2bbfd3bdcL435-L452)
- Added the `StackSourceOrigin` enum to categorize stack source origins in API responses. (`backend/ttnn_visualizer/enums.py` [backend/ttnn_visualizer/enums.pyR14-R21](diffhunk://#diff-8f2e00df92f1c61cf442d0b2b7153c5e043e5a36f2ac03fdb4f2b35daa737a60R14-R21))

**Other improvements:**
- Simplified CORS configuration by removing unnecessary exposed headers. (`backend/ttnn_visualizer/app.py` [backend/ttnn_visualizer/app.pyL206-R206](diffhunk://#diff-14674be812616fc4545d50f7661dafc8f85a2727687bda0471eda8b372f6af3eL206-R206))
- Minor import and utility function updates to support the new features. (`backend/ttnn_visualizer/stack_trace_source.py` [[1]](diffhunk://#diff-9243e99bf45d1fd88bf94b01390ddf8b56658d292a876169202443f2bbfd3bdcL17-R17) `backend/ttnn_visualizer/queries.py` [[2]](diffhunk://#diff-9f005c8ebc47f036afefe9038eb10e51e5d3cded955cfc700a9d7aff6d4a2b0fR36) `backend/ttnn_visualizer/serializers.py` [[3]](diffhunk://#diff-5119a520c2cb7046a7773a8e8e9b7eb0e90ad7c38a0fd44933e46fdeebe14c73R31-R39)

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1391.