### PR TITLE
Add L1Small additional reporting

### DIFF
--- a/backend/ttnn_visualizer/tests/views/test_tensors.py
+++ b/backend/ttnn_visualizer/tests/views/test_tensors.py
@@ -115,6 +115,83 @@ def test_tensors_list_partial_lifetime_fields_are_nullable(client, make_report):
 
 
 # ---------------------------------------------------------------------------
+# /api/tensors — buffer_type filter
+# ---------------------------------------------------------------------------
+
+# Tensors covering multiple buffer_type values across two devices so the filter
+# semantics and its composition with device_id can both be exercised.
+# buffer_type values: 0=DRAM, 1=L1, 3=L1_Small (matches BufferType enum).
+_MIXED_BUFFER_TYPE_INSERTS = """
+INSERT INTO operations VALUES (1, 'op_a', 1.0);
+INSERT INTO tensors VALUES (10, '(2, 4)', 'bfloat16',  'TILE',      '{}', 0, 200, 0);
+INSERT INTO tensors VALUES (20, '(1,)',   'float32',   'ROW_MAJOR', '{}', 0, 300, 1);
+INSERT INTO tensors VALUES (30, '(1,)',   'uint16',    'ROW_MAJOR', '{}', 0, 400, 3);
+INSERT INTO tensors VALUES (40, '(1,)',   'uint16',    'ROW_MAJOR', '{}', 1, 500, 3);
+"""
+
+
+def test_tensors_list_buffer_type_filter(client, make_report):
+    """?buffer_type=N restricts results to tensors with that buffer_type."""
+    instance_id = make_report(_MIXED_BUFFER_TYPE_INSERTS, SCHEMA_V2)
+
+    response = client.get(
+        "/api/tensors",
+        query_string={"instanceId": instance_id, "buffer_type": 3},
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.get_json()
+    ids = sorted(t["id"] for t in data)
+    assert ids == [30, 40]
+
+
+def test_tensors_list_buffer_type_filter_composes_with_device_id(client, make_report):
+    """buffer_type and device_id filters compose with AND semantics."""
+    instance_id = make_report(_MIXED_BUFFER_TYPE_INSERTS, SCHEMA_V2)
+
+    response = client.get(
+        "/api/tensors",
+        query_string={
+            "instanceId": instance_id,
+            "buffer_type": 3,
+            "device_id": 0,
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.get_json()
+    ids = sorted(t["id"] for t in data)
+    assert ids == [30]
+
+
+def test_tensors_list_omitted_buffer_type_returns_all_types(client, make_report):
+    """Omitting buffer_type leaves the list unfiltered by type."""
+    instance_id = make_report(_MIXED_BUFFER_TYPE_INSERTS, SCHEMA_V2)
+
+    response = client.get("/api/tensors", query_string={"instanceId": instance_id})
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.get_json()
+    ids = sorted(t["id"] for t in data)
+    assert ids == [10, 20, 30, 40]
+
+
+def test_tensors_list_non_numeric_buffer_type_is_ignored(client, make_report):
+    """A non-numeric buffer_type query value is silently ignored (no filter applied)."""
+    instance_id = make_report(_MIXED_BUFFER_TYPE_INSERTS, SCHEMA_V2)
+
+    response = client.get(
+        "/api/tensors",
+        query_string={"instanceId": instance_id, "buffer_type": "abc"},
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.get_json()
+    ids = sorted(t["id"] for t in data)
+    assert ids == [10, 20, 30, 40]
+
+
+# ---------------------------------------------------------------------------
 # /api/tensors/<tensor_id> — detail endpoint
 # ---------------------------------------------------------------------------
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -571,9 +571,12 @@ def tensors_list(instance: Instance):
         if rejected is not None:
             return rejected
         device_id = request.args.get("device_id", None)
+        buffer_type_param = request.args.get("buffer_type", None)
         tensor_filters: dict = {}
         if device_id is not None:
             tensor_filters["device_id"] = device_id
+        if buffer_type_param is not None and str.isdigit(buffer_type_param):
+            tensor_filters["buffer_type"] = int(buffer_type_param)
         tensors = list(
             db.query_tensors(db.merge_rank_filter("tensors", tensor_filters, rank))
         )

--- a/src/components/TensorList.tsx
+++ b/src/components/TensorList.tsx
@@ -68,13 +68,20 @@ const TensorList = () => {
 
     const tensorsWithRange = useMemo(() => {
         if (fetchedTensors && selectedOperationRange) {
-            return fetchedTensors.filter(
-                (tensor) =>
+            return fetchedTensors.filter((tensor) => {
+                // Tensors with no producers/consumers (e.g. L1_Small scratch tensors)
+                // can't be range-filtered, so pass them through.
+                if (tensor.producers.length === 0 && tensor.consumers.length === 0) {
+                    return true;
+                }
+
+                return (
                     (tensor.producers.some((producer) => producer >= selectedOperationRange[0]) &&
                         tensor.producers.some((producer) => producer <= selectedOperationRange[1])) ||
                     (tensor.consumers.some((consumer) => consumer >= selectedOperationRange[0]) &&
-                        tensor.consumers.some((consumer) => consumer <= selectedOperationRange[1])),
-            );
+                        tensor.consumers.some((consumer) => consumer <= selectedOperationRange[1]))
+                );
+            });
         }
 
         return fetchedTensors;

--- a/src/components/operation-details/OperationDetailsComponent.tsx
+++ b/src/components/operation-details/OperationDetailsComponent.tsx
@@ -14,6 +14,7 @@ import {
     useOperationDetails,
     useOperationsList,
     usePreviousOperationDetails,
+    useTensors,
 } from '../../hooks/useAPI';
 import 'styles/components/OperationDetailsComponent.scss';
 import StackTrace from './StackTrace';
@@ -74,6 +75,10 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
     const { data: operations } = useOperationsList();
     const l1start = useGetL1StartMarker();
     const l1end = useGetL1SmallMarker();
+    // TEMP (#1291): fetch L1_Small tensors separately while tt-metal does not emit
+    // input_tensors/output_tensors for them. Drop this and the constructor argument
+    // below once proper producer/consumer reporting is in place.
+    const { data: l1SmallTensors } = useTensors(BufferType.L1_SMALL);
 
     const {
         operationDetails: { data: operationDetails, isLoading, status },
@@ -110,12 +115,17 @@ const OperationDetailsComponent: React.FC<OperationDetailsProps> = ({ operationI
                 lateDeallocation: showDeallocationReport,
                 showHex,
             },
+            l1SmallTensors ?? [],
         );
 
-        previousDetails = new OperationDetails(previousOperationDetails, operations, [], {
-            l1start,
-            l1end,
-        });
+        previousDetails = new OperationDetails(
+            previousOperationDetails,
+            operations,
+            [],
+            { l1start, l1end },
+            undefined,
+            l1SmallTensors ?? [],
+        );
 
         l1MemoryData = details.memoryData();
         memorySizeL1 = details.memorySizeL1;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -813,9 +813,10 @@ export const useBufferPages = (operationId: number, address?: number | string, b
     });
 };
 
-export const fetchTensors = async (): Promise<Tensor[]> => {
+export const fetchTensors = async (bufferType?: BufferType): Promise<Tensor[]> => {
     const { data: tensorList } = await axiosInstance.get<Tensor[]>(Endpoints.TENSOR_LIST, {
         maxRedirects: 1,
+        params: bufferType !== undefined ? { buffer_type: bufferType } : undefined,
     });
 
     const operationsList = await fetchOperations();
@@ -835,12 +836,12 @@ export const fetchTensors = async (): Promise<Tensor[]> => {
     return tensorList;
 };
 
-export const useTensors = () => {
+export const useTensors = (bufferType?: BufferType) => {
     const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
 
     return useQuery<Tensor[], AxiosError>({
-        queryFn: () => fetchTensors(),
-        queryKey: ['get-tensors', activeProfilerReport?.path],
+        queryFn: () => fetchTensors(bufferType),
+        queryKey: ['get-tensors', activeProfilerReport?.path, bufferType ?? 'all'],
         retry: false,
         staleTime: Infinity,
     });

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -819,6 +819,12 @@ export const fetchTensors = async (bufferType?: BufferType): Promise<Tensor[]> =
         params: bufferType !== undefined ? { buffer_type: bufferType } : undefined,
     });
 
+    // Skip the operations fetch + enrichment loop when no tensor has a producer
+    // (e.g. an L1_Small-only fetch). fetchOperations is not cheap on large reports.
+    if (!tensorList.some((t) => t.producers.length > 0)) {
+        return tensorList;
+    }
+
     const operationsList = await fetchOperations();
 
     for (const tensor of tensorList) {

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -65,10 +65,14 @@ export class OperationDetails implements Partial<OperationDetailsData> {
         l1end: number;
     };
 
-    // TEMP (#1291): address -> real L1_Small Tensor sourced from /api/tensors?buffer_type=3.
-    // Used by getTensorListByAddress() until tt-metal records producers/consumers for L1_Small
-    // and the standard backward op-walk can locate them via op.inputs/op.outputs.
-    private l1SmallTensorsByAddress: Map<number, Tensor> = new Map();
+    // TEMP (#1291): `${device_id}:${address}` -> real L1_Small Tensor sourced from
+    // /api/tensors?buffer_type=3. Used by getTensorListByAddress() until tt-metal
+    // records producers/consumers for L1_Small and the standard backward op-walk
+    // can locate them via op.inputs/op.outputs.
+    // Composite key avoids cross-device collisions: the same L1_Small address can
+    // exist on multiple devices in multi-chip reports, and would otherwise overwrite
+    // each other in the map.
+    private l1SmallTensorsByAddress: Map<string, Tensor> = new Map();
 
     private options: OperationDetailsOptions = {
         renderPattern: false,
@@ -156,8 +160,11 @@ export class OperationDetails implements Partial<OperationDetailsData> {
         this.memoryConfig = memoryConfig;
         this.l1SmallTensorsByAddress = new Map(
             l1SmallTensors
-                .filter((t): t is Tensor & { address: number } => t.address !== null)
-                .map((t) => [t.address, t]),
+                .filter(
+                    (t): t is Tensor & { address: number; device_id: number } =>
+                        t.address !== null && t.device_id !== null,
+                )
+                .map((t) => [`${t.device_id}:${t.address}`, t]),
         );
 
         this.inputs.forEach((tensor) => {
@@ -597,7 +604,7 @@ ${getMemoryAddress(bufferCondensed.address, this.options.showHex)} <br /> ${form
                 // Remove this entire branch once tt-metal emits proper
                 // input_tensors/output_tensors rows for L1_Small (see tt-metal
                 // graph_processor.cpp::track_allocate).
-                const l1SmallTensor = this.l1SmallTensorsByAddress.get(bufferAddress);
+                const l1SmallTensor = this.l1SmallTensorsByAddress.get(`${buffer.device_id}:${bufferAddress}`);
                 if (l1SmallTensor !== undefined) {
                     tensorsByBufferAddress.set(bufferAddress, {
                         ...l1SmallTensor,

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -65,6 +65,11 @@ export class OperationDetails implements Partial<OperationDetailsData> {
         l1end: number;
     };
 
+    // TEMP (#1291): address -> real L1_Small Tensor sourced from /api/tensors?buffer_type=3.
+    // Used by getTensorListByAddress() until tt-metal records producers/consumers for L1_Small
+    // and the standard backward op-walk can locate them via op.inputs/op.outputs.
+    private l1SmallTensorsByAddress: Map<number, Tensor> = new Map();
+
     private options: OperationDetailsOptions = {
         renderPattern: false,
         lateDeallocation: false,
@@ -128,6 +133,10 @@ export class OperationDetails implements Partial<OperationDetailsData> {
             l1end: number;
         },
         options?: OperationDetailsOptions,
+        // TEMP (#1291): pre-fetched L1_Small tensor list, supplied so the address->tensor
+        // map can be populated with real tensor ids/shape/dtype while tt-metal does not yet
+        // emit input_tensors/output_tensors rows for L1_Small allocations.
+        l1SmallTensors: Tensor[] = [],
     ) {
         this.id = data.id;
         this.inputs = data.inputs;
@@ -145,6 +154,11 @@ export class OperationDetails implements Partial<OperationDetailsData> {
         this.device_operations = this.preprocessConnections(data.device_operations);
         this.options = options || { renderPattern: false, lateDeallocation: false, showHex: false };
         this.memoryConfig = memoryConfig;
+        this.l1SmallTensorsByAddress = new Map(
+            l1SmallTensors
+                .filter((t): t is Tensor & { address: number } => t.address !== null)
+                .map((t) => [t.address, t]),
+        );
 
         this.inputs.forEach((tensor) => {
             tensor.producerNames = tensor.producers.map((op) => {
@@ -575,6 +589,21 @@ ${getMemoryAddress(bufferCondensed.address, this.options.showHex)} <br /> ${form
                     ...tensor,
                     buffer_type: bufferType,
                 });
+            } else if (bufferType === BufferType.L1_SMALL) {
+                // TEMP (#1291): L1_Small tensors are not yet reported with
+                // producers/consumers from tt-metal, so they never match the
+                // backward op-walk above. Look them up by address in the
+                // pre-fetched L1_Small tensor list (/api/tensors?buffer_type=3).
+                // Remove this entire branch once tt-metal emits proper
+                // input_tensors/output_tensors rows for L1_Small (see tt-metal
+                // graph_processor.cpp::track_allocate).
+                const l1SmallTensor = this.l1SmallTensorsByAddress.get(bufferAddress);
+                if (l1SmallTensor !== undefined) {
+                    tensorsByBufferAddress.set(bufferAddress, {
+                        ...l1SmallTensor,
+                        buffer_type: bufferType,
+                    });
+                }
             }
         }
 

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -196,6 +196,7 @@ $row-background: $tt-grey-2;
         }
 
         &.tag-l1-small {
+            color: $tt-grey-2;
             background-color: $tt-yellow-tint-1;
         }
     }


### PR DESCRIPTION
This pull request introduces support for filtering and displaying L1_Small tensors, which currently lack producer/consumer information from the backend (`tt-metal`). The changes include backend support for filtering tensors by buffer type, frontend hooks and API updates to fetch these tensors, and temporary logic in the UI and model to handle the incomplete reporting for L1_Small tensors. This ensures L1_Small tensors are visible and correctly associated in the UI until full backend support is available.

<img width="1442" height="183" alt="image" src="https://github.com/user-attachments/assets/0eab985f-c358-4a7f-8c8a-4a554d79d422" />
<img width="1066" height="728" alt="image" src="https://github.com/user-attachments/assets/8c5a3c7a-5292-44b3-89ce-f22fd3dbf98b" />


closes #1291 