### PR TITLE
Enforce resolved-path containment in folder uploads

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -874,7 +874,7 @@ if not files:
 
 Without the guard, downstream `files[0]` indexing or empty-collection iteration falls over silently or with an opaque error.
 
-> **Note:** the rules above cover **single-file** uploads (NPE, MLIR, future single-blob endpoints). **Folder-upload** branches (profiler/performance report trees) deliberately preserve subpath structure and need a different fix shape — a resolved-path containment check (`dest.resolve().is_relative_to(target.resolve())`). That hardening is tracked separately; ask before extending the `.name` pattern into folder uploads.
+> **Note:** the rules above cover **single-file** uploads (NPE, MLIR, future single-blob endpoints). **Folder-upload** branches (profiler/performance report trees) deliberately preserve subpath structure and use a different fix shape — a resolved-path containment check inside `construct_dest_path` that rejects any candidate whose resolved path lands outside the per-report folder (raising `DataFormatError`, which the view handlers map to 422). Don't extend the `.name` collapse pattern into the folder branch; rely on the containment check.
 
 ---
 
@@ -1021,7 +1021,6 @@ Don't `raise Exception("...")` — there's an existing class for almost every ca
 
 These exist in the codebase today and don't yet have a single canonical answer. Reviewers should flag new code that goes either direction without considering both:
 
-- **Folder-upload sanitization.** Single-file uploads sanitize filenames via `Path(...).name`; folder uploads preserve subpaths and need a resolved-path containment check instead. The latter isn't yet implemented (tracked as a follow-up).
 - **`extract_npe_name` is a misnomer.** It's used by both NPE and MLIR upload handlers. Rename to `extract_uploaded_name` is tracked as a follow-up; don't perpetuate the NPE-specific name in new helpers.
 - **`errorMessage` vs `statusMessage` in file loaders.** `MlirJsonFileLoader.tsx` and `NPEFileLoader.tsx` overload a state field called `errorMessage` with both success and failure text. A rename to `statusMessage` is pending.
 - **Upload size cap.** No `MAX_CONTENT_LENGTH` is set on the Flask app; large uploads succeed until they exhaust memory. Tracked as a separate hardening task.

--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -241,8 +241,8 @@ def construct_dest_path(file, target_directory, folder_name):
         # directory. `resolve(strict=False)` normalises `..` segments and (on
         # macOS) walks shared symlinks like `/tmp` -> `/private/tmp`, so the
         # comparison is symlink-stable.
