### PR TITLE
Avoid transfer progress overlay shifting height

### DIFF
--- a/src/components/FileStatusOverlay.tsx
+++ b/src/components/FileStatusOverlay.tsx
@@ -110,13 +110,13 @@ const FileStatusOverlay = () => {
 
                 {(currentFileName || status === FileStatus.STARTED) && (
                     <p>
-                        {currentFileName ? (
+                        {getFileStatusLabel(status)}
+                        {currentFileName && (
                             <>
-                                {getFileStatusLabel(status)} <u>{currentFileName}</u>
+                                {' '}
+                                <u>{currentFileName}</u>
                                 {showCurrentFileSize && <> ({formatMemorySize(currentFileSize, 1)})</>}
                             </>
-                        ) : (
-                            'Preparing transfer\u2026'
                         )}
                     </p>
                 )}

--- a/src/components/FileStatusOverlay.tsx
+++ b/src/components/FileStatusOverlay.tsx
@@ -108,10 +108,16 @@ const FileStatusOverlay = () => {
                     </p>
                 )}
 
-                {currentFileName && (
+                {(currentFileName || status === FileStatus.STARTED) && (
                     <p>
-                        {getFileStatusLabel(status)} <u>{currentFileName}</u>
-                        {showCurrentFileSize && <> ({formatMemorySize(currentFileSize, 1)})</>}
+                        {currentFileName ? (
+                            <>
+                                {getFileStatusLabel(status)} <u>{currentFileName}</u>
+                                {showCurrentFileSize && <> ({formatMemorySize(currentFileSize, 1)})</>}
+                            </>
+                        ) : (
+                            'Preparing transfer\u2026'
+                        )}
                     </p>
                 )}
                 <p>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -7,11 +7,10 @@ import 'styles/components/ProgressBar.scss';
 
 interface ProgressBarProps {
     progress?: number;
-    estimated?: number;
     ariaLabel?: string;
 }
 
-function ProgressBar({ progress, estimated, ariaLabel = 'Progress bar' }: ProgressBarProps) {
+function ProgressBar({ progress, ariaLabel = 'Progress bar' }: ProgressBarProps) {
     return (
         <div className='progress-bar'>
             <BlueprintProgressBar
@@ -19,14 +18,6 @@ function ProgressBar({ progress, estimated, ariaLabel = 'Progress bar' }: Progre
                 aria-label={ariaLabel}
                 animate
             />
-
-            {progress && estimated ? (
-                <span className='status'>
-                    {progress > 0 ? `${Math.round(progress * 100)}%` : `100%`}
-                    {` - `}
-                    {estimated > 0 ? `${Math.round(estimated)}s left` : '0s left'}
-                </span>
-            ) : null}
         </div>
     );
 }

--- a/src/functions/getFileStatusLabel.ts
+++ b/src/functions/getFileStatusLabel.ts
@@ -4,7 +4,7 @@
 
 import { FileStatus } from '../model/APIData';
 
-const FILE_STATUS_LABEL: Readonly<Record<FileStatus, string>> = Object.freeze({
+export const FILE_STATUS_LABEL: Readonly<Record<FileStatus, string>> = Object.freeze({
     // STARTED is the only label that may render standalone (before the first
     // per-file event populates `currentFileName`), so it's phrased as a
     // self-contained user message rather than a transitive verb — see

--- a/src/functions/getFileStatusLabel.ts
+++ b/src/functions/getFileStatusLabel.ts
@@ -4,11 +4,7 @@
 
 import { FileStatus } from '../model/APIData';
 
-export const FILE_STATUS_LABEL: Readonly<Record<FileStatus, string>> = Object.freeze({
-    // STARTED is the only label that may render standalone (before the first
-    // per-file event populates `currentFileName`), so it's phrased as a
-    // self-contained user message rather than a transitive verb — see
-    // `FileStatusOverlay.tsx` (issue #1599).
+const FILE_STATUS_LABEL: Readonly<Record<FileStatus, string>> = Object.freeze({
     [FileStatus.STARTED]: 'Preparing\u2026',
     [FileStatus.DOWNLOADING]: 'Downloading',
     [FileStatus.UPLOADING]: 'Uploading',

--- a/src/functions/getFileStatusLabel.ts
+++ b/src/functions/getFileStatusLabel.ts
@@ -5,7 +5,11 @@
 import { FileStatus } from '../model/APIData';
 
 const FILE_STATUS_LABEL: Readonly<Record<FileStatus, string>> = Object.freeze({
-    [FileStatus.STARTED]: 'Starting',
+    // STARTED is the only label that may render standalone (before the first
+    // per-file event populates `currentFileName`), so it's phrased as a
+    // self-contained user message rather than a transitive verb — see
+    // `FileStatusOverlay.tsx` (issue #1599).
+    [FileStatus.STARTED]: 'Preparing\u2026',
     [FileStatus.DOWNLOADING]: 'Downloading',
     [FileStatus.UPLOADING]: 'Uploading',
     [FileStatus.FINISHED]: 'Finished',

--- a/src/hooks/useLocal.tsx
+++ b/src/hooks/useLocal.tsx
@@ -9,11 +9,6 @@ import { fileTransferProgressAtom, getInactiveFileTransferProgress } from '../st
 import { FileStatus } from '../model/APIData';
 import Endpoints from '../definitions/Endpoints';
 
-export interface UploadProgress {
-    progress?: number;
-    estimated?: number;
-}
-
 type FileWithRelativePath = File & { webkitRelativePath?: string };
 
 const ua = navigator.userAgent.toLowerCase();

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -30,7 +30,7 @@ import GlobalSwitch from '../components/GlobalSwitch';
 import useClearSelectedBuffer from '../functions/clearSelectedBuffer';
 import MemoryTag from '../components/MemoryTag';
 import { fileTransferProgressAtom, getInactiveFileTransferProgress } from '../store/app';
-import { FileStatus } from '../model/APIData';
+import { FileProgress, FileStatus } from '../model/APIData';
 import NPEProcessingStatus from '../components/NPEProcessingStatus';
 import { MIN_SUPPORTED_VERSION, NPEValidationError } from '../definitions/NPEData';
 
@@ -83,9 +83,7 @@ export default function Styleguide() {
     const [autoCloseTime, setAutoCloseTime] = useState(1000);
     const [timeRemaining, setTimeRemaining] = useState(autoCloseTime);
 
-    const runFileTransferDemo = (
-        initial: typeof SYNC_DEMO_PROGRESS | typeof SYNC_STARTING_DEMO_PROGRESS | typeof UPLOAD_DEMO_PROGRESS,
-    ) => {
+    const runFileTransferDemo = (initial: FileProgress) => {
         setUpdateFileTransferProgress(initial);
         setTimeRemaining(autoCloseTime);
 

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -604,17 +604,11 @@ export default function Styleguide() {
             <h3>Progress bar</h3>
 
             <div className='container short-width'>
-                <ProgressBar
-                    progress={0}
-                    estimated={36}
-                />
+                <ProgressBar progress={0} />
             </div>
 
             <div className='container short-width'>
-                <ProgressBar
-                    progress={0.85}
-                    estimated={1}
-                />
+                <ProgressBar progress={0.85} />
             </div>
 
             <div className='container flex'>

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -51,8 +51,8 @@ const SYNC_DEMO_PROGRESS = {
 };
 
 // STARTED phase of a remote sync: backend has emitted job totals but no
-// per-file event yet, so `currentFileName` is empty and the overlay shows the
-// "Preparing transfer..." placeholder (issue #1599).
+// per-file event yet, so `currentFileName` is empty and the overlay renders
+// the standalone `Preparing\u2026` label (issue #1599).
 const SYNC_STARTING_DEMO_PROGRESS = {
     currentFileName: '',
     numberOfFiles: 3,

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -50,6 +50,20 @@ const SYNC_DEMO_PROGRESS = {
     currentFileSize: 128_000,
 };
 
+// STARTED phase of a remote sync: backend has emitted job totals but no
+// per-file event yet, so `currentFileName` is empty and the overlay shows the
+// "Preparing transfer..." placeholder (issue #1599).
+const SYNC_STARTING_DEMO_PROGRESS = {
+    currentFileName: '',
+    numberOfFiles: 3,
+    percentOfCurrent: 0,
+    finishedFiles: 0,
+    status: FileStatus.STARTED,
+    bytesTransferred: 0,
+    bytesTotal: 512_000,
+    currentFileSize: 0,
+};
+
 const UPLOAD_DEMO_PROGRESS = {
     currentFileName: '',
     numberOfFiles: 5,
@@ -69,7 +83,9 @@ export default function Styleguide() {
     const [autoCloseTime, setAutoCloseTime] = useState(1000);
     const [timeRemaining, setTimeRemaining] = useState(autoCloseTime);
 
-    const runFileTransferDemo = (initial: typeof SYNC_DEMO_PROGRESS | typeof UPLOAD_DEMO_PROGRESS) => {
+    const runFileTransferDemo = (
+        initial: typeof SYNC_DEMO_PROGRESS | typeof SYNC_STARTING_DEMO_PROGRESS | typeof UPLOAD_DEMO_PROGRESS,
+    ) => {
         setUpdateFileTransferProgress(initial);
         setTimeRemaining(autoCloseTime);
 
@@ -610,6 +626,13 @@ export default function Styleguide() {
                     />
 
                     <ButtonGroup>
+                        <Button
+                            onClick={() => runFileTransferDemo(SYNC_STARTING_DEMO_PROGRESS)}
+                            intent={Intent.PRIMARY}
+                            disabled={updateFileTransferProgress.status !== FileStatus.INACTIVE}
+                        >
+                            Open remote sync overlay (preparing)
+                        </Button>
                         <Button
                             onClick={() => runFileTransferDemo(SYNC_DEMO_PROGRESS)}
                             intent={Intent.PRIMARY}

--- a/src/scss/components/ProgressBar.scss
+++ b/src/scss/components/ProgressBar.scss
@@ -6,8 +6,4 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-
-    .status {
-        margin-top: 10px;
-    }
 }

--- a/tests/FileStatusOverlay.spec.tsx
+++ b/tests/FileStatusOverlay.spec.tsx
@@ -23,9 +23,9 @@ afterEach(cleanup);
 describe('FileStatusOverlay status row', () => {
     // Regression for issue #1599: the overlay opens on STARTED (empty filename)
     // and previously showed no per-file row, so the first DOWNLOADING event
-    // injected a new <p> and grew the modal height. Show a placeholder during
-    // STARTED so height stays stable across the STARTED -> DOWNLOADING edge.
-    it('shows a placeholder during the STARTED phase before a filename arrives', () => {
+    // injected a new <p> and grew the modal height. The STARTED label now
+    // renders standalone so height stays stable across STARTED -> DOWNLOADING.
+    it('shows the standalone STARTED label before a filename arrives', () => {
         renderOverlay({
             currentFileName: '',
             numberOfFiles: 3,
@@ -37,7 +37,7 @@ describe('FileStatusOverlay status row', () => {
             currentFileSize: 0,
         });
 
-        expect(screen.getByText(/Preparing transfer/)).toBeInTheDocument();
+        expect(screen.getByText('Preparing\u2026')).toBeInTheDocument();
     });
 
     it('shows the filename row when DOWNLOADING reports a current file', () => {
@@ -53,13 +53,13 @@ describe('FileStatusOverlay status row', () => {
         });
 
         expect(screen.getByText('db.sqlite')).toBeInTheDocument();
-        expect(screen.queryByText(/Preparing transfer/)).not.toBeInTheDocument();
+        expect(screen.queryByText('Preparing\u2026')).not.toBeInTheDocument();
     });
 
     // Uploads stream as a single multipart request, so currentFileName stays
-    // empty throughout. Don't introduce a "Preparing transfer" line that would
-    // persist for the whole upload — the placeholder is scoped to STARTED.
-    it('does not show the placeholder for UPLOADING with no filename', () => {
+    // empty throughout. The STARTED-only guard keeps the per-file row hidden
+    // for UPLOADING — no standalone "Uploading" line for the whole upload.
+    it('does not render the per-file row for UPLOADING with no filename', () => {
         renderOverlay({
             currentFileName: '',
             numberOfFiles: 5,
@@ -70,6 +70,7 @@ describe('FileStatusOverlay status row', () => {
             bytesTotal: 1_024_000,
         });
 
-        expect(screen.queryByText(/Preparing transfer/)).not.toBeInTheDocument();
+        expect(screen.queryByText('Preparing\u2026')).not.toBeInTheDocument();
+        expect(screen.queryByText('Uploading')).not.toBeInTheDocument();
     });
 });

--- a/tests/FileStatusOverlay.spec.tsx
+++ b/tests/FileStatusOverlay.spec.tsx
@@ -2,11 +2,11 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import FileStatusOverlay from '../src/components/FileStatusOverlay';
-import { FILE_STATUS_LABEL } from '../src/functions/getFileStatusLabel';
+import { getFileStatusLabel } from '../src/functions/getFileStatusLabel';
 import { FileProgress, FileStatus } from '../src/model/APIData';
 import { fileTransferProgressAtom } from '../src/store/app';
 import { TestProviders } from './helpers/TestProviders';
@@ -38,7 +38,7 @@ describe('FileStatusOverlay status row', () => {
             currentFileSize: 0,
         });
 
-        expect(screen.getByText(FILE_STATUS_LABEL[FileStatus.STARTED])).toBeInTheDocument();
+        expect(screen.getByText(getFileStatusLabel(FileStatus.STARTED))).toBeInTheDocument();
     });
 
     it('shows the filename row when DOWNLOADING reports a current file', () => {
@@ -54,7 +54,7 @@ describe('FileStatusOverlay status row', () => {
         });
 
         expect(screen.getByText('db.sqlite')).toBeInTheDocument();
-        expect(screen.queryByText(FILE_STATUS_LABEL[FileStatus.STARTED])).not.toBeInTheDocument();
+        expect(screen.queryByText(getFileStatusLabel(FileStatus.STARTED))).not.toBeInTheDocument();
     });
 
     // Uploads stream as a single multipart request, so currentFileName stays
@@ -71,7 +71,7 @@ describe('FileStatusOverlay status row', () => {
             bytesTotal: 1_024_000,
         });
 
-        expect(screen.queryByText(FILE_STATUS_LABEL[FileStatus.STARTED])).not.toBeInTheDocument();
-        expect(screen.queryByText(FILE_STATUS_LABEL[FileStatus.UPLOADING])).not.toBeInTheDocument();
+        expect(screen.queryByText(getFileStatusLabel(FileStatus.STARTED))).not.toBeInTheDocument();
+        expect(screen.queryByText(getFileStatusLabel(FileStatus.UPLOADING))).not.toBeInTheDocument();
     });
 });

--- a/tests/FileStatusOverlay.spec.tsx
+++ b/tests/FileStatusOverlay.spec.tsx
@@ -6,6 +6,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it } from 'vitest';
 import FileStatusOverlay from '../src/components/FileStatusOverlay';
+import { FILE_STATUS_LABEL } from '../src/functions/getFileStatusLabel';
 import { FileProgress, FileStatus } from '../src/model/APIData';
 import { fileTransferProgressAtom } from '../src/store/app';
 import { TestProviders } from './helpers/TestProviders';
@@ -37,7 +38,7 @@ describe('FileStatusOverlay status row', () => {
             currentFileSize: 0,
         });
 
-        expect(screen.getByText('Preparing\u2026')).toBeInTheDocument();
+        expect(screen.getByText(FILE_STATUS_LABEL[FileStatus.STARTED])).toBeInTheDocument();
     });
 
     it('shows the filename row when DOWNLOADING reports a current file', () => {
@@ -53,7 +54,7 @@ describe('FileStatusOverlay status row', () => {
         });
 
         expect(screen.getByText('db.sqlite')).toBeInTheDocument();
-        expect(screen.queryByText('Preparing\u2026')).not.toBeInTheDocument();
+        expect(screen.queryByText(FILE_STATUS_LABEL[FileStatus.STARTED])).not.toBeInTheDocument();
     });
 
     // Uploads stream as a single multipart request, so currentFileName stays
@@ -70,7 +71,7 @@ describe('FileStatusOverlay status row', () => {
             bytesTotal: 1_024_000,
         });
 
-        expect(screen.queryByText('Preparing\u2026')).not.toBeInTheDocument();
-        expect(screen.queryByText('Uploading')).not.toBeInTheDocument();
+        expect(screen.queryByText(FILE_STATUS_LABEL[FileStatus.STARTED])).not.toBeInTheDocument();
+        expect(screen.queryByText(FILE_STATUS_LABEL[FileStatus.UPLOADING])).not.toBeInTheDocument();
     });
 });

--- a/tests/FileStatusOverlay.spec.tsx
+++ b/tests/FileStatusOverlay.spec.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import FileStatusOverlay from '../src/components/FileStatusOverlay';
+import { FileProgress, FileStatus } from '../src/model/APIData';
+import { fileTransferProgressAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+function renderOverlay(progress: FileProgress) {
+    return render(
+        <TestProviders initialAtomValues={[[fileTransferProgressAtom, progress]]}>
+            <FileStatusOverlay />
+        </TestProviders>,
+    );
+}
+
+afterEach(cleanup);
+
+describe('FileStatusOverlay status row', () => {
+    // Regression for issue #1599: the overlay opens on STARTED (empty filename)
+    // and previously showed no per-file row, so the first DOWNLOADING event
+    // injected a new <p> and grew the modal height. Show a placeholder during
+    // STARTED so height stays stable across the STARTED -> DOWNLOADING edge.
+    it('shows a placeholder during the STARTED phase before a filename arrives', () => {
+        renderOverlay({
+            currentFileName: '',
+            numberOfFiles: 3,
+            percentOfCurrent: 0,
+            finishedFiles: 0,
+            status: FileStatus.STARTED,
+            bytesTransferred: 0,
+            bytesTotal: 200,
+            currentFileSize: 0,
+        });
+
+        expect(screen.getByText(/Preparing transfer/)).toBeInTheDocument();
+    });
+
+    it('shows the filename row when DOWNLOADING reports a current file', () => {
+        renderOverlay({
+            currentFileName: 'db.sqlite',
+            numberOfFiles: 3,
+            percentOfCurrent: 0,
+            finishedFiles: 0,
+            status: FileStatus.DOWNLOADING,
+            bytesTransferred: 0,
+            bytesTotal: 200,
+            currentFileSize: 183 * 1024 * 1024,
+        });
+
+        expect(screen.getByText('db.sqlite')).toBeInTheDocument();
+        expect(screen.queryByText(/Preparing transfer/)).not.toBeInTheDocument();
+    });
+
+    // Uploads stream as a single multipart request, so currentFileName stays
+    // empty throughout. Don't introduce a "Preparing transfer" line that would
+    // persist for the whole upload — the placeholder is scoped to STARTED.
+    it('does not show the placeholder for UPLOADING with no filename', () => {
+        renderOverlay({
+            currentFileName: '',
+            numberOfFiles: 5,
+            percentOfCurrent: 0,
+            finishedFiles: 0,
+            status: FileStatus.UPLOADING,
+            bytesTransferred: 64_000,
+            bytesTotal: 1_024_000,
+        });
+
+        expect(screen.queryByText(/Preparing transfer/)).not.toBeInTheDocument();
+    });
+});

--- a/tests/getFileStatusLabel.spec.ts
+++ b/tests/getFileStatusLabel.spec.ts
@@ -8,7 +8,7 @@ import { FileStatus } from '../src/model/APIData';
 
 describe('getFileStatusLabel', () => {
     it.each<[FileStatus, string]>([
-        [FileStatus.STARTED, 'Starting'],
+        [FileStatus.STARTED, 'Preparing\u2026'],
         [FileStatus.DOWNLOADING, 'Downloading'],
         [FileStatus.UPLOADING, 'Uploading'],
         [FileStatus.FINISHED, 'Finished'],


### PR DESCRIPTION
Outputs some text initially so the height doesn't shift.

Simplifies ProgressBar component.

<img width="1264" height="558" alt="Screenshot 2026-05-27 at 14 19 40" src="https://github.com/user-attachments/assets/8dfbf1fa-2d42-4985-84f9-171d4209d140" />


Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1599.