### PR TITLE
Allow input/output tensor details to be view in performance table

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,8 @@
         <script>
             /* SERVER_CONFIG */
         </script>
-
     </head>
-    <body>
-
-
+    <body class="bp6-dark">
         <div id="root"></div>
 
         <script

--- a/src/components/BufferDetails.tsx
+++ b/src/components/BufferDetails.tsx
@@ -25,6 +25,8 @@ interface BufferDetailsProps {
     className?: string;
 }
 
+// TODO: The tensor-details table below largely duplicates the one in PerfTensorRow.tsx.
+// Extract a shared TensorDetailsTable both can consume so the two don't drift.
 function BufferDetails({ tensor, operations, className }: BufferDetailsProps) {
     const { address, dtype, layout, shape } = tensor;
     const firstOperationId = tensor.producers[0];

--- a/src/components/BufferDetails.tsx
+++ b/src/components/BufferDetails.tsx
@@ -5,13 +5,14 @@
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import { Operation, OperationDescription, Tensor } from '../model/APIData';
+import { OperationDescription, Tensor } from '../model/APIData';
 import { getMemoryAddress } from '../functions/math';
 import { toReadableShape, toReadableType } from '../functions/formatting';
 import ROUTES from '../definitions/Routes';
 import 'styles/components/BufferDetails.scss';
 import getDeallocationOperation from '../functions/getDeallocationOperation';
 import getNextAllocationOperation from '../functions/getNextAllocationOperation';
+import { getLastConsumerLink, getOperationLink } from '../functions/getOperationLink';
 import isValidNumber from '../functions/isValidNumber';
 import { ShardSpec } from '../functions/parseMemoryConfig';
 import MemoryConfigRow from './MemoryConfigRow';
@@ -46,7 +47,7 @@ function BufferDetails({ tensor, operations, className }: BufferDetailsProps) {
                         <th>Producer</th>
                         <td>
                             {isValidNumber(firstOperationId)
-                                ? getFirstOperation(firstOperationId, operations)
+                                ? getOperationLink(firstOperationId, operations)
                                 : 'No producer for this tensor'}
                         </td>
                     </tr>
@@ -55,7 +56,7 @@ function BufferDetails({ tensor, operations, className }: BufferDetailsProps) {
                         <th>Last consumer</th>
                         <td>
                             {isValidNumber(lastOperationId)
-                                ? getLastOperation(lastOperationId, operations, tensor)
+                                ? getLastConsumerLink(tensor, operations)
                                 : 'No consumers for this tensor'}
                         </td>
                     </tr>
@@ -153,30 +154,6 @@ function BufferDetails({ tensor, operations, className }: BufferDetailsProps) {
             </table>
         </>
     );
-}
-
-function getFirstOperation(operationId: number, operations: Operation[]) {
-    const op = operations.find((operation) => operation.id === operationId);
-
-    return op ? (
-        <Link to={`${ROUTES.OPERATIONS}/${op.id}`}>
-            {op?.id} {op.name} ({op.operationFileIdentifier})
-        </Link>
-    ) : null;
-}
-
-function getLastOperation(operationId: number, operations: Operation[], tensor: Tensor) {
-    let op = operations.find((operation) => operation.id === operationId);
-
-    if (op?.name.includes('deallocate') && tensor.consumers.length > 1) {
-        op = operations.find((operation) => operation.id === tensor.consumers[tensor.consumers.length - 2]);
-    }
-
-    return op ? (
-        <Link to={`${ROUTES.OPERATIONS}/${op.id}`}>
-            {op?.id} {op.name} ({op.operationFileIdentifier})
-        </Link>
-    ) : null;
 }
 
 export default BufferDetails;

--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -40,6 +40,7 @@ const FeedbackButton = () => {
     return (
         <>
             <Button
+                // bp6-intent-none does not exist in Blueprint CLASSES object
                 className={classNames('feedback-button bp6-intent-none', {
                     'animate-in': isInitialState,
                     'user-is-interacting': isUserInteracting,

--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -40,11 +40,11 @@ const FeedbackButton = () => {
     return (
         <>
             <Button
-                // bp6-intent-none does not exist in Blueprint CLASSES object
-                className={classNames('feedback-button bp6-intent-none', {
+                className={classNames('feedback-button', {
                     'animate-in': isInitialState,
                     'user-is-interacting': isUserInteracting,
                 })}
+                intent={Intent.PRIMARY}
                 text='Feedback'
                 endIcon={IconNames.COMMENT}
                 onClick={() => setIsDialogOpen(true)}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { Link, useLocation } from 'react-router-dom';
-import { Classes } from '@blueprintjs/core';
 import { Helmet } from 'react-helmet-async';
 import { Theme, ToastContainer, ToastPosition, cssTransition } from 'react-toastify';
 import 'styles/components/ToastOverrides.scss';
@@ -29,7 +28,7 @@ function Layout() {
     const state = location.state as { background?: Location };
 
     return (
-        <div className={Classes.DARK}>
+        <>
             <Helmet
                 defaultTitle='TT-NN Visualizer'
                 titleTemplate='%s | TT-NN Visualizer'
@@ -83,7 +82,7 @@ function Layout() {
                 theme={'light' as Theme}
                 transition={BounceIn}
             />
-        </div>
+        </>
     );
 }
 

--- a/src/components/MemoryConfigRow.tsx
+++ b/src/components/MemoryConfigRow.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { toReadableLayout } from '../functions/formatting';
 import { MEMORY_CONFIG_HEADERS, MemoryKeys, ShardSpec, getMemoryConfigHeader } from '../functions/parseMemoryConfig';
 
 interface MemoryConfigRowProps {
@@ -37,7 +38,11 @@ const MemoryConfigRow = ({ header, value }: MemoryConfigRowProps) => {
             ) : (
                 <>
                     <th>{getMemoryConfigHeader(header as MemoryKeys)}</th>
-                    <td>{value as string}</td>
+                    <td>
+                        {header === 'memory_layout' && typeof value === 'string'
+                            ? toReadableLayout(value)
+                            : (value as string)}
+                    </td>
                 </>
             )}
         </tr>

--- a/src/components/buffer-summary/BufferSummaryRow.tsx
+++ b/src/components/buffer-summary/BufferSummaryRow.tsx
@@ -11,7 +11,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { Buffer, Tensor } from '../../model/APIData';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { formatMemorySize, getMemoryAddress } from '../../functions/math';
-import { toReadableShape, toReadableType } from '../../functions/formatting';
+import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
 import { showHexAtom } from '../../store/app';
 import useBufferFocus from '../../hooks/useBufferFocus';
 import { getDimmedColour } from '../../functions/colour';
@@ -190,7 +190,7 @@ const BufferSummaryRow = ({
                             {interactiveBuffer.tensor?.dtype ? toReadableType(interactiveBuffer.tensor.dtype) : ''}{' '}
                             <br />
                             {interactiveBuffer.tensor?.memory_config?.memory_layout
-                                ? interactiveBuffer.tensor?.memory_config?.memory_layout
+                                ? toReadableLayout(interactiveBuffer.tensor.memory_config.memory_layout)
                                 : null}
                             <br />
                             {tensor}

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -7,7 +7,7 @@ import 'highlight.js/styles/a11y-dark.css';
 import 'styles/components/NPEComponent.scss';
 import 'styles/components/NPEZoneFilterComponent.scss';
 import { useEffect, useMemo, useState } from 'react';
-import { Button, ButtonGroup, ButtonVariant, Intent, Size, Slider, Switch } from '@blueprintjs/core';
+import { Button, ButtonGroup, ButtonVariant, Classes, Intent, Size, Slider, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { Fragment } from 'react/jsx-runtime';
@@ -562,7 +562,7 @@ const NPEView = ({ npeData }: NPEViewProps) => {
                         onChange={(value: number) => handleScrubberChange(value)}
                     />
                     <div
-                        className='bp6-slider-progress duplicate'
+                        className={classNames(Classes.SLIDER_PROGRESS, 'duplicate')}
                         style={{ width: `${canvasWidth - RIGHT_MARGIN_OFFSET_PX}px` }}
                     />
                 </div>

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -680,6 +680,7 @@ const PerformanceReport = ({
                                         hiliteHighDispatch={hiliteHighDispatch}
                                         reportName={report}
                                         showHashColumn={false}
+                                        activeReportComparisonIndex={0}
                                     />
                                 )
                             }

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -2,12 +2,14 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Fragment, useMemo } from 'react';
-import classNames from 'classnames';
 import { Button, ButtonVariant, Icon, Intent, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useNavigate } from 'react-router';
+import classNames from 'classnames';
 import { useAtom, useAtomValue } from 'jotai';
+import { Fragment, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import 'styles/components/PerfReport.scss';
+import { OpType, PATTERN_COUNT } from '../../definitions/Performance';
 import {
     ColumnDefinition,
     ColumnKeys,
@@ -16,20 +18,18 @@ import {
     TypedPerfTableRow,
     comparisonKeys,
 } from '../../definitions/PerfTable';
-import 'styles/components/PerfReport.scss';
-import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList } from '../../hooks/useAPI';
+import ROUTES from '../../definitions/Routes';
+import { TEST_IDS } from '../../definitions/TestIds';
+import { formatPercentage, formatSize } from '../../functions/math';
 import { formatCell, isHostOp } from '../../functions/perfFunctions';
+import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList } from '../../hooks/useAPI';
 import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
 import { OperationDescription } from '../../model/APIData';
-import ROUTES from '../../definitions/Routes';
-import { formatPercentage, formatSize } from '../../functions/math';
-import PerfDeviceArchitecture from './PerfDeviceArchitecture';
 import { hideHostOpsAtom, mergeDevicesAtom, selectedPerfRowIdAtom } from '../../store/app';
 import LoadingSpinner from '../LoadingSpinner';
-import { OpType, PATTERN_COUNT } from '../../definitions/Performance';
+import PerfDeviceArchitecture from './PerfDeviceArchitecture';
 import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
 import PerfTensorDrawer from './PerfTensorDrawer';
-import { TEST_IDS } from '../../definitions/TestIds';
 
 interface PerformanceTableProps {
     data: TypedPerfTableRow[];
@@ -97,8 +97,13 @@ const PerformanceTable = ({
 
     const isReportsSynced = opIdsMap.length > 0;
 
-    const canShowTensorDrawer = (row: TypedPerfTableRow): boolean =>
-        isReportsSynced && row.op_type !== OpType.SIGNPOST && !row.raw_op_code.includes('MISSING') && row.id !== null;
+    useEffect(() => {
+        if (!isReportsSynced && selectedPerfRowId !== null) {
+            setSelectedPerfRowId(null);
+        }
+    }, [isReportsSynced, selectedPerfRowId, setSelectedPerfRowId]);
+
+    const enableTensorDrawer = useMemo(() => isReportsSynced, [isReportsSynced]);
 
     const cellFormattingProxy = (
         row: TypedPerfTableRow,
@@ -165,12 +170,10 @@ const PerformanceTable = ({
                 <table className='perf-table monospace'>
                     <thead className='table-header'>
                         <tr>
-                            {isReportsSynced && (
-                                <th
-                                    className='cell-header'
-                                    aria-label='Tensor details'
-                                />
-                            )}
+                            <th
+                                className='cell-header'
+                                aria-label='Tensor details'
+                            />
                             {visibleColumns.map((h) => {
                                 const targetSortDirection =
                                     // eslint-disable-next-line no-nested-ternary
@@ -246,22 +249,25 @@ const PerformanceTable = ({
                                         'is-selected': row.id === selectedPerfRowId,
                                     })}
                                 >
-                                    {isReportsSynced && (
-                                        <td className='cell'>
-                                            {canShowTensorDrawer(row) ? (
-                                                <Tooltip content='View input/output tensor details'>
-                                                    <Button
-                                                        icon={IconNames.INFO_SIGN}
-                                                        variant={ButtonVariant.MINIMAL}
-                                                        size={Size.SMALL}
-                                                        aria-label={`View tensor details for ${row.raw_op_code}`}
-                                                        data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
-                                                        onClick={() => setSelectedPerfRowId(row.id)}
-                                                    />
-                                                </Tooltip>
-                                            ) : null}
-                                        </td>
-                                    )}
+                                    <td className='cell'>
+                                        <Tooltip
+                                            content={
+                                                enableTensorDrawer
+                                                    ? 'View input/output tensor details'
+                                                    : 'Load a synced profiler report to see tensor details'
+                                            }
+                                        >
+                                            <Button
+                                                disabled={!enableTensorDrawer}
+                                                icon={IconNames.INFO_SIGN}
+                                                variant={ButtonVariant.MINIMAL}
+                                                size={Size.SMALL}
+                                                aria-label={`View tensor details for ${row.raw_op_code}`}
+                                                data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
+                                                onClick={() => setSelectedPerfRowId(row.id)}
+                                            />
+                                        </Tooltip>
+                                    </td>
                                     {visibleColumns.map((h) => (
                                         <td
                                             key={h.key}
@@ -287,7 +293,7 @@ const PerformanceTable = ({
                                                 `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
                                             )}
                                         >
-                                            {isReportsSynced && <td className='cell' />}
+                                            <td className='cell' />
                                             {visibleColumns.map((h) => (
                                                 <td
                                                     key={h.key}
@@ -305,7 +311,7 @@ const PerformanceTable = ({
                                 {provideMatmulAdvice && row.op_code.includes('Matmul') && (
                                     <tr>
                                         <td
-                                            colSpan={visibleColumns.length + (isReportsSynced ? 1 : 0)}
+                                            colSpan={visibleColumns.length + 1}
                                             className='cell advice'
                                         >
                                             <ul>
@@ -322,7 +328,7 @@ const PerformanceTable = ({
 
                     <tfoot className='table-footer'>
                         <tr>
-                            {isReportsSynced && <td />}
+                            <td />
                             {visibleColumns.length > 0 &&
                                 data?.length > 0 &&
                                 visibleColumns

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -115,8 +115,14 @@ const PerformanceTable = ({
     useEffect(() => {
         if (!canShowTensorDrawer) {
             setSelectedPerfRowId(null);
+            return;
         }
-    }, [canShowTensorDrawer, setSelectedPerfRowId]);
+
+        // Drop the selection when filters/range no longer include the row
+        if (selectedPerfRowId !== null && !activeReportRows.some((row) => row.id === selectedPerfRowId)) {
+            setSelectedPerfRowId(null);
+        }
+    }, [canShowTensorDrawer, activeReportRows, selectedPerfRowId, setSelectedPerfRowId]);
 
     const getTensorDrawerStatus = (row: TypedPerfTableRow): { canOpen: boolean; reason: string } => {
         if (!isReportsSynced) {

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -40,6 +40,12 @@ interface PerformanceTableProps {
     hiliteHighDispatch: boolean;
     reportName: string | null;
     showHashColumn: boolean;
+    // Identifies which comparison dataset holds the active profiler report's rows. The
+    // tensor-drawer trigger only renders on those rows, since op-id sync from
+    // `useOpToPerfIdFiltered()` and tensor lookups in `useOperationsList()` are both
+    // keyed to the active report. When `null` (default), `data` is the active report
+    // and triggers render on the primary rows.
+    activeReportComparisonIndex?: number | null;
 }
 
 const OP_ID_INSERTION_POINT = 1;
@@ -54,6 +60,7 @@ const PerformanceTable = ({
     hiliteHighDispatch,
     reportName,
     showHashColumn,
+    activeReportComparisonIndex = null,
 }: PerformanceTableProps) => {
     const hideHostOps = useAtomValue(hideHostOpsAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
@@ -98,12 +105,18 @@ const PerformanceTable = ({
     ];
 
     const isReportsSynced = opIdsMap.length > 0;
+    const isPrimaryActiveReport = activeReportComparisonIndex === null;
+    const activeReportRows = useMemo<TypedPerfTableRow[]>(
+        () => (isPrimaryActiveReport ? tableFields : (comparisonDataTableFields[activeReportComparisonIndex] ?? [])),
+        [isPrimaryActiveReport, tableFields, comparisonDataTableFields, activeReportComparisonIndex],
+    );
+    const canShowTensorDrawer = isReportsSynced && activeReportRows.length > 0;
 
     useEffect(() => {
-        if (!isReportsSynced) {
+        if (!canShowTensorDrawer) {
             setSelectedPerfRowId(null);
         }
-    }, [isReportsSynced, setSelectedPerfRowId]);
+    }, [canShowTensorDrawer, setSelectedPerfRowId]);
 
     const getTensorDrawerStatus = (row: TypedPerfTableRow): { canOpen: boolean; reason: string } => {
         if (!isReportsSynced) {
@@ -119,6 +132,32 @@ const PerformanceTable = ({
         }
 
         return { canOpen: true, reason: 'View input/output tensor details' };
+    };
+
+    const renderTensorDrawerTrigger = (row: TypedPerfTableRow) => {
+        if (row.op_type === OpType.SIGNPOST) {
+            return null;
+        }
+
+        const status = getTensorDrawerStatus(row);
+
+        return (
+            <Tooltip content={status.reason}>
+                {/* span wrapper lets the Tooltip attach to disabled buttons (Blueprint quirk) */}
+                <span className='perf-tensor-trigger-wrapper'>
+                    <Button
+                        className='perf-tensor-trigger'
+                        disabled={!status.canOpen}
+                        icon={IconNames.FLOW_LINEAR}
+                        variant={ButtonVariant.MINIMAL}
+                        size={Size.SMALL}
+                        aria-label={`View tensor details for ${row.raw_op_code}`}
+                        data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
+                        onClick={() => setSelectedPerfRowId(row.id)}
+                    />
+                </span>
+            </Tooltip>
+        );
     };
 
     const cellFormattingProxy = (
@@ -258,7 +297,7 @@ const PerformanceTable = ({
                     <tbody>
                         {tableFields?.map((row, i) => {
                             const isSignpost = row.op_type === OpType.SIGNPOST;
-                            const tensorDrawerStatus = getTensorDrawerStatus(row);
+                            const isPrimarySelected = isPrimaryActiveReport && row.id === selectedPerfRowId;
 
                             return (
                                 <Fragment key={i}>
@@ -266,27 +305,11 @@ const PerformanceTable = ({
                                         className={classNames({
                                             'missing-data': row.raw_op_code.includes('MISSING'),
                                             'signpost-op': isSignpost,
-                                            'is-selected': row.id === selectedPerfRowId,
+                                            'is-selected': isPrimarySelected,
                                         })}
                                     >
                                         <td className='cell'>
-                                            {!isSignpost && (
-                                                <Tooltip content={tensorDrawerStatus.reason}>
-                                                    {/* span wrapper lets the Tooltip attach to disabled buttons (Blueprint quirk) */}
-                                                    <span className='perf-tensor-trigger-wrapper'>
-                                                        <Button
-                                                            className='perf-tensor-trigger'
-                                                            disabled={!tensorDrawerStatus.canOpen}
-                                                            icon={IconNames.FLOW_LINEAR}
-                                                            variant={ButtonVariant.MINIMAL}
-                                                            size={Size.SMALL}
-                                                            aria-label={`View tensor details for ${row.raw_op_code}`}
-                                                            data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
-                                                            onClick={() => setSelectedPerfRowId(row.id)}
-                                                        />
-                                                    </span>
-                                                </Tooltip>
-                                            )}
+                                            {isPrimaryActiveReport && renderTensorDrawerTrigger(row)}
                                         </td>
                                         {visibleColumns.map((h) => (
                                             <td
@@ -301,33 +324,45 @@ const PerformanceTable = ({
                                     </tr>
 
                                     {comparisonDataTableFields?.length > 0 &&
-                                        comparisonDataTableFields.map((dataset, index) => (
-                                            <tr
-                                                key={`comparison-${i}-${index}`}
-                                                className={classNames(
-                                                    {
-                                                        'missing-data': dataset[i]?.raw_op_code?.includes('MISSING'),
-                                                        'signpost-op': dataset[i]?.op_type === OpType.SIGNPOST,
-                                                    },
-                                                    'comparison-row',
-                                                    `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
-                                                )}
-                                            >
-                                                <td className='cell' />
-                                                {visibleColumns.map((h) => (
-                                                    <td
-                                                        key={h.key}
-                                                        className={classNames('cell', {
-                                                            'align-right': h.key === ColumnKeys.MathFidelity,
-                                                        })}
-                                                    >
-                                                        {comparisonKeys.includes(h.key) &&
-                                                            dataset[i] &&
-                                                            formatCell(dataset[i], h, operationsList, filters?.[h.key])}
+                                        comparisonDataTableFields.map((dataset, index) => {
+                                            const subRow = dataset[i];
+                                            const isActiveReportRow = index === activeReportComparisonIndex;
+                                            const isSubRowSelected =
+                                                isActiveReportRow && subRow?.id === selectedPerfRowId;
+
+                                            return (
+                                                <tr
+                                                    key={`comparison-${i}-${index}`}
+                                                    className={classNames(
+                                                        {
+                                                            'missing-data': subRow?.raw_op_code?.includes('MISSING'),
+                                                            'signpost-op': subRow?.op_type === OpType.SIGNPOST,
+                                                            'is-selected': isSubRowSelected,
+                                                        },
+                                                        'comparison-row',
+                                                        `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
+                                                    )}
+                                                >
+                                                    <td className='cell'>
+                                                        {isActiveReportRow && subRow
+                                                            ? renderTensorDrawerTrigger(subRow)
+                                                            : null}
                                                     </td>
-                                                ))}
-                                            </tr>
-                                        ))}
+                                                    {visibleColumns.map((h) => (
+                                                        <td
+                                                            key={h.key}
+                                                            className={classNames('cell', {
+                                                                'align-right': h.key === ColumnKeys.MathFidelity,
+                                                            })}
+                                                        >
+                                                            {comparisonKeys.includes(h.key) &&
+                                                                subRow &&
+                                                                formatCell(subRow, h, operationsList, filters?.[h.key])}
+                                                        </td>
+                                                    ))}
+                                                </tr>
+                                            );
+                                        })}
                                     {provideMatmulAdvice && row.op_code.includes('Matmul') && (
                                         <tr>
                                             <td
@@ -374,7 +409,7 @@ const PerformanceTable = ({
                 </p>
             )}
 
-            {isReportsSynced && <PerfTensorDrawer rows={tableFields} />}
+            {canShowTensorDrawer && <PerfTensorDrawer rows={activeReportRows} />}
         </>
     );
 };

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Button, ButtonVariant, Icon, Intent, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useNavigate } from 'react-router';
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import {
     ColumnDefinition,
     ColumnKeys,
@@ -24,10 +24,12 @@ import { OperationDescription } from '../../model/APIData';
 import ROUTES from '../../definitions/Routes';
 import { formatPercentage, formatSize } from '../../functions/math';
 import PerfDeviceArchitecture from './PerfDeviceArchitecture';
-import { hideHostOpsAtom, mergeDevicesAtom } from '../../store/app';
+import { hideHostOpsAtom, mergeDevicesAtom, selectedPerfRowIdAtom } from '../../store/app';
 import LoadingSpinner from '../LoadingSpinner';
 import { OpType, PATTERN_COUNT } from '../../definitions/Performance';
 import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
+import PerfTensorDrawer from './PerfTensorDrawer';
+import { TEST_IDS } from '../../definitions/TestIds';
 
 interface PerformanceTableProps {
     data: TypedPerfTableRow[];
@@ -54,6 +56,7 @@ const PerformanceTable = ({
 }: PerformanceTableProps) => {
     const hideHostOps = useAtomValue(hideHostOpsAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
+    const [selectedPerfRowId, setSelectedPerfRowId] = useAtom(selectedPerfRowIdAtom);
 
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(null);
     const opIdsMap = useOpToPerfIdFiltered();
@@ -91,6 +94,11 @@ const PerformanceTable = ({
         ...Columns.slice(CACHE_HIT_INSERTION_POINT),
         ...(npeManifest && npeManifest.length > 0 ? [{ name: 'NPE', key: ColumnKeys.GlobalCallCount }] : []),
     ];
+
+    const isReportsSynced = opIdsMap.length > 0;
+
+    const canShowTensorDrawer = (row: TypedPerfTableRow): boolean =>
+        isReportsSynced && row.op_type !== OpType.SIGNPOST && !row.raw_op_code.includes('MISSING') && row.id !== null;
 
     const cellFormattingProxy = (
         row: TypedPerfTableRow,
@@ -157,6 +165,12 @@ const PerformanceTable = ({
                 <table className='perf-table monospace'>
                     <thead className='table-header'>
                         <tr>
+                            {isReportsSynced && (
+                                <th
+                                    className='cell-header'
+                                    aria-label='Tensor details'
+                                />
+                            )}
                             {visibleColumns.map((h) => {
                                 const targetSortDirection =
                                     // eslint-disable-next-line no-nested-ternary
@@ -229,8 +243,25 @@ const PerformanceTable = ({
                                     className={classNames({
                                         'missing-data': row.raw_op_code.includes('MISSING'),
                                         'signpost-op': row.op_type === OpType.SIGNPOST,
+                                        'is-selected': row.id === selectedPerfRowId,
                                     })}
                                 >
+                                    {isReportsSynced && (
+                                        <td className='cell'>
+                                            {canShowTensorDrawer(row) ? (
+                                                <Tooltip content='View input/output tensor details'>
+                                                    <Button
+                                                        icon={IconNames.INFO_SIGN}
+                                                        variant={ButtonVariant.MINIMAL}
+                                                        size={Size.SMALL}
+                                                        aria-label={`View tensor details for ${row.raw_op_code}`}
+                                                        data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
+                                                        onClick={() => setSelectedPerfRowId(row.id)}
+                                                    />
+                                                </Tooltip>
+                                            ) : null}
+                                        </td>
+                                    )}
                                     {visibleColumns.map((h) => (
                                         <td
                                             key={h.key}
@@ -256,6 +287,7 @@ const PerformanceTable = ({
                                                 `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
                                             )}
                                         >
+                                            {isReportsSynced && <td className='cell' />}
                                             {visibleColumns.map((h) => (
                                                 <td
                                                     key={h.key}
@@ -273,7 +305,7 @@ const PerformanceTable = ({
                                 {provideMatmulAdvice && row.op_code.includes('Matmul') && (
                                     <tr>
                                         <td
-                                            colSpan={visibleColumns.length}
+                                            colSpan={visibleColumns.length + (isReportsSynced ? 1 : 0)}
                                             className='cell advice'
                                         >
                                             <ul>
@@ -290,6 +322,7 @@ const PerformanceTable = ({
 
                     <tfoot className='table-footer'>
                         <tr>
+                            {isReportsSynced && <td />}
                             {visibleColumns.length > 0 &&
                                 data?.length > 0 &&
                                 visibleColumns
@@ -313,6 +346,8 @@ const PerformanceTable = ({
                     <em>No data to display</em>
                 </p>
             )}
+
+            {isReportsSynced && <PerfTensorDrawer rows={tableFields} />}
         </>
     );
 };

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -5,7 +5,7 @@
 import { Button, ButtonVariant, Icon, Intent, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { Fragment, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import 'styles/components/PerfReport.scss';
@@ -20,6 +20,7 @@ import {
 } from '../../definitions/PerfTable';
 import ROUTES from '../../definitions/Routes';
 import { TEST_IDS } from '../../definitions/TestIds';
+import isValidNumber from '../../functions/isValidNumber';
 import { formatPercentage, formatSize } from '../../functions/math';
 import { formatCell, isHostOp } from '../../functions/perfFunctions';
 import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList } from '../../hooks/useAPI';
@@ -56,7 +57,8 @@ const PerformanceTable = ({
 }: PerformanceTableProps) => {
     const hideHostOps = useAtomValue(hideHostOpsAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
-    const [selectedPerfRowId, setSelectedPerfRowId] = useAtom(selectedPerfRowIdAtom);
+    const selectedPerfRowId = useAtomValue(selectedPerfRowIdAtom);
+    const setSelectedPerfRowId = useSetAtom(selectedPerfRowIdAtom);
 
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(null);
     const opIdsMap = useOpToPerfIdFiltered();
@@ -98,12 +100,26 @@ const PerformanceTable = ({
     const isReportsSynced = opIdsMap.length > 0;
 
     useEffect(() => {
-        if (!isReportsSynced && selectedPerfRowId !== null) {
+        if (!isReportsSynced) {
             setSelectedPerfRowId(null);
         }
-    }, [isReportsSynced, selectedPerfRowId, setSelectedPerfRowId]);
+    }, [isReportsSynced, setSelectedPerfRowId]);
 
-    const enableTensorDrawer = useMemo(() => isReportsSynced, [isReportsSynced]);
+    const getTensorDrawerStatus = (row: TypedPerfTableRow): { canOpen: boolean; reason: string } => {
+        if (!isReportsSynced) {
+            return { canOpen: false, reason: 'Load a synced profiler report to see tensor details' };
+        }
+
+        if (row.raw_op_code.includes('MISSING')) {
+            return { canOpen: false, reason: 'No tensor data for missing operations' };
+        }
+
+        if (!isValidNumber(row.op)) {
+            return { canOpen: false, reason: 'No linked profiler operation for this row' };
+        }
+
+        return { canOpen: true, reason: 'View input/output tensor details' };
+    };
 
     const cellFormattingProxy = (
         row: TypedPerfTableRow,
@@ -240,90 +256,94 @@ const PerformanceTable = ({
                     </thead>
 
                     <tbody>
-                        {tableFields?.map((row, i) => (
-                            <Fragment key={i}>
-                                <tr
-                                    className={classNames({
-                                        'missing-data': row.raw_op_code.includes('MISSING'),
-                                        'signpost-op': row.op_type === OpType.SIGNPOST,
-                                        'is-selected': row.id === selectedPerfRowId,
-                                    })}
-                                >
-                                    <td className='cell'>
-                                        <Tooltip
-                                            content={
-                                                enableTensorDrawer
-                                                    ? 'View input/output tensor details'
-                                                    : 'Load a synced profiler report to see tensor details'
-                                            }
-                                        >
-                                            <Button
-                                                disabled={!enableTensorDrawer}
-                                                icon={IconNames.INFO_SIGN}
-                                                variant={ButtonVariant.MINIMAL}
-                                                size={Size.SMALL}
-                                                aria-label={`View tensor details for ${row.raw_op_code}`}
-                                                data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
-                                                onClick={() => setSelectedPerfRowId(row.id)}
-                                            />
-                                        </Tooltip>
-                                    </td>
-                                    {visibleColumns.map((h) => (
-                                        <td
-                                            key={h.key}
-                                            className={classNames('cell', {
-                                                'align-right': h.key === ColumnKeys.MathFidelity,
-                                            })}
-                                        >
-                                            {cellFormattingProxy(row, h, operationsList, filters?.[h.key])}
-                                        </td>
-                                    ))}
-                                </tr>
+                        {tableFields?.map((row, i) => {
+                            const isSignpost = row.op_type === OpType.SIGNPOST;
+                            const tensorDrawerStatus = getTensorDrawerStatus(row);
 
-                                {comparisonDataTableFields?.length > 0 &&
-                                    comparisonDataTableFields.map((dataset, index) => (
-                                        <tr
-                                            key={`comparison-${i}-${index}`}
-                                            className={classNames(
-                                                {
-                                                    'missing-data': dataset[i]?.raw_op_code?.includes('MISSING'),
-                                                    'signpost-op': dataset[i]?.op_type === OpType.SIGNPOST,
-                                                },
-                                                'comparison-row',
-                                                `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
+                            return (
+                                <Fragment key={i}>
+                                    <tr
+                                        className={classNames({
+                                            'missing-data': row.raw_op_code.includes('MISSING'),
+                                            'signpost-op': isSignpost,
+                                            'is-selected': row.id === selectedPerfRowId,
+                                        })}
+                                    >
+                                        <td className='cell'>
+                                            {!isSignpost && (
+                                                <Tooltip content={tensorDrawerStatus.reason}>
+                                                    {/* span wrapper lets the Tooltip attach to disabled buttons (Blueprint quirk) */}
+                                                    <span className='perf-tensor-trigger-wrapper'>
+                                                        <Button
+                                                            disabled={!tensorDrawerStatus.canOpen}
+                                                            icon={IconNames.INFO_SIGN}
+                                                            variant={ButtonVariant.MINIMAL}
+                                                            size={Size.SMALL}
+                                                            aria-label={`View tensor details for ${row.raw_op_code}`}
+                                                            data-testid={TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON}
+                                                            onClick={() => setSelectedPerfRowId(row.id)}
+                                                        />
+                                                    </span>
+                                                </Tooltip>
                                             )}
-                                        >
-                                            <td className='cell' />
-                                            {visibleColumns.map((h) => (
-                                                <td
-                                                    key={h.key}
-                                                    className={classNames('cell', {
-                                                        'align-right': h.key === ColumnKeys.MathFidelity,
-                                                    })}
-                                                >
-                                                    {comparisonKeys.includes(h.key) &&
-                                                        dataset[i] &&
-                                                        formatCell(dataset[i], h, operationsList, filters?.[h.key])}
-                                                </td>
-                                            ))}
-                                        </tr>
-                                    ))}
-                                {provideMatmulAdvice && row.op_code.includes('Matmul') && (
-                                    <tr>
-                                        <td
-                                            colSpan={visibleColumns.length + 1}
-                                            className='cell advice'
-                                        >
-                                            <ul>
-                                                {row?.advice.map((advice, j) => (
-                                                    <li key={`advice-${j}`}>{advice}</li>
-                                                ))}
-                                            </ul>
                                         </td>
+                                        {visibleColumns.map((h) => (
+                                            <td
+                                                key={h.key}
+                                                className={classNames('cell', {
+                                                    'align-right': h.key === ColumnKeys.MathFidelity,
+                                                })}
+                                            >
+                                                {cellFormattingProxy(row, h, operationsList, filters?.[h.key])}
+                                            </td>
+                                        ))}
                                     </tr>
-                                )}
-                            </Fragment>
-                        ))}
+
+                                    {comparisonDataTableFields?.length > 0 &&
+                                        comparisonDataTableFields.map((dataset, index) => (
+                                            <tr
+                                                key={`comparison-${i}-${index}`}
+                                                className={classNames(
+                                                    {
+                                                        'missing-data': dataset[i]?.raw_op_code?.includes('MISSING'),
+                                                        'signpost-op': dataset[i]?.op_type === OpType.SIGNPOST,
+                                                    },
+                                                    'comparison-row',
+                                                    `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
+                                                )}
+                                            >
+                                                <td className='cell' />
+                                                {visibleColumns.map((h) => (
+                                                    <td
+                                                        key={h.key}
+                                                        className={classNames('cell', {
+                                                            'align-right': h.key === ColumnKeys.MathFidelity,
+                                                        })}
+                                                    >
+                                                        {comparisonKeys.includes(h.key) &&
+                                                            dataset[i] &&
+                                                            formatCell(dataset[i], h, operationsList, filters?.[h.key])}
+                                                    </td>
+                                                ))}
+                                            </tr>
+                                        ))}
+                                    {provideMatmulAdvice && row.op_code.includes('Matmul') && (
+                                        <tr>
+                                            <td
+                                                colSpan={visibleColumns.length + 1}
+                                                className='cell advice'
+                                            >
+                                                <ul>
+                                                    {row?.advice.map((advice, j) => (
+                                                        <li key={`advice-${j}`}>{advice}</li>
+                                                    ))}
+                                                </ul>
+                                            </td>
+                                        </tr>
+                                    )}
+                                </Fragment>
+                            );
+                        })}
                     </tbody>
 
                     <tfoot className='table-footer'>

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -149,6 +149,7 @@ const PerformanceTable = ({
                         className='perf-tensor-trigger'
                         disabled={!status.canOpen}
                         icon={IconNames.FLOW_LINEAR}
+                        intent={Intent.PRIMARY}
                         variant={ButtonVariant.MINIMAL}
                         size={Size.SMALL}
                         aria-label={`View tensor details for ${row.raw_op_code}`}

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -275,8 +275,9 @@ const PerformanceTable = ({
                                                     {/* span wrapper lets the Tooltip attach to disabled buttons (Blueprint quirk) */}
                                                     <span className='perf-tensor-trigger-wrapper'>
                                                         <Button
+                                                            className='perf-tensor-trigger'
                                                             disabled={!tensorDrawerStatus.canOpen}
-                                                            icon={IconNames.INFO_SIGN}
+                                                            icon={IconNames.FLOW_LINEAR}
                                                             variant={ButtonVariant.MINIMAL}
                                                             size={Size.SMALL}
                                                             aria-label={`View tensor details for ${row.raw_op_code}`}

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useMemo } from 'react';
+import { Button, ButtonVariant, Drawer, DrawerSize, Intent } from '@blueprintjs/core';
+import { useNavigate } from 'react-router-dom';
+import { useAtom } from 'jotai';
+import { IconNames } from '@blueprintjs/icons';
+import { TypedPerfTableRow } from '../../definitions/PerfTable';
+import { TEST_IDS } from '../../definitions/TestIds';
+import ROUTES from '../../definitions/Routes';
+import { useOperationsList } from '../../hooks/useAPI';
+import { selectedPerfRowIdAtom } from '../../store/app';
+import PerfTensorPanel from './PerfTensorPanel';
+import 'styles/components/PerfTensorDrawer.scss';
+
+interface PerfTensorDrawerProps {
+    rows: TypedPerfTableRow[];
+}
+
+function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
+    const [selectedPerfRowId, setSelectedPerfRowId] = useAtom(selectedPerfRowIdAtom);
+    const { data: operations = [] } = useOperationsList();
+    const navigate = useNavigate();
+
+    const selectedRow = useMemo(
+        () => rows.find((row) => row.id === selectedPerfRowId) ?? null,
+        [rows, selectedPerfRowId],
+    );
+
+    const matchedOperation = useMemo(() => {
+        if (!selectedRow?.op) {
+            return null;
+        }
+
+        return operations.find((operation) => operation.id === selectedRow.op) ?? null;
+    }, [operations, selectedRow]);
+
+    const handleClose = () => {
+        setSelectedPerfRowId(null);
+    };
+
+    return (
+        <Drawer
+            isOpen={selectedRow !== null}
+            onClose={handleClose}
+            title={
+                selectedRow ? (
+                    <span className='perf-tensor-drawer-title'>
+                        Row {selectedRow.id} — {selectedRow.raw_op_code}
+                    </span>
+                ) : (
+                    'Tensor details'
+                )
+            }
+            size={DrawerSize.SMALL}
+            className='perf-tensor-drawer'
+            data-testid={TEST_IDS.PERF_TENSOR_DRAWER}
+        >
+            <div className='perf-tensor-drawer-content'>
+                {selectedRow ? (
+                    <>
+                        {matchedOperation ? (
+                            <p className='perf-tensor-drawer-op-link'>
+                                <Button
+                                    onClick={() => navigate(`${ROUTES.OPERATIONS}/${matchedOperation.id}`)}
+                                    variant={ButtonVariant.SOLID}
+                                    icon={IconNames.CUBE}
+                                    intent={Intent.PRIMARY}
+                                >
+                                    View operation {matchedOperation.id}: {matchedOperation.name}
+                                </Button>
+                            </p>
+                        ) : null}
+
+                        <PerfTensorPanel
+                            row={selectedRow}
+                            operation={matchedOperation}
+                            operations={operations}
+                        />
+                    </>
+                ) : null}
+            </div>
+        </Drawer>
+    );
+}
+
+export default PerfTensorDrawer;

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -2,10 +2,10 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { Drawer, DrawerSize, Icon } from '@blueprintjs/core';
+import { Button, Drawer, DrawerSize, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import 'styles/components/PerfTensorDrawer.scss';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import ROUTES from '../../definitions/Routes';
@@ -23,6 +23,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
     const selectedPerfRowId = useAtomValue(selectedPerfRowIdAtom);
     const setSelectedPerfRowId = useSetAtom(selectedPerfRowIdAtom);
     const { data: operations = [] } = useOperationsList();
+    const navigate = useNavigate();
 
     const selectedRow = rows.find((row) => row.id === selectedPerfRowId) ?? null;
     const matchedOperation = isValidNumber(selectedRow?.op)
@@ -40,7 +41,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
             title={
                 selectedRow ? (
                     <span className='perf-tensor-drawer-title'>
-                        {selectedRow.id} {selectedRow.raw_op_code}
+                        {matchedOperation?.id} {matchedOperation?.name}
                     </span>
                 ) : (
                     'Tensor details'
@@ -56,15 +57,14 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
                 {matchedOperation ? (
                     <>
                         <p className='perf-tensor-drawer-op-link'>
-                            <Link
-                                className='perf-tensor-drawer-op-link-anchor'
-                                to={`${ROUTES.OPERATIONS}/${matchedOperation.id}`}
+                            <Button
+                                className='navigate-button'
+                                endIcon={IconNames.SEGMENTED_CONTROL}
+                                intent={Intent.PRIMARY}
+                                onClick={() => navigate(`${ROUTES.OPERATIONS}/${matchedOperation.id}`)}
                             >
-                                <Icon icon={IconNames.CUBE} />
-                                <span>
-                                    View operation {matchedOperation.id} {matchedOperation.name}
-                                </span>
-                            </Link>
+                                Memory Details
+                            </Button>
                         </p>
 
                         <PerfTensorPanel

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -48,9 +48,11 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
             }
             size={DrawerSize.SMALL}
             className='perf-tensor-drawer'
-            data-testid={TEST_IDS.PERF_TENSOR_DRAWER}
         >
-            <div className='perf-tensor-drawer-content'>
+            <div
+                className='perf-tensor-drawer-content'
+                data-testid={TEST_IDS.PERF_TENSOR_DRAWER}
+            >
                 {matchedOperation ? (
                     <>
                         <p className='perf-tensor-drawer-op-link'>

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -4,8 +4,7 @@
 
 import { Drawer, DrawerSize, Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useAtom } from 'jotai';
-import { useMemo } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { Link } from 'react-router-dom';
 import 'styles/components/PerfTensorDrawer.scss';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
@@ -21,21 +20,14 @@ interface PerfTensorDrawerProps {
 }
 
 function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
-    const [selectedPerfRowId, setSelectedPerfRowId] = useAtom(selectedPerfRowIdAtom);
+    const selectedPerfRowId = useAtomValue(selectedPerfRowIdAtom);
+    const setSelectedPerfRowId = useSetAtom(selectedPerfRowIdAtom);
     const { data: operations = [] } = useOperationsList();
 
-    const selectedRow = useMemo(
-        () => rows.find((row) => row.id === selectedPerfRowId) ?? null,
-        [rows, selectedPerfRowId],
-    );
-
-    const matchedOperation = useMemo(() => {
-        if (!isValidNumber(selectedRow?.op)) {
-            return null;
-        }
-
-        return operations.find((operation) => operation.id === selectedRow.op) ?? null;
-    }, [operations, selectedRow]);
+    const selectedRow = rows.find((row) => row.id === selectedPerfRowId) ?? null;
+    const matchedOperation = isValidNumber(selectedRow?.op)
+        ? (operations.find((operation) => operation.id === selectedRow.op) ?? null)
+        : null;
 
     const handleClose = () => {
         setSelectedPerfRowId(null);
@@ -68,7 +60,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
                             >
                                 <Icon icon={IconNames.CUBE} />
                                 <span>
-                                    View producer {matchedOperation.id}: {matchedOperation.name}
+                                    View operation {matchedOperation.id}: {matchedOperation.name}
                                 </span>
                             </Link>
                         </p>
@@ -78,7 +70,11 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
                             operations={operations}
                         />
                     </>
-                ) : null}
+                ) : (
+                    <p className='perf-tensor-drawer-empty'>
+                        <em>No linked profiler operation for this row.</em>
+                    </p>
+                )}
             </div>
         </Drawer>
     );

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -40,7 +40,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
             title={
                 selectedRow ? (
                     <span className='perf-tensor-drawer-title'>
-                        Row {selectedRow.id}: {selectedRow.raw_op_code}
+                        {selectedRow.id} {selectedRow.raw_op_code}
                     </span>
                 ) : (
                     'Tensor details'
@@ -62,7 +62,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
                             >
                                 <Icon icon={IconNames.CUBE} />
                                 <span>
-                                    View operation {matchedOperation.id}: {matchedOperation.name}
+                                    View operation {matchedOperation.id} {matchedOperation.name}
                                 </span>
                             </Link>
                         </p>

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -4,7 +4,7 @@
 
 import { Button, Drawer, DrawerSize, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import 'styles/components/PerfTensorDrawer.scss';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
@@ -20,8 +20,7 @@ interface PerfTensorDrawerProps {
 }
 
 function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
-    const selectedPerfRowId = useAtomValue(selectedPerfRowIdAtom);
-    const setSelectedPerfRowId = useSetAtom(selectedPerfRowIdAtom);
+    const [selectedPerfRowId, setSelectedPerfRowId] = useAtom(selectedPerfRowIdAtom);
     const { data: operations = [] } = useOperationsList();
     const navigate = useNavigate();
 

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -2,18 +2,19 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useMemo } from 'react';
-import { Button, ButtonVariant, Drawer, DrawerSize, Intent } from '@blueprintjs/core';
-import { useNavigate } from 'react-router-dom';
-import { useAtom } from 'jotai';
+import { Drawer, DrawerSize, Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
+import { useAtom } from 'jotai';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import 'styles/components/PerfTensorDrawer.scss';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
-import { TEST_IDS } from '../../definitions/TestIds';
 import ROUTES from '../../definitions/Routes';
+import { TEST_IDS } from '../../definitions/TestIds';
+import isValidNumber from '../../functions/isValidNumber';
 import { useOperationsList } from '../../hooks/useAPI';
 import { selectedPerfRowIdAtom } from '../../store/app';
 import PerfTensorPanel from './PerfTensorPanel';
-import 'styles/components/PerfTensorDrawer.scss';
 
 interface PerfTensorDrawerProps {
     rows: TypedPerfTableRow[];
@@ -22,7 +23,6 @@ interface PerfTensorDrawerProps {
 function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
     const [selectedPerfRowId, setSelectedPerfRowId] = useAtom(selectedPerfRowIdAtom);
     const { data: operations = [] } = useOperationsList();
-    const navigate = useNavigate();
 
     const selectedRow = useMemo(
         () => rows.find((row) => row.id === selectedPerfRowId) ?? null,
@@ -30,7 +30,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
     );
 
     const matchedOperation = useMemo(() => {
-        if (!selectedRow?.op) {
+        if (!isValidNumber(selectedRow?.op)) {
             return null;
         }
 
@@ -48,7 +48,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
             title={
                 selectedRow ? (
                     <span className='perf-tensor-drawer-title'>
-                        Row {selectedRow.id} — {selectedRow.raw_op_code}
+                        Row ID {selectedRow.id}: {selectedRow.raw_op_code}
                     </span>
                 ) : (
                     'Tensor details'
@@ -59,23 +59,21 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
             data-testid={TEST_IDS.PERF_TENSOR_DRAWER}
         >
             <div className='perf-tensor-drawer-content'>
-                {selectedRow ? (
+                {matchedOperation ? (
                     <>
-                        {matchedOperation ? (
-                            <p className='perf-tensor-drawer-op-link'>
-                                <Button
-                                    onClick={() => navigate(`${ROUTES.OPERATIONS}/${matchedOperation.id}`)}
-                                    variant={ButtonVariant.SOLID}
-                                    icon={IconNames.CUBE}
-                                    intent={Intent.PRIMARY}
-                                >
-                                    View operation {matchedOperation.id}: {matchedOperation.name}
-                                </Button>
-                            </p>
-                        ) : null}
+                        <p className='perf-tensor-drawer-op-link'>
+                            <Link
+                                className='perf-tensor-drawer-op-link-anchor'
+                                to={`${ROUTES.OPERATIONS}/${matchedOperation.id}`}
+                            >
+                                <Icon icon={IconNames.CUBE} />
+                                <span>
+                                    View producer {matchedOperation.id}: {matchedOperation.name}
+                                </span>
+                            </Link>
+                        </p>
 
                         <PerfTensorPanel
-                            row={selectedRow}
                             operation={matchedOperation}
                             operations={operations}
                         />

--- a/src/components/performance/PerfTensorDrawer.tsx
+++ b/src/components/performance/PerfTensorDrawer.tsx
@@ -40,7 +40,7 @@ function PerfTensorDrawer({ rows }: PerfTensorDrawerProps) {
             title={
                 selectedRow ? (
                     <span className='perf-tensor-drawer-title'>
-                        Row ID {selectedRow.id}: {selectedRow.raw_op_code}
+                        Row {selectedRow.id}: {selectedRow.raw_op_code}
                     </span>
                 ) : (
                     'Tensor details'

--- a/src/components/performance/PerfTensorPanel.tsx
+++ b/src/components/performance/PerfTensorPanel.tsx
@@ -2,129 +2,53 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { Callout, Intent } from '@blueprintjs/core';
-import { TypedPerfTableRow } from '../../definitions/PerfTable';
-import { parsePerfRowTensors } from '../../functions/parsePerfRowTensors';
 import { OperationDescription } from '../../model/APIData';
-import { TEST_IDS } from '../../definitions/TestIds';
 import PerfTensorRow from './PerfTensorRow';
 
 interface PerfTensorPanelProps {
-    row: TypedPerfTableRow;
-    operation: OperationDescription | null;
+    operation: OperationDescription;
     operations: OperationDescription[];
 }
 
-function renderInputSection(
-    isEnriched: boolean,
-    operation: OperationDescription | null,
-    operations: OperationDescription[],
-    basicInputs: ReturnType<typeof parsePerfRowTensors>['inputs'],
-) {
-    if (isEnriched && operation) {
-        if (operation.inputs.length === 0) {
-            return (
-                <p className='perf-tensor-panel-empty'>
-                    <em>No input tensors</em>
-                </p>
-            );
-        }
-
-        return operation.inputs.map((tensor, index) => (
-            <PerfTensorRow
-                key={`input-${tensor.id}-${index}`}
-                mode='enriched'
-                tensor={tensor}
-                operations={operations}
-                label={`Input ${index}`}
-            />
-        ));
-    }
-
-    if (basicInputs.length === 0) {
-        return (
-            <p className='perf-tensor-panel-empty'>
-                <em>No input tensor data</em>
-            </p>
-        );
-    }
-
-    return basicInputs.map((basic) => (
-        <PerfTensorRow
-            key={basic.label}
-            mode='basic'
-            basic={basic}
-        />
-    ));
-}
-
-function renderOutputSection(
-    isEnriched: boolean,
-    operation: OperationDescription | null,
-    operations: OperationDescription[],
-    basicOutputs: ReturnType<typeof parsePerfRowTensors>['outputs'],
-) {
-    if (isEnriched && operation) {
-        if (operation.outputs.length === 0) {
-            return (
-                <p className='perf-tensor-panel-empty'>
-                    <em>No output tensors</em>
-                </p>
-            );
-        }
-
-        return operation.outputs.map((tensor, index) => (
-            <PerfTensorRow
-                key={`output-${tensor.id}-${index}`}
-                mode='enriched'
-                tensor={tensor}
-                operations={operations}
-                label={`Output ${index}`}
-            />
-        ));
-    }
-
-    if (basicOutputs.length === 0) {
-        return (
-            <p className='perf-tensor-panel-empty'>
-                <em>No output tensor data</em>
-            </p>
-        );
-    }
-
-    return basicOutputs.map((basic) => (
-        <PerfTensorRow
-            key={basic.label}
-            mode='basic'
-            basic={basic}
-        />
-    ));
-}
-
-function PerfTensorPanel({ row, operation, operations }: PerfTensorPanelProps) {
-    const isEnriched = operation !== null && row.op !== undefined;
-    const basicTensors = parsePerfRowTensors(row);
-
+function PerfTensorPanel({ operation, operations }: PerfTensorPanelProps) {
     return (
         <div className='perf-tensor-panel'>
-            {!isEnriched ? (
-                <Callout
-                    intent={Intent.PRIMARY}
-                    className='perf-tensor-panel-cta'
-                    data-testid={TEST_IDS.PERF_TENSOR_DRAWER_CTA}
-                >
-                    Load a memory/profiler report to see tensor shapes, addresses, and producer/consumer links.
-                </Callout>
-            ) : null}
-
             <section className='perf-tensor-panel-section'>
                 <h3 className='perf-tensor-panel-heading'>Inputs</h3>
-                {renderInputSection(isEnriched, operation, operations, basicTensors.inputs)}
+
+                {operation.inputs.length > 0 ? (
+                    operation.inputs.map((tensor, index) => (
+                        <PerfTensorRow
+                            key={`input-${tensor.id}-${index}`}
+                            tensor={tensor}
+                            operations={operations}
+                            label={`Input ${index}`}
+                        />
+                    ))
+                ) : (
+                    <p className='perf-tensor-panel-empty'>
+                        <em>No input tensors</em>
+                    </p>
+                )}
             </section>
 
             <section className='perf-tensor-panel-section'>
                 <h3 className='perf-tensor-panel-heading'>Outputs</h3>
-                {renderOutputSection(isEnriched, operation, operations, basicTensors.outputs)}
+
+                {operation.outputs.length > 0 ? (
+                    operation.outputs.map((tensor, index) => (
+                        <PerfTensorRow
+                            key={`output-${tensor.id}-${index}`}
+                            tensor={tensor}
+                            operations={operations}
+                            label={`Output ${index}`}
+                        />
+                    ))
+                ) : (
+                    <p className='perf-tensor-panel-empty'>
+                        <em>No output tensors</em>
+                    </p>
+                )}
             </section>
         </div>
     );

--- a/src/components/performance/PerfTensorPanel.tsx
+++ b/src/components/performance/PerfTensorPanel.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Callout, Intent } from '@blueprintjs/core';
+import { TypedPerfTableRow } from '../../definitions/PerfTable';
+import { parsePerfRowTensors } from '../../functions/parsePerfRowTensors';
+import { OperationDescription } from '../../model/APIData';
+import { TEST_IDS } from '../../definitions/TestIds';
+import PerfTensorRow from './PerfTensorRow';
+
+interface PerfTensorPanelProps {
+    row: TypedPerfTableRow;
+    operation: OperationDescription | null;
+    operations: OperationDescription[];
+}
+
+function renderInputSection(
+    isEnriched: boolean,
+    operation: OperationDescription | null,
+    operations: OperationDescription[],
+    basicInputs: ReturnType<typeof parsePerfRowTensors>['inputs'],
+) {
+    if (isEnriched && operation) {
+        if (operation.inputs.length === 0) {
+            return (
+                <p className='perf-tensor-panel-empty'>
+                    <em>No input tensors</em>
+                </p>
+            );
+        }
+
+        return operation.inputs.map((tensor, index) => (
+            <PerfTensorRow
+                key={`input-${tensor.id}-${index}`}
+                mode='enriched'
+                tensor={tensor}
+                operations={operations}
+                label={`Input ${index}`}
+            />
+        ));
+    }
+
+    if (basicInputs.length === 0) {
+        return (
+            <p className='perf-tensor-panel-empty'>
+                <em>No input tensor data</em>
+            </p>
+        );
+    }
+
+    return basicInputs.map((basic) => (
+        <PerfTensorRow
+            key={basic.label}
+            mode='basic'
+            basic={basic}
+        />
+    ));
+}
+
+function renderOutputSection(
+    isEnriched: boolean,
+    operation: OperationDescription | null,
+    operations: OperationDescription[],
+    basicOutputs: ReturnType<typeof parsePerfRowTensors>['outputs'],
+) {
+    if (isEnriched && operation) {
+        if (operation.outputs.length === 0) {
+            return (
+                <p className='perf-tensor-panel-empty'>
+                    <em>No output tensors</em>
+                </p>
+            );
+        }
+
+        return operation.outputs.map((tensor, index) => (
+            <PerfTensorRow
+                key={`output-${tensor.id}-${index}`}
+                mode='enriched'
+                tensor={tensor}
+                operations={operations}
+                label={`Output ${index}`}
+            />
+        ));
+    }
+
+    if (basicOutputs.length === 0) {
+        return (
+            <p className='perf-tensor-panel-empty'>
+                <em>No output tensor data</em>
+            </p>
+        );
+    }
+
+    return basicOutputs.map((basic) => (
+        <PerfTensorRow
+            key={basic.label}
+            mode='basic'
+            basic={basic}
+        />
+    ));
+}
+
+function PerfTensorPanel({ row, operation, operations }: PerfTensorPanelProps) {
+    const isEnriched = operation !== null && row.op !== undefined;
+    const basicTensors = parsePerfRowTensors(row);
+
+    return (
+        <div className='perf-tensor-panel'>
+            {!isEnriched ? (
+                <Callout
+                    intent={Intent.PRIMARY}
+                    className='perf-tensor-panel-cta'
+                    data-testid={TEST_IDS.PERF_TENSOR_DRAWER_CTA}
+                >
+                    Load a memory/profiler report to see tensor shapes, addresses, and producer/consumer links.
+                </Callout>
+            ) : null}
+
+            <section className='perf-tensor-panel-section'>
+                <h3 className='perf-tensor-panel-heading'>Inputs</h3>
+                {renderInputSection(isEnriched, operation, operations, basicTensors.inputs)}
+            </section>
+
+            <section className='perf-tensor-panel-section'>
+                <h3 className='perf-tensor-panel-heading'>Outputs</h3>
+                {renderOutputSection(isEnriched, operation, operations, basicTensors.outputs)}
+            </section>
+        </div>
+    );
+}
+
+export default PerfTensorPanel;

--- a/src/components/performance/PerfTensorRow.tsx
+++ b/src/components/performance/PerfTensorRow.tsx
@@ -27,7 +27,10 @@ function PerfTensorRow({ tensor, operations, label }: PerfTensorRowProps) {
 
     return (
         <div className='perf-tensor-row'>
-            <h4 className='perf-tensor-row-title'>{label}</h4>
+            <h4 className='perf-tensor-row-title'>
+                {label}{' '}
+                {tensor.buffer_type !== null ? <MemoryTag memory={BufferTypeLabel[tensor.buffer_type]} /> : null}
+            </h4>
 
             <table className='ttnn-table two-tone-rows perf-tensor-row-table'>
                 <tbody>
@@ -73,15 +76,6 @@ function PerfTensorRow({ tensor, operations, label }: PerfTensorRowProps) {
                         <th>Layout</th>
                         <td>{toReadableLayout(tensor.layout)}</td>
                     </tr>
-
-                    {tensor.buffer_type !== null ? (
-                        <tr>
-                            <th>Type</th>
-                            <td>
-                                <MemoryTag memory={BufferTypeLabel[tensor.buffer_type]} />
-                            </td>
-                        </tr>
-                    ) : null}
 
                     {isValidNumber(tensor.address) ? (
                         <tr>

--- a/src/components/performance/PerfTensorRow.tsx
+++ b/src/components/performance/PerfTensorRow.tsx
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Link } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
+import { BasicTensor } from '../../functions/parsePerfRowTensors';
+import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
+import { formatMemorySize, getMemoryAddress } from '../../functions/math';
+import isValidNumber from '../../functions/isValidNumber';
+import { OperationDescription, Tensor } from '../../model/APIData';
+import { BufferType, BufferTypeLabel } from '../../model/BufferType';
+import MemoryTag from '../MemoryTag';
+import MemoryConfigRow from '../MemoryConfigRow';
+import GoldenTensorComparisonIndicator from '../GoldenTensorComparisonIndicator';
+import ROUTES from '../../definitions/Routes';
+import { ShardSpec } from '../../functions/parseMemoryConfig';
+import { showHexAtom } from '../../store/app';
+
+interface PerfTensorRowBasicProps {
+    mode: 'basic';
+    basic: BasicTensor;
+}
+
+interface PerfTensorRowEnrichedProps {
+    mode: 'enriched';
+    tensor: Tensor;
+    operations: OperationDescription[];
+    label: string;
+}
+
+export type PerfTensorRowProps = PerfTensorRowBasicProps | PerfTensorRowEnrichedProps;
+
+function getOperationLink(operationId: number, operations: OperationDescription[]) {
+    const operation = operations.find((entry) => entry.id === operationId);
+
+    if (!operation) {
+        return null;
+    }
+
+    return (
+        <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
+            {operation.id} {operation.name} ({operation.operationFileIdentifier})
+        </Link>
+    );
+}
+
+function getLastConsumerLink(tensor: Tensor, operations: OperationDescription[]) {
+    const lastOperationId = tensor.consumers[tensor.consumers.length - 1];
+
+    if (!isValidNumber(lastOperationId)) {
+        return 'No consumers for this tensor';
+    }
+
+    let operation = operations.find((entry) => entry.id === lastOperationId);
+
+    if (operation?.name.includes('deallocate') && tensor.consumers.length > 1) {
+        operation = operations.find((entry) => entry.id === tensor.consumers[tensor.consumers.length - 2]);
+    }
+
+    return operation ? getOperationLink(operation.id, operations) : null;
+}
+
+function PerfTensorRowBasic({ basic }: { basic: BasicTensor }) {
+    return (
+        <div className='perf-tensor-row perf-tensor-row-basic'>
+            <h4 className='perf-tensor-row-title'>{basic.label}</h4>
+
+            <dl className='perf-tensor-row-fields'>
+                {basic.dtype ? (
+                    <>
+                        <dt>Dtype</dt>
+                        <dd>{toReadableType(basic.dtype)}</dd>
+                    </>
+                ) : null}
+
+                {basic.memory ? (
+                    <>
+                        <dt>Memory</dt>
+                        <dd>{basic.memory}</dd>
+                    </>
+                ) : null}
+
+                {basic.buffer_type !== null ? (
+                    <>
+                        <dt>Type</dt>
+                        <dd>
+                            <MemoryTag memory={BufferTypeLabel[basic.buffer_type]} />
+                        </dd>
+                    </>
+                ) : null}
+
+                {basic.layout ? (
+                    <>
+                        <dt>Layout</dt>
+                        <dd>{basic.layout}</dd>
+                    </>
+                ) : null}
+            </dl>
+        </div>
+    );
+}
+
+function PerfTensorRowEnriched({
+    tensor,
+    operations,
+    label,
+}: {
+    tensor: Tensor;
+    operations: OperationDescription[];
+    label: string;
+}) {
+    const showHex = useAtomValue(showHexAtom);
+    const firstProducerId = tensor.producers[0];
+
+    return (
+        <div className='perf-tensor-row perf-tensor-row-enriched'>
+            <h4 className='perf-tensor-row-title'>{label}</h4>
+
+            <table className='ttnn-table two-tone-rows perf-tensor-row-table'>
+                <tbody>
+                    <tr>
+                        <th>Tensor Id</th>
+                        <td>{tensor.id}</td>
+                    </tr>
+
+                    <tr>
+                        <th>Producer</th>
+                        <td>
+                            {isValidNumber(firstProducerId)
+                                ? getOperationLink(firstProducerId, operations)
+                                : 'No producer for this tensor'}
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th>Last consumer</th>
+                        <td>{getLastConsumerLink(tensor, operations)}</td>
+                    </tr>
+
+                    <tr>
+                        <th>Device Id</th>
+                        <td>{tensor.device_id ?? 'n/a'}</td>
+                    </tr>
+
+                    <tr>
+                        <th>Shape</th>
+                        <td>{toReadableShape(tensor.shape)}</td>
+                    </tr>
+
+                    <tr>
+                        <th>Dtype</th>
+                        <td>{toReadableType(tensor.dtype)}</td>
+                    </tr>
+
+                    <tr>
+                        <th>Layout</th>
+                        <td>{toReadableLayout(tensor.layout)}</td>
+                    </tr>
+
+                    {tensor.buffer_type !== null ? (
+                        <tr>
+                            <th>Type</th>
+                            <td>
+                                <MemoryTag memory={BufferTypeLabel[tensor.buffer_type as BufferType]} />
+                            </td>
+                        </tr>
+                    ) : null}
+
+                    {isValidNumber(tensor.address) ? (
+                        <tr>
+                            <th>Address</th>
+                            <td>{getMemoryAddress(tensor.address, showHex)}</td>
+                        </tr>
+                    ) : null}
+
+                    {tensor.size !== null ? (
+                        <tr>
+                            <th>Size</th>
+                            <td>{formatMemorySize(tensor.size ?? undefined)}</td>
+                        </tr>
+                    ) : null}
+
+                    {tensor.memory_config
+                        ? Object.entries(tensor.memory_config).map(([key, value]) => (
+                              <MemoryConfigRow
+                                  key={key}
+                                  header={key}
+                                  value={value as string | ShardSpec}
+                              />
+                          ))
+                        : null}
+
+                    {tensor.comparison ? (
+                        <>
+                            <tr>
+                                <th>Matches Locally</th>
+                                <td>
+                                    <GoldenTensorComparisonIndicator
+                                        value={tensor.comparison.local.actual_pcc}
+                                        label='Actual PCC:'
+                                    />
+                                    <GoldenTensorComparisonIndicator
+                                        value={tensor.comparison.local.desired_pcc}
+                                        label='Desired PCC:'
+                                    />
+                                </td>
+                            </tr>
+
+                            {tensor.comparison.global ? (
+                                <tr>
+                                    <th>Matches Globally</th>
+                                    <td>
+                                        <GoldenTensorComparisonIndicator
+                                            value={tensor.comparison.global.actual_pcc}
+                                            label='Actual PCC:'
+                                        />
+                                        <GoldenTensorComparisonIndicator
+                                            value={tensor.comparison.global.desired_pcc}
+                                            label='Desired PCC:'
+                                        />
+                                    </td>
+                                </tr>
+                            ) : null}
+                        </>
+                    ) : null}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+function PerfTensorRow(props: PerfTensorRowProps) {
+    const { mode } = props;
+
+    if (mode === 'basic') {
+        const { basic } = props;
+        return <PerfTensorRowBasic basic={basic} />;
+    }
+
+    const { tensor, operations, label } = props;
+
+    return (
+        <PerfTensorRowEnriched
+            tensor={tensor}
+            operations={operations}
+            label={label}
+        />
+    );
+}
+
+export default PerfTensorRow;

--- a/src/components/performance/PerfTensorRow.tsx
+++ b/src/components/performance/PerfTensorRow.tsx
@@ -2,34 +2,25 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { Link } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import { BasicTensor } from '../../functions/parsePerfRowTensors';
-import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
-import { formatMemorySize, getMemoryAddress } from '../../functions/math';
-import isValidNumber from '../../functions/isValidNumber';
-import { OperationDescription, Tensor } from '../../model/APIData';
-import { BufferType, BufferTypeLabel } from '../../model/BufferType';
-import MemoryTag from '../MemoryTag';
-import MemoryConfigRow from '../MemoryConfigRow';
-import GoldenTensorComparisonIndicator from '../GoldenTensorComparisonIndicator';
+import { Link } from 'react-router-dom';
 import ROUTES from '../../definitions/Routes';
+import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
+import isValidNumber from '../../functions/isValidNumber';
+import { formatMemorySize, getMemoryAddress } from '../../functions/math';
 import { ShardSpec } from '../../functions/parseMemoryConfig';
+import { OperationDescription, Tensor } from '../../model/APIData';
+import { BufferTypeLabel } from '../../model/BufferType';
 import { showHexAtom } from '../../store/app';
+import GoldenTensorComparisonIndicator from '../GoldenTensorComparisonIndicator';
+import MemoryConfigRow from '../MemoryConfigRow';
+import MemoryTag from '../MemoryTag';
 
-interface PerfTensorRowBasicProps {
-    mode: 'basic';
-    basic: BasicTensor;
-}
-
-interface PerfTensorRowEnrichedProps {
-    mode: 'enriched';
+export interface PerfTensorRowProps {
     tensor: Tensor;
     operations: OperationDescription[];
     label: string;
 }
-
-export type PerfTensorRowProps = PerfTensorRowBasicProps | PerfTensorRowEnrichedProps;
 
 function getOperationLink(operationId: number, operations: OperationDescription[]) {
     const operation = operations.find((entry) => entry.id === operationId);
@@ -61,60 +52,12 @@ function getLastConsumerLink(tensor: Tensor, operations: OperationDescription[])
     return operation ? getOperationLink(operation.id, operations) : null;
 }
 
-function PerfTensorRowBasic({ basic }: { basic: BasicTensor }) {
-    return (
-        <div className='perf-tensor-row perf-tensor-row-basic'>
-            <h4 className='perf-tensor-row-title'>{basic.label}</h4>
-
-            <dl className='perf-tensor-row-fields'>
-                {basic.dtype ? (
-                    <>
-                        <dt>Dtype</dt>
-                        <dd>{toReadableType(basic.dtype)}</dd>
-                    </>
-                ) : null}
-
-                {basic.memory ? (
-                    <>
-                        <dt>Memory</dt>
-                        <dd>{basic.memory}</dd>
-                    </>
-                ) : null}
-
-                {basic.buffer_type !== null ? (
-                    <>
-                        <dt>Type</dt>
-                        <dd>
-                            <MemoryTag memory={BufferTypeLabel[basic.buffer_type]} />
-                        </dd>
-                    </>
-                ) : null}
-
-                {basic.layout ? (
-                    <>
-                        <dt>Layout</dt>
-                        <dd>{basic.layout}</dd>
-                    </>
-                ) : null}
-            </dl>
-        </div>
-    );
-}
-
-function PerfTensorRowEnriched({
-    tensor,
-    operations,
-    label,
-}: {
-    tensor: Tensor;
-    operations: OperationDescription[];
-    label: string;
-}) {
+function PerfTensorRow({ tensor, operations, label }: PerfTensorRowProps) {
     const showHex = useAtomValue(showHexAtom);
     const firstProducerId = tensor.producers[0];
 
     return (
-        <div className='perf-tensor-row perf-tensor-row-enriched'>
+        <div className='perf-tensor-row'>
             <h4 className='perf-tensor-row-title'>{label}</h4>
 
             <table className='ttnn-table two-tone-rows perf-tensor-row-table'>
@@ -162,7 +105,7 @@ function PerfTensorRowEnriched({
                         <tr>
                             <th>Type</th>
                             <td>
-                                <MemoryTag memory={BufferTypeLabel[tensor.buffer_type as BufferType]} />
+                                <MemoryTag memory={BufferTypeLabel[tensor.buffer_type]} />
                             </td>
                         </tr>
                     ) : null}
@@ -177,7 +120,7 @@ function PerfTensorRowEnriched({
                     {tensor.size !== null ? (
                         <tr>
                             <th>Size</th>
-                            <td>{formatMemorySize(tensor.size ?? undefined)}</td>
+                            <td>{formatMemorySize(tensor.size)}</td>
                         </tr>
                     ) : null}
 
@@ -227,25 +170,6 @@ function PerfTensorRowEnriched({
                 </tbody>
             </table>
         </div>
-    );
-}
-
-function PerfTensorRow(props: PerfTensorRowProps) {
-    const { mode } = props;
-
-    if (mode === 'basic') {
-        const { basic } = props;
-        return <PerfTensorRowBasic basic={basic} />;
-    }
-
-    const { tensor, operations, label } = props;
-
-    return (
-        <PerfTensorRowEnriched
-            tensor={tensor}
-            operations={operations}
-            label={label}
-        />
     );
 }
 

--- a/src/components/performance/PerfTensorRow.tsx
+++ b/src/components/performance/PerfTensorRow.tsx
@@ -21,6 +21,10 @@ export interface PerfTensorRowProps {
     label: string;
 }
 
+// TODO: The tensor-details table below largely duplicates the one in BufferDetails.tsx
+// (Tensor Id, Producer, Last consumer, Device Id, Shape, Dtype, Layout, Address, Size,
+// memory_config, comparison). Extract a shared TensorDetailsTable both can consume so the
+// two don't drift.
 function PerfTensorRow({ tensor, operations, label }: PerfTensorRowProps) {
     const showHex = useAtomValue(showHexAtom);
     const firstProducerId = tensor.producers[0];

--- a/src/components/performance/PerfTensorRow.tsx
+++ b/src/components/performance/PerfTensorRow.tsx
@@ -3,9 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useAtomValue } from 'jotai';
-import { Link } from 'react-router-dom';
-import ROUTES from '../../definitions/Routes';
 import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
+import { getLastConsumerLink, getOperationLink } from '../../functions/getOperationLink';
 import isValidNumber from '../../functions/isValidNumber';
 import { formatMemorySize, getMemoryAddress } from '../../functions/math';
 import { ShardSpec } from '../../functions/parseMemoryConfig';
@@ -20,36 +19,6 @@ export interface PerfTensorRowProps {
     tensor: Tensor;
     operations: OperationDescription[];
     label: string;
-}
-
-function getOperationLink(operationId: number, operations: OperationDescription[]) {
-    const operation = operations.find((entry) => entry.id === operationId);
-
-    if (!operation) {
-        return null;
-    }
-
-    return (
-        <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
-            {operation.id} {operation.name} ({operation.operationFileIdentifier})
-        </Link>
-    );
-}
-
-function getLastConsumerLink(tensor: Tensor, operations: OperationDescription[]) {
-    const lastOperationId = tensor.consumers[tensor.consumers.length - 1];
-
-    if (!isValidNumber(lastOperationId)) {
-        return 'No consumers for this tensor';
-    }
-
-    let operation = operations.find((entry) => entry.id === lastOperationId);
-
-    if (operation?.name.includes('deallocate') && tensor.consumers.length > 1) {
-        operation = operations.find((entry) => entry.id === tensor.consumers[tensor.consumers.length - 2]);
-    }
-
-    return operation ? getOperationLink(operation.id, operations) : null;
 }
 
 function PerfTensorRow({ tensor, operations, label }: PerfTensorRowProps) {
@@ -78,7 +47,11 @@ function PerfTensorRow({ tensor, operations, label }: PerfTensorRowProps) {
 
                     <tr>
                         <th>Last consumer</th>
-                        <td>{getLastConsumerLink(tensor, operations)}</td>
+                        <td>
+                            {isValidNumber(tensor.consumers[tensor.consumers.length - 1])
+                                ? getLastConsumerLink(tensor, operations)
+                                : 'No consumers for this tensor'}
+                        </td>
                     </tr>
 
                     <tr>

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -89,7 +89,6 @@ const LocalFolderPicker = ({
                                 onConfirm={() => handleDelete(folderToDelete)}
                                 cancelButtonText='Cancel'
                                 confirmButtonText='Delete'
-                                className='bp6-dark'
                                 // @ts-expect-error BackdropClassName is not defined in AlertProps
                                 backdropClassName='delete-folder-backdrop'
                             >

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -121,7 +121,6 @@ const RemoteConnectionDialog = ({
                 >
                     <InputGroup
                         id='remote-connection-name'
-                        className='bp6-light'
                         key='name'
                         value={connection.name}
                         onChange={(e) => setConnection({ ...connection, name: e.target.value })}

--- a/src/definitions/TestIds.ts
+++ b/src/definitions/TestIds.ts
@@ -27,6 +27,9 @@ export const TEST_IDS = Object.freeze({
     // Performance components
     PERFORMANCE_CHART: 'performance-chart',
     PERFORMANCE_TABLE: 'performance-table',
+    PERF_TENSOR_DRAWER: 'perf-tensor-drawer',
+    PERF_TENSOR_DRAWER_OPEN_BUTTON: 'perf-tensor-drawer-open-button',
+    PERF_TENSOR_DRAWER_CTA: 'perf-tensor-drawer-cta',
 
     // General UI
     LOADING_SPINNER: 'loading-spinner',

--- a/src/definitions/TestIds.ts
+++ b/src/definitions/TestIds.ts
@@ -29,7 +29,6 @@ export const TEST_IDS = Object.freeze({
     PERFORMANCE_TABLE: 'performance-table',
     PERF_TENSOR_DRAWER: 'perf-tensor-drawer',
     PERF_TENSOR_DRAWER_OPEN_BUTTON: 'perf-tensor-drawer-open-button',
-    PERF_TENSOR_DRAWER_CTA: 'perf-tensor-drawer-cta',
 
     // General UI
     LOADING_SPINNER: 'loading-spinner',

--- a/src/functions/getOperationLink.tsx
+++ b/src/functions/getOperationLink.tsx
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Link } from 'react-router-dom';
+import ROUTES from '../definitions/Routes';
+import { Operation, Tensor } from '../model/APIData';
+
+export const getOperationLink = (operationId: number, operations: Operation[]) => {
+    const operation = operations.find((entry) => entry.id === operationId);
+
+    if (!operation) {
+        return null;
+    }
+
+    return (
+        <Link to={`${ROUTES.OPERATIONS}/${operation.id}`}>
+            {operation.id} {operation.name} ({operation.operationFileIdentifier})
+        </Link>
+    );
+};
+
+/**
+ * The trailing consumer of a tensor is often a `deallocate` op, which is not
+ * a useful target for the user. When that's the case, prefer the consumer one
+ * step earlier in the list so the link points at meaningful work.
+ */
+export const getLastConsumerLink = (tensor: Tensor, operations: Operation[]) => {
+    const lastOperationId = tensor.consumers[tensor.consumers.length - 1];
+    let operation = operations.find((entry) => entry.id === lastOperationId);
+
+    if (operation?.name.includes('deallocate') && tensor.consumers.length > 1) {
+        operation = operations.find((entry) => entry.id === tensor.consumers[tensor.consumers.length - 2]);
+    }
+
+    return operation ? getOperationLink(operation.id, operations) : null;
+};

--- a/src/functions/parsePerfRowTensorAttributes.ts
+++ b/src/functions/parsePerfRowTensorAttributes.ts
@@ -34,7 +34,7 @@ const getBufferType = (type?: string): BufferType | null => {
 const getLayout = (layout?: string): DeviceOperationLayoutTypes | null =>
     layout && KNOWN_LAYOUTS.has(layout) ? (layout as DeviceOperationLayoutTypes) : null;
 
-export const parsePerfRowTensors = (row: Pick<PerfTableRow, 'input_0_memory'>): ParsedPerfRowAttributes => {
+export const parsePerfRowTensorAttributes = (row: Pick<PerfTableRow, 'input_0_memory'>): ParsedPerfRowAttributes => {
     const match = DEV_MEMORY_REGEX.exec(row.input_0_memory);
 
     return {

--- a/src/functions/parsePerfRowTensors.ts
+++ b/src/functions/parsePerfRowTensors.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { PerfTableRow } from '../definitions/PerfTable';
+import { DeviceOperationLayoutTypes } from '../model/APIData';
+import { BufferType } from '../model/BufferType';
+
+const DEV_MEMORY_REGEX = /DEV_(\d+)_(DRAM|L1)_(\w*)/m;
+
+export interface BasicTensor {
+    label: string;
+    dtype: string;
+    memory: string;
+    buffer_type: BufferType | null;
+    layout: DeviceOperationLayoutTypes | null;
+}
+
+export interface ParsedPerfRowTensors {
+    inputs: BasicTensor[];
+    outputs: BasicTensor[];
+    buffer_type: BufferType | null;
+    layout: DeviceOperationLayoutTypes | null;
+}
+
+const getBufferType = (type?: string): BufferType | null => {
+    if (!type) {
+        return null;
+    }
+
+    if (type === 'L1') {
+        return BufferType.L1;
+    }
+
+    if (type === 'DRAM') {
+        return BufferType.DRAM;
+    }
+
+    return null;
+};
+
+const parseMemoryString = (memory: string): Pick<BasicTensor, 'buffer_type' | 'layout'> => {
+    const match = DEV_MEMORY_REGEX.exec(memory);
+
+    return {
+        buffer_type: getBufferType(match?.[2]),
+        layout: match?.[3] ? (match[3] as DeviceOperationLayoutTypes) : null,
+    };
+};
+
+const hasBasicTensorData = (dtype: string, memory: string): boolean => dtype.length > 0 || memory.length > 0;
+
+export const parsePerfRowTensors = (
+    row: Pick<
+        PerfTableRow,
+        | 'input_0_datatype'
+        | 'input_1_datatype'
+        | 'output_datatype'
+        | 'input_0_memory'
+        | 'input_1_memory'
+        | 'output_0_memory'
+    >,
+): ParsedPerfRowTensors => {
+    const inputs: BasicTensor[] = [];
+    const outputs: BasicTensor[] = [];
+
+    if (hasBasicTensorData(row.input_0_datatype, row.input_0_memory)) {
+        inputs.push({
+            label: 'Input 0',
+            dtype: row.input_0_datatype,
+            memory: row.input_0_memory,
+            ...parseMemoryString(row.input_0_memory),
+        });
+    }
+
+    if (hasBasicTensorData(row.input_1_datatype, row.input_1_memory)) {
+        inputs.push({
+            label: 'Input 1',
+            dtype: row.input_1_datatype,
+            memory: row.input_1_memory,
+            ...parseMemoryString(row.input_1_memory),
+        });
+    }
+
+    if (hasBasicTensorData(row.output_datatype, row.output_0_memory)) {
+        outputs.push({
+            label: 'Output',
+            dtype: row.output_datatype,
+            memory: row.output_0_memory,
+            ...parseMemoryString(row.output_0_memory),
+        });
+    }
+
+    const primaryAttributes = parseMemoryString(row.input_0_memory);
+
+    return {
+        inputs,
+        outputs,
+        buffer_type: primaryAttributes.buffer_type,
+        layout: primaryAttributes.layout,
+    };
+};

--- a/src/functions/parsePerfRowTensors.ts
+++ b/src/functions/parsePerfRowTensors.ts
@@ -8,17 +8,7 @@ import { BufferType } from '../model/BufferType';
 
 const DEV_MEMORY_REGEX = /DEV_(\d+)_(DRAM|L1)_(\w*)/m;
 
-export interface BasicTensor {
-    label: string;
-    dtype: string;
-    memory: string;
-    buffer_type: BufferType | null;
-    layout: DeviceOperationLayoutTypes | null;
-}
-
-export interface ParsedPerfRowTensors {
-    inputs: BasicTensor[];
-    outputs: BasicTensor[];
+export interface ParsedPerfRowAttributes {
     buffer_type: BufferType | null;
     layout: DeviceOperationLayoutTypes | null;
 }
@@ -39,64 +29,11 @@ const getBufferType = (type?: string): BufferType | null => {
     return null;
 };
 
-const parseMemoryString = (memory: string): Pick<BasicTensor, 'buffer_type' | 'layout'> => {
-    const match = DEV_MEMORY_REGEX.exec(memory);
+export const parsePerfRowTensors = (row: Pick<PerfTableRow, 'input_0_memory'>): ParsedPerfRowAttributes => {
+    const match = DEV_MEMORY_REGEX.exec(row.input_0_memory);
 
     return {
         buffer_type: getBufferType(match?.[2]),
         layout: match?.[3] ? (match[3] as DeviceOperationLayoutTypes) : null,
-    };
-};
-
-const hasBasicTensorData = (dtype: string, memory: string): boolean => dtype.length > 0 || memory.length > 0;
-
-export const parsePerfRowTensors = (
-    row: Pick<
-        PerfTableRow,
-        | 'input_0_datatype'
-        | 'input_1_datatype'
-        | 'output_datatype'
-        | 'input_0_memory'
-        | 'input_1_memory'
-        | 'output_0_memory'
-    >,
-): ParsedPerfRowTensors => {
-    const inputs: BasicTensor[] = [];
-    const outputs: BasicTensor[] = [];
-
-    if (hasBasicTensorData(row.input_0_datatype, row.input_0_memory)) {
-        inputs.push({
-            label: 'Input 0',
-            dtype: row.input_0_datatype,
-            memory: row.input_0_memory,
-            ...parseMemoryString(row.input_0_memory),
-        });
-    }
-
-    if (hasBasicTensorData(row.input_1_datatype, row.input_1_memory)) {
-        inputs.push({
-            label: 'Input 1',
-            dtype: row.input_1_datatype,
-            memory: row.input_1_memory,
-            ...parseMemoryString(row.input_1_memory),
-        });
-    }
-
-    if (hasBasicTensorData(row.output_datatype, row.output_0_memory)) {
-        outputs.push({
-            label: 'Output',
-            dtype: row.output_datatype,
-            memory: row.output_0_memory,
-            ...parseMemoryString(row.output_0_memory),
-        });
-    }
-
-    const primaryAttributes = parseMemoryString(row.input_0_memory);
-
-    return {
-        inputs,
-        outputs,
-        buffer_type: primaryAttributes.buffer_type,
-        layout: primaryAttributes.layout,
     };
 };

--- a/src/functions/parsePerfRowTensors.ts
+++ b/src/functions/parsePerfRowTensors.ts
@@ -8,6 +8,8 @@ import { BufferType } from '../model/BufferType';
 
 const DEV_MEMORY_REGEX = /DEV_(\d+)_(DRAM|L1)_(\w*)/m;
 
+const KNOWN_LAYOUTS = new Set<string>(Object.values(DeviceOperationLayoutTypes));
+
 export interface ParsedPerfRowAttributes {
     buffer_type: BufferType | null;
     layout: DeviceOperationLayoutTypes | null;
@@ -29,11 +31,14 @@ const getBufferType = (type?: string): BufferType | null => {
     return null;
 };
 
+const getLayout = (layout?: string): DeviceOperationLayoutTypes | null =>
+    layout && KNOWN_LAYOUTS.has(layout) ? (layout as DeviceOperationLayoutTypes) : null;
+
 export const parsePerfRowTensors = (row: Pick<PerfTableRow, 'input_0_memory'>): ParsedPerfRowAttributes => {
     const match = DEV_MEMORY_REGEX.exec(row.input_0_memory);
 
     return {
         buffer_type: getBufferType(match?.[2]),
-        layout: match?.[3] ? (match[3] as DeviceOperationLayoutTypes) : null,
+        layout: getLayout(match?.[3]),
     };
 };

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -36,7 +36,7 @@ import { HIGH_DISPATCH_THRESHOLD_MS, OpType, PerfTabIds } from '../definitions/P
 import { BufferType } from '../model/BufferType';
 import { DeviceOperationLayoutTypes } from '../model/APIData';
 import { StackedColumnKeys, StackedPerfRow, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
-import { parsePerfRowTensors } from '../functions/parsePerfRowTensors';
+import { parsePerfRowTensorAttributes } from '../functions/parsePerfRowTensorAttributes';
 
 const INITIAL_TAB_ID = PerfTabIds.TABLE;
 
@@ -319,7 +319,7 @@ interface RowAttributes {
 }
 
 const getRowAttributes = (row: PerfTableRow): RowAttributes => {
-    const { buffer_type: bufferType, layout } = parsePerfRowTensors(row);
+    const { buffer_type: bufferType, layout } = parsePerfRowTensorAttributes(row);
 
     return {
         buffer_type: bufferType,

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet-async';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Size, Tab, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { HttpStatusCode } from 'axios';
 import getResponseError from '../functions/getResponseError';
 import {
@@ -22,6 +22,7 @@ import {
     activePerformanceReportAtom,
     comparisonPerformanceReportListAtom,
     perfSelectedTabAtom,
+    selectedPerfRowIdAtom,
     selectedPerformanceRangeAtom,
 } from '../store/app';
 import PerfCharts from '../components/performance/PerfCharts';
@@ -35,6 +36,7 @@ import { HIGH_DISPATCH_THRESHOLD_MS, OpType, PerfTabIds } from '../definitions/P
 import { BufferType } from '../model/BufferType';
 import { DeviceOperationLayoutTypes } from '../model/APIData';
 import { StackedColumnKeys, StackedPerfRow, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
+import { parsePerfRowTensors } from '../functions/parsePerfRowTensors';
 
 const INITIAL_TAB_ID = PerfTabIds.TABLE;
 
@@ -61,6 +63,7 @@ export default function Performance() {
     const { data: folderList } = usePerfFolderList();
     const perfRange = usePerformanceRange();
     const opIdsMap = useOpToPerfIdFiltered();
+    const setSelectedPerfRowId = useSetAtom(selectedPerfRowIdAtom);
 
     const shouldDisableComparison = getServerConfig()?.SERVER_MODE;
 
@@ -165,6 +168,10 @@ export default function Performance() {
         () => comparisonStackedData?.map((dataset) => enrichStackedRowData(dataset)) || [],
         [comparisonStackedData],
     );
+
+    useEffect(() => {
+        setSelectedPerfRowId(null);
+    }, [activePerformanceReport?.path, setSelectedPerfRowId]);
 
     // Clear comparison report if users switches active perf report to the comparison report
     useEffect(() => {
@@ -311,29 +318,12 @@ interface RowAttributes {
     layout: DeviceOperationLayoutTypes | null;
 }
 
-const getBufferType = (type?: string): BufferType | null => {
-    if (!type) {
-        return null;
-    }
-
-    if (type === 'L1') {
-        return BufferType.L1;
-    }
-
-    if (type === 'DRAM') {
-        return BufferType.DRAM;
-    }
-
-    return null;
-};
-
 const getRowAttributes = (row: PerfTableRow): RowAttributes => {
-    const regex = /DEV_(\d+)_(DRAM|L1)_(\w*)/m;
-    const matchIn0 = regex.exec(row.input_0_memory);
+    const { buffer_type: bufferType, layout } = parsePerfRowTensors(row);
 
     return {
-        buffer_type: getBufferType(matchIn0?.[2]),
-        layout: matchIn0?.[3] ? (matchIn0[3] as DeviceOperationLayoutTypes) : null,
+        buffer_type: bufferType,
+        layout,
     };
 };
 

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -6,6 +6,7 @@ import {
     Button,
     ButtonGroup,
     ButtonVariant,
+    Classes,
     FormGroup,
     InputGroup,
     Intent,
@@ -512,7 +513,7 @@ export default function Styleguide() {
 
             <FormGroup>
                 <label
-                    className='bp6-file-input'
+                    className={Classes.FILE_INPUT}
                     htmlFor='local-upload'
                 >
                     <input
@@ -520,7 +521,7 @@ export default function Styleguide() {
                         type='file'
                         multiple
                     />
-                    <span className='bp6-file-upload-input'>Select files...</span>
+                    <span className={Classes.FILE_UPLOAD_INPUT}>Select files...</span>
                 </label>
             </FormGroup>
 

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -465,7 +465,6 @@ export default function Styleguide() {
                 className='short-width'
             >
                 <InputGroup
-                    className='bp6-light'
                     onChange={() => {}}
                     leftIcon={IconNames.FOLDER_NEW}
                 />
@@ -473,28 +472,24 @@ export default function Styleguide() {
 
             <div className='container flex'>
                 <InputGroup
-                    className='bp6-light'
                     onChange={() => {}}
                     intent={Intent.PRIMARY}
                     leftIcon={IconNames.FOLDER_NEW}
                 />
 
                 <InputGroup
-                    className='bp6-light'
                     onChange={() => {}}
                     intent={Intent.WARNING}
                     leftIcon={IconNames.FOLDER_NEW}
                 />
 
                 <InputGroup
-                    className='bp6-light'
                     onChange={() => {}}
                     intent={Intent.SUCCESS}
                     leftIcon={IconNames.FOLDER_NEW}
                 />
 
                 <InputGroup
-                    className='bp6-light'
                     onChange={() => {}}
                     intent={Intent.DANGER}
                     leftIcon={IconNames.FOLDER_NEW}

--- a/src/scss/components/FeedbackButton.scss
+++ b/src/scss/components/FeedbackButton.scss
@@ -21,20 +21,24 @@ $button-rotation: -90deg; // Rotate the button to face upwards
     top: 42vh;
     right: -3px;
     z-index: variables.$z-index-2-interactive;
-    background-color: $tt-blue-accent;
     border-radius: 2px 2px 0 0;
     font-size: 16px;
     transform: translateX($hide-offset) rotate($button-rotation);
     transition: transform 0.3s ease-in-out;
     transform-origin: right bottom;
 
-    &:hover,
-    &:focus {
-        background-color: color.adjust($tt-blue, $lightness: -12%);
-    }
+    // Override BlueprintJS intent styles for the feedback button
+    &.bp6-intent-primary {
+        background-color: $tt-blue-accent;
 
-    &:active {
-        background-color: color.adjust($tt-blue, $lightness: -15%);
+        &:hover,
+        &:focus {
+            background-color: color.adjust($tt-blue, $lightness: -12%);
+        }
+
+        &:active {
+            background-color: color.adjust($tt-blue, $lightness: -15%);
+        }
     }
 
     &.animate-in {

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -151,6 +151,10 @@ $header-footer-border: 2px solid colours.$tt-grey-5;
                 background-color: rgb(255 255 255 / 5%);
             }
 
+            &.is-selected {
+                background-color: rgb(255 255 255 / 10%);
+            }
+
             &.comparison-row {
                 border-bottom: 2px solid colours.$tt-sand-shade;
                 background-size: 5px 5px;

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -183,6 +183,14 @@ $header-footer-border: 2px solid colours.$tt-grey-5;
         }
     }
 
+    .perf-tensor-trigger-wrapper {
+        display: inline-flex;
+
+        .perf-tensor-trigger {
+            background-color: transparent;
+        }
+    }
+
     .missing-data {
         background-color: colours.$tt-red-shade;
 

--- a/src/scss/components/PerfTensorDrawer.scss
+++ b/src/scss/components/PerfTensorDrawer.scss
@@ -19,8 +19,10 @@
         margin: 0 0 16px;
     }
 
-    .bp6-drawer-body {
-        overflow-y: auto;
+    .perf-tensor-drawer-op-link-anchor {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
     }
 }
 
@@ -28,10 +30,6 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
-
-    .perf-tensor-panel-cta {
-        margin-bottom: 4px;
-    }
 
     .perf-tensor-panel-section {
         display: flex;
@@ -56,22 +54,6 @@
     .perf-tensor-row-title {
         margin: 0 0 8px;
         font-size: 14px;
-    }
-
-    .perf-tensor-row-fields {
-        display: grid;
-        grid-template-columns: minmax(80px, auto) 1fr;
-        gap: 6px 12px;
-        margin: 0;
-
-        dt {
-            margin: 0;
-            font-weight: 600;
-        }
-
-        dd {
-            margin: 0;
-        }
     }
 
     .perf-tensor-row-table {

--- a/src/scss/components/PerfTensorDrawer.scss
+++ b/src/scss/components/PerfTensorDrawer.scss
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+@use '../definitions/colours' as colours;
+
+.perf-tensor-drawer-content {
+    padding: 10px 20px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.perf-tensor-drawer {
+    .perf-tensor-drawer-title {
+        font-family: var(--monospace-font-family);
+    }
+
+    .perf-tensor-drawer-op-link {
+        margin: 0 0 16px;
+    }
+
+    .bp6-drawer-body {
+        overflow-y: auto;
+    }
+}
+
+.perf-tensor-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+
+    .perf-tensor-panel-cta {
+        margin-bottom: 4px;
+    }
+
+    .perf-tensor-panel-section {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .perf-tensor-panel-heading {
+        margin: 0;
+    }
+
+    .perf-tensor-panel-empty {
+        margin: 0;
+    }
+}
+
+.perf-tensor-row {
+    border: 1px solid colours.$tt-grey-5;
+    border-radius: 4px;
+    padding: 12px;
+
+    .perf-tensor-row-title {
+        margin: 0 0 8px;
+        font-size: 14px;
+    }
+
+    .perf-tensor-row-fields {
+        display: grid;
+        grid-template-columns: minmax(80px, auto) 1fr;
+        gap: 6px 12px;
+        margin: 0;
+
+        dt {
+            margin: 0;
+            font-weight: 600;
+        }
+
+        dd {
+            margin: 0;
+        }
+    }
+
+    .perf-tensor-row-table {
+        width: 100%;
+    }
+}

--- a/src/scss/components/PerfTensorDrawer.scss
+++ b/src/scss/components/PerfTensorDrawer.scss
@@ -24,6 +24,17 @@
         align-items: center;
         gap: 6px;
     }
+
+    .perf-tensor-drawer-empty {
+        margin: 0;
+        color: colours.$tt-grey-3;
+    }
+}
+
+// Inline-flex wrapper keeps the disabled Button as a valid Tooltip target
+// (Blueprint Tooltips do not bind to disabled controls directly).
+.perf-tensor-trigger-wrapper {
+    display: inline-flex;
 }
 
 .perf-tensor-panel {

--- a/src/scss/components/PerfTensorDrawer.scss
+++ b/src/scss/components/PerfTensorDrawer.scss
@@ -5,12 +5,16 @@
 @use '../definitions/colours' as colours;
 
 .perf-tensor-drawer-content {
-    padding: 10px 20px;
+    padding: 10px 15px;
     height: 100%;
     overflow-y: auto;
 }
 
 .perf-tensor-drawer {
+    .bp6-drawer-header {
+        padding-left: 15px;
+    }
+
     .perf-tensor-drawer-title {
         font-family: var(--monospace-font-family);
     }
@@ -31,12 +35,6 @@
     }
 }
 
-// Inline-flex wrapper keeps the disabled Button as a valid Tooltip target
-// (Blueprint Tooltips do not bind to disabled controls directly).
-.perf-tensor-trigger-wrapper {
-    display: inline-flex;
-}
-
 .perf-tensor-panel {
     display: flex;
     flex-direction: column;
@@ -49,6 +47,7 @@
     }
 
     .perf-tensor-panel-heading {
+        text-decoration: underline;
         margin: 0;
     }
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -88,6 +88,7 @@ export const layoutFilterListAtom = atom<TypedPerfTableRow['layout'][]>([]);
 export const mergeDevicesAtom = atom<boolean>(true);
 export const tracingModeAtom = atom<boolean>(false);
 export const stackedGroupByAtom = atom<StackedGroupBy>(StackedGroupBy.OP);
+export const selectedPerfRowIdAtom = atom<number | null>(null);
 
 // NPE
 export const altCongestionColorsAtom = atomWithStorage('altCongestionColors', false);

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -88,6 +88,9 @@ export const layoutFilterListAtom = atom<TypedPerfTableRow['layout'][]>([]);
 export const mergeDevicesAtom = atom<boolean>(true);
 export const tracingModeAtom = atom<boolean>(false);
 export const stackedGroupByAtom = atom<StackedGroupBy>(StackedGroupBy.OP);
+// Valid only while the modal tensor drawer is open — the backdrop blocks perf-tab switching,
+// so a selection can't leak across reports. Cleared on active-report change (Performance.tsx)
+// and on drawer close / row removal / unsynced reports (PerfTable.tsx).
 export const selectedPerfRowIdAtom = atom<number | null>(null);
 
 // NPE

--- a/tests/PerfTable.spec.tsx
+++ b/tests/PerfTable.spec.tsx
@@ -4,6 +4,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { useAtomValue } from 'jotai';
 import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PerfTable from '../src/components/performance/PerfTable';
 import { TypedPerfTableRow, signpostRowDefaults } from '../src/definitions/PerfTable';
@@ -163,4 +164,58 @@ describe('PerfTable tensor-drawer trigger column', () => {
         expect(matmulCell).toHaveClass('is-selected');
         expect(missingCell).not.toHaveClass('is-selected');
     });
+
+    // Regression guard for the clean-up effect inside `PerfTable` that resets
+    // `selectedPerfRowIdAtom` whenever the table can no longer show the drawer
+    // (no op-id sync, no active-report rows). Without this, a stale selection
+    // from a previous render would silently re-open the drawer once sync returns.
+    it('clears selectedPerfRowIdAtom when the reports become unsynced', () => {
+        let opIdMapping: { opId: number; perfId: string }[] = [{ opId: 11, perfId: '1' }];
+        (useOpToPerfIdFiltered as Mock).mockImplementation(() => opIdMapping);
+
+        const { rerender } = render(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, matmulRow.id]]}>
+                <PerfTable
+                    data={[matmulRow]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                />
+                <SelectedRowProbe />
+            </TestProviders>,
+        );
+
+        expect(screen.getByText('Matmul').closest('tr')).toHaveClass('is-selected');
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent('1');
+        expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER)).toBeInTheDocument();
+
+        opIdMapping = [];
+        rerender(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, matmulRow.id]]}>
+                <PerfTable
+                    data={[matmulRow]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                />
+                <SelectedRowProbe />
+            </TestProviders>,
+        );
+
+        expect(screen.getByText('Matmul').closest('tr')).not.toHaveClass('is-selected');
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent('null');
+        expect(screen.queryByTestId(TEST_IDS.PERF_TENSOR_DRAWER)).not.toBeInTheDocument();
+    });
 });
+
+function SelectedRowProbe() {
+    const selected = useAtomValue(selectedPerfRowIdAtom);
+
+    return <span data-testid='selected-row-probe'>{selected === null ? 'null' : String(selected)}</span>;
+}

--- a/tests/PerfTable.spec.tsx
+++ b/tests/PerfTable.spec.tsx
@@ -45,17 +45,25 @@ const missingRow = baseRow({ id: 2, raw_op_code: 'Reshape MISSING', op: undefine
 const unmappedRow = baseRow({ id: 3, raw_op_code: 'AddOp', op: undefined });
 const signpost = signpostRow(4);
 
-function renderTable(rows: TypedPerfTableRow[]) {
+interface RenderTableOptions {
+    comparisonData?: TypedPerfTableRow[][];
+    activeReportComparisonIndex?: number | null;
+}
+
+function renderTable(rows: TypedPerfTableRow[], options: RenderTableOptions = {}) {
+    const { comparisonData = [], activeReportComparisonIndex = null } = options;
+
     return render(
         <TestProviders>
             <PerfTable
                 data={rows}
-                comparisonData={[]}
+                comparisonData={comparisonData}
                 filters={null}
                 provideMatmulAdvice={false}
                 hiliteHighDispatch={false}
                 reportName='unit-test'
                 showHashColumn={false}
+                activeReportComparisonIndex={activeReportComparisonIndex}
             />
         </TestProviders>,
     );
@@ -109,6 +117,27 @@ describe('PerfTable tensor-drawer trigger column', () => {
         fireEvent.click(trigger);
 
         expect(trigger.closest('tr')).toHaveClass('is-selected');
+    });
+
+    it('renders the trigger on the comparison sub-row that holds the active report (comparison-report tab)', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+
+        // Comparison-report tab layout: primary `data` rows are the selected comparison
+        // report, and `comparisonData[0]` rows are the active profiler report.
+        const comparisonReportRow = baseRow({ id: 99, raw_op_code: 'Matmul', op: undefined });
+        const activeReportSubRow = baseRow({ id: 11, raw_op_code: 'Matmul', op: 11 });
+
+        renderTable([comparisonReportRow], {
+            comparisonData: [[activeReportSubRow]],
+            activeReportComparisonIndex: 0,
+        });
+
+        const triggers = screen.getAllByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON);
+        expect(triggers).toHaveLength(1);
+
+        const triggerRow = triggers[0].closest('tr')!;
+        expect(triggerRow).toHaveClass('comparison-row');
+        expect(triggers[0]).toBeEnabled();
     });
 
     it('highlights the row that matches the hydrated selectedPerfRowIdAtom', () => {

--- a/tests/PerfTable.spec.tsx
+++ b/tests/PerfTable.spec.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PerfTable from '../src/components/performance/PerfTable';
+import { TypedPerfTableRow, signpostRowDefaults } from '../src/definitions/PerfTable';
+import { OpType } from '../src/definitions/Performance';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList, usePerfMeta } from '../src/hooks/useAPI';
+import { selectedPerfRowIdAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useGetNPEManifest: vi.fn(),
+    useOpToPerfIdFiltered: vi.fn(),
+    useOperationsList: vi.fn(),
+    usePerfMeta: vi.fn(),
+}));
+
+const baseRow = (
+    overrides: Partial<TypedPerfTableRow> & Pick<TypedPerfTableRow, 'id' | 'raw_op_code'>,
+): TypedPerfTableRow =>
+    ({
+        op_type: OpType.DEVICE_OP,
+        op_code: overrides.raw_op_code,
+        advice: [],
+        bound: null,
+        isFirstHashOccurrence: true,
+        ...overrides,
+    }) as unknown as TypedPerfTableRow;
+
+const signpostRow = (id: number): TypedPerfTableRow =>
+    ({
+        ...signpostRowDefaults,
+        id,
+        op_code: '---SIGNPOST---',
+        raw_op_code: '---SIGNPOST---',
+    }) as unknown as TypedPerfTableRow;
+
+const matmulRow = baseRow({ id: 1, raw_op_code: 'Matmul', op: 11 });
+const missingRow = baseRow({ id: 2, raw_op_code: 'Reshape MISSING', op: undefined });
+const unmappedRow = baseRow({ id: 3, raw_op_code: 'AddOp', op: undefined });
+const signpost = signpostRow(4);
+
+function renderTable(rows: TypedPerfTableRow[]) {
+    return render(
+        <TestProviders>
+            <PerfTable
+                data={rows}
+                comparisonData={[]}
+                filters={null}
+                provideMatmulAdvice={false}
+                hiliteHighDispatch={false}
+                reportName='unit-test'
+                showHashColumn={false}
+            />
+        </TestProviders>,
+    );
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    (useGetNPEManifest as Mock).mockReturnValue({ data: [], error: null });
+    (useOperationsList as Mock).mockReturnValue({ data: [] });
+    (usePerfMeta as Mock).mockReturnValue({ data: null, isLoading: false });
+});
+
+describe('PerfTable tensor-drawer trigger column', () => {
+    it('renders an enabled trigger button on synced data rows', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+        renderTable([matmulRow]);
+
+        const triggers = screen.getAllByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON);
+        expect(triggers).toHaveLength(1);
+        expect(triggers[0]).toBeEnabled();
+    });
+
+    it('omits the trigger button entirely on signpost rows', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+        renderTable([matmulRow, signpost]);
+
+        const signpostCell = screen.getByText('---SIGNPOST---').closest('tr')!;
+        expect(within(signpostCell).queryByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON)).toBeNull();
+    });
+
+    it('disables the trigger button for rows with no linked profiler op', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+        renderTable([unmappedRow]);
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON)).toBeDisabled();
+    });
+
+    it('disables the trigger button when reports are not synced', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([]);
+        renderTable([matmulRow]);
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON)).toBeDisabled();
+    });
+
+    it('marks the row as selected when the trigger is clicked', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+        renderTable([matmulRow]);
+
+        const trigger = screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON);
+        fireEvent.click(trigger);
+
+        expect(trigger.closest('tr')).toHaveClass('is-selected');
+    });
+
+    it('highlights the row that matches the hydrated selectedPerfRowIdAtom', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+
+        render(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, matmulRow.id]]}>
+                <PerfTable
+                    data={[matmulRow, missingRow]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                />
+            </TestProviders>,
+        );
+
+        const matmulCell = screen.getByText('Matmul').closest('tr')!;
+        const missingCell = screen.getByText(/Reshape MISSING/).closest('tr')!;
+
+        expect(matmulCell).toHaveClass('is-selected');
+        expect(missingCell).not.toHaveClass('is-selected');
+    });
+});

--- a/tests/PerfTable.spec.tsx
+++ b/tests/PerfTable.spec.tsx
@@ -212,6 +212,56 @@ describe('PerfTable tensor-drawer trigger column', () => {
         expect(screen.getByTestId('selected-row-probe')).toHaveTextContent('null');
         expect(screen.queryByTestId(TEST_IDS.PERF_TENSOR_DRAWER)).not.toBeInTheDocument();
     });
+
+    // Regression guard for the second clean-up branch: if filters or the range
+    // slider drop the selected row from `activeReportRows` while other rows
+    // remain (drawer still showable), the selection must be cleared so it can't
+    // silently re-open later when the row reappears.
+    it('clears selectedPerfRowIdAtom when the selected row is filtered out of activeReportRows', () => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([{ opId: 11, perfId: '1' }]);
+
+        const otherRow = baseRow({ id: 7, raw_op_code: 'OtherOp', op: 12 });
+
+        const { rerender } = render(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, matmulRow.id]]}>
+                <PerfTable
+                    data={[matmulRow, otherRow]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                />
+                <SelectedRowProbe />
+            </TestProviders>,
+        );
+
+        expect(screen.getByText('Matmul').closest('tr')).toHaveClass('is-selected');
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent('1');
+
+        rerender(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, matmulRow.id]]}>
+                <PerfTable
+                    data={[otherRow]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                />
+                <SelectedRowProbe />
+            </TestProviders>,
+        );
+
+        // Matmul cell renders inside the table body; the drawer header still
+        // surfaces the row's op code from the previous selection until the
+        // Drawer animates closed, so scope the lookup to the table.
+        const tableBody = screen.getByRole('table').querySelector('tbody')!;
+        expect(within(tableBody).queryByText('Matmul')).not.toBeInTheDocument();
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent('null');
+    });
 });
 
 function SelectedRowProbe() {

--- a/tests/PerfTensorDrawer.spec.tsx
+++ b/tests/PerfTensorDrawer.spec.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PerfTensorDrawer from '../src/components/performance/PerfTensorDrawer';
+import { TypedPerfTableRow } from '../src/definitions/PerfTable';
+import { OpType } from '../src/definitions/Performance';
+import ROUTES from '../src/definitions/Routes';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import { useOperationsList } from '../src/hooks/useAPI';
+import { OperationDescription, Tensor } from '../src/model/APIData';
+import { BufferType } from '../src/model/BufferType';
+import { selectedPerfRowIdAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useOperationsList: vi.fn(),
+}));
+
+const tensor: Tensor = {
+    id: 100,
+    address: 4096,
+    buffer_type: BufferType.L1,
+    producers: [10],
+    consumers: [12],
+    producerNames: [],
+    consumerNames: [],
+    shape: 'Shape([1, 32, 32])',
+    dtype: 'DataType::BFLOAT16',
+    layout: 'Layout::TILE',
+    memory_config: null,
+    device_id: 0,
+    comparison: null,
+    io: 'input',
+    size: 2048,
+};
+
+const matmulOp: OperationDescription = {
+    id: 11,
+    name: 'matmul_op',
+    inputs: [tensor],
+    outputs: [{ ...tensor, id: 101, io: 'output', producers: [11], consumers: [] }],
+    stack_trace: '',
+    stack_trace_source_file_id: null,
+    device_operations: [],
+    operationFileIdentifier: 'matmul.cpp',
+    error: null,
+    duration: 1,
+    arguments: [],
+    processedConnections: [],
+    deviceOperationNameList: ['Matmul'],
+};
+
+const makeRow = (
+    overrides: Partial<TypedPerfTableRow> & Pick<TypedPerfTableRow, 'id' | 'raw_op_code'>,
+): TypedPerfTableRow =>
+    ({
+        op_type: OpType.DEVICE_OP,
+        op_code: overrides.raw_op_code,
+        advice: [],
+        bound: null,
+        isFirstHashOccurrence: true,
+        ...overrides,
+    }) as unknown as TypedPerfTableRow;
+
+const mappedRow = makeRow({ id: 1, raw_op_code: 'Matmul', op: 11 });
+const unmappedRow = makeRow({ id: 2, raw_op_code: 'Reshape', op: undefined });
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    (useOperationsList as Mock).mockReturnValue({ data: [matmulOp] });
+});
+
+describe('PerfTensorDrawer', () => {
+    it('renders the operation link and tensor panel when the selected row maps to an op', () => {
+        render(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, mappedRow.id]]}>
+                <PerfTensorDrawer rows={[mappedRow]} />
+            </TestProviders>,
+        );
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER)).toBeInTheDocument();
+        expect(screen.getByText(/Row 1:/)).toBeInTheDocument();
+
+        const opLink = screen.getByRole('link', { name: /View operation 11: matmul_op/i });
+        expect(opLink).toHaveAttribute('href', `${ROUTES.OPERATIONS}/11`);
+
+        expect(screen.getByText('Inputs')).toBeInTheDocument();
+        expect(screen.getByText('Outputs')).toBeInTheDocument();
+        expect(screen.getByText('100')).toBeInTheDocument();
+        expect(screen.getByText('101')).toBeInTheDocument();
+    });
+
+    it('shows the empty-state message when the selected row has no matching operation', () => {
+        render(
+            <TestProviders initialAtomValues={[[selectedPerfRowIdAtom, unmappedRow.id]]}>
+                <PerfTensorDrawer rows={[unmappedRow]} />
+            </TestProviders>,
+        );
+
+        expect(screen.getByText('No linked profiler operation for this row.')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /View operation/i })).not.toBeInTheDocument();
+    });
+});

--- a/tests/PerfTensorDrawer.spec.tsx
+++ b/tests/PerfTensorDrawer.spec.tsx
@@ -84,9 +84,9 @@ describe('PerfTensorDrawer', () => {
         );
 
         expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER)).toBeInTheDocument();
-        expect(screen.getByText(/Row 1:/)).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /1\s+Matmul/ })).toBeInTheDocument();
 
-        const opLink = screen.getByRole('link', { name: /View operation 11: matmul_op/i });
+        const opLink = screen.getByRole('link', { name: /View operation 11\s+matmul_op/i });
         expect(opLink).toHaveAttribute('href', `${ROUTES.OPERATIONS}/11`);
 
         expect(screen.getByText('Inputs')).toBeInTheDocument();

--- a/tests/PerfTensorDrawer.spec.tsx
+++ b/tests/PerfTensorDrawer.spec.tsx
@@ -84,9 +84,11 @@ describe('PerfTensorDrawer', () => {
         );
 
         expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER)).toBeInTheDocument();
-        expect(screen.getByRole('heading', { name: /1\s+Matmul/ })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /11\s+matmul_op/ })).toBeInTheDocument();
 
-        const opLink = screen.getByRole('link', { name: /View operation 11\s+matmul_op/i });
+        expect(screen.getByRole('button', { name: 'Memory Details' })).toBeInTheDocument();
+
+        const opLink = screen.getByRole('link', { name: /11 matmul_op \(matmul\.cpp\)/i });
         expect(opLink).toHaveAttribute('href', `${ROUTES.OPERATIONS}/11`);
 
         expect(screen.getByText('Inputs')).toBeInTheDocument();
@@ -103,6 +105,7 @@ describe('PerfTensorDrawer', () => {
         );
 
         expect(screen.getByText('No linked profiler operation for this row.')).toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: /View operation/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Memory Details' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /matmul_op/i })).not.toBeInTheDocument();
     });
 });

--- a/tests/PerfTensorPanel.spec.tsx
+++ b/tests/PerfTensorPanel.spec.tsx
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import PerfTensorPanel from '../src/components/performance/PerfTensorPanel';
+import { BoundType, TypedPerfTableRow } from '../src/definitions/PerfTable';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import ROUTES from '../src/definitions/Routes';
+import { OperationDescription, Tensor } from '../src/model/APIData';
+import { BufferType } from '../src/model/BufferType';
+import { OpType } from '../src/definitions/Performance';
+import { TestProviders } from './helpers/TestProviders';
+
+const baseRow: TypedPerfTableRow = {
+    id: 42,
+    global_call_count: 0,
+    advice: [],
+    total_percent: 1,
+    bound: BoundType.FLOP,
+    op_code: 'Matmul',
+    raw_op_code: 'Matmul',
+    device: 0,
+    device_time: 10,
+    op_to_op_gap: 0,
+    cores: 1,
+    dram: 0,
+    dram_percent: 0,
+    flops: 0,
+    flops_percent: 0,
+    math_fidelity: 'HiFi4',
+    output_datatype: 'DataType::BFLOAT16',
+    output_0_memory: 'DEV_0_DRAM_TILE',
+    input_0_datatype: 'DataType::BFLOAT16',
+    input_1_datatype: '',
+    dram_sharded: '',
+    input_0_memory: 'DEV_0_L1_TILE',
+    input_1_memory: '',
+    inner_dim_block_size: '',
+    output_subblock_h: '',
+    output_subblock_w: '',
+    pm_ideal_ns: null,
+    op_type: OpType.DEVICE_OP,
+    hash: null,
+    cache_hit: null,
+    buffer_type: BufferType.L1,
+    layout: null,
+    isFirstHashOccurrence: true,
+};
+
+const enrichedTensor: Tensor = {
+    id: 100,
+    address: 4096,
+    buffer_type: BufferType.L1,
+    producers: [10],
+    consumers: [12],
+    producerNames: [],
+    consumerNames: [],
+    shape: 'Shape([1, 32, 32])',
+    dtype: 'DataType::BFLOAT16',
+    layout: 'Layout::TILE',
+    memory_config: null,
+    device_id: 0,
+    comparison: null,
+    io: 'input',
+    size: 2048,
+};
+
+const operations: OperationDescription[] = [
+    {
+        id: 11,
+        name: 'matmul_op',
+        inputs: [enrichedTensor],
+        outputs: [{ ...enrichedTensor, id: 101, io: 'output', producers: [11], consumers: [13] }],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+        device_operations: [],
+        operationFileIdentifier: 'matmul.cpp',
+        error: null,
+        duration: 1,
+        arguments: [],
+        processedConnections: [],
+        deviceOperationNameList: ['Matmul'],
+    },
+    {
+        id: 10,
+        name: 'producer_op',
+        inputs: [],
+        outputs: [],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+        device_operations: [],
+        operationFileIdentifier: 'producer.cpp',
+        error: null,
+        duration: 1,
+        arguments: [],
+        processedConnections: [],
+        deviceOperationNameList: [],
+    },
+    {
+        id: 12,
+        name: 'consumer_op',
+        inputs: [],
+        outputs: [],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+        device_operations: [],
+        operationFileIdentifier: 'consumer.cpp',
+        error: null,
+        duration: 1,
+        arguments: [],
+        processedConnections: [],
+        deviceOperationNameList: [],
+    },
+];
+
+function renderPanel(
+    row: TypedPerfTableRow,
+    operation: OperationDescription | null,
+    ops: OperationDescription[] = operations,
+) {
+    return render(
+        <TestProviders>
+            <PerfTensorPanel
+                row={row}
+                operation={operation}
+                operations={ops}
+            />
+        </TestProviders>,
+    );
+}
+
+afterEach(cleanup);
+
+describe('PerfTensorPanel', () => {
+    it('shows basic tensor info and CTA when not enriched', () => {
+        renderPanel(baseRow, null);
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER_CTA)).toBeInTheDocument();
+        expect(screen.getByText('Input 0')).toBeInTheDocument();
+        expect(screen.getByText('DEV_0_L1_TILE')).toBeInTheDocument();
+        expect(screen.getByText('DEV_0_DRAM_TILE')).toBeInTheDocument();
+        expect(screen.queryByText('Tensor Id')).not.toBeInTheDocument();
+    });
+
+    it('shows enriched tensor fields and hides CTA when operation is matched', () => {
+        renderPanel({ ...baseRow, op: 11 }, operations[0]);
+
+        expect(screen.queryByTestId(TEST_IDS.PERF_TENSOR_DRAWER_CTA)).not.toBeInTheDocument();
+        expect(screen.getAllByText('Tensor Id')).toHaveLength(2);
+        expect(screen.getByText('100')).toBeInTheDocument();
+        expect(screen.getByText('101')).toBeInTheDocument();
+        expect(screen.getAllByText('[1, 32, 32]')).toHaveLength(2);
+        expect(screen.getAllByText('2 KiB')).toHaveLength(2);
+    });
+
+    it('links producer and consumer operations to operation details', () => {
+        renderPanel({ ...baseRow, op: 11 }, operations[0]);
+
+        expect(screen.getByRole('link', { name: /10 producer_op/i })).toHaveAttribute(
+            'href',
+            `${ROUTES.OPERATIONS}/10`,
+        );
+        expect(screen.getByRole('link', { name: /12 consumer_op/i })).toHaveAttribute(
+            'href',
+            `${ROUTES.OPERATIONS}/12`,
+        );
+    });
+});

--- a/tests/PerfTensorPanel.spec.tsx
+++ b/tests/PerfTensorPanel.spec.tsx
@@ -6,49 +6,10 @@ import { cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it } from 'vitest';
 import PerfTensorPanel from '../src/components/performance/PerfTensorPanel';
-import { BoundType, TypedPerfTableRow } from '../src/definitions/PerfTable';
-import { TEST_IDS } from '../src/definitions/TestIds';
 import ROUTES from '../src/definitions/Routes';
 import { OperationDescription, Tensor } from '../src/model/APIData';
 import { BufferType } from '../src/model/BufferType';
-import { OpType } from '../src/definitions/Performance';
 import { TestProviders } from './helpers/TestProviders';
-
-const baseRow: TypedPerfTableRow = {
-    id: 42,
-    global_call_count: 0,
-    advice: [],
-    total_percent: 1,
-    bound: BoundType.FLOP,
-    op_code: 'Matmul',
-    raw_op_code: 'Matmul',
-    device: 0,
-    device_time: 10,
-    op_to_op_gap: 0,
-    cores: 1,
-    dram: 0,
-    dram_percent: 0,
-    flops: 0,
-    flops_percent: 0,
-    math_fidelity: 'HiFi4',
-    output_datatype: 'DataType::BFLOAT16',
-    output_0_memory: 'DEV_0_DRAM_TILE',
-    input_0_datatype: 'DataType::BFLOAT16',
-    input_1_datatype: '',
-    dram_sharded: '',
-    input_0_memory: 'DEV_0_L1_TILE',
-    input_1_memory: '',
-    inner_dim_block_size: '',
-    output_subblock_h: '',
-    output_subblock_w: '',
-    pm_ideal_ns: null,
-    op_type: OpType.DEVICE_OP,
-    hash: null,
-    cache_hit: null,
-    buffer_type: BufferType.L1,
-    layout: null,
-    isFirstHashOccurrence: true,
-};
 
 const enrichedTensor: Tensor = {
     id: 100,
@@ -116,15 +77,10 @@ const operations: OperationDescription[] = [
     },
 ];
 
-function renderPanel(
-    row: TypedPerfTableRow,
-    operation: OperationDescription | null,
-    ops: OperationDescription[] = operations,
-) {
+function renderPanel(operation: OperationDescription, ops: OperationDescription[] = operations) {
     return render(
         <TestProviders>
             <PerfTensorPanel
-                row={row}
                 operation={operation}
                 operations={ops}
             />
@@ -135,20 +91,9 @@ function renderPanel(
 afterEach(cleanup);
 
 describe('PerfTensorPanel', () => {
-    it('shows basic tensor info and CTA when not enriched', () => {
-        renderPanel(baseRow, null);
+    it('renders enriched input and output tensor fields', () => {
+        renderPanel(operations[0]);
 
-        expect(screen.getByTestId(TEST_IDS.PERF_TENSOR_DRAWER_CTA)).toBeInTheDocument();
-        expect(screen.getByText('Input 0')).toBeInTheDocument();
-        expect(screen.getByText('DEV_0_L1_TILE')).toBeInTheDocument();
-        expect(screen.getByText('DEV_0_DRAM_TILE')).toBeInTheDocument();
-        expect(screen.queryByText('Tensor Id')).not.toBeInTheDocument();
-    });
-
-    it('shows enriched tensor fields and hides CTA when operation is matched', () => {
-        renderPanel({ ...baseRow, op: 11 }, operations[0]);
-
-        expect(screen.queryByTestId(TEST_IDS.PERF_TENSOR_DRAWER_CTA)).not.toBeInTheDocument();
         expect(screen.getAllByText('Tensor Id')).toHaveLength(2);
         expect(screen.getByText('100')).toBeInTheDocument();
         expect(screen.getByText('101')).toBeInTheDocument();
@@ -157,7 +102,7 @@ describe('PerfTensorPanel', () => {
     });
 
     it('links producer and consumer operations to operation details', () => {
-        renderPanel({ ...baseRow, op: 11 }, operations[0]);
+        renderPanel(operations[0]);
 
         expect(screen.getByRole('link', { name: /10 producer_op/i })).toHaveAttribute(
             'href',
@@ -167,5 +112,12 @@ describe('PerfTensorPanel', () => {
             'href',
             `${ROUTES.OPERATIONS}/12`,
         );
+    });
+
+    it('shows an empty state when the operation has no input or output tensors', () => {
+        renderPanel({ ...operations[0], inputs: [], outputs: [] });
+
+        expect(screen.getByText('No input tensors')).toBeInTheDocument();
+        expect(screen.getByText('No output tensors')).toBeInTheDocument();
     });
 });

--- a/tests/Performance.spec.tsx
+++ b/tests/Performance.spec.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useAtom, useSetAtom } from 'jotai';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Performance from '../src/routes/Performance';
+import {
+    useOpToPerfIdFiltered,
+    usePerfFolderList,
+    usePerformanceComparisonReport,
+    usePerformanceRange,
+    usePerformanceReport,
+} from '../src/hooks/useAPI';
+import { activePerformanceReportAtom, selectedPerfRowIdAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useOpToPerfIdFiltered: vi.fn(),
+    usePerfFolderList: vi.fn(),
+    usePerformanceComparisonReport: vi.fn(),
+    usePerformanceRange: vi.fn(),
+    usePerformanceReport: vi.fn(),
+}));
+
+vi.mock('../src/functions/getServerConfig', () => ({
+    default: () => ({ SERVER_MODE: true }),
+}));
+
+const REPORT_A = { path: '/reports/a', reportName: 'report-a' };
+const REPORT_B = { path: '/reports/b', reportName: 'report-b' };
+const SELECTED_ROW_ID = 100;
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    // Keep Performance in its loading-spinner early-return path so the test does
+    // not have to mount the full table/chart subtree. Effects still run after
+    // commit, which is exactly what we want to exercise.
+    (usePerformanceReport as Mock).mockReturnValue({ data: undefined, isLoading: true, error: null });
+    (usePerformanceComparisonReport as Mock).mockReturnValue({ data: undefined });
+    (usePerfFolderList as Mock).mockReturnValue({ data: undefined });
+    (usePerformanceRange as Mock).mockReturnValue(null);
+    (useOpToPerfIdFiltered as Mock).mockReturnValue([]);
+});
+
+function PerformanceController() {
+    const [selected, setSelected] = useAtom(selectedPerfRowIdAtom);
+    const setReport = useSetAtom(activePerformanceReportAtom);
+
+    return (
+        <div>
+            <span data-testid='selected-row-probe'>{selected === null ? 'null' : String(selected)}</span>
+            <button
+                type='button'
+                data-testid='select-row'
+                onClick={() => setSelected(SELECTED_ROW_ID)}
+            >
+                select
+            </button>
+            <button
+                type='button'
+                data-testid='set-report-a'
+                onClick={() => setReport(REPORT_A)}
+            >
+                a
+            </button>
+            <button
+                type='button'
+                data-testid='set-report-b'
+                onClick={() => setReport(REPORT_B)}
+            >
+                b
+            </button>
+        </div>
+    );
+}
+
+describe('Performance route', () => {
+    it('clears selectedPerfRowIdAtom when the active performance report changes', () => {
+        render(
+            <TestProviders>
+                <Performance />
+                <PerformanceController />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByTestId('set-report-a'));
+
+        fireEvent.click(screen.getByTestId('select-row'));
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent(String(SELECTED_ROW_ID));
+
+        fireEvent.click(screen.getByTestId('set-report-b'));
+
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent('null');
+    });
+
+    it('does not re-clear selectedPerfRowIdAtom while the active report is unchanged', () => {
+        render(
+            <TestProviders>
+                <Performance />
+                <PerformanceController />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByTestId('set-report-a'));
+        fireEvent.click(screen.getByTestId('select-row'));
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent(String(SELECTED_ROW_ID));
+
+        fireEvent.click(screen.getByTestId('set-report-a'));
+
+        expect(screen.getByTestId('selected-row-probe')).toHaveTextContent(String(SELECTED_ROW_ID));
+    });
+});

--- a/tests/getOperationLink.spec.tsx
+++ b/tests/getOperationLink.spec.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getLastConsumerLink, getOperationLink } from '../src/functions/getOperationLink';
+import ROUTES from '../src/definitions/Routes';
+import { Operation, Tensor } from '../src/model/APIData';
+import { TestProviders } from './helpers/TestProviders';
+
+const makeOperation = (overrides: Pick<Operation, 'id' | 'name'> & Partial<Operation>): Operation => ({
+    inputs: [],
+    outputs: [],
+    stack_trace: '',
+    stack_trace_source_file_id: null,
+    device_operations: [],
+    operationFileIdentifier: `${overrides.name}.cpp`,
+    error: null,
+    ...overrides,
+});
+
+const makeTensor = (consumers: number[]): Tensor =>
+    ({
+        id: 1,
+        address: 0,
+        buffer_type: null,
+        producers: [],
+        consumers,
+        producerNames: [],
+        consumerNames: [],
+        shape: 'Shape([1])',
+        dtype: 'DataType::BFLOAT16',
+        layout: 'Layout::TILE',
+        memory_config: null,
+        device_id: 0,
+        comparison: null,
+        io: null,
+        size: null,
+    }) as unknown as Tensor;
+
+const renderLink = (node: ReturnType<typeof getOperationLink>) => render(<TestProviders>{node}</TestProviders>);
+
+afterEach(cleanup);
+
+describe('getOperationLink', () => {
+    const matmul = makeOperation({ id: 11, name: 'matmul' });
+    const operations: Operation[] = [matmul];
+
+    it('renders a link to the matching operation', () => {
+        renderLink(getOperationLink(11, operations));
+
+        const link = screen.getByRole('link', { name: /11 matmul/i });
+        expect(link).toHaveAttribute('href', `${ROUTES.OPERATIONS}/11`);
+        expect(link).toHaveTextContent('(matmul.cpp)');
+    });
+
+    it('returns null when the operation id is not found', () => {
+        expect(getOperationLink(999, operations)).toBeNull();
+    });
+});
+
+describe('getLastConsumerLink', () => {
+    const matmul = makeOperation({ id: 11, name: 'matmul' });
+    const consumer = makeOperation({ id: 12, name: 'consumer_op' });
+    const dealloc = makeOperation({ id: 13, name: 'deallocate' });
+    const operations: Operation[] = [matmul, consumer, dealloc];
+
+    it('links to the trailing consumer when it is not a deallocate op', () => {
+        const tensor = makeTensor([11, 12]);
+        renderLink(getLastConsumerLink(tensor, operations));
+
+        const link = screen.getByRole('link', { name: /12 consumer_op/i });
+        expect(link).toHaveAttribute('href', `${ROUTES.OPERATIONS}/12`);
+    });
+
+    it('skips a trailing deallocate and links to the prior consumer', () => {
+        const tensor = makeTensor([11, 12, 13]);
+        renderLink(getLastConsumerLink(tensor, operations));
+
+        const link = screen.getByRole('link', { name: /12 consumer_op/i });
+        expect(link).toHaveAttribute('href', `${ROUTES.OPERATIONS}/12`);
+        expect(screen.queryByRole('link', { name: /13 deallocate/i })).not.toBeInTheDocument();
+    });
+
+    it('falls back to the deallocate op when it is the only consumer', () => {
+        const tensor = makeTensor([13]);
+        renderLink(getLastConsumerLink(tensor, operations));
+
+        const link = screen.getByRole('link', { name: /13 deallocate/i });
+        expect(link).toHaveAttribute('href', `${ROUTES.OPERATIONS}/13`);
+    });
+
+    it('returns null when no consumer operation is found', () => {
+        const tensor = makeTensor([999]);
+        expect(getLastConsumerLink(tensor, operations)).toBeNull();
+    });
+});

--- a/tests/helpers/testForPortal.ts
+++ b/tests/helpers/testForPortal.ts
@@ -2,12 +2,11 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { Classes } from '@blueprintjs/core';
 import { expect } from 'vitest';
 
-const PORTAL_CLASS = '.bp6-portal';
-
 const testForPortal = () => {
-    const portal = document.querySelector(PORTAL_CLASS);
+    const portal = document.querySelector(`.${Classes.PORTAL}`);
     expect(portal).not.toBeNull();
 };
 

--- a/tests/parsePerfRowTensorAttributes.spec.ts
+++ b/tests/parsePerfRowTensorAttributes.spec.ts
@@ -3,41 +3,41 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { parsePerfRowTensors } from '../src/functions/parsePerfRowTensors';
+import { parsePerfRowTensorAttributes } from '../src/functions/parsePerfRowTensorAttributes';
 import { BufferType } from '../src/model/BufferType';
 import { DeviceOperationLayoutTypes } from '../src/model/APIData';
 
-describe('parsePerfRowTensors', () => {
+describe('parsePerfRowTensorAttributes', () => {
     it('extracts L1 buffer type and TILE layout from input_0_memory', () => {
-        const parsed = parsePerfRowTensors({ input_0_memory: 'DEV_0_L1_TILE' });
+        const parsed = parsePerfRowTensorAttributes({ input_0_memory: 'DEV_0_L1_TILE' });
 
         expect(parsed.buffer_type).toBe(BufferType.L1);
         expect(parsed.layout).toBe(DeviceOperationLayoutTypes.TILE);
     });
 
     it('extracts DRAM buffer type and INTERLEAVED layout', () => {
-        const parsed = parsePerfRowTensors({ input_0_memory: 'DEV_0_DRAM_INTERLEAVED' });
+        const parsed = parsePerfRowTensorAttributes({ input_0_memory: 'DEV_0_DRAM_INTERLEAVED' });
 
         expect(parsed.buffer_type).toBe(BufferType.DRAM);
         expect(parsed.layout).toBe(DeviceOperationLayoutTypes.INTERLEAVED);
     });
 
     it('returns null fields when input_0_memory is empty', () => {
-        const parsed = parsePerfRowTensors({ input_0_memory: '' });
+        const parsed = parsePerfRowTensorAttributes({ input_0_memory: '' });
 
         expect(parsed.buffer_type).toBeNull();
         expect(parsed.layout).toBeNull();
     });
 
     it('returns null fields when input_0_memory is unrecognized', () => {
-        const parsed = parsePerfRowTensors({ input_0_memory: 'UNKNOWN_MEMORY' });
+        const parsed = parsePerfRowTensorAttributes({ input_0_memory: 'UNKNOWN_MEMORY' });
 
         expect(parsed.buffer_type).toBeNull();
         expect(parsed.layout).toBeNull();
     });
 
     it('returns a null layout when the captured layout is not a known DeviceOperationLayoutTypes member', () => {
-        const parsed = parsePerfRowTensors({ input_0_memory: 'DEV_0_L1_FOO' });
+        const parsed = parsePerfRowTensorAttributes({ input_0_memory: 'DEV_0_L1_FOO' });
 
         expect(parsed.buffer_type).toBe(BufferType.L1);
         expect(parsed.layout).toBeNull();

--- a/tests/parsePerfRowTensors.spec.ts
+++ b/tests/parsePerfRowTensors.spec.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { BoundType, PerfTableRow } from '../src/definitions/PerfTable';
+import { parsePerfRowTensors } from '../src/functions/parsePerfRowTensors';
+import { BufferType } from '../src/model/BufferType';
+import { DeviceOperationLayoutTypes } from '../src/model/APIData';
+import { OpType } from '../src/definitions/Performance';
+
+const baseRow: PerfTableRow = {
+    id: '1',
+    global_call_count: 0,
+    advice: [],
+    total_percent: '1.0',
+    bound: BoundType.FLOP,
+    op_code: 'Matmul',
+    raw_op_code: 'Matmul',
+    device: '0',
+    device_time: '10',
+    op_to_op_gap: '0',
+    cores: '1',
+    dram: '0',
+    dram_percent: '0',
+    flops: '0',
+    flops_percent: '0',
+    math_fidelity: 'HiFi4',
+    output_datatype: 'DataType::BFLOAT16',
+    output_0_memory: 'DEV_0_DRAM_TILE',
+    input_0_datatype: 'DataType::BFLOAT16',
+    input_1_datatype: 'DataType::BFLOAT16',
+    dram_sharded: '',
+    input_0_memory: 'DEV_0_L1_TILE',
+    input_1_memory: 'DEV_0_DRAM_INTERLEAVED',
+    inner_dim_block_size: '',
+    output_subblock_h: '',
+    output_subblock_w: '',
+    pm_ideal_ns: '',
+    op_type: OpType.DEVICE_OP,
+    hash: null,
+    cache_hit: null,
+};
+
+describe('parsePerfRowTensors', () => {
+    it('parses input and output slots from perf row strings', () => {
+        const parsed = parsePerfRowTensors(baseRow);
+
+        expect(parsed.inputs).toHaveLength(2);
+        expect(parsed.outputs).toHaveLength(1);
+        expect(parsed.inputs[0]).toMatchObject({
+            label: 'Input 0',
+            dtype: 'DataType::BFLOAT16',
+            memory: 'DEV_0_L1_TILE',
+            buffer_type: BufferType.L1,
+            layout: DeviceOperationLayoutTypes.TILE,
+        });
+        expect(parsed.outputs[0]).toMatchObject({
+            label: 'Output',
+            dtype: 'DataType::BFLOAT16',
+            memory: 'DEV_0_DRAM_TILE',
+            buffer_type: BufferType.DRAM,
+            layout: DeviceOperationLayoutTypes.TILE,
+        });
+    });
+
+    it('derives table row attributes from input_0_memory', () => {
+        const parsed = parsePerfRowTensors(baseRow);
+
+        expect(parsed.buffer_type).toBe(BufferType.L1);
+        expect(parsed.layout).toBe(DeviceOperationLayoutTypes.TILE);
+    });
+
+    it('returns empty sections when tensor strings are missing', () => {
+        const parsed = parsePerfRowTensors({
+            ...baseRow,
+            input_0_datatype: '',
+            input_1_datatype: '',
+            output_datatype: '',
+            input_0_memory: '',
+            input_1_memory: '',
+            output_0_memory: '',
+        });
+
+        expect(parsed.inputs).toHaveLength(0);
+        expect(parsed.outputs).toHaveLength(0);
+        expect(parsed.buffer_type).toBeNull();
+        expect(parsed.layout).toBeNull();
+    });
+
+    it('handles single-input ops with only input_0 populated', () => {
+        const parsed = parsePerfRowTensors({
+            ...baseRow,
+            input_1_datatype: '',
+            input_1_memory: '',
+        });
+
+        expect(parsed.inputs).toHaveLength(1);
+        expect(parsed.inputs[0].label).toBe('Input 0');
+    });
+
+    it('returns null buffer type for unrecognized memory prefixes', () => {
+        const parsed = parsePerfRowTensors({
+            ...baseRow,
+            input_0_memory: 'UNKNOWN_MEMORY',
+        });
+
+        expect(parsed.inputs[0].buffer_type).toBeNull();
+        expect(parsed.inputs[0].layout).toBeNull();
+    });
+});

--- a/tests/parsePerfRowTensors.spec.ts
+++ b/tests/parsePerfRowTensors.spec.ts
@@ -35,4 +35,11 @@ describe('parsePerfRowTensors', () => {
         expect(parsed.buffer_type).toBeNull();
         expect(parsed.layout).toBeNull();
     });
+
+    it('returns a null layout when the captured layout is not a known DeviceOperationLayoutTypes member', () => {
+        const parsed = parsePerfRowTensors({ input_0_memory: 'DEV_0_L1_FOO' });
+
+        expect(parsed.buffer_type).toBe(BufferType.L1);
+        expect(parsed.layout).toBeNull();
+    });
 });

--- a/tests/parsePerfRowTensors.spec.ts
+++ b/tests/parsePerfRowTensors.spec.ts
@@ -3,109 +3,36 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { BoundType, PerfTableRow } from '../src/definitions/PerfTable';
 import { parsePerfRowTensors } from '../src/functions/parsePerfRowTensors';
 import { BufferType } from '../src/model/BufferType';
 import { DeviceOperationLayoutTypes } from '../src/model/APIData';
-import { OpType } from '../src/definitions/Performance';
-
-const baseRow: PerfTableRow = {
-    id: '1',
-    global_call_count: 0,
-    advice: [],
-    total_percent: '1.0',
-    bound: BoundType.FLOP,
-    op_code: 'Matmul',
-    raw_op_code: 'Matmul',
-    device: '0',
-    device_time: '10',
-    op_to_op_gap: '0',
-    cores: '1',
-    dram: '0',
-    dram_percent: '0',
-    flops: '0',
-    flops_percent: '0',
-    math_fidelity: 'HiFi4',
-    output_datatype: 'DataType::BFLOAT16',
-    output_0_memory: 'DEV_0_DRAM_TILE',
-    input_0_datatype: 'DataType::BFLOAT16',
-    input_1_datatype: 'DataType::BFLOAT16',
-    dram_sharded: '',
-    input_0_memory: 'DEV_0_L1_TILE',
-    input_1_memory: 'DEV_0_DRAM_INTERLEAVED',
-    inner_dim_block_size: '',
-    output_subblock_h: '',
-    output_subblock_w: '',
-    pm_ideal_ns: '',
-    op_type: OpType.DEVICE_OP,
-    hash: null,
-    cache_hit: null,
-};
 
 describe('parsePerfRowTensors', () => {
-    it('parses input and output slots from perf row strings', () => {
-        const parsed = parsePerfRowTensors(baseRow);
-
-        expect(parsed.inputs).toHaveLength(2);
-        expect(parsed.outputs).toHaveLength(1);
-        expect(parsed.inputs[0]).toMatchObject({
-            label: 'Input 0',
-            dtype: 'DataType::BFLOAT16',
-            memory: 'DEV_0_L1_TILE',
-            buffer_type: BufferType.L1,
-            layout: DeviceOperationLayoutTypes.TILE,
-        });
-        expect(parsed.outputs[0]).toMatchObject({
-            label: 'Output',
-            dtype: 'DataType::BFLOAT16',
-            memory: 'DEV_0_DRAM_TILE',
-            buffer_type: BufferType.DRAM,
-            layout: DeviceOperationLayoutTypes.TILE,
-        });
-    });
-
-    it('derives table row attributes from input_0_memory', () => {
-        const parsed = parsePerfRowTensors(baseRow);
+    it('extracts L1 buffer type and TILE layout from input_0_memory', () => {
+        const parsed = parsePerfRowTensors({ input_0_memory: 'DEV_0_L1_TILE' });
 
         expect(parsed.buffer_type).toBe(BufferType.L1);
         expect(parsed.layout).toBe(DeviceOperationLayoutTypes.TILE);
     });
 
-    it('returns empty sections when tensor strings are missing', () => {
-        const parsed = parsePerfRowTensors({
-            ...baseRow,
-            input_0_datatype: '',
-            input_1_datatype: '',
-            output_datatype: '',
-            input_0_memory: '',
-            input_1_memory: '',
-            output_0_memory: '',
-        });
+    it('extracts DRAM buffer type and INTERLEAVED layout', () => {
+        const parsed = parsePerfRowTensors({ input_0_memory: 'DEV_0_DRAM_INTERLEAVED' });
 
-        expect(parsed.inputs).toHaveLength(0);
-        expect(parsed.outputs).toHaveLength(0);
+        expect(parsed.buffer_type).toBe(BufferType.DRAM);
+        expect(parsed.layout).toBe(DeviceOperationLayoutTypes.INTERLEAVED);
+    });
+
+    it('returns null fields when input_0_memory is empty', () => {
+        const parsed = parsePerfRowTensors({ input_0_memory: '' });
+
         expect(parsed.buffer_type).toBeNull();
         expect(parsed.layout).toBeNull();
     });
 
-    it('handles single-input ops with only input_0 populated', () => {
-        const parsed = parsePerfRowTensors({
-            ...baseRow,
-            input_1_datatype: '',
-            input_1_memory: '',
-        });
+    it('returns null fields when input_0_memory is unrecognized', () => {
+        const parsed = parsePerfRowTensors({ input_0_memory: 'UNKNOWN_MEMORY' });
 
-        expect(parsed.inputs).toHaveLength(1);
-        expect(parsed.inputs[0].label).toBe('Input 0');
-    });
-
-    it('returns null buffer type for unrecognized memory prefixes', () => {
-        const parsed = parsePerfRowTensors({
-            ...baseRow,
-            input_0_memory: 'UNKNOWN_MEMORY',
-        });
-
-        expect(parsed.inputs[0].buffer_type).toBeNull();
-        expect(parsed.inputs[0].layout).toBeNull();
+        expect(parsed.buffer_type).toBeNull();
+        expect(parsed.layout).toBeNull();
     });
 });

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -2,23 +2,24 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { Classes } from '@blueprintjs/core';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { AxiosResponse } from 'axios';
-import { TestProviders } from './helpers/TestProviders';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyncConfigurator';
-import getButtonWithText from './helpers/getButtonWithText';
-import getAllButtonsWithText from './helpers/getAllButtonsWithText';
-import remoteConnection from './data/remoteConnection.json';
-import mockProfilerFolderList from './data/mockProfilerFolderList.json';
-import mockRemoteProfilerFolderList from './data/mockRemoteProfilerFolderList.json';
-import mockPerformanceReportFolders from './data/mockPerformanceReportFolders.json';
-import mockRemotePerformanceFolderList from './data/mockRemotePerformanceFolderList.json';
-import mockInstance from './data/mockInstance.json';
-import { TEST_IDS } from '../src/definitions/TestIds';
-import testForPortal from './helpers/testForPortal';
 import { RemoteConnection } from '../src/definitions/RemoteConnection';
+import { TEST_IDS } from '../src/definitions/TestIds';
 import { LOCAL_STORAGE_KEY_CONNECTIONS, LOCAL_STORAGE_KEY_SELECTED } from '../src/hooks/useRemote';
+import mockInstance from './data/mockInstance.json';
+import mockPerformanceReportFolders from './data/mockPerformanceReportFolders.json';
+import mockProfilerFolderList from './data/mockProfilerFolderList.json';
+import mockRemotePerformanceFolderList from './data/mockRemotePerformanceFolderList.json';
+import mockRemoteProfilerFolderList from './data/mockRemoteProfilerFolderList.json';
+import remoteConnection from './data/remoteConnection.json';
+import getAllButtonsWithText from './helpers/getAllButtonsWithText';
+import getButtonWithText from './helpers/getButtonWithText';
+import testForPortal from './helpers/testForPortal';
+import { TestProviders } from './helpers/TestProviders';
 
 // Scrub the markup after each test
 afterEach(() => {
@@ -36,7 +37,6 @@ const CONNECTION_NAME = 'Local - ssh://localhost:2222/';
 const NO_SELECTION = '(No selection)';
 
 const HTML_DISABLED = 'disabled';
-const INTENT_SUCCESS_CLASS = 'bp6-intent-success';
 
 const { mockUseReportFolderList, mockUsePerfFolderList, mockUseInstance, mockUseReportMetadata } = vi.hoisted(() => {
     return {
@@ -313,7 +313,7 @@ it('sets active performance report and syncs it on selection', async () => {
 
     // Verify the sync button appears
     const syncButton = await screen.findByTestId(TEST_IDS.REMOTE_SYNC_BUTTON, undefined, WAIT_FOR_OPTIONS);
-    expect(syncButton.classList.contains(INTENT_SUCCESS_CLASS)).toBe(true);
+    expect(syncButton.classList.contains(Classes.INTENT_SUCCESS)).toBe(true);
 });
 
 it('handles connection with default port (22)', () => {


### PR DESCRIPTION
Adds a button when synced performance data is available to show the input/output tensors in situ.

<img width="1348" height="876" alt="Screenshot 2026-06-03 at 10 04 44" src="https://github.com/user-attachments/assets/00bf07af-d99c-433b-ac74-59fd1ef4440f" />

<img width="1348" height="876" alt="Screenshot 2026-06-03 at 10 04 40" src="https://github.com/user-attachments/assets/16c1cacb-519e-4ef4-b26f-d1c62ba20b07" />

This pull request introduces several improvements and refactors to the UI, with a major new feature: the ability to view tensor details directly from the performance table via a side drawer. It also includes code cleanup, improved Blueprint class usage, and minor theme-related changes.

**New Feature: Tensor Details Drawer in Performance Table**
- Added a new `PerfTensorDrawer` component that displays detailed tensor information for a selected row in the performance table. Users can open this drawer by clicking a new button in each row (except for signpost rows), with tooltips explaining availability. The drawer links to the corresponding operation and shows input/output tensor details. [[1]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afR100-R123) [[2]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afR189-R192) [[3]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afL226-R290) [[4]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afR316) [[5]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afL276-R334) [[6]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afL288-R352) [[7]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afR376-R377) [[8]](diffhunk://#diff-45a205e65bd2e13e7fc4e68370c1c168c214e5d30a9e0c70d7a134f8a519b2e7R1-R85)

**Refactoring and Cleanup in Buffer Details**
- Replaced the custom `getFirstOperation` and `getLastOperation` functions with shared `getOperationLink` and `getLastConsumerLink` helpers for code reuse and maintainability in `BufferDetails`. [[1]](diffhunk://#diff-3e40a66332bf492516dbbcc7c3cfff7777d2f030de195e6c9a15a3b2ab2eb4e3L8-R15) [[2]](diffhunk://#diff-3e40a66332bf492516dbbcc7c3cfff7777d2f030de195e6c9a15a3b2ab2eb4e3L49-R50) [[3]](diffhunk://#diff-3e40a66332bf492516dbbcc7c3cfff7777d2f030de195e6c9a15a3b2ab2eb4e3L58-R59) [[4]](diffhunk://#diff-3e40a66332bf492516dbbcc7c3cfff7777d2f030de195e6c9a15a3b2ab2eb4e3L158-L181)

**Blueprint and Styling Improvements**
- Improved Blueprint usage by using the `Classes` object for class names where appropriate and adding clarifying comments. Updated slider progress styling in the NPE view for consistency. [[1]](diffhunk://#diff-312c2d0fe5fd948a64592fd95d40e9e5356143de0932350f54d1194bd602959bL10-R10) [[2]](diffhunk://#diff-312c2d0fe5fd948a64592fd95d40e9e5356143de0932350f54d1194bd602959bL565-R565) [[3]](diffhunk://#diff-f50526e6735745f3a666f62f3dc3aee4b3d8144cf970856fc508cf33636e8497R43)

**Theme and Layout Adjustments**
- Set the default body class to `bp6-dark` for dark mode and removed the Blueprint `Classes.DARK` wrapper from the layout, simplifying theme handling. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L36-R37) [[2]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L6) [[3]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L32-R31) [[4]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L86-R85)

**Performance Table Code Modernization**
- Updated imports and hooks in `PerfTable.tsx` for consistency, added missing styles, and improved state management for row selection and synchronization with profiler reports. [[1]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afL5-R12) [[2]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afL19-R33) [[3]](diffhunk://#diff-1333a1aa976a08fcdd6b7f9961e2df176de754dcb05d8b60dbf5b8bd8fa8f0afR60-R61)

These changes collectively enhance the user experience, streamline the codebase, and lay the groundwork for further improvements to tensor and operation introspection.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1513.