-        resolved_dest = dest_path.resolve()
-        resolved_root = report_root.resolve()
+        resolved_dest = dest_path.resolve(strict=False)
+        resolved_root = report_root.resolve(strict=False)
         if not (
             resolved_dest == resolved_root
             or resolved_dest.is_relative_to(resolved_root)

--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -217,8 +217,9 @@ def construct_dest_path(file, target_directory, folder_name):
     if folder_name:
         # Folder uploads legitimately carry sub-paths in `file.filename`
         # (e.g. `subdir/file.csv`) and `validate_files` / `os.utime` accounting
-        # depend on that. Path-traversal hardening for the folder branch is a
-        # separate, broader follow-up — see PR_REVIEW_TRIAGE_2.md §1.J.
+        # depend on that, so we can't just collapse to the basename the way
+        # the single-file branch does. Instead, build the candidate path and
+        # then assert a resolved-path containment check below.
         prefixed_folder_name = f"{prefix}{folder_name}"
         # Chromium-based browsers send each file's relative path as the
         # multipart filename (e.g. `report/db.sqlite`), while Safari sends just
@@ -229,7 +230,31 @@ def construct_dest_path(file, target_directory, folder_name):
         head, sep, tail = relative_filename.partition("/")
         if sep and head == folder_name:
             relative_filename = tail
-        dest_path = Path(target_directory) / prefixed_folder_name / relative_filename
+        report_root = Path(target_directory) / prefixed_folder_name
+        dest_path = report_root / relative_filename
+
+        # Defense against `../` (or absolute-path) traversal in the
+        # client-supplied filename. The single-file branch hardens this by
+        # collapsing to `Path(...).name`, which we can't do here because legit
+        # folder uploads need their sub-paths preserved. Instead, resolve both
+        # paths and require the destination to stay within the per-report
+        # directory. `resolve(strict=False)` normalises `..` segments and (on
+        # macOS) walks shared symlinks like `/tmp` -> `/private/tmp`, so the
+        # comparison is symlink-stable.
+        resolved_dest = dest_path.resolve()
+        resolved_root = report_root.resolve()
+        if not (
+            resolved_dest == resolved_root
+            or resolved_dest.is_relative_to(resolved_root)
+        ):
+            logger.warning(
+                "Upload filename %r escapes report directory %s",
+                str(file.filename),
+                resolved_root,
+            )
+            raise DataFormatError(
+                f"Upload filename {file.filename!r} escapes report directory"
+            )
     else:
         # Single-file branch (NPE, MLIR): collapse the client-supplied
         # filename to its basename so `"../etc/passwd.json"` / `"/etc/x.json"`

--- a/backend/ttnn_visualizer/tests/test_file_uploads.py
+++ b/backend/ttnn_visualizer/tests/test_file_uploads.py
@@ -639,11 +639,15 @@ def test_performance_upload_chromium_style_lands_under_report_folder(
 
 
 def test_profiler_upload_rejects_traversal_within_folder(app, client, make_report):
-    """Folder upload with a `../`-bearing filename must 422 and write nothing.
+    """Folder upload with a `../`-bearing filename must 422 and stay contained.
 
     End-to-end counterpart to the `construct_dest_path` unit tests: confirms
     the handler propagates `DataFormatError` from the upload pipeline as the
-    expected 422 status, and that no file from the batch makes it onto disk.
+    expected 422 status, that no file from the batch escapes the profiler
+    directory, and that the traversal-bearing `escape.json` is never written.
+    Earlier files in the batch may land on disk before the bad one raises —
+    that non-atomic behaviour is preserved here and is not what this test
+    targets.
     """
     instance_id = make_report()
     app.config["LOCAL_DATA_DIRECTORY"] = Path(app.config["LOCAL_DATA_DIRECTORY"])

--- a/backend/ttnn_visualizer/tests/test_file_uploads.py
+++ b/backend/ttnn_visualizer/tests/test_file_uploads.py
@@ -93,8 +93,10 @@ def test_construct_dest_path_folder_branch_unchanged_for_subpaths(app, tmp_path)
     """Folder uploads legitimately carry sub-paths; hardening must not break them.
 
     `validate_files` / `os.utime` accounting rely on filenames like
-    `subdir/file.csv` reaching `dest_path`. Path-traversal hardening for the
-    folder branch is a broader follow-up tracked in PR_REVIEW_TRIAGE_2.md.
+    `subdir/file.csv` reaching `dest_path`. The folder branch's traversal
+    hardening is a *resolved-path containment* check (see the dedicated
+    `_rejects_*` tests below), which permits legitimate sub-paths and only
+    rejects candidates whose resolved path escapes the per-report folder.
     """
     with app.app_context():
         dest = construct_dest_path(

--- a/backend/ttnn_visualizer/tests/test_file_uploads.py
+++ b/backend/ttnn_visualizer/tests/test_file_uploads.py
@@ -18,7 +18,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from ttnn_visualizer.enums import ConnectionTestStates
+from ttnn_visualizer.exceptions import DataFormatError
 from ttnn_visualizer.file_uploads import (
     construct_dest_path,
     extract_npe_name,
@@ -143,39 +145,69 @@ def test_construct_dest_path_folder_branch_safari_basename_only(app, tmp_path):
         assert dest.parent.parent == tmp_path
 
 
-def test_construct_dest_path_folder_branch_traversal_posture_pinned(app, tmp_path):
-    """Pin the documented posture: dedup may shorten an escape but never widens it.
+def test_construct_dest_path_folder_branch_rejects_escape_via_dotdot(app, tmp_path):
+    """Resolved-path containment: `../` after the leading folder must be rejected.
 
-    The folder-upload branch is intentionally permissive about sub-paths — it
-    has to be, because Chromium and Safari alike legitimately carry
-    `subdir/file.csv` patterns. A full path-traversal sweep across this
-    branch is the explicit follow-up tracked at `PR_REVIEW_TRIAGE_2.md §1.J`.
+    Folder uploads legitimately carry sub-paths in `file.filename`, so we
+    can't collapse to the basename the way the single-file branch does.
+    `construct_dest_path` instead resolves the candidate path and requires
+    it to stay inside the per-report directory; a `..` segment that lands
+    beside the report folder (the pre-fix "documented gap") is now an error.
+    """
+    with app.app_context():
+        with pytest.raises(DataFormatError):
+            construct_dest_path(
+                _faux_file("my-report/../escape"),
+                tmp_path,
+                folder_name="my-report",
+            )
 
-    Until that lands, the contract this test pins is:
 
-    * A `..` segment after the leading folder name CAN escape the per-report
-      directory (this is the known gap), but
-    * It MUST NOT escape `target_directory` itself (any future change that
-      breaks this is a real regression).
+def test_construct_dest_path_folder_branch_rejects_deep_dotdot_escape(app, tmp_path):
+    """Multi-segment `../../..` escapes (beyond `target_directory`) are rejected too."""
+    with app.app_context():
+        with pytest.raises(DataFormatError):
+            construct_dest_path(
+                _faux_file("my-report/../../../etc/passwd"),
+                tmp_path,
+                folder_name="my-report",
+            )
 
-    A future hardening commit should flip the first assertion (escape becomes
-    blocked) without touching the second.
+
+def test_construct_dest_path_folder_branch_rejects_absolute_filename(app, tmp_path):
+    """An absolute `file.filename` in the folder branch must not replace the root."""
+    with app.app_context():
+        with pytest.raises(DataFormatError):
+            construct_dest_path(
+                _faux_file("/etc/passwd"),
+                tmp_path,
+                folder_name="my-report",
+            )
+
+
+def test_construct_dest_path_folder_branch_allows_intermediate_dotdot(app, tmp_path):
+    """`subdir/../file.csv` resolves back into the report dir and must pass.
+
+    The containment check is on the resolved path, not a textual `..` scan,
+    so paths whose `..` segments cancel out before leaving the report folder
+    are still legitimate (e.g. a sibling-subdir reference that ends up at
+    `report_root/file.csv`).
     """
     with app.app_context():
         dest = construct_dest_path(
-            _faux_file("my-report/../escape"),
+            _faux_file("my-report/subdir/../file.csv"),
             tmp_path,
             folder_name="my-report",
         )
+        # `construct_dest_path` returns the un-resolved path so consumers see
+        # the literal sub-path they supplied; the containment guarantee is on
+        # the *resolved* form. The report directory carries a `<timestamp>_`
+        # prefix in SERVER_MODE so we match the resolved parent by suffix
+        # rather than reconstructing the prefix here.
         resolved = dest.resolve()
-        target = tmp_path.resolve()
-        # Hard invariant: still inside `target_directory`.
-        assert target in resolved.parents or resolved == target
-        # Documented gap: lands beside the report folder, not under it.
-        # When this stops being true (i.e. the file lands under
-        # `<target>/my-report/`), the §1.J follow-up has shipped and this
-        # test should be tightened to assert the new, stricter posture.
-        assert resolved.parent == target
+        assert resolved.name == "file.csv"
+        assert resolved.parent.name.endswith("my-report")
+        assert resolved.parent.parent == tmp_path.resolve()
 
 
 # ---- extract_npe_name: feeds the DB; rebuilt into a read path later --------
@@ -602,3 +634,52 @@ def test_performance_upload_chromium_style_lands_under_report_folder(
     assert any(p.name.startswith("ops_perf_results") for p in report_dir.iterdir())
     assert not (perf_root / "profile_log_device.csv").exists()
     assert not (report_dir / "perf_run").exists()
+
+
+def test_profiler_upload_rejects_traversal_within_folder(app, client, make_report):
+    """Folder upload with a `../`-bearing filename must 422 and write nothing.
+
+    End-to-end counterpart to the `construct_dest_path` unit tests: confirms
+    the handler propagates `DataFormatError` from the upload pipeline as the
+    expected 422 status, and that no file from the batch makes it onto disk.
+    """
+    instance_id = make_report()
+    app.config["LOCAL_DATA_DIRECTORY"] = Path(app.config["LOCAL_DATA_DIRECTORY"])
+    app.config["SERVER_MODE"] = False
+
+    profiler_root = (
+        Path(app.config["LOCAL_DATA_DIRECTORY"]) / app.config["PROFILER_DIRECTORY_NAME"]
+    ).resolve()
+
+    response = client.post(
+        "/api/local/upload/profiler",
+        query_string={"instanceId": instance_id},
+        data={
+            "files": [
+                (BytesIO(b"sqlite-bytes"), "evil_report/db.sqlite"),
+                (BytesIO(b"{}"), "evil_report/../escape.json"),
+            ],
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.get_data(
+        as_text=True
+    )
+
+    # The legitimate first file may have been written before the bad one
+    # raised (this is the existing non-atomic-upload behaviour and is not
+    # what this fix targets), but nothing must have *escaped* the profiler
+    # directory — the whole point of the containment check.
+    local_root = Path(app.config["LOCAL_DATA_DIRECTORY"]).resolve()
+    for path in local_root.rglob("*"):
+        if not path.is_file():
+            continue
+        resolved = path.resolve()
+        assert (
+            profiler_root in resolved.parents or resolved == profiler_root
+        ), f"File escaped profiler directory: {resolved}"
+        # And specifically: no `escape.json` landed *anywhere*.
+        assert (
+            path.name != "escape.json"
+        ), f"`../escape.json` should have been rejected, found {resolved}"


### PR DESCRIPTION
Closes #1526.

## Summary

The single-file upload branch (`construct_dest_path` in `backend/ttnn_visualizer/file_uploads.py`) hardens against `../`-style traversal by collapsing the client-supplied filename to its basename. The folder branch can't do the same — legitimate Chromium uploads (`webkitRelativePath` payloads) and explicit sub-paths legitimately carry `subdir/file.csv` shapes the rest of the pipeline relies on.

The previously documented gap was tracked in test `test_construct_dest_path_folder_branch_traversal_posture_pinned`: a filename like `<folder>/../escape` silently landed beside the report folder, and a sufficiently deep `../../../` payload could escape `target_directory` entirely.

This PR closes that gap with a **resolved-path containment check** on the folder branch:

- Build the candidate `dest_path`, then `resolve()` both it and the per-report folder root.
- If the candidate doesn't sit inside the report root, raise `DataFormatError`.
- `Path.resolve(strict=False)` normalises `..` and walks shared symlinks (e.g. macOS `/tmp` -> `/private/tmp`) so the comparison is symlink-stable.

The existing upload view handlers (`/api/local/upload/profiler`, `/api/local/upload/performance`, `/api/local/upload/mlir`, `/api/local/upload/npe`) already map `DataFormatError` to **HTTP 422** via `response_unprocessable_entity()`, so callers automatically get the right status without further wiring.

### Test plan

- [x] Replaced the pinned "documented gap" test with three explicit rejection tests:
  - `<folder>/../escape` → `DataFormatError`
  - `<folder>/../../../etc/passwd` → `DataFormatError`
  - absolute `/etc/passwd` filename → `DataFormatError`
- [x] Added a positive test for `<folder>/subdir/../file.csv` (resolves back into the report dir, must still be accepted) so the check doesn't over-reject.
- [x] Added an end-to-end profiler-upload regression test that drives `/api/local/upload/profiler` with a traversal-bearing filename and asserts (a) **422** status, and (b) nothing escapes the profiler directory on disk.
- [x] Full backend test suite green: `pnpm flask:test` (183 tests pass).
- [x] `pnpm flask:lint` clean.
- [x] `pnpm flask:mypy` clean.

### Notes / follow-ups

- The non-malware-scanner branch of `save_uploaded_files` saves files in-order; a containment failure on file N still leaves files 1..N-1 on disk. That's pre-existing behaviour and out of scope for this PR — the security-relevant invariant (no file escapes the report folder) holds. Atomic / staged folder uploads are tracked separately if/when needed.


Made with [Cursor](https://cursor.com)