### PR TITLE
Standardize component typing; replace React.FC across frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Open pull requests with **`dev`** as the base branch by default.
 - When using third-party generic containers (`DataSet<T>`, `Map<K, V>`), spell out the type parameter rather than relying on inference that obscures intent.
 - Respect `react-hooks/exhaustive-deps`. If you suppress it, add a one-line comment explaining the trade-off and why the missing dep is intentionally stable.
 - Default to **`interface ComponentNameProps`** for component props (the `Props` suffix is required), declared immediately above the component. Reserve `type` for unions, generic-constrained mappings, and `Omit`/`Pick` derivations.
+- Don't annotate components with **`React.FC`**, **`FC`**, or **`React.FunctionComponent`**. Type props directly on the function (`function Foo({…}: FooProps)` / `const Foo = ({…}: FooProps) =>`). Components with children declare **`children: ReactNode`** on `FooProps`.
 - Prefer **`null`** over **`undefined`** for intentional “no value” in your own state, return types, and API-shaped data (`T | null`, default `null`). Keep **`undefined`** for optional properties, omitted keys, and third-party signatures you cannot change.
 
 ### CSS / SCSS

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -158,6 +158,27 @@ interface SearchFieldProps {
 export default function SearchField({ placeholder, onSearch }: SearchFieldProps) { … }
 ```
 
+### Don't use `React.FC` / `FC` for component typing
+
+**Rationale.** The codebase mixed two styles (`function Foo({ x }: FooProps)` vs `const Foo: React.FC<FooProps> = …`). `React.FC` is deprecated by the React team, changes return-type inference (`ReactNode` vs `JSX.Element | null`), and under older `@types/react` versions it implicitly added `children` to every props type. Under `@types/react` 18 that foot-gun is gone, but a single canonical style keeps reviews predictable and eases a future React 19 migration.
+
+Type props **on the function signature**, not on a separate `FC` annotation:
+
+```tsx
+interface SocketProviderProps {
+    children: ReactNode;
+}
+
+export const SocketProvider = ({ children }: SocketProviderProps) => { … };
+```
+
+```tsx
+// Don't
+const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => { … };
+```
+
+Components that accept element children declare `children: ReactNode` (or `children?: ReactNode`) on `*Props` — don't wrap the interface in `PropsWithChildren` just to satisfy `React.FC`. ESLint bans `FC`, `React.FC`, `FunctionComponent`, and `React.FunctionComponent` via `no-restricted-syntax` in `eslint.config.cjs`.
+
 Reserve `type` for unions, generic-constrained mappings, and `Omit`/`Pick` derivations:
 
 ```ts
@@ -372,10 +393,9 @@ return () => {
     socket.off('disconnect');
     socket.off('connect_error');
     socket.off('reconnect');
+    socket.off('fileTransferProgress');
 };
 ```
-
-> The current cleanup `off()`s connect/disconnect/connect_error/reconnect but **does not** unregister the `fileTransferProgress` handler registered at `src/libs/SocketProvider.tsx`. That's tracked as a pre-existing gap (see [Known inconsistencies](#known-inconsistencies)). New listeners should follow the pairing rule.
 
 Adding a new event handler? Add the matching `off()` in the same change. Don't introduce a second `io(...)` call elsewhere in the codebase — the connection is shared.
 
@@ -1026,7 +1046,6 @@ These exist in the codebase today and don't yet have a single canonical answer. 
 - **`errorMessage` vs `statusMessage` in file loaders.** `MlirJsonFileLoader.tsx` and `NPEFileLoader.tsx` overload a state field called `errorMessage` with both success and failure text. A rename to `statusMessage` is pending.
 - **Upload size cap.** No `MAX_CONTENT_LENGTH` is set on the Flask app; large uploads succeed until they exhaust memory. Tracked as a separate hardening task.
 - **Default-export vs named-export of components.** The codebase mixes `export default function Foo()` and `export function Foo()`. Components are predominantly default-exported; hooks and utility functions are predominantly named-exported. Mirror the file you're editing.
-- **Two component-typing styles coexist: plain props parameter vs `React.FC<...>`.** Plenty of components are written as `function Foo({ x }: FooProps)`, but `React.FC<FooProps>` (and the bare `: FC<FooProps>` variant) is also in active use across ~30+ files (`src/libs/SocketProvider.tsx`, `src/routes/GraphView.tsx`, `src/components/OperationGraphComponent.tsx`, `src/components/npe/NPEViewComponent.tsx`, `src/components/operation-details/OperationDetailsComponent.tsx`, and many more). The codebase has no single canonical answer. Mirror the file you're editing. The community-wide foot-gun of `React.FC` (implicit `children` in older `@types/react`) is a real consideration, but it's not a project-wide migration in this repo.
 - **Raw `toast()` in `useBufferFocus`.** `src/hooks/useBufferFocus.tsx` calls `toast()` from `react-toastify` directly because it needs `autoClose: false` and persists the returned `Id` into `activeToastAtom` — capabilities `createToastNotification` doesn't expose. Intentional exception, not a precedent. New code still goes through `createToastNotification`; if you need richer options, extend the wrapper.
 - **`print()` calls in `sockets.py`.** `backend/ttnn_visualizer/sockets.py` use `print()` instead of `logger.info / debug`. Pre-existing tech debt; do not introduce new `print()` calls anywhere else in the backend.
 - **`flake8 max-line-length = 79` vs `black line-length = 88`.** `.flake8` and `pyproject.toml` disagree. Black wins in practice because `pnpm flask:format` runs it; the flake8 setting only matters if `pre-commit` runs flake8 in isolation, which CI does not. Don't expand or contract files to satisfy 79 — 88 is the source of truth.
@@ -1034,4 +1053,3 @@ These exist in the codebase today and don't yet have a single canonical answer. 
 - **`Config.__new__` lacks a return annotation.** `backend/ttnn_visualizer/settings.py` returns the singleton without typing the return, surfacing a mypy `attr-defined` error in `database_migrations.py` against `cast(DefaultConfig, Config()).SQLALCHEMY_DATABASE_URI`. Fix is `def __new__(cls) -> "DefaultConfig":`; tracked as a follow-up.
 - **`useQuery<Data, AxiosError>` not universal.** Four hooks in `useAPI.tsx` (`useGetClusterDescription`, `usePerfMeta`, `useReportFolderList`, `useInstance`) leave the error generic implicit (`unknown`). Call sites currently don't read `error.status` on these specific queries, but the rule is "spell out both generics" — tighten when you touch them.
 - **`dataclasses.asdict(...)` vs `to_dict()` for serialisation.** Models that inherit `SerializeableDataclass` get a `to_dict()` that handles `enum.Enum` conversion; using `dataclasses.asdict` instead (e.g. `views.py`) skips that handling. Safe when the dataclass has no enum fields; otherwise use `.to_dict()`. Reviewers should flag `asdict` on any dataclass with enum-typed fields.
-- **`SocketProvider` cleanup is incomplete.** `src/libs/SocketProvider.tsx` `off()`s `connect`/`disconnect`/`connect_error`/`reconnect` but not the `fileTransferProgress` handler registered alongside them. Pre-existing; the listener list will grow on every remount of the provider (rare in production, common under StrictMode in dev). New listeners follow the pairing rule; the existing miss is tracked tech debt.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -143,7 +143,31 @@ module.exports = defineConfig([
             'import/prefer-default-export': 'off',
             'max-classes-per-file': 'off',
             'no-plusplus': 'off',
-            'no-restricted-syntax': 'off',
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: "TSTypeReference[typeName.name='FC']",
+                    message:
+                        'Type props directly: function Foo({…}: FooProps). Do not use FC. Declare children: ReactNode on FooProps if needed.',
+                },
+                {
+                    selector:
+                        "TSTypeReference[typeName.type='TSQualifiedName'][typeName.left.name='React'][typeName.right.name='FC']",
+                    message:
+                        'Type props directly: function Foo({…}: FooProps). Do not use React.FC. Declare children: ReactNode on FooProps if needed.',
+                },
+                {
+                    selector: "TSTypeReference[typeName.name='FunctionComponent']",
+                    message:
+                        'Type props directly: function Foo({…}: FooProps). Do not use FunctionComponent.',
+                },
+                {
+                    selector:
+                        "TSTypeReference[typeName.type='TSQualifiedName'][typeName.left.name='React'][typeName.right.name='FunctionComponent']",
+                    message:
+                        'Type props directly: function Foo({…}: FooProps). Do not use React.FunctionComponent.',
+                },
+            ],
             'no-shadow': 'off',
             'no-underscore-dangle': 'off',
             'no-unused-vars': 'off',
@@ -158,7 +182,13 @@ module.exports = defineConfig([
                 },
             ],
 
-            'react/function-component-definition': 0,
+            'react/function-component-definition': [
+                'error',
+                {
+                    namedComponents: ['function-declaration', 'arrow-function'],
+                    unnamedComponents: 'arrow-function',
+                },
+            ],
 
             'react/jsx-filename-extension': [
                 'warn',

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -19,9 +19,10 @@ interface CollapsibleProps {
     keepChildrenMounted?: boolean;
     onExpandToggle?: (state: boolean) => void;
     isDisabled?: boolean;
+    children?: React.ReactNode;
 }
 
-const Collapsible: React.FC<React.PropsWithChildren<CollapsibleProps>> = ({
+const Collapsible = ({
     label,
     additionalElements = undefined,
     isOpen = true,
@@ -32,7 +33,7 @@ const Collapsible: React.FC<React.PropsWithChildren<CollapsibleProps>> = ({
     onExpandToggle,
     children,
     isDisabled = false,
-}) => {
+}: CollapsibleProps) => {
     const [isOpenState, setIsOpenState] = React.useState(isOpen);
     const [prevIsOpenProp, setPrevIsOpenProp] = React.useState(isOpen);
     const icon = isOpenState ? IconNames.CARET_UP : IconNames.CARET_DOWN;

--- a/src/components/FileStatusOverlay.tsx
+++ b/src/components/FileStatusOverlay.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React from 'react';
 import { useAtom } from 'jotai';
 import Overlay from './Overlay';
 import ProgressBar from './ProgressBar';
@@ -11,7 +10,7 @@ import { fileTransferProgressAtom } from '../store/app';
 import { FileStatus } from '../model/APIData';
 import { formatPercentage } from '../functions/math';
 
-const FileStatusOverlay: React.FC = () => {
+const FileStatusOverlay = () => {
     const [progress] = useAtom(fileTransferProgressAtom);
     const { currentFileName, finishedFiles, numberOfFiles, percentOfCurrent, status } = progress;
 

--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import classNames from 'classnames';
-import React from 'react';
 
 interface HighlightedTextProps {
     text: string;
@@ -11,7 +10,7 @@ interface HighlightedTextProps {
     className?: string;
 }
 
-const HighlightedText: React.FC<HighlightedTextProps> = ({ text, filter, className }) => {
+const HighlightedText = ({ text, filter, className }: HighlightedTextProps) => {
     const index = text.toLowerCase().indexOf(filter.toLowerCase());
 
     if (index === -1) {

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -26,7 +26,7 @@ const ICON_COLOURS = {
     error: 'error-icon',
 };
 
-const ListItem: React.FC<ListItemProps> = ({
+const ListItem = ({
     filterName,
     filterQuery,
     icon,
@@ -34,7 +34,7 @@ const ListItem: React.FC<ListItemProps> = ({
     intent = Intent.NONE,
     tags,
     children,
-}) => {
+}: ListItemProps) => {
     return (
         <div className={classNames(ICON_COLOURS[iconColour], 'list-item')}>
             <Icon

--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable react-hooks/set-state-in-effect */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Edge, IdType, Network, Node } from 'vis-network';
 import { DataSet } from 'vis-data';
 import 'vis-network/styles/vis-network.css';
@@ -37,10 +37,12 @@ enum NodeRelation {
     Output = 'output',
 }
 
-const OperationGraph: React.FC<{
+interface OperationGraphProps {
     operationList: OperationList;
     operationId?: number;
-}> = ({ operationList, operationId }) => {
+}
+
+const OperationGraph = ({ operationList, operationId }: OperationGraphProps) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
     const navigate = useNavigate();
 
@@ -717,7 +719,11 @@ const OperationGraph: React.FC<{
     );
 };
 
-const TensorDetailsComponent: React.FC<{ tensor: Tensor }> = ({ tensor }) => {
+interface OperationGraphTensorDetailsProps {
+    tensor: Tensor;
+}
+
+const TensorDetailsComponent = ({ tensor }: OperationGraphTensorDetailsProps) => {
     return (
         <div className='tensor-details'>
             <h3 className='tensor-header'>
@@ -788,10 +794,12 @@ const groupTensorsByConnectedOp = (
     return Array.from(groups.values());
 };
 
-const ConnectedOpHeader: React.FC<{
+interface ConnectedOpHeaderProps {
     group: ConnectedOpGroup;
     onLocate: (opId: number) => void;
-}> = ({ group, onLocate }) => {
+}
+
+const ConnectedOpHeader = ({ group, onLocate }: ConnectedOpHeaderProps) => {
     return (
         <div className='connected-op-header'>
             <h2 className='connected-op-name'>{group.label}</h2>
@@ -813,21 +821,23 @@ const ConnectedOpHeader: React.FC<{
     );
 };
 
-const OperationGraphInfoComponent: React.FC<{
+interface OperationGraphInfoComponentProps {
     currentOperationId: number;
     operationList: OperationList;
     operationNamesById: Map<number, string>;
     onNavigate: NavigateFunction;
     onLocateConnectedNode: (opId: number) => void;
     onRecenterOnCurrent: () => void;
-}> = ({
+}
+
+const OperationGraphInfoComponent = ({
     currentOperationId,
     operationList,
     operationNamesById,
     onNavigate,
     onLocateConnectedNode,
     onRecenterOnCurrent,
-}) => {
+}: OperationGraphInfoComponentProps) => {
     const operation = operationList.find((op) => op.id === currentOperationId);
 
     const inputGroups = useMemo(

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -7,7 +7,7 @@
 /* eslint-disable no-continue */
 /* eslint-disable no-nested-ternary */
 
-import React, {
+import {
     type MouseEvent,
     createContext,
     memo,
@@ -267,7 +267,7 @@ function builtGraphToReactFlow(built: BuiltGraph): { nodes: MLNode[]; edges: Edg
     return { nodes, edges };
 }
 
-const MlGraphInner: React.FC<ViewProps> = ({ data }) => {
+const MlGraphInner = ({ data }: ViewProps) => {
     const { fitView, getViewport, setViewport } = useReactFlow();
     const graph = data.graphs[0];
     const [nodes, setNodes, onNodesChange] = useNodesState<MLNode>([]);
@@ -776,7 +776,7 @@ const MlGraphInner: React.FC<ViewProps> = ({ data }) => {
     );
 };
 
-const MlGraphWithProvider: React.FC<ViewProps> = (props) => (
+const MlGraphWithProvider = (props: ViewProps) => (
     <ReactFlowProvider>
         {/* Keying on graph.id remounts the inner subtree when the user
             switches graphs — cleaner than imperatively resetting half a

--- a/src/components/mlir/MlirJsonFileLoader.tsx
+++ b/src/components/mlir/MlirJsonFileLoader.tsx
@@ -30,7 +30,7 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
     [ConnectionTestStates.WARNING]: Intent.WARNING,
 };
 
-const MlirJsonFileLoader: React.FC = () => {
+const MlirJsonFileLoader = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const { uploadMlirFile } = useLocalConnection();
     const [mlirJsonFileName, setMlirJsonFileName] = useAtom(activeMlirJsonAtom);

--- a/src/components/npe/ActiveTransferDetails.tsx
+++ b/src/components/npe/ActiveTransferDetails.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { Button, ButtonVariant, Icon, Switch, Tag } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -196,7 +196,7 @@ interface ZoneDetailsProps {
     zones: string;
 }
 
-const ZoneDetails: React.FC<ZoneDetailsProps> = ({ zones }) => {
+const ZoneDetails = ({ zones }: ZoneDetailsProps) => {
     const render = zones.split('/').map((zone: string, index: number) => (
         <Tag
             style={{ marginLeft: `${15 * index}px` }}

--- a/src/components/npe/EmptyChipRenderer.tsx
+++ b/src/components/npe/EmptyChipRenderer.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { JSX } from 'react';
+import { JSX } from 'react';
 import classNames from 'classnames';
 import { NPE_COORDINATES, NPE_COORDINATE_INDEX } from '../../model/NPEModel';
 
@@ -21,7 +21,7 @@ interface EmptyChipRendererProps {
     renderChipId: boolean;
 }
 
-export const EmptyChipRenderer: React.FC<EmptyChipRendererProps> = ({
+export const EmptyChipRenderer = ({
     id,
     width,
     height,

--- a/src/components/npe/NPEDemoSelect.tsx
+++ b/src/components/npe/NPEDemoSelect.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC } from 'react';
 import { Button, ButtonVariant, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
@@ -34,11 +33,13 @@ const NPE_DEMO_DATA: NPEDemoData[] = [
     },
 ];
 
-const NPEDemoSelect: FC<{
+interface NPEDemoSelectProps {
     selectedDemo: NPEDemoData | null;
     setSelectedDemo: (demo: NPEDemoData | null) => void;
     setDemoData: (data: NPEData | null) => void;
-}> = ({ selectedDemo, setSelectedDemo, setDemoData }) => {
+}
+
+const NPEDemoSelect = ({ selectedDemo, setSelectedDemo, setDemoData }: NPEDemoSelectProps) => {
     const renderItem: ItemRenderer<NPEDemoData> = (item, { handleClick, modifiers }) => (
         <div
             className='folder-picker-menu-item'

--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -30,7 +30,7 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
     [ConnectionTestStates.WARNING]: Intent.WARNING,
 };
 
-const NPEFileLoader: React.FC = () => {
+const NPEFileLoader = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const { uploadNpeFile } = useLocalConnection();
     const [npeFileName, setActiveNpe] = useAtom(activeNpeOpTraceAtom);

--- a/src/components/npe/NPEMetadata.tsx
+++ b/src/components/npe/NPEMetadata.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React from 'react';
 import { Tooltip } from '@blueprintjs/core';
 import { CommonInfo, NPE_KPI, NPE_KPI_METADATA } from '../../model/NPEModel';
 import Collapsible from '../Collapsible';
@@ -12,7 +11,7 @@ interface NPEMetadataProps {
     numTransfers: number;
 }
 
-const NPEMetadata: React.FC<NPEMetadataProps> = ({ info, numTransfers }) => {
+const NPEMetadata = ({ info, numTransfers }: NPEMetadataProps) => {
     const hasKey = (key: keyof CommonInfo) => {
         return NPE_KPI_METADATA[key] !== undefined && NPE_KPI_METADATA[key] !== null;
     };

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -43,7 +43,7 @@ interface NPEHeatMapProps {
 const HEATMAP_HEIGHT = 30;
 const ZONE_HEIGHT = 10;
 
-const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
+const NPETimelineComponent = ({
     timestepList,
     canvasWidth,
     nocType = null,
@@ -52,7 +52,7 @@ const NPETimelineComponent: React.FC<NPEHeatMapProps> = ({
     cyclesPerTimestep,
     selectedZoneList = [],
     navigationCallback,
-}) => {
+}: NPEHeatMapProps) => {
     const altCongestionColors = useAtomValue(altCongestionColorsAtom);
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const [hoverMap, setHoverMap] = useState<Map<string, Rect>>(new Map());

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -6,7 +6,7 @@
 import 'highlight.js/styles/a11y-dark.css';
 import 'styles/components/NPEComponent.scss';
 import 'styles/components/NPEZoneFilterComponent.scss';
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button, ButtonGroup, ButtonVariant, Intent, Size, Slider, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
@@ -76,7 +76,7 @@ const getRootZoneKey = (proc: KERNEL_PROCESS, address: NPE_COORDINATES): Rootzon
     return `${proc}:${address.join(',')}`;
 };
 
-const NPEView: React.FC<NPEViewProps> = ({ npeData }) => {
+const NPEView = ({ npeData }: NPEViewProps) => {
     const [highlightedTransfer, setHighlightedTransfer] = useState<NoCTransfer | null>(null);
     const [highlightedRoute, setHighlightedRoute] = useState<number | null>(null);
     const [selectedTimestep, setSelectedTimestep] = useState<number>(0);

--- a/src/components/npe/NPEZoneFilterComponent.tsx
+++ b/src/components/npe/NPEZoneFilterComponent.tsx
@@ -30,14 +30,14 @@ interface NPEZoneFilterComponentProps {
     onZoneClick: (zone: NPEZone) => void;
 }
 
-const NPEZoneFilterComponent: React.FC<NPEZoneFilterComponentProps> = ({
+const NPEZoneFilterComponent = ({
     npeData,
     open = false,
     onClose,
     onSelect,
     onExpand,
     onZoneClick,
-}) => {
+}: NPEZoneFilterComponentProps) => {
     const [selectedDeviceId, setSelectedDeviceId] = React.useState<number | null>(null);
     const [selectedCoreAddress, setSelectedCoreAddress] = React.useState<string | null>(null);
     const sortCoreAddress = useCallback((a: NPERootZone, b: NPERootZone) => {

--- a/src/components/npe/TensixTransferRenderer.tsx
+++ b/src/components/npe/TensixTransferRenderer.tsx
@@ -14,13 +14,7 @@ interface SVGTensixRendererProps {
     style?: React.CSSProperties;
 }
 
-const TensixTransferRenderer: React.FC<SVGTensixRendererProps> = ({
-    width,
-    height,
-    data,
-    isMulticolor = false,
-    style,
-}: SVGTensixRendererProps) => {
+const TensixTransferRenderer = ({ width, height, data, isMulticolor = false, style }: SVGTensixRendererProps) => {
     const strokeLength = 5;
     const dashMap: Map<NoCID, number> = new Map();
     const dashArray: Map<NoCID, number[]> = new Map();

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -479,11 +479,13 @@ function useDeviceOperationsFullRenderModel(args: {
     };
 }
 
-const DeviceOperationsFullRender: React.FC<{
+interface DeviceOperationsFullRenderProps {
     deviceOperations: Node[];
     details: OperationDetails;
     onLegendClick: (address: number, tensorId?: number, colorVariance?: number) => void;
-}> = ({ deviceOperations, details, onLegendClick }) => {
+}
+
+const DeviceOperationsFullRender = ({ deviceOperations, details, onLegendClick }: DeviceOperationsFullRenderProps) => {
     hljs.registerLanguage('cpp', cpp);
     const [deviceOperationsArgsOpen, setDeviceOperationsArgsOpen] = useState(false);
     const [deviceOperationsArgsNode, setDeviceOperationsArgsNode] = useState<DeviceOperationNode | null>(null);
@@ -523,13 +525,14 @@ const DeviceOperationsFullRender: React.FC<{
     );
 };
 
-const DeviceOperationNodeComponent: React.FC<
-    React.PropsWithChildren<{
-        title: string;
-        memoryInfo?: JSX.Element;
-        _node: Node;
-    }>
-> = ({ title, memoryInfo, _node, children }) => {
+interface DeviceOperationNodeComponentProps {
+    title: string;
+    memoryInfo?: JSX.Element;
+    _node: Node;
+    children?: React.ReactNode;
+}
+
+const DeviceOperationNodeComponent = ({ title, memoryInfo, _node, children }: DeviceOperationNodeComponentProps) => {
     return (
         <div className='device-operation'>
             <hr />
@@ -546,7 +549,12 @@ const DeviceOperationNodeComponent: React.FC<
     );
 };
 
-const DeviceID: React.FC<{ _deviceId?: number | string; _node?: Node }> = ({ _deviceId, _node }) => {
+interface DeviceIDProps {
+    _deviceId?: number | string;
+    _node?: Node;
+}
+
+const DeviceID = ({ _deviceId, _node }: DeviceIDProps) => {
     // if (_node === undefined) {
     return null;
     // }
@@ -564,11 +572,13 @@ const DeviceID: React.FC<{ _deviceId?: number | string; _node?: Node }> = ({ _de
     // );
     // return _deviceId !== undefined && <span className='device-id'>{_deviceId}</span>;
 };
-const DeviceOperationArgumentsComponent: React.FC<{
+interface DeviceOperationArgumentsComponentProps {
     node: DeviceOperationNode | null;
     open: boolean;
     onClose: () => void;
-}> = ({ node, open, onClose }) => {
+}
+
+const DeviceOperationArgumentsComponent = ({ node, open, onClose }: DeviceOperationArgumentsComponentProps) => {
     return (
         <Overlay2
             isOpen={open}

--- a/src/components/operation-details/DeviceOperationsGraphComponent.tsx
+++ b/src/components/operation-details/DeviceOperationsGraphComponent.tsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable no-continue */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Network } from 'vis-network/standalone';
 import { DataSet } from 'vis-data';
 import { Edge, IdType } from 'vis-network';
@@ -67,11 +67,13 @@ const getTensorMetadata = (tensor: TensorNode) => {
     };
 };
 
-const DeviceOperationTensorList: React.FC<{
+interface DeviceOperationTensorListProps {
     title: string;
     tensors: TensorNode[];
     variant: 'inputs' | 'outputs';
-}> = ({ title, tensors, variant }) => {
+}
+
+const DeviceOperationTensorList = ({ title, tensors, variant }: DeviceOperationTensorListProps) => {
     return (
         <section className={`graph-details-section ${variant}`}>
             <h4>{title}</h4>
@@ -123,9 +125,11 @@ const DeviceOperationTensorList: React.FC<{
     );
 };
 
-const DeviceOperationGraphInfoComponent: React.FC<{
+interface DeviceOperationGraphInfoComponentProps {
     operation: ConnectedDeviceOperation | null;
-}> = ({ operation }) => {
+}
+
+const DeviceOperationGraphInfoComponent = ({ operation }: DeviceOperationGraphInfoComponentProps) => {
     if (!operation) {
         return (
             <aside className='graph-side-panel empty'>
@@ -225,7 +229,7 @@ function removeRedundantEdgesViaIntermediateNodes(edges: Edge[]): Edge[] {
     });
 }
 
-const GraphComponent: React.FC<GraphComponentProps> = ({ data, open, onClose }) => {
+const GraphComponent = ({ data, open, onClose }: GraphComponentProps) => {
     const networkRef = useRef<Network | null>(null);
     const [currentOperationId, setCurrentOperationId] = useState<number | null>(null);
 

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -23,7 +23,7 @@ const LEGEND_AXIS_MARKER_COLORS: Partial<Record<MarkerType, string>> = {
     [MarkerType.L1_START]: L1_START_MARKER_COLOR,
 };
 
-export const MemoryLegendElement: React.FC<{
+interface MemoryLegendElementProps {
     chunk: FragmentationEntry;
     memSize: number;
     selectedTensorAddress: number | null;
@@ -37,7 +37,9 @@ export const MemoryLegendElement: React.FC<{
     className?: string;
     numCores?: number;
     userL1ZoomRange?: [number, number];
-}> = ({
+}
+
+export const MemoryLegendElement = ({
     // no wrap eslint
     chunk,
     memSize,
@@ -51,7 +53,7 @@ export const MemoryLegendElement: React.FC<{
     className,
     numCores,
     userL1ZoomRange,
-}) => {
+}: MemoryLegendElementProps) => {
     const showHex = useAtomValue(showHexAtom);
     const selectedBufferColour = useAtomValue(selectedBufferColourAtom);
     const legendMarkerColor =

--- a/src/components/operation-details/MemoryLegendGroup.tsx
+++ b/src/components/operation-details/MemoryLegendGroup.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, ButtonVariant, Collapse, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { FragmentationEntry } from '../../model/APIData';
@@ -10,14 +10,16 @@ import { OperationDetails } from '../../model/OperationDetails';
 import { MemoryLegendElement } from './MemoryLegendElement';
 import 'styles/components/MemoryLegendElement.scss';
 
-export const MemoryLegendGroup: React.FC<{
+interface MemoryLegendGroupProps {
     group: FragmentationEntry[];
     memSize: number;
     selectedTensorAddress: number | null;
     operationDetails: OperationDetails;
     onLegendClick: (selectedTensorAddress: number, tensorId?: number, colorVariance?: number) => void;
     userL1ZoomRange?: [number, number];
-}> = ({
+}
+
+export const MemoryLegendGroup = ({
     // no wrap eslint
     group,
     memSize,
@@ -25,7 +27,7 @@ export const MemoryLegendGroup: React.FC<{
     operationDetails,
     onLegendClick,
     userL1ZoomRange,
-}) => {
+}: MemoryLegendGroupProps) => {
     const [isOpen, setIsOpen] = useState(false);
 
     return (

--- a/src/components/operation-details/MemoryPlotRenderer.tsx
+++ b/src/components/operation-details/MemoryPlotRenderer.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { CSSProperties, useMemo, useState } from 'react';
+import { CSSProperties, useMemo, useState } from 'react';
 import { Config, Layout, PlotData, Shape } from 'plotly.js';
 import { useAtomValue } from 'jotai';
 import Plot from '../../libs/PlotComponent';
@@ -24,7 +24,7 @@ export interface MemoryPlotRendererProps {
     markers?: PlotMarker[];
 }
 
-const MemoryPlotRenderer: React.FC<MemoryPlotRendererProps> = ({
+const MemoryPlotRenderer = ({
     chartDataList,
     isZoomedIn,
     memoryZoomEnd,
@@ -35,7 +35,7 @@ const MemoryPlotRenderer: React.FC<MemoryPlotRendererProps> = ({
     configuration,
     style,
     markers,
-}) => {
+}: MemoryPlotRendererProps) => {
     const showHex = useAtomValue(showHexAtom);
     const chartData = useMemo(() => chartDataList.flat(), [chartDataList]);
 

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, ButtonGroup, ButtonVariant, Intent, Label, RangeSlider, Size, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom } from 'jotai';
@@ -54,7 +54,7 @@ interface ZoomMemoryChunk {
     size: number;
 }
 
-const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationId }) => {
+const OperationDetailsComponent = ({ operationId }: OperationDetailsProps) => {
     const [renderMemoryLayoutPattern, setRenderMemoryLayout] = useAtom(renderMemoryLayoutAtom);
     const [showHex, setShowHex] = useAtom(showHexAtom);
     const [showMemoryRegions, setShowMemoryRegions] = useAtom(showMemoryRegionsAtom);

--- a/src/components/operation-details/TensorDetailsComponent.tsx
+++ b/src/components/operation-details/TensorDetailsComponent.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import classNames from 'classnames';
 import { Button, Icon, Intent, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -32,13 +32,13 @@ export interface TensorDetailsComponentProps {
     userL1ZoomRange?: [number, number];
 }
 
-const TensorDetailsComponent: React.FC<TensorDetailsComponentProps> = ({
+const TensorDetailsComponent = ({
     tensor,
     onTensorClick,
     operationId,
     plotZoomRange,
     userL1ZoomRange,
-}) => {
+}: TensorDetailsComponentProps) => {
     const [overlayOpen, setOverlayOpen] = useState(false);
     const useHex = useAtomValue(showHexAtom);
 

--- a/src/components/performance/ComparisonReportSelector.tsx
+++ b/src/components/performance/ComparisonReportSelector.tsx
@@ -4,7 +4,7 @@
 
 import { Button, ButtonVariant, FormGroup } from '@blueprintjs/core';
 import { useAtom, useAtomValue } from 'jotai';
-import React, { FC } from 'react';
+import React from 'react';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import LocalFolderPicker from '../report-selection/LocalFolderPicker';
@@ -20,13 +20,13 @@ interface ComparisonReportSelectorProps {
     className?: string;
 }
 
-const ComparisonReportSelector: FC<ComparisonReportSelectorProps> = ({
+const ComparisonReportSelector = ({
     folderList,
     reportIndex,
     label,
     subLabel,
     className,
-}) => {
+}: ComparisonReportSelectorProps) => {
     const [comparisonReportList, setComparisonReportList] = useAtom(comparisonPerformanceReportListAtom);
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
 

--- a/src/components/performance/NonFilterablePerfCharts.tsx
+++ b/src/components/performance/NonFilterablePerfCharts.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import PerfCoreCountUtilizationChart from './PerfCoreCountUtilizationChart';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
@@ -23,11 +23,7 @@ interface NonFilterablePerfChartsProps {
     opCodeOptions: Marker[];
 }
 
-const NonFilterablePerfCharts: FC<NonFilterablePerfChartsProps> = ({
-    chartData,
-    secondaryData = [],
-    opCodeOptions,
-}) => {
+const NonFilterablePerfCharts = ({ chartData, secondaryData = [], opCodeOptions }: NonFilterablePerfChartsProps) => {
     const performanceReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
 

--- a/src/components/performance/PerfCharts.tsx
+++ b/src/components/performance/PerfCharts.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC } from 'react';
 import PerfDeviceKernelDurationChart from './PerfDeviceKernelDurationChart';
 import PerfDeviceKernelRuntimeChart from './PerfDeviceKernelRuntimeChart';
 import PerfOpCountVsRuntimeChart from './PerfOpCountVsRuntimeChart';
@@ -15,7 +14,7 @@ interface PerfChartsProps {
     selectedOpCodes: Marker[];
 }
 
-const PerfCharts: FC<PerfChartsProps> = ({ filteredPerfData, comparisonData, selectedOpCodes }) => {
+const PerfCharts = ({ filteredPerfData, comparisonData, selectedOpCodes }: PerfChartsProps) => {
     const data = [filteredPerfData, ...(comparisonData || [])].filter((set) => set.length > 0);
 
     return (

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import {
     Button,
@@ -74,13 +74,13 @@ interface PerformanceReportProps {
 const INITIAL_TAB_ID = 'perf-table-0'; // `perf-table-${index}`
 const STACKED_GROUP_BY = [StackedGroupBy.CATEGORY, StackedGroupBy.MEMORY, StackedGroupBy.OP];
 
-const PerformanceReport: FC<PerformanceReportProps> = ({
+const PerformanceReport = ({
     data,
     comparisonData,
     stackedData,
     comparisonStackedData,
     signposts,
-}) => {
+}: PerformanceReportProps) => {
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const activeComparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const [isStackedView, setIsStackedView] = useAtom(isStackedViewAtom);

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC, Fragment, useMemo } from 'react';
+import { Fragment, useMemo } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonVariant, Icon, Intent, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -43,7 +43,7 @@ const OP_ID_INSERTION_POINT = 1;
 const HIGH_DISPATCH_INSERTION_POINT = 5;
 const CACHE_HIT_INSERTION_POINT = 15;
 
-const PerformanceTable: FC<PerformanceTableProps> = ({
+const PerformanceTable = ({
     data,
     comparisonData,
     filters,
@@ -51,7 +51,7 @@ const PerformanceTable: FC<PerformanceTableProps> = ({
     hiliteHighDispatch,
     reportName,
     showHashColumn,
-}) => {
+}: PerformanceTableProps) => {
     const hideHostOps = useAtomValue(hideHostOpsAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
 

--- a/src/components/performance/PerformanceFileLoader.tsx
+++ b/src/components/performance/PerformanceFileLoader.tsx
@@ -8,7 +8,7 @@ interface PerformanceFileLoaderProps {
     onFileLoad: (data: unknown) => void;
 }
 
-const PerformanceFileLoader: React.FC<PerformanceFileLoaderProps> = ({ onFileLoad }) => {
+const PerformanceFileLoader = ({ onFileLoad }: PerformanceFileLoaderProps) => {
     const [, setFileName] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
 

--- a/src/components/performance/StackedPerfTable.tsx
+++ b/src/components/performance/StackedPerfTable.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC, Fragment, useMemo } from 'react';
+import { Fragment, useMemo } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonVariant, Icon, Intent, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -33,13 +33,13 @@ interface StackedPerformanceTableProps {
     reportName: string | null;
 }
 
-const StackedPerformanceTable: FC<StackedPerformanceTableProps> = ({
+const StackedPerformanceTable = ({
     data,
     stackedData,
     stackedComparisonData,
     filters,
     reportName,
-}) => {
+}: StackedPerformanceTableProps) => {
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(null);
     const { error: npeManifestError } = useGetNPEManifest();
     const mergeDevices = useAtomValue(mergeDevicesAtom);

--- a/src/components/report-selection/AddRemoteConnection.tsx
+++ b/src/components/report-selection/AddRemoteConnection.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC, useState } from 'react';
+import { useState } from 'react';
 
 import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -15,7 +15,7 @@ interface AddRemoteConnectionProps {
     onAddConnection: (remoteConnection: RemoteConnection) => void;
 }
 
-const AddRemoteConnection: FC<AddRemoteConnectionProps> = ({ disabled, onAddConnection }) => {
+const AddRemoteConnection = ({ disabled, onAddConnection }: AddRemoteConnectionProps) => {
     const [isAddConnectionDialogOpen, setIsAddConnectionDialogOpen] = useState(false);
 
     return (

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -4,7 +4,7 @@
 
 import { FileInput, FormGroup, Icon, IconName, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { ChangeEvent, type FC, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
@@ -76,7 +76,7 @@ const directoryErrorStatus: ConnectionStatus = {
     message: 'Selected directory does not contain a valid report',
 };
 
-const LocalFolderOptions: FC = () => {
+const LocalFolderOptions = () => {
     const queryClient = useQueryClient();
     const [profilerReportLocation, setProfilerReportLocation] = useAtom(profilerReportLocationAtom);
     const [performanceReportLocation, setPerformanceReportLocation] = useAtom(performanceReportLocationAtom);

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -5,7 +5,7 @@
 import { Button, Dialog, DialogBody, DialogFooter, FormGroup, InputGroup, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { AxiosError } from 'axios';
-import { FC, useState } from 'react';
+import { useState } from 'react';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 import { RemoteConnection } from '../../definitions/RemoteConnection';
 import useRemoteConnection from '../../hooks/useRemote';
@@ -42,7 +42,7 @@ const DEFAULT_CONNECTION: RemoteConnection = {
     username: '',
 };
 
-const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
+const RemoteConnectionDialog = ({
     open,
     onSave,
     onClose,
@@ -50,7 +50,7 @@ const RemoteConnectionDialog: FC<RemoteConnectionDialogProps> = ({
     title = 'Add new remote connection',
     buttonLabel = 'Add connection',
     remoteConnection,
-}) => {
+}: RemoteConnectionDialogProps) => {
     const [connection, setConnection] = useState<Partial<RemoteConnection>>(remoteConnection ?? DEFAULT_CONNECTION);
     const [connectionTests, setConnectionTests] = useState<ConnectionStatus[]>([]);
     const { testConnection } = useRemoteConnection();

--- a/src/components/report-selection/RemoteConnectionSelector.tsx
+++ b/src/components/report-selection/RemoteConnectionSelector.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { FC, useState } from 'react';
+import React, { useState } from 'react';
 import { Button, MenuItem, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRendererProps, Select } from '@blueprintjs/select';
@@ -25,7 +25,7 @@ interface RemoteConnectionSelectorProps {
 const EDIT_CONNECTION_LABEL = 'Edit selected connection';
 const REMOVE_CONNECTION_LABEL = 'Remove selected connection';
 
-const RemoteConnectionSelector: FC<RemoteConnectionSelectorProps> = ({
+const RemoteConnectionSelector = ({
     connectionList,
     connection,
     disabled,
@@ -34,7 +34,7 @@ const RemoteConnectionSelector: FC<RemoteConnectionSelectorProps> = ({
     onEditConnection,
     onRemoveConnection,
     onSyncRemoteFolderList,
-}) => {
+}: RemoteConnectionSelectorProps) => {
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
     const selectedConnection = connection ?? connectionList[0];
 

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -5,7 +5,7 @@
 import { Button, Icon, Intent, MenuItem, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import { type ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
-import { FC, type PropsWithChildren } from 'react';
+import { type ReactNode } from 'react';
 import 'styles/components/FolderPicker.scss';
 import {
     NEVER_SYNCED_LABEL,
@@ -93,9 +93,10 @@ interface RemoteFolderSelectorProps {
     onSelectFolder: (folder: RemoteFolder) => void;
     type: FolderTypes;
     showReportName?: boolean;
+    children?: ReactNode;
 }
 
-const RemoteFolderSelector: FC<PropsWithChildren<RemoteFolderSelectorProps>> = ({
+const RemoteFolderSelector = ({
     remoteFolder,
     remoteFolderList = [],
     loading = false,
@@ -106,7 +107,7 @@ const RemoteFolderSelector: FC<PropsWithChildren<RemoteFolderSelectorProps>> = (
     icon = IconNames.DOCUMENT_OPEN,
     type,
     showReportName,
-}) => {
+}: RemoteFolderSelectorProps) => {
     const { persistentState } = useRemoteConnection();
     const remoteConnection = persistentState.selectedConnection;
 

--- a/src/components/report-selection/RemoteSyncButton.tsx
+++ b/src/components/report-selection/RemoteSyncButton.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { Button, ButtonVariant, Intent, PopoverPosition, Tooltip } from '@blueprintjs/core';
-import React, { FC } from 'react';
+import React from 'react';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import {
     NEVER_SYNCED_LABEL,
@@ -23,13 +23,13 @@ interface RemoteSyncButtonProps {
     handleClick(selectedFolder: RemoteFolder | undefined): Promise<void>;
 }
 
-const RemoteSyncButton: FC<RemoteSyncButtonProps> = ({
+const RemoteSyncButton = ({
     selectedReportFolder,
     isSyncingReportFolder,
     isSelectedReportFolderOutdated,
     isDisabled,
     handleClick,
-}) => {
+}: RemoteSyncButtonProps) => {
     return (
         <Tooltip
             content={getTooltipContent(selectedReportFolder, isSyncingReportFolder, isSelectedReportFolderOutdated)}

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
@@ -29,7 +29,7 @@ import { updateInstance, useReportMetadata } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation, evaluateDbVersion } from '../../functions/compareDbVersion';
 
-const RemoteSyncConfigurator: FC = () => {
+const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
     const { setPersistentSelectedConnection, setPersistentSavedConnectionList } = remote;
     const queryClient = useQueryClient();

--- a/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
+++ b/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React from 'react';
 import { BufferPage } from '../../model/APIData';
 import { pageDataToChunkArray } from '../../functions/getChartData';
 
@@ -13,12 +12,7 @@ interface SVGBufferRendererProps {
     memoryEnd: number;
 }
 
-const SVGBufferRenderer: React.FC<SVGBufferRendererProps> = ({
-    height,
-    data,
-    memoryStart,
-    memoryEnd,
-}: SVGBufferRendererProps) => {
+const SVGBufferRenderer = ({ height, data, memoryStart, memoryEnd }: SVGBufferRendererProps) => {
     const memoryRange = memoryEnd - memoryStart;
     const mergedRange = pageDataToChunkArray(data);
 

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, ButtonVariant, Card, Overlay2, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { PlotData } from 'plotly.js';
@@ -32,7 +32,7 @@ export interface TensorVisualisationComponentProps {
     plotZoomRange: [number, number];
 }
 
-const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> = ({
+const TensorVisualisationComponent = ({
     title,
     operationId,
     address,
@@ -42,7 +42,7 @@ const TensorVisualisationComponent: React.FC<TensorVisualisationComponentProps> 
     tensorByAddress,
     plotZoomRange,
     tensorId,
-}) => {
+}: TensorVisualisationComponentProps) => {
     const { data } = useBufferPages(operationId, address, bufferType);
     const { data: devices } = useDevices();
     const showHex = useAtomValue(showHexAtom);

--- a/src/libs/SocketProvider.tsx
+++ b/src/libs/SocketProvider.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 /* eslint-disable no-console */
-import React, { ReactNode, createContext, useEffect } from 'react';
+import { ReactNode, createContext, useEffect } from 'react';
 import { Socket, io } from 'socket.io-client';
 import { useSetAtom } from 'jotai';
 import { getOrCreateInstanceId } from './axiosInstance';
@@ -23,7 +23,7 @@ interface SocketProviderProps {
     children: ReactNode;
 }
 
-export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
+export const SocketProvider = ({ children }: SocketProviderProps) => {
     const setFileTransferProgress = useSetAtom(fileTransferProgressAtom);
     const instanceId = getOrCreateInstanceId();
 
@@ -69,6 +69,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
             socket.off('disconnect');
             socket.off('connect_error');
             socket.off('reconnect');
+            socket.off('fileTransferProgress');
         };
     }, [instanceId, setFileTransferProgress]);
 

--- a/src/routes/GraphView.tsx
+++ b/src/routes/GraphView.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router';
 
@@ -13,7 +13,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import useClearSelectedBuffer from '../functions/clearSelectedBuffer';
 import { selectedOperationRangeAtom } from '../store/app';
 
-const GraphView: React.FC = () => {
+const GraphView = () => {
     const { data: operationList, isLoading } = useOperationsList();
     const { operationId } = useParams<{ operationId?: string }>();
     const selectedOperationRange = useAtomValue(selectedOperationRangeAtom);

--- a/src/routes/MLIR.tsx
+++ b/src/routes/MLIR.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { FC, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { HttpStatusCode } from 'axios';
 import { useAtomValue } from 'jotai';
@@ -14,7 +14,7 @@ import MlirJsonFileLoader from '../components/mlir/MlirJsonFileLoader';
 import MlGraph from '../components/mlir/MLIRViewReactFlow';
 import MlirProcessingStatus from '../components/MlirProcessingStatus';
 
-const MLIR: FC = () => {
+const MLIR = () => {
     const { filepath } = useParams<{ filepath?: string }>();
     const mlirJsonFilename = useAtomValue(activeMlirJsonAtom);
     const { data: mlirData, isLoading, error: httpError } = useMLIR(filepath ? null : mlirJsonFilename);

--- a/src/routes/NPE.tsx
+++ b/src/routes/NPE.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { FC, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router';
@@ -17,7 +17,7 @@ import NPEProcessingStatus from '../components/NPEProcessingStatus';
 import NPEDemoSelect, { NPEDemoData } from '../components/npe/NPEDemoSelect';
 import { NPEValidationError, validateNpeData } from '../definitions/NPEData';
 
-const NPE: FC = () => {
+const NPE = () => {
     const { filepath } = useParams<{ filepath?: string }>();
     const npeFileName = useAtomValue(activeNpeOpTraceAtom);
     const { data: loadedData, isLoading: isLoadingNPE, error: httpError } = useNpe(filepath ? null : npeFileName);


### PR DESCRIPTION
Closes #1527.

## Summary

Resolves the component-typing inconsistency tracked in [#1527](https://github.com/tenstorrent/ttnn-visualizer/issues/1527) by picking **one** canonical style and enforcing it.

**Canonical style:** type props on the function signature — `function Foo({ … }: FooProps)` or `const Foo = ({ … }: FooProps) =>`. Components with children declare `children: ReactNode` (or optional) on `FooProps`.

**Migration:** 56 components across 43 files moved off `React.FC` / `FC` / inline `FC<{…}>` annotations. Inline prop types promoted to `interface *Props` where they violated the existing `ComponentNameProps` rule. `PropsWithChildren<…>` wrappers unwrapped into explicit `children` on `CollapsibleProps`, `RemoteFolderSelectorProps`, and `DeviceOperationNodeComponentProps`.

**Enforcement:**
- `AGENTS.md` + new `CONVENTIONS.md` § “Don't use React.FC / FC”
- `react/function-component-definition` → error (function-declaration or arrow-function)
- `no-restricted-syntax` bans `FC`, `React.FC`, `FunctionComponent`, `React.FunctionComponent`

**Drive-by (same PR, small):** `SocketProvider` effect cleanup now `socket.off('fileTransferProgress')` so StrictMode remounts don't leak listeners; CONVENTIONS socket example updated; removed resolved Known-inconsistencies bullets for component typing and SocketProvider cleanup.

## Test plan

- [x] `pnpm lint` — 0 errors / 0 warnings
- [x] `pnpm lint:ts` — clean
- [x] `pnpm test` — 114 passed
- [x] `pnpm build` — clean

Made with [Cursor](https://cursor.com)