### PR TITLE
Reject empty NPE traces and show UI message

### DIFF
--- a/src/components/NPEProcessingStatus.tsx
+++ b/src/components/NPEProcessingStatus.tsx
@@ -39,6 +39,9 @@ const ProcessingErrors: Record<NPEValidationError, { title: string }> = {
     [NPEValidationError.INVALID_NPE_DATA]: {
         title: 'Invalid NPE data',
     },
+    [NPEValidationError.EMPTY_NPE_TRACE]: {
+        title: 'Empty NPE trace',
+    },
 };
 
 interface NPEProcessingStatusProps {
@@ -109,6 +112,19 @@ const NPEProcessingStatus = ({ dataVersion, hasUploadedFile, errorCode, isLoadin
                                     The uploaded data cannot be parsed as valid JSON.
                                 </p>
                                 <p>Check the file contents or use {NPE_REPO_URL} to generate a new dataset.</p>
+                            </>
+                        );
+                    case NPEValidationError.EMPTY_NPE_TRACE:
+                        return (
+                            <>
+                                <p data-testid={TEST_IDS.NPE_PROCESSING_EMPTY_TRACE}>
+                                    This NPE trace contains no transfers or timesteps. The producer completed but
+                                    captured no NoC activity.
+                                </p>
+                                <p>
+                                    Check the cycle range and instrumented region in your {NPE_REPO_URL} run
+                                    configuration, then regenerate the report.
+                                </p>
                             </>
                         );
 

--- a/src/definitions/NPEData.ts
+++ b/src/definitions/NPEData.ts
@@ -14,6 +14,7 @@ export enum NPEValidationError {
     INVALID_NPE_VERSION,
     INVALID_JSON,
     INVALID_NPE_DATA,
+    EMPTY_NPE_TRACE,
 }
 
 export const validateNpeData = (data: unknown): NPEValidationError => {
@@ -28,6 +29,19 @@ export const validateNpeData = (data: unknown): NPEValidationError => {
 
     if (!hasAllKeys) {
         return NPEValidationError.INVALID_NPE_DATA;
+    }
+
+    // Reject traces with no transfers or no timesteps. The trace itself is well-formed,
+    // but NPEViewComponent dereferences `timestep_data[selectedTimestep].active_transfers`
+    // and crashes if either is empty. This is a distinct condition from malformed data —
+    // the producer completed but captured no activity.
+    if (
+        !Array.isArray(npeData.noc_transfers) ||
+        !Array.isArray(npeData.timestep_data) ||
+        npeData.noc_transfers.length === 0 ||
+        npeData.timestep_data.length === 0
+    ) {
+        return NPEValidationError.EMPTY_NPE_TRACE;
     }
 
     const parsedVersion = dataVersion ? semverParse(dataVersion) : null;

--- a/src/definitions/TestIds.ts
+++ b/src/definitions/TestIds.ts
@@ -39,5 +39,6 @@ export const TEST_IDS = Object.freeze({
     NPE_PROCESSING_INVALID_VERSION: 'npe-processing-invalid-version',
     NPE_PROCESSING_INVALID_DATA: 'npe-processing-invalid-data',
     NPE_PROCESSING_INVALID_JSON: 'npe-processing-invalid-json',
+    NPE_PROCESSING_EMPTY_TRACE: 'npe-processing-empty-trace',
     NPE_PROCESSING_UNHANDLED_ERROR: 'npe-processing-unhandled-error',
 });

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -680,6 +680,14 @@ export default function Styleguide() {
                     isLoading={false}
                 />
 
+                <h4>Empty NPE trace (no transfers or timesteps)</h4>
+                <NPEProcessingStatus
+                    hasUploadedFile
+                    dataVersion={MIN_SUPPORTED_VERSION}
+                    errorCode={NPEValidationError.EMPTY_NPE_TRACE}
+                    isLoading={false}
+                />
+
                 <h4>Unprocessable JSON error (HTTP 422)</h4>
                 <NPEProcessingStatus
                     hasUploadedFile

--- a/tests/npeErrorHandling.spec.tsx
+++ b/tests/npeErrorHandling.spec.tsx
@@ -71,6 +71,21 @@ it('handles invalid JSON data', () => {
     expect(screen.getByTestId(TEST_IDS.NPE_PROCESSING_INVALID_JSON).textContent).toBeDefined();
 });
 
+it('handles empty NPE traces', () => {
+    render(
+        <TestProviders>
+            <NPEProcessingStatus
+                isLoading={false}
+                hasUploadedFile
+                dataVersion={MIN_SUPPORTED_VERSION}
+                errorCode={NPEValidationError.EMPTY_NPE_TRACE}
+            />
+        </TestProviders>,
+    );
+
+    expect(screen.getByTestId(TEST_IDS.NPE_PROCESSING_EMPTY_TRACE).textContent).toBeDefined();
+});
+
 it('handles unknown errors', () => {
     render(
         <TestProviders>

--- a/tests/validateNpeData.spec.ts
+++ b/tests/validateNpeData.spec.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { NPEValidationError, validateNpeData } from '../src/definitions/NPEData';
+
+const validData = {
+    common_info: { version: '1.0.0' },
+    noc_transfers: [{ id: 0 }],
+    timestep_data: [{ active_transfers: [] }],
+};
+
+describe('validateNpeData', () => {
+    it('returns OK for a well-formed payload', () => {
+        expect(validateNpeData(validData)).toBe(NPEValidationError.OK);
+    });
+
+    it('returns INVALID_NPE_DATA for non-object input', () => {
+        expect(validateNpeData(null)).toBe(NPEValidationError.INVALID_NPE_DATA);
+        expect(validateNpeData('not-an-object')).toBe(NPEValidationError.INVALID_NPE_DATA);
+    });
+
+    it('returns INVALID_NPE_DATA when required top-level keys are missing', () => {
+        expect(validateNpeData({ common_info: { version: '1.0.0' } })).toBe(NPEValidationError.INVALID_NPE_DATA);
+    });
+
+    it('returns EMPTY_NPE_TRACE when noc_transfers is empty', () => {
+        expect(
+            validateNpeData({
+                ...validData,
+                noc_transfers: [],
+            }),
+        ).toBe(NPEValidationError.EMPTY_NPE_TRACE);
+    });
+
+    it('returns EMPTY_NPE_TRACE when timestep_data is empty', () => {
+        expect(
+            validateNpeData({
+                ...validData,
+                timestep_data: [],
+            }),
+        ).toBe(NPEValidationError.EMPTY_NPE_TRACE);
+    });
+
+    it('returns EMPTY_NPE_TRACE when both transfer arrays are empty', () => {
+        expect(
+            validateNpeData({
+                ...validData,
+                noc_transfers: [],
+                timestep_data: [],
+            }),
+        ).toBe(NPEValidationError.EMPTY_NPE_TRACE);
+    });
+
+    it('returns INVALID_NPE_VERSION when version is missing', () => {
+        expect(
+            validateNpeData({
+                ...validData,
+                common_info: {},
+            }),
+        ).toBe(NPEValidationError.INVALID_NPE_VERSION);
+    });
+
+    it('returns INVALID_NPE_VERSION when major version does not match', () => {
+        expect(
+            validateNpeData({
+                ...validData,
+                common_info: { version: '0.5.0' },
+            }),
+        ).toBe(NPEValidationError.INVALID_NPE_VERSION);
+    });
+});


### PR DESCRIPTION
Add explicit EMPTY_NPE_TRACE validation and handling. This introduces a new NPEValidationError value and updates validateNpeData to reject traces with no noc_transfers or no timestep_data (to avoid downstream dereference crashes). NPEProcessingStatus now renders a user-facing message (with a test id) for empty traces, the styleguide includes an example, and tests were added/updated to cover the new validation and UI behavior.

<img width="857" height="393" alt="image" src="https://github.com/user-attachments/assets/1cca67bd-c577-4c76-a809-84ed7aade2d4" />


closes #1595 