### PR TITLE
mlir selected node properties panel

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -38,7 +38,14 @@ import '@xyflow/react/dist/style.css';
 
 import { Button } from '@blueprintjs/core';
 import { GraphBundle } from '../../model/MLIRJsonModel';
-import type { BuiltGraph, IncomingEdgeView, OutgoingEdge, SourceNode, WorkerNode } from './mlirGraphTypes';
+import type {
+    BuiltGraph,
+    IncomingEdgeView,
+    IndexedPortMetadata,
+    OutgoingEdge,
+    SourceNode,
+    WorkerNode,
+} from './mlirGraphTypes';
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
@@ -518,6 +525,36 @@ const MlGraphInner = ({ data }: ViewProps) => {
 
     const selectedSourceNode = selectedNodeId ? (sourceNodeById.get(selectedNodeId) ?? null) : null;
 
+    // Region-output partner map. When a namespace is expanded, the layout
+    // worker remaps edges that conceptually flow out of the region's outer op
+    // (e.g. `stablehlo.reduce`) so they're rendered as sourced from the
+    // region's terminator (e.g. `stablehlo.return`). The two ops are visually
+    // distinct but represent the same logical output: the outer op carries
+    // `outputsMetadata` (shape/dtype/__tensor_tag/…), the terminator carries
+    // the rendered outgoing edges (consumers). Without bonding them, the
+    // panel reports inconsistent data depending on which side of the pair
+    // the user selected. Built bidirectionally so `partner.get(outerOp) ===
+    // returnNode` and `partner.get(returnNode) === outerOp`.
+    const regionOutputPartnerByNodeId = useMemo<Map<string, string>>(() => {
+        const result = new Map<string, string>();
+        if (!interactionIndex) {
+            return result;
+        }
+        const outerOpByNamespace = new Map<string, string>();
+        for (const [outerOpId, namespace] of Object.entries(interactionIndex.outerNamespaceByNodeId)) {
+            outerOpByNamespace.set(namespace, outerOpId);
+        }
+        for (const namespace of expandedNamespaces) {
+            const outerOpId = outerOpByNamespace.get(namespace);
+            const returnNodeId = interactionIndex.namespaceReturnNodeByNamespace[namespace];
+            if (outerOpId && returnNodeId && outerOpId !== returnNodeId) {
+                result.set(outerOpId, returnNodeId);
+                result.set(returnNodeId, outerOpId);
+            }
+        }
+        return result;
+    }, [interactionIndex, expandedNamespaces]);
+
     // Both panel I/O sections read from the React Flow `edges` array — i.e.
     // the connections actually drawn on the canvas — rather than from the
     // source-data inversion. Terminator ops (e.g. `stablehlo.return`) have
@@ -532,9 +569,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (!selectedNodeId) {
             return [];
         }
+        // Also pick up edges sourced from the region-output partner so that
+        // selecting either side of the (outer op ↔ terminator) pair surfaces
+        // the same consumers.
+        const partnerNodeId = regionOutputPartnerByNodeId.get(selectedNodeId);
         const result: OutgoingEdge[] = [];
         for (const edge of edges) {
-            if (edge.source !== selectedNodeId) {
+            if (edge.source !== selectedNodeId && edge.source !== partnerNodeId) {
                 continue;
             }
             result.push({
@@ -545,7 +586,25 @@ const MlGraphInner = ({ data }: ViewProps) => {
             });
         }
         return result;
-    }, [edges, selectedNodeId]);
+    }, [edges, selectedNodeId, regionOutputPartnerByNodeId]);
+
+    // Output port metadata for the panel: the selected node's own metadata
+    // when present, else the partner's. For a region's terminator (no own
+    // `outputsMetadata`) this surfaces the outer op's port metadata, so the
+    // Outputs section stays consistent across both sides of the pair.
+    const selectedOutputsMetadata = useMemo<IndexedPortMetadata[]>(() => {
+        if (!selectedSourceNode) {
+            return [];
+        }
+        if (selectedSourceNode.outputsMetadata.length > 0) {
+            return selectedSourceNode.outputsMetadata;
+        }
+        const partnerNodeId = regionOutputPartnerByNodeId.get(selectedSourceNode.id);
+        if (!partnerNodeId) {
+            return [];
+        }
+        return sourceNodeById.get(partnerNodeId)?.outputsMetadata ?? [];
+    }, [selectedSourceNode, regionOutputPartnerByNodeId, sourceNodeById]);
     const selectedIncomingEdges = useMemo<IncomingEdgeView[]>(() => {
         if (!selectedNodeId) {
             return [];
@@ -855,6 +914,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     node={selectedSourceNode}
                     incomingEdges={selectedIncomingEdges}
                     outgoingEdges={selectedOutgoingEdges}
+                    outputsMetadata={selectedOutputsMetadata}
                     onClose={closeDetailsPanel}
                     onRecenter={recenterOnSelected}
                 />

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -38,7 +38,7 @@ import '@xyflow/react/dist/style.css';
 
 import { Button } from '@blueprintjs/core';
 import { GraphBundle } from '../../model/MLIRJsonModel';
-import type { BuiltGraph, OutgoingEdge, SourceNode, WorkerNode } from './mlirGraphTypes';
+import type { BuiltGraph, IncomingEdgeView, OutgoingEdge, SourceNode, WorkerNode } from './mlirGraphTypes';
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
@@ -518,14 +518,16 @@ const MlGraphInner = ({ data }: ViewProps) => {
 
     const selectedSourceNode = selectedNodeId ? (sourceNodeById.get(selectedNodeId) ?? null) : null;
 
-    // Outgoing edges for the details panel ("Outputs" section) are read from
-    // the React Flow `edges` array — i.e. the connections actually drawn on
-    // the canvas — rather than inverted from source-data `incomingEdges`.
-    // Terminator ops (e.g. `stablehlo.return`) have outgoing arrows that the
-    // layout worker synthesises for region plumbing but that don't exist as
-    // back-references in the raw graph JSON, so the source-data inversion
-    // would miss them. The label captures the tensor shape (e.g.
-    // "[7, 3072] bf16") so the panel can surface that alongside each consumer.
+    // Both panel I/O sections read from the React Flow `edges` array — i.e.
+    // the connections actually drawn on the canvas — rather than from the
+    // source-data inversion. Terminator ops (e.g. `stablehlo.return`) have
+    // outgoing arrows that the layout worker synthesises for region plumbing
+    // but that never round-trip through the raw graph JSON, so the source-
+    // data inversion would miss them. The edge `label` carries the tensor
+    // shape (e.g. "[7, 3072] bf16"), and for inputs we additionally enrich
+    // with the producer's `outputsMetadata` for the relevant source port —
+    // that's the per-port shape/dtype/`__tensor_tag` payload that flows
+    // along the wire.
     const selectedOutgoingEdges = useMemo<OutgoingEdge[]>(() => {
         if (!selectedNodeId) {
             return [];
@@ -544,6 +546,28 @@ const MlGraphInner = ({ data }: ViewProps) => {
         }
         return result;
     }, [edges, selectedNodeId]);
+    const selectedIncomingEdges = useMemo<IncomingEdgeView[]>(() => {
+        if (!selectedNodeId) {
+            return [];
+        }
+        const result: IncomingEdgeView[] = [];
+        for (const edge of edges) {
+            if (edge.target !== selectedNodeId) {
+                continue;
+            }
+            const sourcePortId = edge.sourceHandle ?? '0';
+            const producer = sourceNodeById.get(edge.source);
+            const sourcePortMetadata = producer?.outputsMetadata.find((p) => p.id === sourcePortId) ?? null;
+            result.push({
+                sourceNodeId: edge.source,
+                sourceNodeOutputId: sourcePortId,
+                targetNodeInputId: edge.targetHandle ?? '0',
+                label: typeof edge.label === 'string' ? edge.label : undefined,
+                sourcePortMetadata,
+            });
+        }
+        return result;
+    }, [edges, selectedNodeId, sourceNodeById]);
 
     const closeDetailsPanel = useCallback(() => {
         setSelectedNodeId(null);
@@ -829,6 +853,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             {selectedSourceNode && (
                 <MlirNodeDetailsPanel
                     node={selectedSourceNode}
+                    incomingEdges={selectedIncomingEdges}
                     outgoingEdges={selectedOutgoingEdges}
                     onClose={closeDetailsPanel}
                     onRecenter={recenterOnSelected}

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -38,7 +38,7 @@ import '@xyflow/react/dist/style.css';
 
 import { Button } from '@blueprintjs/core';
 import { GraphBundle } from '../../model/MLIRJsonModel';
-import type { BuiltGraph, SourceNode, WorkerNode } from './mlirGraphTypes';
+import type { BuiltGraph, OutgoingEdge, SourceNode, WorkerNode } from './mlirGraphTypes';
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
@@ -515,7 +515,35 @@ const MlGraphInner = ({ data }: ViewProps) => {
         }
         return result;
     }, [sourceNodes]);
+
     const selectedSourceNode = selectedNodeId ? (sourceNodeById.get(selectedNodeId) ?? null) : null;
+
+    // Outgoing edges for the details panel ("Outputs" section) are read from
+    // the React Flow `edges` array — i.e. the connections actually drawn on
+    // the canvas — rather than inverted from source-data `incomingEdges`.
+    // Terminator ops (e.g. `stablehlo.return`) have outgoing arrows that the
+    // layout worker synthesises for region plumbing but that don't exist as
+    // back-references in the raw graph JSON, so the source-data inversion
+    // would miss them. The label captures the tensor shape (e.g.
+    // "[7, 3072] bf16") so the panel can surface that alongside each consumer.
+    const selectedOutgoingEdges = useMemo<OutgoingEdge[]>(() => {
+        if (!selectedNodeId) {
+            return [];
+        }
+        const result: OutgoingEdge[] = [];
+        for (const edge of edges) {
+            if (edge.source !== selectedNodeId) {
+                continue;
+            }
+            result.push({
+                targetNodeId: edge.target,
+                sourceNodeOutputId: edge.sourceHandle ?? '0',
+                targetNodeInputId: edge.targetHandle ?? '0',
+                label: typeof edge.label === 'string' ? edge.label : undefined,
+            });
+        }
+        return result;
+    }, [edges, selectedNodeId]);
 
     const closeDetailsPanel = useCallback(() => {
         setSelectedNodeId(null);
@@ -801,6 +829,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             {selectedSourceNode && (
                 <MlirNodeDetailsPanel
                     node={selectedSourceNode}
+                    outgoingEdges={selectedOutgoingEdges}
                     onClose={closeDetailsPanel}
                     onRecenter={recenterOnSelected}
                 />

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -594,6 +594,52 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // with the producer's `outputsMetadata` for the relevant source port —
     // that's the per-port shape/dtype/`__tensor_tag` payload that flows
     // along the wire.
+    //
+    // Index `edges` once per build by source-id and target-id so each
+    // selection change is O(degree of selected node) instead of O(|E|).
+    // MLIR graphs can run into the tens of thousands of edges; without
+    // these indices, every node click would re-walk the whole edge list.
+    const { outgoingEdgesByNodeId, incomingEdgesByNodeId } = useMemo<{
+        outgoingEdgesByNodeId: Map<string, Edge[]>;
+        incomingEdgesByNodeId: Map<string, Edge[]>;
+    }>(() => {
+        const outgoing = new Map<string, Edge[]>();
+        const incoming = new Map<string, Edge[]>();
+        for (const edge of edges) {
+            const fromBucket = outgoing.get(edge.source);
+            if (fromBucket) {
+                fromBucket.push(edge);
+            } else {
+                outgoing.set(edge.source, [edge]);
+            }
+            const toBucket = incoming.get(edge.target);
+            if (toBucket) {
+                toBucket.push(edge);
+            } else {
+                incoming.set(edge.target, [edge]);
+            }
+        }
+        return { outgoingEdgesByNodeId: outgoing, incomingEdgesByNodeId: incoming };
+    }, [edges]);
+
+    // Per-node output-port lookup so incoming-edge enrichment can grab the
+    // producer's port metadata in O(1) instead of `find()`-ing through the
+    // producer's `outputsMetadata` array on every edge.
+    const outputsPortMetadataByNodeIdAndPortId = useMemo<Map<string, Map<string, IndexedPortMetadata>>>(() => {
+        const result = new Map<string, Map<string, IndexedPortMetadata>>();
+        for (const sourceNode of sourceNodes) {
+            if (sourceNode.outputsMetadata.length === 0) {
+                continue;
+            }
+            const portMap = new Map<string, IndexedPortMetadata>();
+            for (const port of sourceNode.outputsMetadata) {
+                portMap.set(port.id, port);
+            }
+            result.set(sourceNode.id, portMap);
+        }
+        return result;
+    }, [sourceNodes]);
+
     const selectedOutgoingEdges = useMemo<OutgoingEdge[]>(() => {
         if (!selectedNodeId) {
             return [];
@@ -602,21 +648,31 @@ const MlGraphInner = ({ data }: ViewProps) => {
         // selecting either side of the (outer op ↔ terminator) pair surfaces
         // the same consumers.
         const partnerNodeId = regionOutputPartnerByNodeId.get(selectedNodeId);
-        const result: OutgoingEdge[] = [];
-        for (const edge of edges) {
-            if (edge.source !== selectedNodeId && edge.source !== partnerNodeId) {
-                continue;
+        const buckets: Edge[][] = [];
+        const selfBucket = outgoingEdgesByNodeId.get(selectedNodeId);
+        if (selfBucket) {
+            buckets.push(selfBucket);
+        }
+        if (partnerNodeId) {
+            const partnerBucket = outgoingEdgesByNodeId.get(partnerNodeId);
+            if (partnerBucket) {
+                buckets.push(partnerBucket);
             }
-            result.push({
-                targetNodeId: edge.target,
-                targetNodeLabel: sourceNodeById.get(edge.target)?.label ?? null,
-                sourceNodeOutputId: edge.sourceHandle ?? '0',
-                targetNodeInputId: edge.targetHandle ?? '0',
-                label: typeof edge.label === 'string' ? edge.label : undefined,
-            });
+        }
+        const result: OutgoingEdge[] = [];
+        for (const bucket of buckets) {
+            for (const edge of bucket) {
+                result.push({
+                    targetNodeId: edge.target,
+                    targetNodeLabel: sourceNodeById.get(edge.target)?.label ?? null,
+                    sourceNodeOutputId: edge.sourceHandle ?? '0',
+                    targetNodeInputId: edge.targetHandle ?? '0',
+                    label: typeof edge.label === 'string' ? edge.label : undefined,
+                });
+            }
         }
         return result;
-    }, [edges, selectedNodeId, regionOutputPartnerByNodeId, sourceNodeById]);
+    }, [outgoingEdgesByNodeId, selectedNodeId, regionOutputPartnerByNodeId, sourceNodeById]);
 
     // Output port metadata for the panel: the selected node's own metadata
     // when present, else the partner's. For a region's terminator (no own
@@ -645,34 +701,58 @@ const MlGraphInner = ({ data }: ViewProps) => {
         // their edges back to the anchor's input port (the index of the
         // arg in `namespaceInputByNamespace[ns]`).
         const argIdxByArgId = inputArgIdxByArgIdByAnchor.get(selectedNodeId);
-        const result: IncomingEdgeView[] = [];
-        for (const edge of edges) {
-            let targetInputId: string | null = null;
-            if (edge.target === selectedNodeId) {
-                targetInputId = edge.targetHandle ?? '0';
-            } else if (argIdxByArgId) {
-                const idx = argIdxByArgId.get(edge.target);
-                if (idx !== undefined) {
-                    targetInputId = String(idx);
-                }
-            }
-            if (targetInputId === null) {
-                continue;
-            }
-            const sourcePortId = edge.sourceHandle ?? '0';
-            const producer = sourceNodeById.get(edge.source);
-            const sourcePortMetadata = producer?.outputsMetadata.find((p) => p.id === sourcePortId) ?? null;
-            result.push({
-                sourceNodeId: edge.source,
-                sourceNodeLabel: producer?.label ?? null,
-                sourceNodeOutputId: sourcePortId,
-                targetNodeInputId: targetInputId,
-                label: typeof edge.label === 'string' ? edge.label : undefined,
-                sourcePortMetadata,
+        // Build the (bucket, targetInputId resolver) pairs we need to walk.
+        // Direct edges hitting the selection use their own targetHandle; arg
+        // edges resolve to the anchor's input-port index via `argIdxByArgId`.
+        const pairs: Array<{ bucket: Edge[]; resolveTargetInputId: (edge: Edge) => string | null }> = [];
+        const selfBucket = incomingEdgesByNodeId.get(selectedNodeId);
+        if (selfBucket) {
+            pairs.push({
+                bucket: selfBucket,
+                resolveTargetInputId: (edge) => edge.targetHandle ?? '0',
             });
         }
+        if (argIdxByArgId) {
+            for (const [argNodeId, portIdx] of argIdxByArgId) {
+                const argBucket = incomingEdgesByNodeId.get(argNodeId);
+                if (argBucket) {
+                    const portIdStr = String(portIdx);
+                    pairs.push({
+                        bucket: argBucket,
+                        resolveTargetInputId: () => portIdStr,
+                    });
+                }
+            }
+        }
+        const result: IncomingEdgeView[] = [];
+        for (const { bucket, resolveTargetInputId } of pairs) {
+            for (const edge of bucket) {
+                const targetInputId = resolveTargetInputId(edge);
+                if (targetInputId === null) {
+                    continue;
+                }
+                const sourcePortId = edge.sourceHandle ?? '0';
+                const producer = sourceNodeById.get(edge.source);
+                const sourcePortMetadata =
+                    outputsPortMetadataByNodeIdAndPortId.get(edge.source)?.get(sourcePortId) ?? null;
+                result.push({
+                    sourceNodeId: edge.source,
+                    sourceNodeLabel: producer?.label ?? null,
+                    sourceNodeOutputId: sourcePortId,
+                    targetNodeInputId: targetInputId,
+                    label: typeof edge.label === 'string' ? edge.label : undefined,
+                    sourcePortMetadata,
+                });
+            }
+        }
         return result;
-    }, [edges, selectedNodeId, sourceNodeById, inputArgIdxByArgIdByAnchor]);
+    }, [
+        incomingEdgesByNodeId,
+        outputsPortMetadataByNodeIdAndPortId,
+        selectedNodeId,
+        sourceNodeById,
+        inputArgIdxByArgIdByAnchor,
+    ]);
 
     const closeDetailsPanel = useCallback(() => {
         setSelectedNodeId(null);

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -609,13 +609,14 @@ const MlGraphInner = ({ data }: ViewProps) => {
             }
             result.push({
                 targetNodeId: edge.target,
+                targetNodeLabel: sourceNodeById.get(edge.target)?.label ?? null,
                 sourceNodeOutputId: edge.sourceHandle ?? '0',
                 targetNodeInputId: edge.targetHandle ?? '0',
                 label: typeof edge.label === 'string' ? edge.label : undefined,
             });
         }
         return result;
-    }, [edges, selectedNodeId, regionOutputPartnerByNodeId]);
+    }, [edges, selectedNodeId, regionOutputPartnerByNodeId, sourceNodeById]);
 
     // Output port metadata for the panel: the selected node's own metadata
     // when present, else the partner's. For a region's terminator (no own
@@ -663,6 +664,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             const sourcePortMetadata = producer?.outputsMetadata.find((p) => p.id === sourcePortId) ?? null;
             result.push({
                 sourceNodeId: edge.source,
+                sourceNodeLabel: producer?.label ?? null,
                 sourceNodeOutputId: sourcePortId,
                 targetNodeInputId: targetInputId,
                 label: typeof edge.label === 'string' ? edge.label : undefined,

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -41,6 +41,7 @@ import { GraphBundle } from '../../model/MLIRJsonModel';
 import type { BuiltGraph, SourceNode, WorkerNode } from './mlirGraphTypes';
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
+import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
 
 // Re-uses `WorkerNode['data']` (the canonical shape produced by the layout
 // worker) and tacks on `highlight` — a view-layer-only flag. Set when this
@@ -503,6 +504,30 @@ const MlGraphInner = ({ data }: ViewProps) => {
 
     const nodeTypes = useMemo(() => ({ mlirOp: MlirOpNode, mlirGroup: MlirGroupNode }) as const, []);
 
+    // Look up the canonical SourceNode for the current selection so the
+    // details panel reads from the same authoritative shape that drove the
+    // graph build. `sourceNodes` is already memoised above, so this map is
+    // rebuilt only when the underlying graph changes.
+    const sourceNodeById = useMemo(() => {
+        const result = new Map<string, SourceNode>();
+        for (const sourceNode of sourceNodes) {
+            result.set(sourceNode.id, sourceNode);
+        }
+        return result;
+    }, [sourceNodes]);
+    const selectedSourceNode = selectedNodeId ? (sourceNodeById.get(selectedNodeId) ?? null) : null;
+
+    const closeDetailsPanel = useCallback(() => {
+        setSelectedNodeId(null);
+    }, []);
+
+    const recenterOnSelected = useCallback(() => {
+        if (!selectedNodeId) {
+            return;
+        }
+        void fitView({ nodes: [{ id: selectedNodeId }], padding: 0.3, duration: 200 });
+    }, [fitView, selectedNodeId]);
+
     // Edge display rules:
     // 1. Drop edges where either endpoint is a real-namespace group node.
     //    The worker's internal-edges loop emits these for nested expanded
@@ -772,6 +797,14 @@ const MlGraphInner = ({ data }: ViewProps) => {
             >
                 Re-layout
             </Button>
+
+            {selectedSourceNode && (
+                <MlirNodeDetailsPanel
+                    node={selectedSourceNode}
+                    onClose={closeDetailsPanel}
+                    onRecenter={recenterOnSelected}
+                />
+            )}
         </div>
     );
 };

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -525,34 +525,63 @@ const MlGraphInner = ({ data }: ViewProps) => {
 
     const selectedSourceNode = selectedNodeId ? (sourceNodeById.get(selectedNodeId) ?? null) : null;
 
-    // Region-output partner map. When a namespace is expanded, the layout
-    // worker remaps edges that conceptually flow out of the region's outer op
-    // (e.g. `stablehlo.reduce`) so they're rendered as sourced from the
-    // region's terminator (e.g. `stablehlo.return`). The two ops are visually
-    // distinct but represent the same logical output: the outer op carries
-    // `outputsMetadata` (shape/dtype/__tensor_tag/…), the terminator carries
-    // the rendered outgoing edges (consumers). Without bonding them, the
-    // panel reports inconsistent data depending on which side of the pair
-    // the user selected. Built bidirectionally so `partner.get(outerOp) ===
-    // returnNode` and `partner.get(returnNode) === outerOp`.
-    const regionOutputPartnerByNodeId = useMemo<Map<string, string>>(() => {
-        const result = new Map<string, string>();
+    // Region partnership maps for expanded namespaces. The layout worker
+    // remaps cross-region edges in two symmetric ways when a namespace is
+    // expanded:
+    //
+    //   - Outputs: edges conceptually flowing OUT of the region's anchor op
+    //     (e.g. `stablehlo.reduce`) are rendered as sourced from the
+    //     terminator (e.g. `stablehlo.return`). The anchor carries
+    //     `outputsMetadata`; the terminator carries the rendered consumer
+    //     edges. Bonded bidirectionally so selecting either side surfaces
+    //     the same data.
+    //
+    //   - Inputs: edges conceptually flowing INTO the anchor op are rendered
+    //     as targeting the namespace's inner input-arg node for the matching
+    //     port (`namespaceInputByNamespace[ns][portIdx]`). To surface those
+    //     under the anchor's Inputs section, we keep an inverse map from
+    //     arg id → the anchor + port index it represents.
+    //
+    // `anchorByNamespace` is the right key here: it maps every namespace
+    // (top-level or nested) to its representative op. `outerNamespaceByNodeId`
+    // only records *parent-level toggles* (an op in the parent namespace
+    // that controls a child), so it silently misses top-level regions whose
+    // anchor lives inside the namespace — which is exactly the case for ops
+    // like a top-level `stablehlo.all_reduce_N`. All three maps are populated
+    // only for expanded namespaces; collapsed regions need no pairing.
+    const { regionOutputPartnerByNodeId, inputArgIdxByArgIdByAnchor } = useMemo<{
+        regionOutputPartnerByNodeId: Map<string, string>;
+        inputArgIdxByArgIdByAnchor: Map<string, Map<string, number>>;
+    }>(() => {
+        const outputPartner = new Map<string, string>();
+        const inputArgsByAnchor = new Map<string, Map<string, number>>();
         if (!interactionIndex) {
-            return result;
-        }
-        const outerOpByNamespace = new Map<string, string>();
-        for (const [outerOpId, namespace] of Object.entries(interactionIndex.outerNamespaceByNodeId)) {
-            outerOpByNamespace.set(namespace, outerOpId);
+            return {
+                regionOutputPartnerByNodeId: outputPartner,
+                inputArgIdxByArgIdByAnchor: inputArgsByAnchor,
+            };
         }
         for (const namespace of expandedNamespaces) {
-            const outerOpId = outerOpByNamespace.get(namespace);
+            const anchorNodeId = interactionIndex.anchorByNamespace[namespace];
+            if (!anchorNodeId) {
+                continue;
+            }
             const returnNodeId = interactionIndex.namespaceReturnNodeByNamespace[namespace];
-            if (outerOpId && returnNodeId && outerOpId !== returnNodeId) {
-                result.set(outerOpId, returnNodeId);
-                result.set(returnNodeId, outerOpId);
+            if (returnNodeId && returnNodeId !== anchorNodeId) {
+                outputPartner.set(anchorNodeId, returnNodeId);
+                outputPartner.set(returnNodeId, anchorNodeId);
+            }
+            const inputArgs = interactionIndex.namespaceInputByNamespace[namespace];
+            if (inputArgs && inputArgs.length > 0) {
+                const argToIdx = new Map<string, number>();
+                inputArgs.forEach((argId, idx) => argToIdx.set(argId, idx));
+                inputArgsByAnchor.set(anchorNodeId, argToIdx);
             }
         }
-        return result;
+        return {
+            regionOutputPartnerByNodeId: outputPartner,
+            inputArgIdxByArgIdByAnchor: inputArgsByAnchor,
+        };
     }, [interactionIndex, expandedNamespaces]);
 
     // Both panel I/O sections read from the React Flow `edges` array — i.e.
@@ -609,9 +638,24 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (!selectedNodeId) {
             return [];
         }
+        // When the selection is the anchor op of an expanded region, the
+        // layout worker has rewritten its cross-region incoming edges to land
+        // on the inner input-arg nodes. Walk those args too and attribute
+        // their edges back to the anchor's input port (the index of the
+        // arg in `namespaceInputByNamespace[ns]`).
+        const argIdxByArgId = inputArgIdxByArgIdByAnchor.get(selectedNodeId);
         const result: IncomingEdgeView[] = [];
         for (const edge of edges) {
-            if (edge.target !== selectedNodeId) {
+            let targetInputId: string | null = null;
+            if (edge.target === selectedNodeId) {
+                targetInputId = edge.targetHandle ?? '0';
+            } else if (argIdxByArgId) {
+                const idx = argIdxByArgId.get(edge.target);
+                if (idx !== undefined) {
+                    targetInputId = String(idx);
+                }
+            }
+            if (targetInputId === null) {
                 continue;
             }
             const sourcePortId = edge.sourceHandle ?? '0';
@@ -620,13 +664,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
             result.push({
                 sourceNodeId: edge.source,
                 sourceNodeOutputId: sourcePortId,
-                targetNodeInputId: edge.targetHandle ?? '0',
+                targetNodeInputId: targetInputId,
                 label: typeof edge.label === 'string' ? edge.label : undefined,
                 sourcePortMetadata,
             });
         }
         return result;
-    }, [edges, selectedNodeId, sourceNodeById]);
+    }, [edges, selectedNodeId, sourceNodeById, inputArgIdxByArgIdByAnchor]);
 
     const closeDetailsPanel = useCallback(() => {
         setSelectedNodeId(null);

--- a/src/components/mlir/MlirAttrValue.tsx
+++ b/src/components/mlir/MlirAttrValue.tsx
@@ -81,7 +81,7 @@ const MlirAttrValue = ({ value }: MlirAttrValueProps) => {
     if (parsed.kind === 'scalar') {
         return <span className='mlir-attr-value mlir-attr-value-scalar'>{parsed.text}</span>;
     }
-    return <NestedTree data={parsed.kind === 'array' ? parsed.parsed : parsed.parsed} />;
+    return <NestedTree data={parsed.parsed} />;
 };
 
 export default MlirAttrValue;

--- a/src/components/mlir/MlirAttrValue.tsx
+++ b/src/components/mlir/MlirAttrValue.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { tryParseAttrValue } from './attrFormatter';
+import { ParsedAttrKind, tryParseAttrValue } from './attrFormatter';
 
 interface MlirAttrValueProps {
     value: string;
@@ -78,7 +78,7 @@ const NestedTree = ({ data }: NestedTreeProps) => {
 
 const MlirAttrValue = ({ value }: MlirAttrValueProps) => {
     const parsed = tryParseAttrValue(value);
-    if (parsed.kind === 'scalar') {
+    if (parsed.kind === ParsedAttrKind.Scalar) {
         return <span className='mlir-attr-value mlir-attr-value-scalar'>{parsed.text}</span>;
     }
     return <NestedTree data={parsed.parsed} />;

--- a/src/components/mlir/MlirAttrValue.tsx
+++ b/src/components/mlir/MlirAttrValue.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { tryParseAttrValue } from './attrFormatter';
+
+interface MlirAttrValueProps {
+    value: string;
+}
+
+const renderPrimitive = (v: unknown): string => {
+    if (v === null) {
+        return 'null';
+    }
+    if (typeof v === 'string') {
+        return v;
+    }
+    return String(v);
+};
+
+interface NestedTreeProps {
+    data: unknown;
+}
+
+// Recursive walker for parsed JSON. Renders objects as `key: value` rows and
+// arrays as `[i]: value` rows. Nested objects/arrays produce further indented
+// children. Primitives are rendered as text. The component is intentionally
+// styleless beyond two class hooks (`.mlir-attr-tree`, `.mlir-attr-row`) — the
+// panel SCSS owns all visual details.
+const NestedTree = ({ data }: NestedTreeProps) => {
+    if (Array.isArray(data)) {
+        if (data.length === 0) {
+            return <span className='mlir-attr-empty'>[]</span>;
+        }
+        return (
+            <ul className='mlir-attr-tree'>
+                {data.map((item, idx) => (
+                    <li
+                        key={idx}
+                        className='mlir-attr-row'
+                    >
+                        <span className='mlir-attr-key'>[{idx}]</span>
+                        {Array.isArray(item) || (item !== null && typeof item === 'object') ? (
+                            <NestedTree data={item} />
+                        ) : (
+                            <span className='mlir-attr-value'>{renderPrimitive(item)}</span>
+                        )}
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+    if (data !== null && typeof data === 'object') {
+        const entries = Object.entries(data as Record<string, unknown>);
+        if (entries.length === 0) {
+            return <span className='mlir-attr-empty'>{'{}'}</span>;
+        }
+        return (
+            <ul className='mlir-attr-tree'>
+                {entries.map(([k, v]) => (
+                    <li
+                        key={k}
+                        className='mlir-attr-row'
+                    >
+                        <span className='mlir-attr-key'>{k}</span>
+                        {Array.isArray(v) || (v !== null && typeof v === 'object') ? (
+                            <NestedTree data={v} />
+                        ) : (
+                            <span className='mlir-attr-value'>{renderPrimitive(v)}</span>
+                        )}
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+    return <span className='mlir-attr-value'>{renderPrimitive(data)}</span>;
+};
+
+const MlirAttrValue = ({ value }: MlirAttrValueProps) => {
+    const parsed = tryParseAttrValue(value);
+    if (parsed.kind === 'scalar') {
+        return <span className='mlir-attr-value mlir-attr-value-scalar'>{parsed.text}</span>;
+    }
+    return <NestedTree data={parsed.kind === 'array' ? parsed.parsed : parsed.parsed} />;
+};
+
+export default MlirAttrValue;

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { ReactNode } from 'react';
+import { useAtom } from 'jotai';
+import { Button, ButtonVariant, Collapse, Size, Tooltip } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import 'styles/components/MlirNodeDetailsPanel.scss';
+import classNames from 'classnames';
+import type { SourceNode } from './mlirGraphTypes';
+import MlirAttrValue from './MlirAttrValue';
+import { mlirNodeDetailsCollapsedAtom } from '../../store/app';
+
+interface MlirNodeDetailsPanelProps {
+    node: SourceNode;
+    onClose: () => void;
+    onRecenter: () => void;
+}
+
+type SectionKey = 'attrs' | 'inputs' | 'outputs';
+
+interface DetailsSectionProps {
+    title: string;
+    sectionKey: SectionKey;
+    collapsed: boolean;
+    onToggle: (key: SectionKey) => void;
+    emptyHint: string;
+    isEmpty: boolean;
+    count?: number;
+    children: ReactNode;
+}
+
+// Local collapsible section. We don't reuse the shared `Collapsible` component
+// because we need (a) parent-driven open/close state synced to the persisted
+// atom, (b) a distinct visual treatment (the section header acts as a band
+// with a count badge), and (c) section-specific class hooks so #1548 can
+// later style the I/O bodies independently.
+const DetailsSection = ({
+    title,
+    sectionKey,
+    collapsed,
+    onToggle,
+    emptyHint,
+    isEmpty,
+    count,
+    children,
+}: DetailsSectionProps) => (
+    <section className={classNames('mlir-node-details-section', `mlir-node-details-${sectionKey}`)}>
+        <button
+            type='button'
+            className='mlir-node-details-section-header'
+            aria-expanded={!collapsed}
+            onClick={() => onToggle(sectionKey)}
+        >
+            <span className='mlir-node-details-section-caret'>{collapsed ? '▸' : '▾'}</span>
+            <span className='mlir-node-details-section-title'>{title}</span>
+            {typeof count === 'number' && <span className='mlir-node-details-section-count'>{count}</span>}
+        </button>
+        <Collapse
+            isOpen={!collapsed}
+            keepChildrenMounted
+        >
+            <div className='mlir-node-details-section-body'>
+                {isEmpty ? <p className='mlir-node-details-empty'>{emptyHint}</p> : children}
+            </div>
+        </Collapse>
+    </section>
+);
+
+const MlirNodeDetailsPanel = ({ node, onClose, onRecenter }: MlirNodeDetailsPanelProps) => {
+    const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
+
+    const toggleSection = (key: SectionKey) => {
+        setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
+    };
+
+    return (
+        <aside
+            className='mlir-node-details-panel'
+            aria-label='Selected node details'
+        >
+            <header className='mlir-node-details-header'>
+                <div className='mlir-node-details-titles'>
+                    <h2 className='mlir-node-details-label'>{node.label}</h2>
+                    <p
+                        className='mlir-node-details-id'
+                        title={node.id}
+                    >
+                        {node.id}
+                    </p>
+                </div>
+                <div className='mlir-node-details-actions'>
+                    <Tooltip content='Recenter on this node'>
+                        <Button
+                            size={Size.SMALL}
+                            variant={ButtonVariant.MINIMAL}
+                            icon={IconNames.LOCATE}
+                            aria-label='Recenter on this node'
+                            onClick={onRecenter}
+                        />
+                    </Tooltip>
+                    <Tooltip content='Close'>
+                        <Button
+                            size={Size.SMALL}
+                            variant={ButtonVariant.MINIMAL}
+                            icon={IconNames.CROSS}
+                            aria-label='Close node details'
+                            onClick={onClose}
+                        />
+                    </Tooltip>
+                </div>
+            </header>
+
+            <DetailsSection
+                title='Attributes'
+                sectionKey='attrs'
+                collapsed={collapsed.attrs}
+                onToggle={toggleSection}
+                emptyHint='No attributes.'
+                isEmpty={node.attrs.length === 0}
+                count={node.attrs.length}
+            >
+                <dl className='mlir-node-details-attrs'>
+                    {node.attrs.map((attr) => (
+                        <div
+                            className='mlir-node-details-attr-row'
+                            key={attr.key}
+                        >
+                            <dt className='mlir-node-details-attr-key'>{attr.key}</dt>
+                            <dd className='mlir-node-details-attr-value'>
+                                <MlirAttrValue value={attr.value} />
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            </DetailsSection>
+
+            <DetailsSection
+                title='Inputs'
+                sectionKey='inputs'
+                collapsed={collapsed.inputs}
+                onToggle={toggleSection}
+                emptyHint='No inputs.'
+                isEmpty={node.incomingEdges.length === 0}
+                count={node.incomingEdges.length}
+            >
+                {/* Placeholder rendering — #1548 replaces this with paginated
+                    per-port metadata and #1549 adds click-to-locate. */}
+                <ul className='mlir-node-details-io-list'>
+                    {node.incomingEdges.map((edge, idx) => (
+                        <li
+                            key={`${edge.sourceNodeId}:${edge.sourceNodeOutputId}->${edge.targetNodeInputId}:${idx}`}
+                            className='mlir-node-details-io-row'
+                        >
+                            <span className='mlir-node-details-io-id'>{edge.sourceNodeId}</span>
+                            <span className='mlir-node-details-io-port'>
+                                out {edge.sourceNodeOutputId} → in {edge.targetNodeInputId}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            </DetailsSection>
+
+            <DetailsSection
+                title='Outputs'
+                sectionKey='outputs'
+                collapsed={collapsed.outputs}
+                onToggle={toggleSection}
+                emptyHint='No outputs.'
+                isEmpty={node.outputsMetadata.length === 0}
+                count={node.outputsMetadata.length}
+            >
+                {/* Placeholder rendering — #1548 replaces this with paginated
+                    per-port metadata and locate affordances. */}
+                <ul className='mlir-node-details-io-list'>
+                    {node.outputsMetadata.map((port) => (
+                        <li
+                            key={port.id}
+                            className='mlir-node-details-io-row mlir-node-details-output-row'
+                        >
+                            <span className='mlir-node-details-io-port'>port {port.id}</span>
+                            {port.attrs.length === 0 ? (
+                                <span className='mlir-node-details-empty-inline'>no metadata</span>
+                            ) : (
+                                <dl className='mlir-node-details-attrs mlir-node-details-port-attrs'>
+                                    {port.attrs.map((attr) => (
+                                        <div
+                                            className='mlir-node-details-attr-row'
+                                            key={attr.key}
+                                        >
+                                            <dt className='mlir-node-details-attr-key'>{attr.key}</dt>
+                                            <dd className='mlir-node-details-attr-value'>
+                                                <MlirAttrValue value={attr.value} />
+                                            </dd>
+                                        </div>
+                                    ))}
+                                </dl>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </DetailsSection>
+        </aside>
+    );
+};
+
+export default MlirNodeDetailsPanel;

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -10,6 +10,7 @@ import 'styles/components/MlirNodeDetailsPanel.scss';
 import classNames from 'classnames';
 import type { IncomingEdgeView, IndexedPortMetadata, OutgoingEdge, SourceNode } from './mlirGraphTypes';
 import MlirAttrValue from './MlirAttrValue';
+import MlirPortAttrs from './MlirPortAttrs';
 import { mlirNodeDetailsCollapsedAtom } from '../../store/app';
 
 interface MlirNodeDetailsPanelProps {
@@ -217,21 +218,7 @@ const MlirNodeDetailsPanel = ({
                                 out {edge.sourceNodeOutputId} → in {edge.targetNodeInputId}
                             </span>
                             {edge.label && <span className='mlir-node-details-io-shape'>{edge.label}</span>}
-                            {edge.sourcePortMetadata && edge.sourcePortMetadata.attrs.length > 0 && (
-                                <dl className='mlir-node-details-attrs mlir-node-details-port-attrs'>
-                                    {edge.sourcePortMetadata.attrs.map((attr) => (
-                                        <div
-                                            className='mlir-node-details-attr-row'
-                                            key={attr.key}
-                                        >
-                                            <dt className='mlir-node-details-attr-key'>{attr.key}</dt>
-                                            <dd className='mlir-node-details-attr-value'>
-                                                <MlirAttrValue value={attr.value} />
-                                            </dd>
-                                        </div>
-                                    ))}
-                                </dl>
-                            )}
+                            {edge.sourcePortMetadata && <MlirPortAttrs attrs={edge.sourcePortMetadata.attrs} />}
                         </li>
                     ))}
                 </ul>
@@ -255,21 +242,7 @@ const MlirNodeDetailsPanel = ({
                             className='mlir-node-details-io-row mlir-node-details-output-row'
                         >
                             <span className='mlir-node-details-io-port'>port {port.portId}</span>
-                            {port.metadata && port.metadata.attrs.length > 0 && (
-                                <dl className='mlir-node-details-attrs mlir-node-details-port-attrs'>
-                                    {port.metadata.attrs.map((attr) => (
-                                        <div
-                                            className='mlir-node-details-attr-row'
-                                            key={attr.key}
-                                        >
-                                            <dt className='mlir-node-details-attr-key'>{attr.key}</dt>
-                                            <dd className='mlir-node-details-attr-value'>
-                                                <MlirAttrValue value={attr.value} />
-                                            </dd>
-                                        </div>
-                                    ))}
-                                </dl>
-                            )}
+                            {port.metadata && <MlirPortAttrs attrs={port.metadata.attrs} />}
                             {port.consumers.length > 0 && (
                                 <ul className='mlir-node-details-consumer-list'>
                                     {port.consumers.map((consumer, idx) => (

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -16,6 +16,14 @@ interface MlirNodeDetailsPanelProps {
     node: SourceNode;
     incomingEdges: IncomingEdgeView[];
     outgoingEdges: OutgoingEdge[];
+    /**
+     * Output-port metadata to render in the Outputs section. Usually
+     * `node.outputsMetadata`, but for nodes that share a logical output with
+     * a region partner (e.g. a `stablehlo.return` terminator paired with its
+     * outer `stablehlo.reduce`), the view supplies the partner's metadata so
+     * both selections render consistent data.
+     */
+    outputsMetadata: IndexedPortMetadata[];
     onClose: () => void;
     onRecenter: () => void;
 }
@@ -80,6 +88,7 @@ const MlirNodeDetailsPanel = ({
     node,
     incomingEdges,
     outgoingEdges,
+    outputsMetadata,
     onClose,
     onRecenter,
 }: MlirNodeDetailsPanelProps) => {
@@ -90,7 +99,9 @@ const MlirNodeDetailsPanel = ({
     };
 
     // Output ports come from two independent sources:
-    //   1. `outputsMetadata` — per-port shape/dtype/etc declared on the node.
+    //   1. `outputsMetadata` — per-port shape/dtype/etc. For region terminator
+    //      ops the view sources this from the outer-op partner so both ends
+    //      of the pair show the same per-port info.
     //   2. Outgoing edges — synthesised consumer connections. Terminator ops
     //      (e.g. `stablehlo.return`) have empty outputsMetadata but still
     //      carry outgoing edges for region plumbing.
@@ -107,7 +118,7 @@ const MlirNodeDetailsPanel = ({
             }
         }
         const seen = new Set<string>();
-        const ports: OutputPortView[] = node.outputsMetadata.map((port) => {
+        const ports: OutputPortView[] = outputsMetadata.map((port) => {
             seen.add(port.id);
             return {
                 portId: port.id,
@@ -121,7 +132,7 @@ const MlirNodeDetailsPanel = ({
             }
         }
         return ports;
-    }, [node.outputsMetadata, outgoingEdges]);
+    }, [outputsMetadata, outgoingEdges]);
 
     return (
         <aside

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -37,6 +37,38 @@ interface OutputPortView {
 
 type SectionKey = 'attrs' | 'inputs' | 'outputs';
 
+interface NodeRefProps {
+    label: string | null;
+    id: string;
+}
+
+/** Two-line node reference: op label on top, raw id below.
+ *
+ * Producer/consumer rows in Inputs/Outputs need to surface the op name
+ * (e.g. `stablehlo.add`) because the raw id is usually a location string
+ * (`loc("-":33:13)__1`) that doesn't read as the op. We show both so the
+ * user can match the row to a node on the canvas by either signal.
+ *
+ * When the label is missing or duplicates the id (rare — e.g. synthesised
+ * arg nodes), we collapse to just the id so we don't render the same
+ * string twice. */
+const NodeRef = ({ label, id }: NodeRefProps) => {
+    if (label && label !== id) {
+        return (
+            <>
+                <span className='mlir-node-details-io-label'>{label}</span>
+                <span
+                    className='mlir-node-details-io-loc'
+                    title={id}
+                >
+                    {id}
+                </span>
+            </>
+        );
+    }
+    return <span className='mlir-node-details-io-id'>{id}</span>;
+};
+
 interface DetailsSectionProps {
     title: string;
     sectionKey: SectionKey;
@@ -213,12 +245,24 @@ const MlirNodeDetailsPanel = ({
                             key={`${edge.sourceNodeId}:${edge.sourceNodeOutputId}->${edge.targetNodeInputId}:${idx}`}
                             className='mlir-node-details-io-row'
                         >
-                            <span className='mlir-node-details-io-id'>{edge.sourceNodeId}</span>
+                            <NodeRef
+                                label={edge.sourceNodeLabel}
+                                id={edge.sourceNodeId}
+                            />
                             <span className='mlir-node-details-io-port'>
                                 out {edge.sourceNodeOutputId} → in {edge.targetNodeInputId}
                             </span>
-                            {edge.label && <span className='mlir-node-details-io-shape'>{edge.label}</span>}
-                            {edge.sourcePortMetadata && <MlirPortAttrs attrs={edge.sourcePortMetadata.attrs} />}
+                            {/* When sourcePortMetadata is present, MlirPortAttrs renders
+                                a compact `[shape] dtype` pill derived from the same
+                                tensor attrs that produced `edge.label`. Showing both is
+                                redundant and the slightly different font sizes look like
+                                a visual bug — fall back to edge.label only when no port
+                                metadata is available (e.g. input args, raw producers). */}
+                            {edge.sourcePortMetadata ? (
+                                <MlirPortAttrs attrs={edge.sourcePortMetadata.attrs} />
+                            ) : (
+                                edge.label && <span className='mlir-node-details-io-shape'>{edge.label}</span>
+                            )}
                         </li>
                     ))}
                 </ul>
@@ -250,7 +294,10 @@ const MlirNodeDetailsPanel = ({
                                             key={`${consumer.targetNodeId}:${consumer.targetNodeInputId}:${idx}`}
                                             className='mlir-node-details-consumer-row'
                                         >
-                                            <span className='mlir-node-details-io-id'>{consumer.targetNodeId}</span>
+                                            <NodeRef
+                                                label={consumer.targetNodeLabel}
+                                                id={consumer.targetNodeId}
+                                            />
                                             <span className='mlir-node-details-io-port'>
                                                 in {consumer.targetNodeInputId}
                                             </span>

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -2,20 +2,27 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import type { ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { useAtom } from 'jotai';
 import { Button, ButtonVariant, Collapse, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirNodeDetailsPanel.scss';
 import classNames from 'classnames';
-import type { SourceNode } from './mlirGraphTypes';
+import type { IndexedPortMetadata, OutgoingEdge, SourceNode } from './mlirGraphTypes';
 import MlirAttrValue from './MlirAttrValue';
 import { mlirNodeDetailsCollapsedAtom } from '../../store/app';
 
 interface MlirNodeDetailsPanelProps {
     node: SourceNode;
+    outgoingEdges: OutgoingEdge[];
     onClose: () => void;
     onRecenter: () => void;
+}
+
+interface OutputPortView {
+    portId: string;
+    metadata: IndexedPortMetadata | null;
+    consumers: OutgoingEdge[];
 }
 
 type SectionKey = 'attrs' | 'inputs' | 'outputs';
@@ -68,12 +75,46 @@ const DetailsSection = ({
     </section>
 );
 
-const MlirNodeDetailsPanel = ({ node, onClose, onRecenter }: MlirNodeDetailsPanelProps) => {
+const MlirNodeDetailsPanel = ({ node, outgoingEdges, onClose, onRecenter }: MlirNodeDetailsPanelProps) => {
     const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
 
     const toggleSection = (key: SectionKey) => {
         setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
     };
+
+    // Output ports come from two independent sources:
+    //   1. `outputsMetadata` — per-port shape/dtype/etc declared on the node.
+    //   2. Outgoing edges — synthesised consumer connections. Terminator ops
+    //      (e.g. `stablehlo.return`) have empty outputsMetadata but still
+    //      carry outgoing edges for region plumbing.
+    // We union the two by port id, preserving the order from outputsMetadata
+    // and appending any extra ports discovered only via outgoing edges.
+    const outputPorts = useMemo<OutputPortView[]>(() => {
+        const consumersByPort = new Map<string, OutgoingEdge[]>();
+        for (const edge of outgoingEdges) {
+            const list = consumersByPort.get(edge.sourceNodeOutputId);
+            if (list) {
+                list.push(edge);
+            } else {
+                consumersByPort.set(edge.sourceNodeOutputId, [edge]);
+            }
+        }
+        const seen = new Set<string>();
+        const ports: OutputPortView[] = node.outputsMetadata.map((port) => {
+            seen.add(port.id);
+            return {
+                portId: port.id,
+                metadata: port,
+                consumers: consumersByPort.get(port.id) ?? [],
+            };
+        });
+        for (const [portId, consumers] of consumersByPort) {
+            if (!seen.has(portId)) {
+                ports.push({ portId, metadata: null, consumers });
+            }
+        }
+        return ports;
+    }, [node.outputsMetadata, outgoingEdges]);
 
     return (
         <aside
@@ -168,23 +209,21 @@ const MlirNodeDetailsPanel = ({ node, onClose, onRecenter }: MlirNodeDetailsPane
                 collapsed={collapsed.outputs}
                 onToggle={toggleSection}
                 emptyHint='No outputs.'
-                isEmpty={node.outputsMetadata.length === 0}
-                count={node.outputsMetadata.length}
+                isEmpty={outputPorts.length === 0}
+                count={outputPorts.length}
             >
                 {/* Placeholder rendering — #1548 replaces this with paginated
                     per-port metadata and locate affordances. */}
                 <ul className='mlir-node-details-io-list'>
-                    {node.outputsMetadata.map((port) => (
+                    {outputPorts.map((port) => (
                         <li
-                            key={port.id}
+                            key={port.portId}
                             className='mlir-node-details-io-row mlir-node-details-output-row'
                         >
-                            <span className='mlir-node-details-io-port'>port {port.id}</span>
-                            {port.attrs.length === 0 ? (
-                                <span className='mlir-node-details-empty-inline'>no metadata</span>
-                            ) : (
+                            <span className='mlir-node-details-io-port'>port {port.portId}</span>
+                            {port.metadata && port.metadata.attrs.length > 0 && (
                                 <dl className='mlir-node-details-attrs mlir-node-details-port-attrs'>
-                                    {port.attrs.map((attr) => (
+                                    {port.metadata.attrs.map((attr) => (
                                         <div
                                             className='mlir-node-details-attr-row'
                                             key={attr.key}
@@ -196,6 +235,27 @@ const MlirNodeDetailsPanel = ({ node, onClose, onRecenter }: MlirNodeDetailsPane
                                         </div>
                                     ))}
                                 </dl>
+                            )}
+                            {port.consumers.length > 0 && (
+                                <ul className='mlir-node-details-consumer-list'>
+                                    {port.consumers.map((consumer, idx) => (
+                                        <li
+                                            key={`${consumer.targetNodeId}:${consumer.targetNodeInputId}:${idx}`}
+                                            className='mlir-node-details-consumer-row'
+                                        >
+                                            <span className='mlir-node-details-io-id'>{consumer.targetNodeId}</span>
+                                            <span className='mlir-node-details-io-port'>
+                                                in {consumer.targetNodeInputId}
+                                            </span>
+                                            {consumer.label && (
+                                                <span className='mlir-node-details-io-shape'>{consumer.label}</span>
+                                            )}
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                            {!port.metadata && port.consumers.length === 0 && (
+                                <span className='mlir-node-details-empty-inline'>no metadata</span>
                             )}
                         </li>
                     ))}

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -8,12 +8,13 @@ import { Button, ButtonVariant, Collapse, Size, Tooltip } from '@blueprintjs/cor
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirNodeDetailsPanel.scss';
 import classNames from 'classnames';
-import type { IndexedPortMetadata, OutgoingEdge, SourceNode } from './mlirGraphTypes';
+import type { IncomingEdgeView, IndexedPortMetadata, OutgoingEdge, SourceNode } from './mlirGraphTypes';
 import MlirAttrValue from './MlirAttrValue';
 import { mlirNodeDetailsCollapsedAtom } from '../../store/app';
 
 interface MlirNodeDetailsPanelProps {
     node: SourceNode;
+    incomingEdges: IncomingEdgeView[];
     outgoingEdges: OutgoingEdge[];
     onClose: () => void;
     onRecenter: () => void;
@@ -75,7 +76,13 @@ const DetailsSection = ({
     </section>
 );
 
-const MlirNodeDetailsPanel = ({ node, outgoingEdges, onClose, onRecenter }: MlirNodeDetailsPanelProps) => {
+const MlirNodeDetailsPanel = ({
+    node,
+    incomingEdges,
+    outgoingEdges,
+    onClose,
+    onRecenter,
+}: MlirNodeDetailsPanelProps) => {
     const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
 
     const toggleSection = (key: SectionKey) => {
@@ -183,13 +190,13 @@ const MlirNodeDetailsPanel = ({ node, outgoingEdges, onClose, onRecenter }: Mlir
                 collapsed={collapsed.inputs}
                 onToggle={toggleSection}
                 emptyHint='No inputs.'
-                isEmpty={node.incomingEdges.length === 0}
-                count={node.incomingEdges.length}
+                isEmpty={incomingEdges.length === 0}
+                count={incomingEdges.length}
             >
                 {/* Placeholder rendering — #1548 replaces this with paginated
                     per-port metadata and #1549 adds click-to-locate. */}
                 <ul className='mlir-node-details-io-list'>
-                    {node.incomingEdges.map((edge, idx) => (
+                    {incomingEdges.map((edge, idx) => (
                         <li
                             key={`${edge.sourceNodeId}:${edge.sourceNodeOutputId}->${edge.targetNodeInputId}:${idx}`}
                             className='mlir-node-details-io-row'
@@ -198,6 +205,22 @@ const MlirNodeDetailsPanel = ({ node, outgoingEdges, onClose, onRecenter }: Mlir
                             <span className='mlir-node-details-io-port'>
                                 out {edge.sourceNodeOutputId} → in {edge.targetNodeInputId}
                             </span>
+                            {edge.label && <span className='mlir-node-details-io-shape'>{edge.label}</span>}
+                            {edge.sourcePortMetadata && edge.sourcePortMetadata.attrs.length > 0 && (
+                                <dl className='mlir-node-details-attrs mlir-node-details-port-attrs'>
+                                    {edge.sourcePortMetadata.attrs.map((attr) => (
+                                        <div
+                                            className='mlir-node-details-attr-row'
+                                            key={attr.key}
+                                        >
+                                            <dt className='mlir-node-details-attr-key'>{attr.key}</dt>
+                                            <dd className='mlir-node-details-attr-value'>
+                                                <MlirAttrValue value={attr.value} />
+                                            </dd>
+                                        </div>
+                                    ))}
+                                </dl>
+                            )}
                         </li>
                     ))}
                 </ul>

--- a/src/components/mlir/MlirPortAttrs.tsx
+++ b/src/components/mlir/MlirPortAttrs.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import type { IndexedAttr } from './mlirGraphTypes';
-import { tryParseAttrValue } from './attrFormatter';
+import { ParsedAttrKind, tryParseAttrValue } from './attrFormatter';
 import MlirAttrValue from './MlirAttrValue';
 
 /**
@@ -37,12 +37,12 @@ const formatCompactTensor = (attrs: IndexedAttr[]): string | null => {
     for (const attr of attrs) {
         if (attr.key === 'shape') {
             const parsed = tryParseAttrValue(attr.value);
-            if (parsed.kind === 'array' && parsed.parsed.every(isPrimitive)) {
+            if (parsed.kind === ParsedAttrKind.Array && parsed.parsed.every(isPrimitive)) {
                 shape = parsed.parsed;
             }
         } else if (attr.key === 'dtype') {
             const parsed = tryParseAttrValue(attr.value);
-            if (parsed.kind === 'scalar') {
+            if (parsed.kind === ParsedAttrKind.Scalar) {
                 dtype = parsed.text;
             }
         }

--- a/src/components/mlir/MlirPortAttrs.tsx
+++ b/src/components/mlir/MlirPortAttrs.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { IndexedAttr } from './mlirGraphTypes';
+import { tryParseAttrValue } from './attrFormatter';
+import MlirAttrValue from './MlirAttrValue';
+
+/**
+ * Renders the attribute block for a single port (used for both the Outputs
+ * section's per-port metadata and the Inputs section's producer port
+ * metadata). When the port carries a parseable tensor shape + dtype, the
+ * common case collapses to a single compact pill (e.g. `[1, 7, 3072] f32`),
+ * with any remaining "extra" attrs (e.g. `schedule`, `broadcast_dimensions`)
+ * rendered below as a regular key/value list. Falls back to the full
+ * key/value rendering when the tensor pieces can't be extracted.
+ *
+ * Suppressed in the extras list:
+ *   - `shape`, `dtype`           — already in the compact pill.
+ *   - `rank`                     — redundant with `shape.length`.
+ *   - `__tensor_tag`             — names the consumer; useful in the canvas
+ *                                  edge label and in the Outputs consumer
+ *                                  row, but noisy here.
+ */
+const SUPPRESSED_ATTR_KEYS = new Set(['shape', 'dtype', 'rank', '__tensor_tag']);
+
+interface MlirPortAttrsProps {
+    attrs: IndexedAttr[];
+}
+
+const isPrimitive = (value: unknown): value is string | number | boolean | null =>
+    value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+
+const formatCompactTensor = (attrs: IndexedAttr[]): string | null => {
+    let shape: unknown[] | null = null;
+    let dtype: string | null = null;
+    for (const attr of attrs) {
+        if (attr.key === 'shape') {
+            const parsed = tryParseAttrValue(attr.value);
+            if (parsed.kind === 'array' && parsed.parsed.every(isPrimitive)) {
+                shape = parsed.parsed;
+            }
+        } else if (attr.key === 'dtype') {
+            const parsed = tryParseAttrValue(attr.value);
+            if (parsed.kind === 'scalar') {
+                dtype = parsed.text;
+            }
+        }
+    }
+    if (shape === null || dtype === null) {
+        return null;
+    }
+    return `[${shape.map((dim) => String(dim)).join(', ')}] ${dtype}`;
+};
+
+const renderAttrList = (attrs: IndexedAttr[]) => (
+    <dl className='mlir-node-details-attrs mlir-node-details-port-attrs'>
+        {attrs.map((attr) => (
+            <div
+                className='mlir-node-details-attr-row'
+                key={attr.key}
+            >
+                <dt className='mlir-node-details-attr-key'>{attr.key}</dt>
+                <dd className='mlir-node-details-attr-value'>
+                    <MlirAttrValue value={attr.value} />
+                </dd>
+            </div>
+        ))}
+    </dl>
+);
+
+const MlirPortAttrs = ({ attrs }: MlirPortAttrsProps) => {
+    if (attrs.length === 0) {
+        return null;
+    }
+    const compact = formatCompactTensor(attrs);
+    if (compact === null) {
+        return renderAttrList(attrs);
+    }
+    const extras = attrs.filter((attr) => !SUPPRESSED_ATTR_KEYS.has(attr.key));
+    return (
+        <div className='mlir-port-attrs'>
+            <div className='mlir-port-attrs-compact'>{compact}</div>
+            {extras.length > 0 && renderAttrList(extras)}
+        </div>
+    );
+};
+
+export default MlirPortAttrs;

--- a/src/components/mlir/attrFormatter.ts
+++ b/src/components/mlir/attrFormatter.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * MLIR attribute values arrive as strings in the graph JSON — even when they
+ * represent arrays, objects, numbers, or booleans (see KeyValueAttr in
+ * `MLIRJsonModel.ts`). For rendering we want to distinguish three cases:
+ *
+ *   1. Scalars (plain strings, numbers, booleans, MLIR pseudo-JSON like
+ *      `tensor<4x8xf32>`) — render inline as text.
+ *   2. JSON objects — render as an indented key/value tree.
+ *   3. JSON arrays — render as an indented index/value tree.
+ *
+ * This helper is best-effort: if `JSON.parse` rejects the value, or the
+ * parsed result is a primitive (string/number/boolean/null), we treat it as a
+ * scalar. Only `object` (non-null) and `array` results escalate to nested
+ * rendering. Reused by the node details panel (#1547) and by future
+ * port-attr rendering (#1548).
+ */
+export type ParsedAttrValue =
+    | { kind: 'scalar'; text: string }
+    | { kind: 'object'; parsed: Record<string, unknown> }
+    | { kind: 'array'; parsed: unknown[] };
+
+export const tryParseAttrValue = (value: string): ParsedAttrValue => {
+    if (value === '') {
+        return { kind: 'scalar', text: value };
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(value);
+    } catch {
+        return { kind: 'scalar', text: value };
+    }
+    if (Array.isArray(parsed)) {
+        return { kind: 'array', parsed };
+    }
+    if (parsed !== null && typeof parsed === 'object') {
+        return { kind: 'object', parsed: parsed as Record<string, unknown> };
+    }
+    return { kind: 'scalar', text: value };
+};

--- a/src/components/mlir/attrFormatter.ts
+++ b/src/components/mlir/attrFormatter.ts
@@ -18,26 +18,32 @@
  * rendering. Reused by the node details panel (#1547) and by future
  * port-attr rendering (#1548).
  */
+export enum ParsedAttrKind {
+    Scalar = 'scalar',
+    Object = 'object',
+    Array = 'array',
+}
+
 export type ParsedAttrValue =
-    | { kind: 'scalar'; text: string }
-    | { kind: 'object'; parsed: Record<string, unknown> }
-    | { kind: 'array'; parsed: unknown[] };
+    | { kind: ParsedAttrKind.Scalar; text: string }
+    | { kind: ParsedAttrKind.Object; parsed: Record<string, unknown> }
+    | { kind: ParsedAttrKind.Array; parsed: unknown[] };
 
 export const tryParseAttrValue = (value: string): ParsedAttrValue => {
     if (value === '') {
-        return { kind: 'scalar', text: value };
+        return { kind: ParsedAttrKind.Scalar, text: value };
     }
     let parsed: unknown;
     try {
         parsed = JSON.parse(value);
     } catch {
-        return { kind: 'scalar', text: value };
+        return { kind: ParsedAttrKind.Scalar, text: value };
     }
     if (Array.isArray(parsed)) {
-        return { kind: 'array', parsed };
+        return { kind: ParsedAttrKind.Array, parsed };
     }
     if (parsed !== null && typeof parsed === 'object') {
-        return { kind: 'object', parsed: parsed as Record<string, unknown> };
+        return { kind: ParsedAttrKind.Object, parsed: parsed as Record<string, unknown> };
     }
-    return { kind: 'scalar', text: value };
+    return { kind: ParsedAttrKind.Scalar, text: value };
 };

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -21,6 +21,8 @@ export type IndexedEdge = {
  */
 export type OutgoingEdge = {
     targetNodeId: string;
+    /** Consumer op label (e.g. "stablehlo.reshape"). null when the target node is unknown to the source-data index. */
+    targetNodeLabel: string | null;
     sourceNodeOutputId: string;
     targetNodeInputId: string;
     label?: string;
@@ -37,6 +39,8 @@ export type OutgoingEdge = {
  */
 export type IncomingEdgeView = {
     sourceNodeId: string;
+    /** Producer op label (e.g. "stablehlo.add"). null when the source node is unknown to the source-data index. */
+    sourceNodeLabel: string | null;
     sourceNodeOutputId: string;
     targetNodeInputId: string;
     label?: string;

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -162,6 +162,8 @@ export type WorkerInteractionIndex = {
     anchorByNamespace: Record<string, string>;
     anchorNamespaceByNodeId: Record<string, string>;
     outerNamespaceByNodeId: Record<string, string>;
+    /** Return / terminator node id per namespace (e.g. stablehlo.return). */
+    namespaceReturnNodeByNamespace: Record<string, string>;
 };
 
 export type WorkerIndexedMessage = {

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -26,6 +26,23 @@ export type OutgoingEdge = {
     label?: string;
 };
 
+/**
+ * Incoming-edge view used to render producers ("Inputs") for a selected node
+ * in the details panel. Derived from the rendered React Flow edges (same
+ * basis as OutgoingEdge), plus the producer's `outputsMetadata` for the
+ * corresponding source port — that's the tensor metadata that flows along
+ * the wire (`shape`, `dtype`, `__tensor_tag`, …). When the producer doesn't
+ * declare metadata for that port, `sourcePortMetadata` is null and the row
+ * shows just the source id + port + label.
+ */
+export type IncomingEdgeView = {
+    sourceNodeId: string;
+    sourceNodeOutputId: string;
+    targetNodeInputId: string;
+    label?: string;
+    sourcePortMetadata: IndexedPortMetadata | null;
+};
+
 export type IndexedAttr = { key: string; value: string };
 export type IndexedPortMetadata = { id: string; attrs: IndexedAttr[] };
 

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -10,6 +10,22 @@ export type IndexedEdge = {
     targetNodeInputId: string;
 };
 
+/**
+ * Outgoing-edge view used to render consumers ("Outputs") for a selected node
+ * in the details panel. Derived from the rendered React Flow edges rather
+ * than the raw source data — terminator ops like `stablehlo.return` have
+ * synthesised outgoing connections that the layout worker emits but that
+ * never round-trip through the source data's `incomingEdges`. `label` is the
+ * tensor shape that the edge carries on the canvas (e.g. "[7, 3072] bf16"),
+ * when present.
+ */
+export type OutgoingEdge = {
+    targetNodeId: string;
+    sourceNodeOutputId: string;
+    targetNodeInputId: string;
+    label?: string;
+};
+
 export type IndexedAttr = { key: string; value: string };
 export type IndexedPortMetadata = { id: string; attrs: IndexedAttr[] };
 

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -164,6 +164,14 @@ export type WorkerInteractionIndex = {
     outerNamespaceByNodeId: Record<string, string>;
     /** Return / terminator node id per namespace (e.g. stablehlo.return). */
     namespaceReturnNodeByNamespace: Record<string, string>;
+    /**
+     * Per-namespace inner input-arg node ids, indexed by the outer op's
+     * input port. Used to reverse the layout worker's input remapping —
+     * cross-region edges targeting the outer op are rendered as targeting
+     * `namespaceInputByNamespace[ns][portIdx]`, so the panel needs this map
+     * to attribute those edges back to the outer op's input port.
+     */
+    namespaceInputByNamespace: Record<string, string[]>;
 };
 
 export type WorkerIndexedMessage = {

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -119,6 +119,7 @@ self.addEventListener('message', (event: MessageEvent<WorkerInboundMessage>) => 
                     anchorByNamespace: index.anchorByNamespace,
                     anchorNamespaceByNodeId: index.anchorNamespaceByNodeId,
                     outerNamespaceByNodeId: index.outerNamespaceByNodeId,
+                    namespaceReturnNodeByNamespace: index.namespaceReturnNodeByNamespace,
                 },
             });
         } catch (error) {

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -120,6 +120,7 @@ self.addEventListener('message', (event: MessageEvent<WorkerInboundMessage>) => 
                     anchorNamespaceByNodeId: index.anchorNamespaceByNodeId,
                     outerNamespaceByNodeId: index.outerNamespaceByNodeId,
                     namespaceReturnNodeByNamespace: index.namespaceReturnNodeByNamespace,
+                    namespaceInputByNamespace: index.namespaceInputByNamespace,
                 },
             });
         } catch (error) {

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -837,6 +837,7 @@ export default function Styleguide() {
                 <div className='styleguide-bounded-host'>
                     <MlirNodeDetailsPanel
                         node={MLIR_RICH_NODE}
+                        incomingEdges={[]}
                         outgoingEdges={MLIR_RICH_NODE_OUTGOING}
                         onClose={() => {}}
                         onRecenter={() => {}}
@@ -847,6 +848,7 @@ export default function Styleguide() {
                 <div className='styleguide-bounded-host'>
                     <MlirNodeDetailsPanel
                         node={MLIR_TERMINATOR_NODE}
+                        incomingEdges={[]}
                         outgoingEdges={MLIR_TERMINATOR_OUTGOING}
                         onClose={() => {}}
                         onRecenter={() => {}}
@@ -857,6 +859,7 @@ export default function Styleguide() {
                 <div className='styleguide-bounded-host'>
                     <MlirNodeDetailsPanel
                         node={MLIR_EMPTY_NODE}
+                        incomingEdges={[]}
                         outgoingEdges={[]}
                         onClose={() => {}}
                         onRecenter={() => {}}

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -34,7 +34,7 @@ import { FileProgress, FileStatus } from '../model/APIData';
 import NPEProcessingStatus from '../components/NPEProcessingStatus';
 import { MIN_SUPPORTED_VERSION, NPEValidationError } from '../definitions/NPEData';
 import MlirNodeDetailsPanel from '../components/mlir/MlirNodeDetailsPanel';
-import type { OutgoingEdge, SourceNode } from '../components/mlir/mlirGraphTypes';
+import type { IncomingEdgeView, OutgoingEdge, SourceNode } from '../components/mlir/mlirGraphTypes';
 
 const FORM_GROUP = {
     label: 'Form label',
@@ -91,7 +91,6 @@ const MLIR_RICH_NODE: SourceNode = {
             key: 'dot_dimension_numbers',
             value: '{"lhs_contracting_dims":[1],"rhs_contracting_dims":[0],"lhs_batching_dims":[],"rhs_batching_dims":[]}',
         },
-        { key: 'tensor', value: 'tensor<4x8xf32>' },
         { key: 'is_stable', value: 'true' },
         { key: 'cost', value: '128' },
     ],
@@ -100,13 +99,22 @@ const MLIR_RICH_NODE: SourceNode = {
         { sourceNodeId: '%arg7', sourceNodeOutputId: '0', targetNodeInputId: '1' },
         { sourceNodeId: 'loc("-":3:8)__0', sourceNodeOutputId: '2', targetNodeInputId: '2' },
     ],
+    // Port 0 has shape + dtype (renders as a compact `[4, 8] f32` pill) plus
+    // `schedule` (renders as an extra below the pill). `rank` and
+    // `__tensor_tag` are also present but are filtered out by the panel —
+    // they're included here so the example reflects what real adapter
+    // output looks like.
+    // Port 1 carries no metadata at all and shows the "no metadata" hint
+    // unless it has consumers.
     outputsMetadata: [
         {
             id: '0',
             attrs: [
-                { key: 'shape', value: 'tensor<4x8xf32>' },
+                { key: 'shape', value: '[4, 8]' },
                 { key: 'dtype', value: 'f32' },
-                { key: 'tag', value: 'primary' },
+                { key: '__tensor_tag', value: '%result_42' },
+                { key: 'rank', value: '2' },
+                { key: 'schedule', value: '12' },
             ],
         },
         { id: '1', attrs: [] },
@@ -114,6 +122,53 @@ const MLIR_RICH_NODE: SourceNode = {
     config: null,
 };
 
+// Incoming-edge view fixtures for the rich-node example:
+//   - First edge has rich port metadata → compact pill + `broadcast_dimensions` extra.
+//   - Second edge has port metadata with only shape/dtype → compact pill, no extras.
+//   - Third edge has no port metadata → falls back to the bare `edge.label` shape line.
+const MLIR_RICH_NODE_INCOMING: IncomingEdgeView[] = [
+    {
+        sourceNodeId: 'loc("-":3:8)__0',
+        sourceNodeLabel: 'stablehlo.broadcast_in_dim',
+        sourceNodeOutputId: '0',
+        targetNodeInputId: '0',
+        label: '[4, 8] f32',
+        sourcePortMetadata: {
+            id: '0',
+            attrs: [
+                { key: 'shape', value: '[4, 8]' },
+                { key: 'dtype', value: 'f32' },
+                { key: 'broadcast_dimensions', value: '[0]' },
+            ],
+        },
+    },
+    {
+        sourceNodeId: 'loc("-":2:8)__0',
+        sourceNodeLabel: 'stablehlo.constant',
+        sourceNodeOutputId: '0',
+        targetNodeInputId: '1',
+        label: '[8] f32',
+        sourcePortMetadata: {
+            id: '0',
+            attrs: [
+                { key: 'shape', value: '[8]' },
+                { key: 'dtype', value: 'f32' },
+            ],
+        },
+    },
+    {
+        sourceNodeId: '%arg42',
+        sourceNodeLabel: '%arg42',
+        sourceNodeOutputId: '0',
+        targetNodeInputId: '2',
+        label: '[4] f32',
+        sourcePortMetadata: null,
+    },
+];
+
+// Outgoing-edge fixtures: port 0 fans out to two consumers. We give the
+// fan-out a heterogeneous shape so the example shows that the edge label
+// belongs to the *edge*, not the port.
 const MLIR_RICH_NODE_OUTGOING: OutgoingEdge[] = [
     {
         targetNodeId: 'loc("-":7:4)__2',
@@ -851,11 +906,17 @@ export default function Styleguide() {
             <div className='container'>
                 <h3>MLIR Node Details Panel</h3>
 
-                <h4>Selected op with attrs + I/O (nested JSON attribute included)</h4>
+                <h4>Selected op with rich attrs, port metadata, and fan-out outputs</h4>
+                <p>
+                    Inputs demonstrate the three port-metadata states: rich (compact pill + extras), shape/dtype only
+                    (compact pill alone), and no metadata (fall back to the edge&apos;s shape label). Outputs show the
+                    compact pill with a `schedule` extra plus a sibling port that has no metadata. `rank` and
+                    `__tensor_tag` are present in the source data but filtered out of the rendered view.
+                </p>
                 <div className='styleguide-bounded-host'>
                     <MlirNodeDetailsPanel
                         node={MLIR_RICH_NODE}
-                        incomingEdges={[]}
+                        incomingEdges={MLIR_RICH_NODE_INCOMING}
                         outgoingEdges={MLIR_RICH_NODE_OUTGOING}
                         outputsMetadata={MLIR_RICH_NODE.outputsMetadata}
                         onClose={() => {}}

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -34,7 +34,7 @@ import { FileProgress, FileStatus } from '../model/APIData';
 import NPEProcessingStatus from '../components/NPEProcessingStatus';
 import { MIN_SUPPORTED_VERSION, NPEValidationError } from '../definitions/NPEData';
 import MlirNodeDetailsPanel from '../components/mlir/MlirNodeDetailsPanel';
-import type { SourceNode } from '../components/mlir/mlirGraphTypes';
+import type { OutgoingEdge, SourceNode } from '../components/mlir/mlirGraphTypes';
 
 const FORM_GROUP = {
     label: 'Form label',
@@ -114,6 +114,11 @@ const MLIR_RICH_NODE: SourceNode = {
     config: null,
 };
 
+const MLIR_RICH_NODE_OUTGOING: OutgoingEdge[] = [
+    { targetNodeId: 'loc("-":7:4)__2', sourceNodeOutputId: '0', targetNodeInputId: '0', label: '[4, 8] f32' },
+    { targetNodeId: 'loc("-":9:4)__3', sourceNodeOutputId: '0', targetNodeInputId: '1', label: '[4, 8] f32' },
+];
+
 const MLIR_EMPTY_NODE: SourceNode = {
     id: 'input_0',
     label: '%arg0',
@@ -123,6 +128,25 @@ const MLIR_EMPTY_NODE: SourceNode = {
     outputsMetadata: [],
     config: null,
 };
+
+// Terminator-style op: empty outputsMetadata but synthesised outgoing edges
+// (e.g. `stablehlo.return` plumbing its region value to a downstream op).
+const MLIR_TERMINATOR_NODE: SourceNode = {
+    id: 'loc("-":24:8)__1',
+    label: 'stablehlo.return',
+    namespace: 'func.func_main/stablehlo.all_reduce_0',
+    attrs: [
+        { key: 'full_location', value: 'loc("-":24:8)' },
+        { key: 'schedule', value: '20' },
+    ],
+    incomingEdges: [{ sourceNodeId: 'loc("-":23:16)__1', sourceNodeOutputId: '0', targetNodeInputId: '0' }],
+    outputsMetadata: [],
+    config: null,
+};
+
+const MLIR_TERMINATOR_OUTGOING: OutgoingEdge[] = [
+    { targetNodeId: 'stablehlo.reshape_0', sourceNodeOutputId: '0', targetNodeInputId: '0', label: '[7, 3072] bf16' },
+];
 
 export default function Styleguide() {
     const [updateFileTransferProgress, setUpdateFileTransferProgress] = useAtom(fileTransferProgressAtom);
@@ -813,6 +837,17 @@ export default function Styleguide() {
                 <div className='styleguide-bounded-host'>
                     <MlirNodeDetailsPanel
                         node={MLIR_RICH_NODE}
+                        outgoingEdges={MLIR_RICH_NODE_OUTGOING}
+                        onClose={() => {}}
+                        onRecenter={() => {}}
+                    />
+                </div>
+
+                <h4>Terminator op (empty outputs metadata, but has outgoing edges)</h4>
+                <div className='styleguide-bounded-host'>
+                    <MlirNodeDetailsPanel
+                        node={MLIR_TERMINATOR_NODE}
+                        outgoingEdges={MLIR_TERMINATOR_OUTGOING}
                         onClose={() => {}}
                         onRecenter={() => {}}
                     />
@@ -822,6 +857,7 @@ export default function Styleguide() {
                 <div className='styleguide-bounded-host'>
                     <MlirNodeDetailsPanel
                         node={MLIR_EMPTY_NODE}
+                        outgoingEdges={[]}
                         onClose={() => {}}
                         onRecenter={() => {}}
                     />

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -839,6 +839,7 @@ export default function Styleguide() {
                         node={MLIR_RICH_NODE}
                         incomingEdges={[]}
                         outgoingEdges={MLIR_RICH_NODE_OUTGOING}
+                        outputsMetadata={MLIR_RICH_NODE.outputsMetadata}
                         onClose={() => {}}
                         onRecenter={() => {}}
                     />
@@ -850,6 +851,7 @@ export default function Styleguide() {
                         node={MLIR_TERMINATOR_NODE}
                         incomingEdges={[]}
                         outgoingEdges={MLIR_TERMINATOR_OUTGOING}
+                        outputsMetadata={MLIR_TERMINATOR_NODE.outputsMetadata}
                         onClose={() => {}}
                         onRecenter={() => {}}
                     />
@@ -861,6 +863,7 @@ export default function Styleguide() {
                         node={MLIR_EMPTY_NODE}
                         incomingEdges={[]}
                         outgoingEdges={[]}
+                        outputsMetadata={[]}
                         onClose={() => {}}
                         onRecenter={() => {}}
                     />

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -33,6 +33,8 @@ import { fileTransferProgressAtom, getInactiveFileTransferProgress } from '../st
 import { FileProgress, FileStatus } from '../model/APIData';
 import NPEProcessingStatus from '../components/NPEProcessingStatus';
 import { MIN_SUPPORTED_VERSION, NPEValidationError } from '../definitions/NPEData';
+import MlirNodeDetailsPanel from '../components/mlir/MlirNodeDetailsPanel';
+import type { SourceNode } from '../components/mlir/mlirGraphTypes';
 
 const FORM_GROUP = {
     label: 'Form label',
@@ -77,6 +79,50 @@ const UPLOAD_DEMO_PROGRESS = {
 const TIME_REMAINING_INTERVAL = 100;
 
 const LATEST_APP_VERSION = '0.80.0';
+
+const MLIR_RICH_NODE: SourceNode = {
+    id: 'loc("-":4:12)__1',
+    label: 'stablehlo.dot_general',
+    namespace: 'func.func_main/stablehlo.dot_general_0',
+    attrs: [
+        { key: 'name', value: 'f0_dot' },
+        { key: 'precision_config', value: '["DEFAULT","DEFAULT"]' },
+        {
+            key: 'dot_dimension_numbers',
+            value: '{"lhs_contracting_dims":[1],"rhs_contracting_dims":[0],"lhs_batching_dims":[],"rhs_batching_dims":[]}',
+        },
+        { key: 'tensor', value: 'tensor<4x8xf32>' },
+        { key: 'is_stable', value: 'true' },
+        { key: 'cost', value: '128' },
+    ],
+    incomingEdges: [
+        { sourceNodeId: '%arg42', sourceNodeOutputId: '0', targetNodeInputId: '0' },
+        { sourceNodeId: '%arg7', sourceNodeOutputId: '0', targetNodeInputId: '1' },
+        { sourceNodeId: 'loc("-":3:8)__0', sourceNodeOutputId: '2', targetNodeInputId: '2' },
+    ],
+    outputsMetadata: [
+        {
+            id: '0',
+            attrs: [
+                { key: 'shape', value: 'tensor<4x8xf32>' },
+                { key: 'dtype', value: 'f32' },
+                { key: 'tag', value: 'primary' },
+            ],
+        },
+        { id: '1', attrs: [] },
+    ],
+    config: null,
+};
+
+const MLIR_EMPTY_NODE: SourceNode = {
+    id: 'input_0',
+    label: '%arg0',
+    namespace: '',
+    attrs: [],
+    incomingEdges: [],
+    outputsMetadata: [],
+    config: null,
+};
 
 export default function Styleguide() {
     const [updateFileTransferProgress, setUpdateFileTransferProgress] = useAtom(fileTransferProgressAtom);
@@ -758,6 +804,28 @@ export default function Styleguide() {
                     appVersion='0.77.0'
                     latestAppVersion={LATEST_APP_VERSION}
                 />
+            </div>
+
+            <div className='container'>
+                <h3>MLIR Node Details Panel</h3>
+
+                <h4>Selected op with attrs + I/O (nested JSON attribute included)</h4>
+                <div className='styleguide-bounded-host'>
+                    <MlirNodeDetailsPanel
+                        node={MLIR_RICH_NODE}
+                        onClose={() => {}}
+                        onRecenter={() => {}}
+                    />
+                </div>
+
+                <h4>Selected node with no attributes and no I/O (empty states)</h4>
+                <div className='styleguide-bounded-host'>
+                    <MlirNodeDetailsPanel
+                        node={MLIR_EMPTY_NODE}
+                        onClose={() => {}}
+                        onRecenter={() => {}}
+                    />
+                </div>
             </div>
         </>
     );

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -115,8 +115,20 @@ const MLIR_RICH_NODE: SourceNode = {
 };
 
 const MLIR_RICH_NODE_OUTGOING: OutgoingEdge[] = [
-    { targetNodeId: 'loc("-":7:4)__2', sourceNodeOutputId: '0', targetNodeInputId: '0', label: '[4, 8] f32' },
-    { targetNodeId: 'loc("-":9:4)__3', sourceNodeOutputId: '0', targetNodeInputId: '1', label: '[4, 8] f32' },
+    {
+        targetNodeId: 'loc("-":7:4)__2',
+        targetNodeLabel: 'stablehlo.add',
+        sourceNodeOutputId: '0',
+        targetNodeInputId: '0',
+        label: '[4, 8] f32',
+    },
+    {
+        targetNodeId: 'loc("-":9:4)__3',
+        targetNodeLabel: 'stablehlo.reshape',
+        sourceNodeOutputId: '0',
+        targetNodeInputId: '1',
+        label: '[4, 8] f32',
+    },
 ];
 
 const MLIR_EMPTY_NODE: SourceNode = {
@@ -145,7 +157,13 @@ const MLIR_TERMINATOR_NODE: SourceNode = {
 };
 
 const MLIR_TERMINATOR_OUTGOING: OutgoingEdge[] = [
-    { targetNodeId: 'stablehlo.reshape_0', sourceNodeOutputId: '0', targetNodeInputId: '0', label: '[7, 3072] bf16' },
+    {
+        targetNodeId: 'stablehlo.reshape_0',
+        targetNodeLabel: 'stablehlo.reshape',
+        sourceNodeOutputId: '0',
+        targetNodeInputId: '0',
+        label: '[7, 3072] bf16',
+    },
 ];
 
 export default function Styleguide() {

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -247,6 +247,24 @@
     word-break: break-all;
 }
 
+// Op label for a producer/consumer reference (e.g. `stablehlo.add`).
+// Prominent line so the user can match the row to a canvas node by name;
+// raw id renders below in `.mlir-node-details-io-loc` for disambiguation.
+.mlir-node-details-io-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: $tt-white;
+    word-break: break-all;
+}
+
+// Subdued secondary line for the raw node id below the op label.
+.mlir-node-details-io-loc {
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-grey-6;
+    word-break: break-all;
+}
+
 .mlir-node-details-io-port {
     font-family: monospace;
     font-size: 10px;

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -258,6 +258,31 @@
     border-left: 1px solid rgb(255 255 255 / 10%);
 }
 
+.mlir-node-details-consumer-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-left: 8px;
+    border-left: 1px solid rgb(255 255 255 / 10%);
+}
+
+.mlir-node-details-consumer-row {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 2px 0;
+}
+
+.mlir-node-details-io-shape {
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-teal-tint-1;
+    word-break: break-all;
+}
+
 /* On narrower viewports, shrink the panel so the canvas remains usable. */
 @media screen and (width <= 1200px) {
     .mlir-node-details-panel {

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -258,6 +258,23 @@
     border-left: 1px solid rgb(255 255 255 / 10%);
 }
 
+// Compact tensor descriptor (e.g. `[1, 7, 3072] f32`) shown in place of the
+// full shape/dtype/rank/__tensor_tag breakdown for port-metadata blocks.
+// Any non-standard attrs (`schedule`, `broadcast_dimensions`, etc.) render
+// as the usual key/value list below the pill via .mlir-node-details-port-attrs.
+.mlir-port-attrs {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.mlir-port-attrs-compact {
+    font-family: monospace;
+    font-size: 11px;
+    color: $tt-teal-tint-1;
+    word-break: break-all;
+}
+
 .mlir-node-details-consumer-list {
     margin: 0;
     padding: 0;

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+@use '../definitions/colours' as *;
+
+/* The panel docks inside the MLIR view pane (top-right corner of the
+ * React Flow canvas). Make sure the pane is a positioned ancestor so the
+ * panel's absolute placement anchors to the canvas area rather than the
+ * document — also lets the existing `.mlir-relayout-button` continue to
+ * pin to top-left inside the canvas. */
+/* stylelint-disable selector-class-pattern */
+.mlir-view-pane {
+    position: relative;
+}
+
+.mlir-node-details-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 450px;
+    height: 100%;
+    z-index: 10;
+    background: rgb(52 52 52 / 95%);
+    color: $tt-grey-7;
+    border-left: 1px solid rgb(255 255 255 / 8%);
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    font-size: 12px;
+}
+
+.mlir-node-details-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px;
+    background: $tt-grey-3;
+    border-bottom: 1px solid rgb(255 255 255 / 8%);
+}
+
+.mlir-node-details-titles {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.mlir-node-details-label {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: $tt-white;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mlir-node-details-id {
+    margin: 2px 0 0;
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-grey-6;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: text;
+}
+
+.mlir-node-details-actions {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+}
+
+.mlir-node-details-section {
+    border-bottom: 1px solid rgb(255 255 255 / 6%);
+
+    &:last-of-type {
+        border-bottom: none;
+    }
+}
+
+.mlir-node-details-section-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: $tt-grey-4;
+    border: none;
+    border-left: 3px solid transparent;
+    color: $tt-grey-7;
+    font-size: 12px;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover {
+        background: rgb(87 87 87 / 80%);
+    }
+
+    .mlir-node-details-inputs & {
+        border-left-color: var(--graph-input-edge);
+    }
+
+    .mlir-node-details-outputs & {
+        border-left-color: var(--graph-output-edge);
+    }
+}
+
+.mlir-node-details-section-caret {
+    width: 12px;
+    color: $tt-grey-6;
+    font-size: 11px;
+    line-height: 1;
+}
+
+.mlir-node-details-section-title {
+    flex: 1 1 auto;
+}
+
+.mlir-node-details-section-count {
+    background: rgb(0 0 0 / 30%);
+    color: $tt-grey-7;
+    padding: 1px 6px;
+    border-radius: 8px;
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    font-weight: 500;
+}
+
+.mlir-node-details-section-body {
+    padding: 8px 12px 10px;
+}
+
+.mlir-node-details-empty {
+    margin: 0;
+    color: $tt-grey-5;
+    font-style: italic;
+    font-size: 11px;
+}
+
+.mlir-node-details-empty-inline {
+    color: $tt-grey-5;
+    font-style: italic;
+    font-size: 11px;
+}
+
+.mlir-node-details-attrs {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.mlir-node-details-attr-row {
+    display: grid;
+    grid-template-columns: minmax(80px, max-content) 1fr;
+    gap: 6px;
+    align-items: baseline;
+}
+
+.mlir-node-details-attr-key {
+    margin: 0;
+    font-weight: 600;
+    color: $tt-grey-6;
+    font-family: monospace;
+    font-size: 11px;
+    word-break: break-all;
+}
+
+.mlir-node-details-attr-value {
+    margin: 0;
+    color: $tt-grey-7;
+    font-size: 11px;
+    word-break: break-word;
+    min-width: 0;
+}
+
+.mlir-attr-value-scalar {
+    font-family: monospace;
+    color: $tt-white;
+}
+
+.mlir-attr-tree {
+    margin: 0;
+    padding-left: 12px;
+    list-style: none;
+    border-left: 1px solid rgb(255 255 255 / 10%);
+}
+
+.mlir-attr-row {
+    display: grid;
+    grid-template-columns: minmax(40px, max-content) 1fr;
+    gap: 6px;
+    align-items: baseline;
+    padding: 1px 0;
+}
+
+.mlir-attr-key {
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-purple-tint-1;
+}
+
+.mlir-attr-value {
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-grey-7;
+    word-break: break-word;
+}
+
+.mlir-attr-empty {
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-grey-5;
+}
+
+.mlir-node-details-io-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.mlir-node-details-io-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 6px;
+    background: rgb(255 255 255 / 4%);
+    border-radius: 4px;
+
+    &.mlir-node-details-output-row {
+        gap: 6px;
+    }
+}
+
+.mlir-node-details-io-id {
+    font-family: monospace;
+    font-size: 11px;
+    color: $tt-white;
+    word-break: break-all;
+}
+
+.mlir-node-details-io-port {
+    font-family: monospace;
+    font-size: 10px;
+    color: $tt-grey-6;
+}
+
+.mlir-node-details-port-attrs {
+    padding-left: 8px;
+    border-left: 1px solid rgb(255 255 255 / 10%);
+}
+
+/* On narrower viewports, shrink the panel so the canvas remains usable. */
+@media screen and (width <= 1200px) {
+    .mlir-node-details-panel {
+        width: 360px;
+    }
+}
+/* stylelint-enable selector-class-pattern */

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -50,7 +50,7 @@
 .mlir-node-details-label {
     margin: 0;
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 700;
     color: $tt-white;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -93,7 +93,7 @@
     border-left: 3px solid transparent;
     color: $tt-grey-7;
     font-size: 12px;
-    font-weight: 600;
+    font-weight: 700;
     text-align: left;
     cursor: pointer;
 
@@ -164,7 +164,7 @@
 
 .mlir-node-details-attr-key {
     margin: 0;
-    font-weight: 600;
+    font-weight: 700;
     color: $tt-grey-6;
     font-family: monospace;
     font-size: 11px;
@@ -252,7 +252,7 @@
 // raw id renders below in `.mlir-node-details-io-loc` for disambiguation.
 .mlir-node-details-io-label {
     font-size: 11px;
-    font-weight: 600;
+    font-weight: 700;
     color: $tt-white;
     word-break: break-all;
 }

--- a/src/scss/routes/Styleguide.scss
+++ b/src/scss/routes/Styleguide.scss
@@ -99,3 +99,14 @@
     right: 0;
     z-index: variables.$z-index-3-overlay;
 }
+
+// Bounded host for components that normally pin to a viewport-sized parent.
+// Used by the MLIR Node Details panel (absolute inside `.mlir-view-pane`).
+.styleguide-bounded-host {
+    position: relative;
+    width: 100%;
+    height: 520px;
+    background: $tt-grey-2;
+    border: 1px dashed rgba($tt-grey-5, 0.5);
+    overflow: hidden;
+}

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -51,6 +51,10 @@ export const performanceRangeAtom = atom<NumberRange | null>(null);
 export const selectedPerformanceRangeAtom = atom<NumberRange | null>(null);
 export const activeNpeOpTraceAtom = atom<string | null>(null);
 export const activeMlirJsonAtom = atom<string | null>(null);
+export const mlirNodeDetailsCollapsedAtom = atomWithStorage<{ attrs: boolean; inputs: boolean; outputs: boolean }>(
+    'mlirNodeDetailsCollapsed',
+    { attrs: false, inputs: true, outputs: true },
+);
 export const hasClusterDescriptionAtom = atom(false);
 
 // Operations route

--- a/tests/MlirNodeDetailsPanel.spec.tsx
+++ b/tests/MlirNodeDetailsPanel.spec.tsx
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MlirNodeDetailsPanel from '../src/components/mlir/MlirNodeDetailsPanel';
+import type {
+    IncomingEdgeView,
+    IndexedPortMetadata,
+    OutgoingEdge,
+    SourceNode,
+} from '../src/components/mlir/mlirGraphTypes';
+import { mlirNodeDetailsCollapsedAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+import type { AtomProviderInitialValues } from './helpers/atomProvider';
+
+afterEach(cleanup);
+
+// Hydrate the collapsed-state atom with everything open so assertions
+// don't have to click section headers first. The collapsed default is
+// `{ attrs: false, inputs: true, outputs: true }` — the test wants all
+// three bodies expanded.
+const ALL_OPEN: AtomProviderInitialValues = [
+    [mlirNodeDetailsCollapsedAtom, { attrs: false, inputs: false, outputs: false }],
+];
+
+const BASE_NODE: SourceNode = {
+    id: 'loc("-":4:12)__1',
+    label: 'stablehlo.dot_general',
+    namespace: 'func.func_main/stablehlo.dot_general_0',
+    attrs: [
+        { key: 'precision_config', value: '["DEFAULT","DEFAULT"]' },
+        { key: 'is_stable', value: 'true' },
+    ],
+    incomingEdges: [],
+    outputsMetadata: [],
+    config: null,
+};
+
+const SHAPE_DTYPE_PORT: IndexedPortMetadata = {
+    id: '0',
+    attrs: [
+        { key: 'shape', value: '[4, 8]' },
+        { key: 'dtype', value: 'f32' },
+    ],
+};
+
+interface RenderPanelOverrides {
+    node?: SourceNode;
+    incomingEdges?: IncomingEdgeView[];
+    outgoingEdges?: OutgoingEdge[];
+    outputsMetadata?: IndexedPortMetadata[];
+    onClose?: () => void;
+    onRecenter?: () => void;
+}
+
+function renderPanel(overrides: RenderPanelOverrides = {}) {
+    const node = overrides.node ?? BASE_NODE;
+    return render(
+        <TestProviders initialAtomValues={ALL_OPEN}>
+            <MlirNodeDetailsPanel
+                node={node}
+                incomingEdges={overrides.incomingEdges ?? []}
+                outgoingEdges={overrides.outgoingEdges ?? []}
+                outputsMetadata={overrides.outputsMetadata ?? node.outputsMetadata}
+                onClose={overrides.onClose ?? (() => {})}
+                onRecenter={overrides.onRecenter ?? (() => {})}
+            />
+        </TestProviders>,
+    );
+}
+
+describe('MlirNodeDetailsPanel header', () => {
+    it('renders the op label as the heading and the raw node id below', () => {
+        renderPanel();
+        expect(screen.getByRole('heading', { name: 'stablehlo.dot_general' })).toBeInTheDocument();
+        expect(screen.getByText('loc("-":4:12)__1')).toBeInTheDocument();
+    });
+
+    it('calls onClose when the close button is clicked', () => {
+        const onClose = vi.fn();
+        renderPanel({ onClose });
+        fireEvent.click(screen.getByRole('button', { name: 'Close node details' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onRecenter when the recenter button is clicked', () => {
+        const onRecenter = vi.fn();
+        renderPanel({ onRecenter });
+        fireEvent.click(screen.getByRole('button', { name: 'Recenter on this node' }));
+        expect(onRecenter).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('MlirNodeDetailsPanel Attributes section', () => {
+    it('renders each attribute as a key/value row, with a count badge in the header', () => {
+        const { container } = renderPanel();
+        const attrsSection = container.querySelector('.mlir-node-details-attrs');
+        expect(attrsSection).not.toBeNull();
+        expect(within(attrsSection as HTMLElement).getByText('precision_config')).toBeInTheDocument();
+        expect(within(attrsSection as HTMLElement).getByText('is_stable')).toBeInTheDocument();
+        // Section count badge equals the number of attrs.
+        expect(screen.getByText('Attributes').parentElement?.textContent).toContain(String(BASE_NODE.attrs.length));
+    });
+
+    it('shows the empty hint when there are no attrs', () => {
+        renderPanel({ node: { ...BASE_NODE, attrs: [] } });
+        expect(screen.getByText('No attributes.')).toBeInTheDocument();
+    });
+});
+
+describe('MlirNodeDetailsPanel Inputs section', () => {
+    it('shows the empty hint when there are no incoming edges', () => {
+        renderPanel();
+        expect(screen.getByText('No inputs.')).toBeInTheDocument();
+    });
+
+    it('renders the producer op label as the primary line and the raw id below', () => {
+        const incoming: IncomingEdgeView[] = [
+            {
+                sourceNodeId: 'loc("-":3:8)__0',
+                sourceNodeLabel: 'stablehlo.broadcast_in_dim',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[4, 8] f32',
+                sourcePortMetadata: SHAPE_DTYPE_PORT,
+            },
+        ];
+        const { container } = renderPanel({ incomingEdges: incoming });
+        const inputsBody = container.querySelector('.mlir-node-details-inputs .mlir-node-details-section-body');
+        expect(inputsBody).not.toBeNull();
+        expect(within(inputsBody as HTMLElement).getByText('stablehlo.broadcast_in_dim')).toBeInTheDocument();
+        expect(within(inputsBody as HTMLElement).getByText('loc("-":3:8)__0')).toBeInTheDocument();
+    });
+
+    it('collapses to a single id line when the producer label duplicates the id (e.g. arg nodes)', () => {
+        const incoming: IncomingEdgeView[] = [
+            {
+                sourceNodeId: '%arg42',
+                sourceNodeLabel: '%arg42',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[8] f32',
+                sourcePortMetadata: null,
+            },
+        ];
+        const { container } = renderPanel({ incomingEdges: incoming });
+        const inputsBody = container.querySelector('.mlir-node-details-inputs .mlir-node-details-section-body');
+        // Only the id renders — there's no separate label/loc pair.
+        const matches = within(inputsBody as HTMLElement).getAllByText('%arg42');
+        expect(matches).toHaveLength(1);
+        expect(matches[0].className).toContain('mlir-node-details-io-id');
+    });
+
+    it('renders the compact port pill from sourcePortMetadata and suppresses the redundant edge.label', () => {
+        // edge.label and the port-derived compact pill carry the same `[shape] dtype`
+        // string. Rendering both made the row look like a sizing bug — the panel
+        // now suppresses edge.label when port metadata is present.
+        const incoming: IncomingEdgeView[] = [
+            {
+                sourceNodeId: 'loc("-":3:8)__0',
+                sourceNodeLabel: 'stablehlo.broadcast_in_dim',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[4, 8] f32',
+                sourcePortMetadata: SHAPE_DTYPE_PORT,
+            },
+        ];
+        const { container } = renderPanel({ incomingEdges: incoming });
+        const inputsBody = container.querySelector('.mlir-node-details-inputs .mlir-node-details-section-body');
+        expect(inputsBody?.querySelector('.mlir-port-attrs-compact')?.textContent).toBe('[4, 8] f32');
+        // edge.label uses .mlir-node-details-io-shape — should not be in the inputs row.
+        expect(inputsBody?.querySelector('.mlir-node-details-io-shape')).toBeNull();
+    });
+
+    it('falls back to the edge.label shape line when sourcePortMetadata is null', () => {
+        const incoming: IncomingEdgeView[] = [
+            {
+                sourceNodeId: '%arg42',
+                sourceNodeLabel: '%arg42',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[4] f32',
+                sourcePortMetadata: null,
+            },
+        ];
+        const { container } = renderPanel({ incomingEdges: incoming });
+        const inputsBody = container.querySelector('.mlir-node-details-inputs .mlir-node-details-section-body');
+        expect(inputsBody?.querySelector('.mlir-port-attrs-compact')).toBeNull();
+        expect(inputsBody?.querySelector('.mlir-node-details-io-shape')?.textContent).toBe('[4] f32');
+    });
+
+    it('renders the producer port → consumer port mapping for each incoming edge', () => {
+        const incoming: IncomingEdgeView[] = [
+            {
+                sourceNodeId: 'loc("-":3:8)__0',
+                sourceNodeLabel: 'stablehlo.broadcast_in_dim',
+                sourceNodeOutputId: '2',
+                targetNodeInputId: '1',
+                sourcePortMetadata: null,
+            },
+        ];
+        renderPanel({ incomingEdges: incoming });
+        expect(screen.getByText('out 2 → in 1')).toBeInTheDocument();
+    });
+});
+
+describe('MlirNodeDetailsPanel Outputs section', () => {
+    it('shows the empty hint when there are no outputs and no outgoing edges', () => {
+        renderPanel();
+        expect(screen.getByText('No outputs.')).toBeInTheDocument();
+    });
+
+    it('renders the compact port pill for each output port that carries shape + dtype', () => {
+        const { container } = renderPanel({ outputsMetadata: [SHAPE_DTYPE_PORT] });
+        const outputsBody = container.querySelector('.mlir-node-details-outputs .mlir-node-details-section-body');
+        expect(outputsBody?.querySelector('.mlir-port-attrs-compact')?.textContent).toBe('[4, 8] f32');
+    });
+
+    it('renders the consumer list under the originating port, with the consumer label and shape', () => {
+        const outgoing: OutgoingEdge[] = [
+            {
+                targetNodeId: 'loc("-":7:4)__2',
+                targetNodeLabel: 'stablehlo.add',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[4, 8] f32',
+            },
+            {
+                targetNodeId: 'loc("-":9:4)__3',
+                targetNodeLabel: 'stablehlo.reshape',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '1',
+                label: '[4, 8] f32',
+            },
+        ];
+        const { container } = renderPanel({
+            outputsMetadata: [SHAPE_DTYPE_PORT],
+            outgoingEdges: outgoing,
+        });
+        const consumerList = container.querySelector('.mlir-node-details-consumer-list');
+        expect(consumerList).not.toBeNull();
+        expect(within(consumerList as HTMLElement).getByText('stablehlo.add')).toBeInTheDocument();
+        expect(within(consumerList as HTMLElement).getByText('stablehlo.reshape')).toBeInTheDocument();
+        expect(within(consumerList as HTMLElement).getByText('in 0')).toBeInTheDocument();
+        expect(within(consumerList as HTMLElement).getByText('in 1')).toBeInTheDocument();
+        // Consumer rows DO render edge.label (no producing port metadata at that nesting level).
+        expect(consumerList?.querySelectorAll('.mlir-node-details-io-shape')).toHaveLength(2);
+    });
+
+    it('surfaces consumer-only ports synthesised from outgoing edges when outputsMetadata is empty', () => {
+        // Terminator ops (e.g. `stablehlo.return`) carry no outputsMetadata
+        // of their own but still have outgoing edges. The panel should still
+        // show the port + consumer list rather than the empty hint.
+        const outgoing: OutgoingEdge[] = [
+            {
+                targetNodeId: 'stablehlo.reshape_0',
+                targetNodeLabel: 'stablehlo.reshape',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[7, 3072] bf16',
+            },
+        ];
+        const { container } = renderPanel({ outputsMetadata: [], outgoingEdges: outgoing });
+        expect(screen.queryByText('No outputs.')).toBeNull();
+        expect(screen.getByText('port 0')).toBeInTheDocument();
+        const consumerList = container.querySelector('.mlir-node-details-consumer-list');
+        expect(within(consumerList as HTMLElement).getByText('stablehlo.reshape')).toBeInTheDocument();
+    });
+
+    it('renders an explicit port that carries empty attrs as a bare `port X` row with no metadata block', () => {
+        // Some adapter outputs declare an output port but ship an empty
+        // `attrs` array (the port exists, it just has no descriptors).
+        // The panel should still surface the port id; it just has nothing
+        // else to render for it — no compact pill, no extras list, no
+        // consumer list, no "no metadata" hint.
+        const emptyPort: IndexedPortMetadata = { id: '1', attrs: [] };
+        const { container } = renderPanel({ outputsMetadata: [emptyPort] });
+        const outputsBody = container.querySelector('.mlir-node-details-outputs .mlir-node-details-section-body');
+        expect(outputsBody).not.toBeNull();
+        expect(within(outputsBody as HTMLElement).getByText('port 1')).toBeInTheDocument();
+        expect(outputsBody?.querySelector('.mlir-port-attrs-compact')).toBeNull();
+        expect(outputsBody?.querySelector('.mlir-node-details-consumer-list')).toBeNull();
+    });
+});

--- a/tests/MlirPortAttrs.spec.tsx
+++ b/tests/MlirPortAttrs.spec.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import MlirPortAttrs from '../src/components/mlir/MlirPortAttrs';
+import type { IndexedAttr } from '../src/components/mlir/mlirGraphTypes';
+
+afterEach(cleanup);
+
+const shapeDtype: IndexedAttr[] = [
+    { key: 'shape', value: '[1, 7, 3072]' },
+    { key: 'dtype', value: 'f32' },
+];
+
+describe('MlirPortAttrs', () => {
+    it('renders nothing when attrs is empty', () => {
+        const { container } = render(<MlirPortAttrs attrs={[]} />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders the compact `[shape] dtype` pill for a standard tensor port', () => {
+        const { container } = render(<MlirPortAttrs attrs={shapeDtype} />);
+        const pill = container.querySelector('.mlir-port-attrs-compact');
+        expect(pill).not.toBeNull();
+        expect(pill?.textContent).toBe('[1, 7, 3072] f32');
+        // No extras → no key/value list at all.
+        expect(container.querySelector('.mlir-node-details-port-attrs')).toBeNull();
+    });
+
+    it('suppresses `rank` and `__tensor_tag` from the extras list when the compact pill is shown', () => {
+        const attrs: IndexedAttr[] = [
+            ...shapeDtype,
+            { key: 'rank', value: '3' },
+            { key: '__tensor_tag', value: '%result_7' },
+        ];
+        const { container } = render(<MlirPortAttrs attrs={attrs} />);
+        expect(container.querySelector('.mlir-port-attrs-compact')).not.toBeNull();
+        expect(screen.queryByText('rank')).toBeNull();
+        expect(screen.queryByText('__tensor_tag')).toBeNull();
+        // Pill is the only block in the DOM apart from the wrapper.
+        expect(container.querySelector('.mlir-node-details-port-attrs')).toBeNull();
+    });
+
+    it('renders extras (e.g. `schedule`, `broadcast_dimensions`) below the compact pill', () => {
+        const attrs: IndexedAttr[] = [
+            ...shapeDtype,
+            { key: 'schedule', value: '12' },
+            { key: 'broadcast_dimensions', value: '[0, 2]' },
+        ];
+        const { container } = render(<MlirPortAttrs attrs={attrs} />);
+        expect(container.querySelector('.mlir-port-attrs-compact')).not.toBeNull();
+        const extras = container.querySelector('.mlir-node-details-port-attrs');
+        expect(extras).not.toBeNull();
+        // Both extra keys land in the list; shape/dtype don't.
+        expect(screen.getByText('schedule')).toBeInTheDocument();
+        expect(screen.getByText('broadcast_dimensions')).toBeInTheDocument();
+        expect(screen.queryByText('shape')).toBeNull();
+        expect(screen.queryByText('dtype')).toBeNull();
+    });
+
+    it('falls back to the full key/value list when `shape` is not a JSON array of primitives', () => {
+        // Real adapters occasionally emit `shape` as the MLIR tensor type
+        // string (e.g. `tensor<4x8xf32>`) which `tryParseAttrValue` treats
+        // as a scalar. The compact pill can't form, so we should fall back
+        // to showing every attr verbatim.
+        const attrs: IndexedAttr[] = [
+            { key: 'shape', value: 'tensor<4x8xf32>' },
+            { key: 'dtype', value: 'f32' },
+        ];
+        const { container } = render(<MlirPortAttrs attrs={attrs} />);
+        expect(container.querySelector('.mlir-port-attrs-compact')).toBeNull();
+        expect(screen.getByText('shape')).toBeInTheDocument();
+        expect(screen.getByText('dtype')).toBeInTheDocument();
+    });
+
+    it('falls back to the full key/value list when `dtype` is missing', () => {
+        const attrs: IndexedAttr[] = [
+            { key: 'shape', value: '[4, 8]' },
+            { key: 'schedule', value: '12' },
+        ];
+        const { container } = render(<MlirPortAttrs attrs={attrs} />);
+        expect(container.querySelector('.mlir-port-attrs-compact')).toBeNull();
+        expect(screen.getByText('shape')).toBeInTheDocument();
+        expect(screen.getByText('schedule')).toBeInTheDocument();
+    });
+});

--- a/tests/mlirAttrFormatter.spec.ts
+++ b/tests/mlirAttrFormatter.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { tryParseAttrValue } from '../src/components/mlir/attrFormatter';
+
+describe('tryParseAttrValue', () => {
+    it('returns a scalar for an empty string without attempting to parse it', () => {
+        expect(tryParseAttrValue('')).toEqual({ kind: 'scalar', text: '' });
+    });
+
+    it.each([
+        ['MLIR pseudo-JSON', 'tensor<4x8xf32>'],
+        ['identifier-style token', 'f32'],
+        ['unbalanced bracket', '[4, 8'],
+        ['stray colon', 'foo: bar'],
+    ])('falls back to scalar for unparseable input (%s)', (_label, value) => {
+        expect(tryParseAttrValue(value)).toEqual({ kind: 'scalar', text: value });
+    });
+
+    it.each([
+        ['number', '42'],
+        ['boolean', 'true'],
+        ['null literal', 'null'],
+        ['JSON string', '"hello"'],
+    ])('keeps JSON primitives (%s) as scalars and preserves the original text', (_label, value) => {
+        // Primitives are valid JSON but render better as their original
+        // textual form (e.g. show `"hello"` rather than `hello`).
+        expect(tryParseAttrValue(value)).toEqual({ kind: 'scalar', text: value });
+    });
+
+    it('returns an object kind for JSON object input', () => {
+        const result = tryParseAttrValue('{"lhs":[1],"rhs":[0]}');
+        expect(result).toEqual({
+            kind: 'object',
+            parsed: { lhs: [1], rhs: [0] },
+        });
+    });
+
+    it('returns an array kind for JSON array input, preserving element types', () => {
+        const result = tryParseAttrValue('[1, 7, 3072]');
+        expect(result).toEqual({ kind: 'array', parsed: [1, 7, 3072] });
+    });
+
+    it('returns an array kind for mixed-primitive arrays without coercion', () => {
+        // Important for the port-metadata compact pill: a `shape` attr is
+        // recognised as a tensor descriptor only when every element is a
+        // primitive, so the array structure has to round-trip faithfully.
+        const result = tryParseAttrValue('[1, "x", true, null]');
+        expect(result).toEqual({ kind: 'array', parsed: [1, 'x', true, null] });
+    });
+});

--- a/tests/mlirAttrFormatter.spec.ts
+++ b/tests/mlirAttrFormatter.spec.ts
@@ -3,11 +3,11 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { tryParseAttrValue } from '../src/components/mlir/attrFormatter';
+import { ParsedAttrKind, tryParseAttrValue } from '../src/components/mlir/attrFormatter';
 
 describe('tryParseAttrValue', () => {
     it('returns a scalar for an empty string without attempting to parse it', () => {
-        expect(tryParseAttrValue('')).toEqual({ kind: 'scalar', text: '' });
+        expect(tryParseAttrValue('')).toEqual({ kind: ParsedAttrKind.Scalar, text: '' });
     });
 
     it.each([
@@ -16,7 +16,7 @@ describe('tryParseAttrValue', () => {
         ['unbalanced bracket', '[4, 8'],
         ['stray colon', 'foo: bar'],
     ])('falls back to scalar for unparseable input (%s)', (_label, value) => {
-        expect(tryParseAttrValue(value)).toEqual({ kind: 'scalar', text: value });
+        expect(tryParseAttrValue(value)).toEqual({ kind: ParsedAttrKind.Scalar, text: value });
     });
 
     it.each([
@@ -27,20 +27,20 @@ describe('tryParseAttrValue', () => {
     ])('keeps JSON primitives (%s) as scalars and preserves the original text', (_label, value) => {
         // Primitives are valid JSON but render better as their original
         // textual form (e.g. show `"hello"` rather than `hello`).
-        expect(tryParseAttrValue(value)).toEqual({ kind: 'scalar', text: value });
+        expect(tryParseAttrValue(value)).toEqual({ kind: ParsedAttrKind.Scalar, text: value });
     });
 
     it('returns an object kind for JSON object input', () => {
         const result = tryParseAttrValue('{"lhs":[1],"rhs":[0]}');
         expect(result).toEqual({
-            kind: 'object',
+            kind: ParsedAttrKind.Object,
             parsed: { lhs: [1], rhs: [0] },
         });
     });
 
     it('returns an array kind for JSON array input, preserving element types', () => {
         const result = tryParseAttrValue('[1, 7, 3072]');
-        expect(result).toEqual({ kind: 'array', parsed: [1, 7, 3072] });
+        expect(result).toEqual({ kind: ParsedAttrKind.Array, parsed: [1, 7, 3072] });
     });
 
     it('returns an array kind for mixed-primitive arrays without coercion', () => {
@@ -48,6 +48,6 @@ describe('tryParseAttrValue', () => {
         // recognised as a tensor descriptor only when every element is a
         // primitive, so the array structure has to round-trip faithfully.
         const result = tryParseAttrValue('[1, "x", true, null]');
-        expect(result).toEqual({ kind: 'array', parsed: [1, 'x', true, null] });
+        expect(result).toEqual({ kind: ParsedAttrKind.Array, parsed: [1, 'x', true, null] });
     });
 });


### PR DESCRIPTION
This pull request introduces a new node details panel for the MLIR React Flow graph, providing a comprehensive, interactive view of node properties, inputs, and outputs. The implementation includes the creation of a recursive attribute value renderer and the necessary data wiring to support advanced region and edge handling.

<img width="1568" height="1108" alt="image" src="https://github.com/user-attachments/assets/2b0c90d5-1352-433d-9076-3fed3e866611" />

closes #1547
