### PR TITLE
Add navigation bar for charts

### DIFF
--- a/src/components/buffer-summary/BufferSummaryTab.tsx
+++ b/src/components/buffer-summary/BufferSummaryTab.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { RefObject } from 'react';
 import { useAtomValue } from 'jotai';
 import { Callout, Intent } from '@blueprintjs/core';
 import BufferSummaryPlotRenderer from './BufferSummaryPlotRenderer';
@@ -14,12 +13,7 @@ import { useBuffers, useCreateTensorsByOperationByIdList } from '../../hooks/use
 import LoadingSpinner from '../LoadingSpinner';
 import BufferSummaryTable from './BufferSummaryTable';
 
-interface BufferSummaryTabProps {
-    plotRef: RefObject<HTMLHeadingElement>;
-    tableRef: RefObject<HTMLHeadingElement>;
-}
-
-function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
+function BufferSummaryTab() {
     const selectedTabId = useAtomValue(selectedBufferSummaryTabAtom);
     const activePerformanceReport = useAtomValue(activeProfilerReportAtom);
     const selectedBufferType = selectedTabId === TAB_IDS.L1 ? BufferType.L1 : BufferType.DRAM;
@@ -47,10 +41,7 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
     return buffersByOperation && uniqueBuffersByOperationList && tensorListByOperation ? (
         <>
             <h2>Plot view</h2>
-            <div
-                ref={plotRef}
-                id={SECTION_IDS.PLOT}
-            >
+            <div id={SECTION_IDS.PLOT}>
                 {selectedTabId === TAB_IDS.DRAM ? (
                     <BufferSummaryPlotRendererDRAM
                         uniqueBuffersByOperationList={uniqueBuffersByOperationList}
@@ -65,10 +56,7 @@ function BufferSummaryTab({ plotRef, tableRef }: BufferSummaryTabProps) {
             </div>
 
             <h2>Table view</h2>
-            <div
-                ref={tableRef}
-                id={SECTION_IDS.TABLE}
-            >
+            <div id={SECTION_IDS.TABLE}>
                 <BufferSummaryTable
                     buffersByOperation={buffersByOperation.filter((op) => op.buffers.length > 0)}
                     tensorListByOperation={tensorListByOperation}

--- a/src/components/performance/NonFilterablePerfCharts.tsx
+++ b/src/components/performance/NonFilterablePerfCharts.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import PerfCoreCountUtilizationChart from './PerfCoreCountUtilizationChart';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
@@ -10,20 +9,32 @@ import PerfOperationTypesChart from './PerfOperationTypesChart';
 import SkeletalChart from './SkeletalChart';
 import PerfOperationKernelUtilizationChart from './PerfOperationKernelUtilizationChart';
 import PerfKernelDurationUtilizationChart from './PerfKernelDurationUtilizationChart';
-import 'styles/components/PerfCharts.scss';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import PerfDeviceTimeChart from './PerfDeviceTimeChart';
 import getCoreCount from '../../functions/getCoreCount';
 import { DeviceArchitecture } from '../../definitions/DeviceArchitecture';
 import { usePerfMeta } from '../../hooks/useAPI';
+import { PerfChartId, getOperationTypesChartId } from '../../definitions/PerformanceCharts';
 
 interface NonFilterablePerfChartsProps {
     chartData: TypedPerfTableRow[];
     secondaryData?: TypedPerfTableRow[][];
     opCodeOptions: Marker[];
+    matmulData: TypedPerfTableRow[][];
+    convData: TypedPerfTableRow[][];
+    hasMatmulData: boolean;
+    hasConvData: boolean;
 }
 
-const NonFilterablePerfCharts = ({ chartData, secondaryData = [], opCodeOptions }: NonFilterablePerfChartsProps) => {
+const NonFilterablePerfCharts = ({
+    chartData,
+    secondaryData = [],
+    opCodeOptions,
+    matmulData,
+    convData,
+    hasMatmulData,
+    hasConvData,
+}: NonFilterablePerfChartsProps) => {
     const performanceReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
 
@@ -33,37 +44,33 @@ const NonFilterablePerfCharts = ({ chartData, secondaryData = [], opCodeOptions 
     const architecture = deviceMeta?.architecture ?? DeviceArchitecture.WORMHOLE;
     const maxCores = getCoreCount(architecture, datasets[0] ?? []);
 
-    const matmulData = useMemo(
-        () => datasets.map((set) => set.filter((row) => row.raw_op_code.toLowerCase().includes('matmul'))),
-        [datasets],
-    );
-
-    const convData = useMemo(
-        () => datasets.map((set) => set.filter((row) => row.raw_op_code.toLowerCase().includes('conv'))),
-        [datasets],
-    );
-
     return (
-        <div className='charts'>
+        <>
             <h2>Matmul operations</h2>
 
-            {matmulData.filter((data) => data.length).length > 0 ? (
+            {hasMatmulData ? (
                 <>
                     <PerfCoreCountUtilizationChart
                         datasets={matmulData}
                         maxCores={maxCores}
+                        chartId={PerfChartId.MatmulCoreCountUtilization}
                     />
 
-                    <PerfDeviceTimeChart datasets={matmulData} />
+                    <PerfDeviceTimeChart
+                        datasets={matmulData}
+                        chartId={PerfChartId.MatmulDeviceTime}
+                    />
 
                     <PerfOperationKernelUtilizationChart
                         datasets={matmulData}
                         maxCores={maxCores}
+                        chartId={PerfChartId.MatmulKernelDurationUtilization}
                     />
 
                     <PerfKernelDurationUtilizationChart
                         datasets={matmulData}
                         maxCores={maxCores}
+                        chartId={PerfChartId.MatmulUtilizationVsKernelDuration}
                     />
                 </>
             ) : (
@@ -72,23 +79,29 @@ const NonFilterablePerfCharts = ({ chartData, secondaryData = [], opCodeOptions 
 
             <h2>Conv operations</h2>
 
-            {convData.filter((data) => data.length).length > 0 ? (
+            {hasConvData ? (
                 <>
                     <PerfCoreCountUtilizationChart
                         datasets={convData}
                         maxCores={maxCores}
+                        chartId={PerfChartId.ConvCoreCountUtilization}
                     />
 
-                    <PerfDeviceTimeChart datasets={convData} />
+                    <PerfDeviceTimeChart
+                        datasets={convData}
+                        chartId={PerfChartId.ConvDeviceTime}
+                    />
 
                     <PerfOperationKernelUtilizationChart
                         datasets={convData}
                         maxCores={maxCores}
+                        chartId={PerfChartId.ConvKernelDurationUtilization}
                     />
 
                     <PerfKernelDurationUtilizationChart
                         datasets={convData}
                         maxCores={maxCores}
+                        chartId={PerfChartId.ConvUtilizationVsKernelDuration}
                     />
                 </>
             ) : (
@@ -103,6 +116,7 @@ const NonFilterablePerfCharts = ({ chartData, secondaryData = [], opCodeOptions 
                         reportTitle={comparisonReportList ? performanceReport.reportName : ''}
                         data={chartData}
                         opCodes={opCodeOptions}
+                        id={getOperationTypesChartId('active')}
                     />
                 )}
 
@@ -113,10 +127,11 @@ const NonFilterablePerfCharts = ({ chartData, secondaryData = [], opCodeOptions 
                         reportTitle={performanceReport ? report : ''}
                         data={secondaryData[index]}
                         opCodes={opCodeOptions}
+                        id={getOperationTypesChartId(`comparison-${index}`)}
                     />
                 ))}
             </div>
-        </div>
+        </>
     );
 };
 

--- a/src/components/performance/PerfChart.tsx
+++ b/src/components/performance/PerfChart.tsx
@@ -11,6 +11,7 @@ import 'styles/components/PerfChart.scss';
 interface PerfChartProps {
     chartData: Partial<PlotData>[];
     configuration: PlotConfiguration;
+    id?: string;
     title: string;
 }
 
@@ -18,7 +19,7 @@ const GRID_COLOUR = '#575757';
 const LINE_COLOUR = '#575757';
 const LEGEND_COLOUR = '#FFF';
 
-function PerfChart({ chartData, configuration, title }: PerfChartProps) {
+function PerfChart({ chartData, configuration, id, title }: PerfChartProps) {
     const layout: Partial<Layout> = {
         autosize: true,
         paper_bgcolor: 'transparent',
@@ -106,7 +107,10 @@ function PerfChart({ chartData, configuration, title }: PerfChartProps) {
     };
 
     return (
-        <div className={classNames('chart-container', { 'legend-instructions': configuration.showLegend })}>
+        <div
+            id={id}
+            className={classNames('chart-container', { 'legend-instructions': configuration.showLegend })}
+        >
             <h3>{title}</h3>
 
             <Plot

--- a/src/components/performance/PerfCharts.tsx
+++ b/src/components/performance/PerfCharts.tsx
@@ -6,7 +6,6 @@ import PerfDeviceKernelDurationChart from './PerfDeviceKernelDurationChart';
 import PerfDeviceKernelRuntimeChart from './PerfDeviceKernelRuntimeChart';
 import PerfOpCountVsRuntimeChart from './PerfOpCountVsRuntimeChart';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
-import 'styles/components/PerfCharts.scss';
 
 interface PerfChartsProps {
     filteredPerfData: TypedPerfTableRow[];
@@ -18,7 +17,7 @@ const PerfCharts = ({ filteredPerfData, comparisonData, selectedOpCodes }: PerfC
     const data = [filteredPerfData, ...(comparisonData || [])].filter((set) => set.length > 0);
 
     return (
-        <div className='charts'>
+        <>
             <PerfOpCountVsRuntimeChart
                 datasets={data}
                 selectedOpCodes={selectedOpCodes}
@@ -27,7 +26,7 @@ const PerfCharts = ({ filteredPerfData, comparisonData, selectedOpCodes }: PerfC
             <PerfDeviceKernelRuntimeChart datasets={data} />
 
             <PerfDeviceKernelDurationChart datasets={data} />
-        </div>
+        </>
     );
 };
 

--- a/src/components/performance/PerfChartsIndex.tsx
+++ b/src/components/performance/PerfChartsIndex.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Button, Menu, MenuItem, Popover, PopoverPosition } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import ROUTES from '../../definitions/Routes';
+import { type PerfChartIndexEntry } from '../../definitions/PerformanceCharts';
+import 'styles/components/PerfChartsIndex.scss';
+
+interface PerfChartsIndexProps {
+    entries: PerfChartIndexEntry[];
+    activeId: string | null;
+}
+
+const DEFAULT_BUTTON_TEXT = 'Jump to chart';
+
+function PerfChartsIndex({ entries, activeId }: PerfChartsIndexProps) {
+    if (entries.length === 0) {
+        return null;
+    }
+
+    const activeLabel = entries.find((entry) => entry.id === activeId)?.label ?? DEFAULT_BUTTON_TEXT;
+
+    return (
+        <div className='perf-charts-index'>
+            <Popover
+                position={PopoverPosition.BOTTOM_LEFT}
+                minimal
+                content={
+                    <Menu className='perf-charts-index-menu'>
+                        {entries.map((entry) => (
+                            <MenuItem
+                                key={entry.id}
+                                text={entry.label}
+                                href={`${ROUTES.PERFORMANCE}#${entry.id}`}
+                                active={entry.id === activeId}
+                            />
+                        ))}
+                    </Menu>
+                }
+            >
+                <Button
+                    className='perf-charts-index-trigger'
+                    icon={IconNames.PROPERTIES}
+                    endIcon={IconNames.CARET_DOWN}
+                    text={<span className='perf-charts-index-trigger-label'>{activeLabel}</span>}
+                />
+            </Popover>
+        </div>
+    );
+}
+
+export default PerfChartsIndex;

--- a/src/components/performance/PerfCoreCountUtilizationChart.tsx
+++ b/src/components/performance/PerfCoreCountUtilizationChart.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from 'jotai';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import getCoreUtilization from '../../functions/getCoreUtilization';
 import { PlotConfiguration, getDeviceUtilizationAxisConfig } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import PerfChart from './PerfChart';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom, mergeDevicesAtom } from '../../store/app';
 import getPlotLabel from '../../functions/getPlotLabel';
@@ -18,9 +19,10 @@ import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
 interface PerfCoreCountUtilizationChartProps {
     datasets?: TypedPerfTableRow[][];
     maxCores: number;
+    chartId: PerfChartId;
 }
 
-function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCountUtilizationChartProps) {
+function PerfCoreCountUtilizationChart({ datasets = [], maxCores, chartId }: PerfCoreCountUtilizationChartProps) {
     const perfReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
@@ -83,7 +85,8 @@ function PerfCoreCountUtilizationChart({ datasets = [], maxCores }: PerfCoreCoun
         <>
             {maxY2Value > 0 && mergeDevices && <PerfMultiDeviceNotice />}
             <PerfChart
-                title='Core Count + Utilization'
+                id={chartId}
+                title={PERF_CHART_LABELS[chartId]}
                 chartData={[...chartDataDuration, ...chartDataUtilization]}
                 configuration={configuration}
             />

--- a/src/components/performance/PerfDeviceKernelDurationChart.tsx
+++ b/src/components/performance/PerfDeviceKernelDurationChart.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from 'jotai';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import PerfChart from './PerfChart';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import getPlotLabel from '../../functions/getPlotLabel';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import { getPrimaryDataColours } from '../../definitions/PerformancePlotColours';
@@ -55,7 +56,8 @@ function PerfDeviceKernelDurationChart({ datasets = [] }: PerfDeviceKernelDurati
 
     return (
         <PerfChart
-            title='Device Kernel Duration vs Core Count'
+            id={PerfChartId.KernelDurationVsCoreCount}
+            title={PERF_CHART_LABELS[PerfChartId.KernelDurationVsCoreCount]}
             chartData={chartData}
             configuration={configuration}
         />

--- a/src/components/performance/PerfDeviceKernelRuntimeChart.tsx
+++ b/src/components/performance/PerfDeviceKernelRuntimeChart.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from 'jotai';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import PerfChart from './PerfChart';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import getPlotLabel from '../../functions/getPlotLabel';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import { getPrimaryDataColours, getSecondaryDataColours } from '../../definitions/PerformancePlotColours';
@@ -88,7 +89,8 @@ function PerfDeviceKernelRuntimeChart({ datasets = [] }: PerfDeviceKernelRuntime
 
     return (
         <PerfChart
-            title='Core Count + Device Kernel Runtime'
+            id={PerfChartId.CoreCountKernelRuntime}
+            title={PERF_CHART_LABELS[PerfChartId.CoreCountKernelRuntime]}
             chartData={[...chartDataCoreCount, ...chartDataDuration]}
             configuration={configuration}
         />

--- a/src/components/performance/PerfDeviceTimeChart.tsx
+++ b/src/components/performance/PerfDeviceTimeChart.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import PerfChart from './PerfChart';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import getPlotLabel from '../../functions/getPlotLabel';
@@ -15,9 +16,10 @@ import { getPrimaryDataColours, getSecondaryDataColours } from '../../definition
 
 interface PerfDeviceTimeChartProps {
     datasets?: TypedPerfTableRow[][];
+    chartId: PerfChartId;
 }
 
-function PerfDeviceTimeChart({ datasets = [] }: PerfDeviceTimeChartProps) {
+function PerfDeviceTimeChart({ datasets = [], chartId }: PerfDeviceTimeChartProps) {
     const perfReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
 
@@ -79,7 +81,8 @@ function PerfDeviceTimeChart({ datasets = [] }: PerfDeviceTimeChartProps) {
 
     return (
         <PerfChart
-            title='Device Time + Ideal Time'
+            id={chartId}
+            title={PERF_CHART_LABELS[chartId]}
             chartData={[...deviceTimes, ...idealTimes]}
             configuration={configuration}
         />

--- a/src/components/performance/PerfKernelDurationUtilizationChart.tsx
+++ b/src/components/performance/PerfKernelDurationUtilizationChart.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from 'jotai';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import getCoreUtilization from '../../functions/getCoreUtilization';
 import { PlotConfiguration, getDeviceUtilizationAxisConfig } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import PerfChart from './PerfChart';
 import getPlotLabel from '../../functions/getPlotLabel';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom, mergeDevicesAtom } from '../../store/app';
@@ -17,9 +18,10 @@ import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
 interface PerfKernelDurationUtilizationChartProps {
     datasets: TypedPerfTableRow[][];
     maxCores: number;
+    chartId: PerfChartId;
 }
 
-function PerfKernelDurationUtilizationChart({ datasets, maxCores }: PerfKernelDurationUtilizationChartProps) {
+function PerfKernelDurationUtilizationChart({ datasets, maxCores, chartId }: PerfKernelDurationUtilizationChartProps) {
     const perfReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
@@ -59,7 +61,8 @@ function PerfKernelDurationUtilizationChart({ datasets, maxCores }: PerfKernelDu
         <>
             {maxYValue > 0 && mergeDevices && <PerfMultiDeviceNotice />}
             <PerfChart
-                title='Utilization vs Device Kernel Duration'
+                id={chartId}
+                title={PERF_CHART_LABELS[chartId]}
                 chartData={chartData}
                 configuration={configuration}
             />

--- a/src/components/performance/PerfOpCountVsRuntimeChart.tsx
+++ b/src/components/performance/PerfOpCountVsRuntimeChart.tsx
@@ -7,6 +7,7 @@ import { PlotData } from 'plotly.js';
 import { useAtomValue } from 'jotai';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import PerfChart from './PerfChart';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import getPlotLabel from '../../functions/getPlotLabel';
@@ -94,7 +95,8 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
 
     return (
         <PerfChart
-            title='Operation Count vs Device Time'
+            id={PerfChartId.OpCountVsRuntime}
+            title={PERF_CHART_LABELS[PerfChartId.OpCountVsRuntime]}
             chartData={[...opCountData.flat(), ...opDeviceTimeData.flat()]}
             configuration={configuration}
         />

--- a/src/components/performance/PerfOperationKernelUtilizationChart.tsx
+++ b/src/components/performance/PerfOperationKernelUtilizationChart.tsx
@@ -9,6 +9,7 @@ import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import getCoreUtilization from '../../functions/getCoreUtilization';
 import PerfChart from './PerfChart';
 import { PlotConfiguration, getDeviceUtilizationAxisConfig } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import { getAxisUpperRange } from '../../functions/perfFunctions';
 import getPlotLabel from '../../functions/getPlotLabel';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom, mergeDevicesAtom } from '../../store/app';
@@ -18,9 +19,14 @@ import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
 interface PerfOperationKernelUtilizationChartProps {
     datasets?: TypedPerfTableRow[][];
     maxCores: number;
+    chartId: PerfChartId;
 }
 
-function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOperationKernelUtilizationChartProps) {
+function PerfOperationKernelUtilizationChart({
+    datasets = [],
+    maxCores,
+    chartId,
+}: PerfOperationKernelUtilizationChartProps) {
     const perfReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const mergeDevices = useAtomValue(mergeDevicesAtom);
@@ -89,7 +95,8 @@ function PerfOperationKernelUtilizationChart({ datasets = [], maxCores }: PerfOp
         <>
             {maxY2Value > 0 && mergeDevices && <PerfMultiDeviceNotice />}
             <PerfChart
-                title='Device Kernel Duration + Utilization'
+                id={chartId}
+                title={PERF_CHART_LABELS[chartId]}
                 chartData={[...chartDataDuration, ...chartDataUtilization]}
                 configuration={configuration}
             />

--- a/src/components/performance/PerfOperationTypesChart.tsx
+++ b/src/components/performance/PerfOperationTypesChart.tsx
@@ -7,6 +7,7 @@ import { Layout, PlotData } from 'plotly.js';
 import { useMemo } from 'react';
 import Plot from '../../libs/PlotComponent';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
+import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
 import 'styles/components/PerformanceOperationTypesChart.scss';
 import { PerfChartConfig } from '../../definitions/PlotConfigurations';
 
@@ -15,6 +16,7 @@ interface PerfOperationTypesChartProps {
     opCodes: Marker[];
     data?: TypedPerfTableRow[];
     className?: string;
+    id?: string;
 }
 
 const LAYOUT: Partial<Layout> = {
@@ -29,7 +31,13 @@ const LAYOUT: Partial<Layout> = {
     showlegend: false,
 };
 
-function PerfOperationTypesChart({ reportTitle, data = [], opCodes, className = '' }: PerfOperationTypesChartProps) {
+function PerfOperationTypesChart({
+    reportTitle,
+    data = [],
+    opCodes,
+    className = '',
+    id,
+}: PerfOperationTypesChartProps) {
     const filteredOpCodes = useMemo(
         () => [...new Set(data?.filter((row) => row.raw_op_code !== undefined).map((row) => row.raw_op_code))],
         [data],
@@ -56,8 +64,11 @@ function PerfOperationTypesChart({ reportTitle, data = [], opCodes, className = 
     );
 
     return (
-        <div className={classNames('operation-types-chart', className)}>
-            <h3>Operation Types</h3>
+        <div
+            id={id}
+            className={classNames('operation-types-chart', className)}
+        >
+            <h3>{PERF_CHART_LABELS[PerfChartId.OperationTypes]}</h3>
             <p>{reportTitle}</p>
 
             <Plot

--- a/src/components/performance/PerformanceChartsTab.tsx
+++ b/src/components/performance/PerformanceChartsTab.tsx
@@ -24,6 +24,8 @@ interface PerformanceChartsTabProps {
     updateOpCodes: (opCodes: Marker[]) => void;
 }
 
+export const PERF_CHARTS_NAV_OFFSET_PX = 60;
+
 const PerformanceChartsTab = ({
     filteredPerfData,
     filteredComparisonData,
@@ -66,7 +68,7 @@ const PerformanceChartsTab = ({
     );
 
     const chartIndexIds = useMemo(() => chartIndexEntries.map((entry) => entry.id), [chartIndexEntries]);
-    const activeId = useActiveSection(chartIndexIds);
+    const activeId = useActiveSection(chartIndexIds, PERF_CHARTS_NAV_OFFSET_PX);
 
     return (
         <div className='charts-container'>

--- a/src/components/performance/PerformanceChartsTab.tsx
+++ b/src/components/performance/PerformanceChartsTab.tsx
@@ -9,14 +9,7 @@ import PerfCharts from './PerfCharts';
 import PerfChartsIndex from './PerfChartsIndex';
 import NonFilterablePerfCharts from './NonFilterablePerfCharts';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
-import {
-    CONV_CHART_ENTRIES,
-    FILTERABLE_CHART_ENTRIES,
-    MATMUL_CHART_ENTRIES,
-    type PerfChartIndexEntry,
-    getOperationTypesChartId,
-    getOperationTypesChartLabel,
-} from '../../definitions/PerformanceCharts';
+import { buildChartIndexEntries } from '../../definitions/PerformanceCharts';
 import { useActiveSection } from '../../hooks/useActiveSection';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import 'styles/components/PerfCharts.scss';
@@ -61,33 +54,16 @@ const PerformanceChartsTab = ({
     const hasMatmulData = matmulData.some((set) => set.length > 0);
     const hasConvData = convData.some((set) => set.length > 0);
 
-    const chartIndexEntries = useMemo(() => {
-        const entries: PerfChartIndexEntry[] = [...FILTERABLE_CHART_ENTRIES];
-
-        if (hasMatmulData) {
-            entries.push(...MATMUL_CHART_ENTRIES);
-        }
-
-        if (hasConvData) {
-            entries.push(...CONV_CHART_ENTRIES);
-        }
-
-        if (performanceReport) {
-            entries.push({
-                id: getOperationTypesChartId('active'),
-                label: getOperationTypesChartLabel(comparisonReportList ? performanceReport.reportName : ''),
-            });
-        }
-
-        comparisonReportList?.forEach((report, index) => {
-            entries.push({
-                id: getOperationTypesChartId(`comparison-${index}`),
-                label: getOperationTypesChartLabel(performanceReport ? report : ''),
-            });
-        });
-
-        return entries;
-    }, [comparisonReportList, hasConvData, hasMatmulData, performanceReport]);
+    const chartIndexEntries = useMemo(
+        () =>
+            buildChartIndexEntries({
+                hasMatmulData,
+                hasConvData,
+                activeReportName: performanceReport?.reportName ?? null,
+                comparisonReportNames: comparisonReportList,
+            }),
+        [comparisonReportList, hasConvData, hasMatmulData, performanceReport],
+    );
 
     const chartIndexIds = useMemo(() => chartIndexEntries.map((entry) => entry.id), [chartIndexEntries]);
     const activeId = useActiveSection(chartIndexIds);

--- a/src/components/performance/PerformanceChartsTab.tsx
+++ b/src/components/performance/PerformanceChartsTab.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useMemo } from 'react';
+import { useAtomValue } from 'jotai';
+import PerfChartFilter from './PerfChartFilter';
+import PerfCharts from './PerfCharts';
+import PerfChartsIndex from './PerfChartsIndex';
+import NonFilterablePerfCharts from './NonFilterablePerfCharts';
+import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
+import {
+    CONV_CHART_ENTRIES,
+    FILTERABLE_CHART_ENTRIES,
+    MATMUL_CHART_ENTRIES,
+    type PerfChartIndexEntry,
+    getOperationTypesChartId,
+    getOperationTypesChartLabel,
+} from '../../definitions/PerformanceCharts';
+import { useActiveSection } from '../../hooks/useActiveSection';
+import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
+import 'styles/components/PerfCharts.scss';
+
+interface PerformanceChartsTabProps {
+    filteredPerfData: TypedPerfTableRow[];
+    filteredComparisonData?: TypedPerfTableRow[][];
+    enrichedData: TypedPerfTableRow[];
+    enrichedComparisonData?: TypedPerfTableRow[][];
+    selectedOpCodes: Marker[];
+    opCodeOptions: Marker[];
+    updateOpCodes: (opCodes: Marker[]) => void;
+}
+
+const PerformanceChartsTab = ({
+    filteredPerfData,
+    filteredComparisonData,
+    enrichedData,
+    enrichedComparisonData,
+    selectedOpCodes,
+    opCodeOptions,
+    updateOpCodes,
+}: PerformanceChartsTabProps) => {
+    const performanceReport = useAtomValue(activePerformanceReportAtom);
+    const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
+
+    const datasets = useMemo(
+        () => [enrichedData, ...(enrichedComparisonData || [])].filter((set) => set.length > 0),
+        [enrichedData, enrichedComparisonData],
+    );
+
+    const matmulData = useMemo(
+        () => datasets.map((set) => set.filter((row) => row.raw_op_code.toLowerCase().includes('matmul'))),
+        [datasets],
+    );
+
+    const convData = useMemo(
+        () => datasets.map((set) => set.filter((row) => row.raw_op_code.toLowerCase().includes('conv'))),
+        [datasets],
+    );
+
+    const hasMatmulData = matmulData.some((set) => set.length > 0);
+    const hasConvData = convData.some((set) => set.length > 0);
+
+    const chartIndexEntries = useMemo(() => {
+        const entries: PerfChartIndexEntry[] = [...FILTERABLE_CHART_ENTRIES];
+
+        if (hasMatmulData) {
+            entries.push(...MATMUL_CHART_ENTRIES);
+        }
+
+        if (hasConvData) {
+            entries.push(...CONV_CHART_ENTRIES);
+        }
+
+        if (performanceReport) {
+            entries.push({
+                id: getOperationTypesChartId('active'),
+                label: getOperationTypesChartLabel(comparisonReportList ? performanceReport.reportName : ''),
+            });
+        }
+
+        comparisonReportList?.forEach((report, index) => {
+            entries.push({
+                id: getOperationTypesChartId(`comparison-${index}`),
+                label: getOperationTypesChartLabel(performanceReport ? report : ''),
+            });
+        });
+
+        return entries;
+    }, [comparisonReportList, hasConvData, hasMatmulData, performanceReport]);
+
+    const chartIndexIds = useMemo(() => chartIndexEntries.map((entry) => entry.id), [chartIndexEntries]);
+    const activeId = useActiveSection(chartIndexIds);
+
+    return (
+        <div className='charts-container'>
+            <aside className='charts-sidebar'>
+                <PerfChartFilter
+                    opCodeOptions={opCodeOptions}
+                    selectedOpCodes={selectedOpCodes}
+                    updateOpCodes={updateOpCodes}
+                />
+            </aside>
+
+            <div className='charts-column'>
+                <PerfChartsIndex
+                    entries={chartIndexEntries}
+                    activeId={activeId}
+                />
+
+                <div className='charts'>
+                    <PerfCharts
+                        filteredPerfData={filteredPerfData}
+                        comparisonData={filteredComparisonData}
+                        selectedOpCodes={selectedOpCodes}
+                    />
+
+                    <NonFilterablePerfCharts
+                        chartData={enrichedData}
+                        secondaryData={enrichedComparisonData || []}
+                        opCodeOptions={opCodeOptions}
+                        matmulData={matmulData}
+                        convData={convData}
+                        hasMatmulData={hasMatmulData}
+                        hasConvData={hasConvData}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default PerformanceChartsTab;

--- a/src/definitions/PerformanceCharts.ts
+++ b/src/definitions/PerformanceCharts.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+export enum PerfChartId {
+    OpCountVsRuntime = 'perf-chart-op-count-vs-runtime',
+    CoreCountKernelRuntime = 'perf-chart-core-count-kernel-runtime',
+    KernelDurationVsCoreCount = 'perf-chart-kernel-duration-vs-core-count',
+    MatmulCoreCountUtilization = 'perf-chart-matmul-core-count-utilization',
+    MatmulDeviceTime = 'perf-chart-matmul-device-time',
+    MatmulKernelDurationUtilization = 'perf-chart-matmul-kernel-duration-utilization',
+    MatmulUtilizationVsKernelDuration = 'perf-chart-matmul-utilization-vs-kernel-duration',
+    ConvCoreCountUtilization = 'perf-chart-conv-core-count-utilization',
+    ConvDeviceTime = 'perf-chart-conv-device-time',
+    ConvKernelDurationUtilization = 'perf-chart-conv-kernel-duration-utilization',
+    ConvUtilizationVsKernelDuration = 'perf-chart-conv-utilization-vs-kernel-duration',
+    OperationTypes = 'perf-chart-operation-types',
+}
+
+export const PERF_CHART_LABELS: Record<PerfChartId, string> = {
+    [PerfChartId.OpCountVsRuntime]: 'Operation Count vs Device Time',
+    [PerfChartId.CoreCountKernelRuntime]: 'Core Count + Device Kernel Runtime',
+    [PerfChartId.KernelDurationVsCoreCount]: 'Device Kernel Duration vs Core Count',
+    [PerfChartId.MatmulCoreCountUtilization]: 'Matmul · Core Count + Utilization',
+    [PerfChartId.MatmulDeviceTime]: 'Matmul · Device Time + Ideal Time',
+    [PerfChartId.MatmulKernelDurationUtilization]: 'Matmul · Device Kernel Duration + Utilization',
+    [PerfChartId.MatmulUtilizationVsKernelDuration]: 'Matmul · Utilization vs Device Kernel Duration',
+    [PerfChartId.ConvCoreCountUtilization]: 'Conv · Core Count + Utilization',
+    [PerfChartId.ConvDeviceTime]: 'Conv · Device Time + Ideal Time',
+    [PerfChartId.ConvKernelDurationUtilization]: 'Conv · Device Kernel Duration + Utilization',
+    [PerfChartId.ConvUtilizationVsKernelDuration]: 'Conv · Utilization vs Device Kernel Duration',
+    [PerfChartId.OperationTypes]: 'Operation Types',
+};
+
+export function getOperationTypesChartId(key: 'active' | `comparison-${number}`): string {
+    return `${PerfChartId.OperationTypes}-${key}`;
+}
+
+export function getOperationTypesChartLabel(reportTitle: string): string {
+    return reportTitle
+        ? `${PERF_CHART_LABELS[PerfChartId.OperationTypes]} — ${reportTitle}`
+        : PERF_CHART_LABELS[PerfChartId.OperationTypes];
+}
+
+export interface PerfChartIndexEntry {
+    id: string;
+    label: string;
+}
+
+export const FILTERABLE_CHART_ENTRIES: PerfChartIndexEntry[] = [
+    {
+        id: PerfChartId.OpCountVsRuntime,
+        label: PERF_CHART_LABELS[PerfChartId.OpCountVsRuntime],
+    },
+    {
+        id: PerfChartId.CoreCountKernelRuntime,
+        label: PERF_CHART_LABELS[PerfChartId.CoreCountKernelRuntime],
+    },
+    {
+        id: PerfChartId.KernelDurationVsCoreCount,
+        label: PERF_CHART_LABELS[PerfChartId.KernelDurationVsCoreCount],
+    },
+];
+
+export const MATMUL_CHART_ENTRIES: PerfChartIndexEntry[] = [
+    {
+        id: PerfChartId.MatmulCoreCountUtilization,
+        label: PERF_CHART_LABELS[PerfChartId.MatmulCoreCountUtilization],
+    },
+    {
+        id: PerfChartId.MatmulDeviceTime,
+        label: PERF_CHART_LABELS[PerfChartId.MatmulDeviceTime],
+    },
+    {
+        id: PerfChartId.MatmulKernelDurationUtilization,
+        label: PERF_CHART_LABELS[PerfChartId.MatmulKernelDurationUtilization],
+    },
+    {
+        id: PerfChartId.MatmulUtilizationVsKernelDuration,
+        label: PERF_CHART_LABELS[PerfChartId.MatmulUtilizationVsKernelDuration],
+    },
+];
+
+export const CONV_CHART_ENTRIES: PerfChartIndexEntry[] = [
+    {
+        id: PerfChartId.ConvCoreCountUtilization,
+        label: PERF_CHART_LABELS[PerfChartId.ConvCoreCountUtilization],
+    },
+    {
+        id: PerfChartId.ConvDeviceTime,
+        label: PERF_CHART_LABELS[PerfChartId.ConvDeviceTime],
+    },
+    {
+        id: PerfChartId.ConvKernelDurationUtilization,
+        label: PERF_CHART_LABELS[PerfChartId.ConvKernelDurationUtilization],
+    },
+    {
+        id: PerfChartId.ConvUtilizationVsKernelDuration,
+        label: PERF_CHART_LABELS[PerfChartId.ConvUtilizationVsKernelDuration],
+    },
+];

--- a/src/definitions/PerformanceCharts.ts
+++ b/src/definitions/PerformanceCharts.ts
@@ -99,3 +99,49 @@ export const CONV_CHART_ENTRIES: PerfChartIndexEntry[] = [
         label: PERF_CHART_LABELS[PerfChartId.ConvUtilizationVsKernelDuration],
     },
 ];
+
+interface ChartIndexParams {
+    hasMatmulData: boolean;
+    hasConvData: boolean;
+    activeReportName: string | null;
+    comparisonReportNames: string[] | null;
+}
+
+/**
+ * Assembles the ordered list of chart-index entries shown in the "jump to chart" menu, matching the
+ * order charts render on the page: filterable charts, then matmul/conv groups (only when present),
+ * then one Operation Types entry per visible report. Operation Types labels carry the report name
+ * only while a comparison is active, mirroring the chart headings.
+ */
+export function buildChartIndexEntries({
+    hasMatmulData,
+    hasConvData,
+    activeReportName,
+    comparisonReportNames,
+}: ChartIndexParams): PerfChartIndexEntry[] {
+    const entries: PerfChartIndexEntry[] = [...FILTERABLE_CHART_ENTRIES];
+
+    if (hasMatmulData) {
+        entries.push(...MATMUL_CHART_ENTRIES);
+    }
+
+    if (hasConvData) {
+        entries.push(...CONV_CHART_ENTRIES);
+    }
+
+    if (activeReportName !== null) {
+        entries.push({
+            id: getOperationTypesChartId('active'),
+            label: getOperationTypesChartLabel(comparisonReportNames ? activeReportName : ''),
+        });
+    }
+
+    comparisonReportNames?.forEach((report, index) => {
+        entries.push({
+            id: getOperationTypesChartId(`comparison-${index}`),
+            label: getOperationTypesChartLabel(activeReportName !== null ? report : ''),
+        });
+    });
+
+    return entries;
+}

--- a/src/definitions/PerformanceCharts.ts
+++ b/src/definitions/PerformanceCharts.ts
@@ -42,6 +42,10 @@ export function getOperationTypesChartLabel(reportTitle: string): string {
         : PERF_CHART_LABELS[PerfChartId.OperationTypes];
 }
 
+export function getOperationTypesEntryLabel(reportName: string, hasComparison: boolean): string {
+    return getOperationTypesChartLabel(hasComparison ? reportName : '');
+}
+
 export interface PerfChartIndexEntry {
     id: string;
     label: string;
@@ -129,17 +133,19 @@ export function buildChartIndexEntries({
         entries.push(...CONV_CHART_ENTRIES);
     }
 
+    const hasComparison = Boolean(comparisonReportNames);
+
     if (activeReportName !== null) {
         entries.push({
             id: getOperationTypesChartId('active'),
-            label: getOperationTypesChartLabel(comparisonReportNames ? activeReportName : ''),
+            label: getOperationTypesEntryLabel(activeReportName, hasComparison),
         });
     }
 
     comparisonReportNames?.forEach((report, index) => {
         entries.push({
             id: getOperationTypesChartId(`comparison-${index}`),
-            label: getOperationTypesChartLabel(activeReportName !== null ? report : ''),
+            label: getOperationTypesEntryLabel(report, activeReportName !== null),
         });
     });
 

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -7,7 +7,12 @@ import { useEffect, useState } from 'react';
 const ID_SEPARATOR = '|';
 
 export function useActiveSection<TId extends string>(ids: TId[], offsetPx = 250): TId | null {
-    const [activeId, setActiveId] = useState<TId | null>(ids[0] ?? null);
+    const [trackedId, setTrackedId] = useState<TId | null>(ids[0] ?? null);
+
+    // The set of sections can change after mount (e.g. matmul/conv charts appear as data loads, or
+    // comparison reports are toggled). Clamp during render so a stale id never leaks out: keep the
+    // tracked section while it's still present, otherwise fall back to the first section.
+    const activeId = trackedId !== null && ids.includes(trackedId) ? trackedId : (ids[0] ?? null);
 
     // Callers commonly pass a fresh array literal each render. Keying the effect on the joined
     // ids (rather than the array reference) keeps the scroll listener from re-subscribing on
@@ -24,7 +29,7 @@ export function useActiveSection<TId extends string>(ids: TId[], offsetPx = 250)
             sectionIds.forEach((id) => {
                 const element = document.getElementById(id);
 
-                if (element?.offsetHeight && element.offsetTop) {
+                if (element && element.offsetHeight > 0) {
                     const sectionHeight = element.offsetHeight;
                     const sectionTop = element.offsetTop - offsetPx;
 
@@ -35,7 +40,7 @@ export function useActiveSection<TId extends string>(ids: TId[], offsetPx = 250)
             });
 
             if (current !== null) {
-                setActiveId(current);
+                setTrackedId(current);
             }
         }
 

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -4,15 +4,24 @@
 
 import { useEffect, useState } from 'react';
 
+const ID_SEPARATOR = '|';
+
 export function useActiveSection<TId extends string>(ids: TId[], offsetPx = 250): TId | null {
     const [activeId, setActiveId] = useState<TId | null>(ids[0] ?? null);
 
+    // Callers commonly pass a fresh array literal each render. Keying the effect on the joined
+    // ids (rather than the array reference) keeps the scroll listener from re-subscribing on
+    // every render, while still re-running when the actual set of sections changes.
+    const idsKey = ids.join(ID_SEPARATOR);
+
     useEffect(() => {
+        const sectionIds = idsKey ? (idsKey.split(ID_SEPARATOR) as TId[]) : [];
+
         function navHighlighter() {
             const { scrollY } = window;
             let current: TId | null = null;
 
-            ids.forEach((id) => {
+            sectionIds.forEach((id) => {
                 const element = document.getElementById(id);
 
                 if (element?.offsetHeight && element.offsetTop) {
@@ -34,7 +43,7 @@ export function useActiveSection<TId extends string>(ids: TId[], offsetPx = 250)
         navHighlighter();
 
         return () => window.removeEventListener('scroll', navHighlighter);
-    }, [ids, offsetPx]);
+    }, [idsKey, offsetPx]);
 
     return activeId;
 }

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useEffect, useState } from 'react';
+
+export function useActiveSection<TId extends string>(ids: TId[], offsetPx = 250): TId | null {
+    const [activeId, setActiveId] = useState<TId | null>(ids[0] ?? null);
+
+    useEffect(() => {
+        function navHighlighter() {
+            const { scrollY } = window;
+            let current: TId | null = null;
+
+            ids.forEach((id) => {
+                const element = document.getElementById(id);
+
+                if (element?.offsetHeight && element.offsetTop) {
+                    const sectionHeight = element.offsetHeight;
+                    const sectionTop = element.offsetTop - offsetPx;
+
+                    if (scrollY > sectionTop && scrollY <= sectionTop + sectionHeight) {
+                        current = id;
+                    }
+                }
+            });
+
+            if (current !== null) {
+                setActiveId(current);
+            }
+        }
+
+        window.addEventListener('scroll', navHighlighter);
+        navHighlighter();
+
+        return () => window.removeEventListener('scroll', navHighlighter);
+    }, [ids, offsetPx]);
+
+    return activeId;
+}

--- a/src/routes/BufferSummary.tsx
+++ b/src/routes/BufferSummary.tsx
@@ -2,12 +2,12 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { AnchorButton, ButtonGroup, ButtonVariant, Intent, Size, Tab, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useAtom } from 'jotai';
 import useBufferFocus from '../hooks/useBufferFocus';
+import { useActiveSection } from '../hooks/useActiveSection';
 import ROUTES from '../definitions/Routes';
 import BufferSummaryTab from '../components/buffer-summary/BufferSummaryTab';
 import 'styles/components/BufferSummary.scss';
@@ -17,33 +17,8 @@ import { selectedBufferSummaryTabAtom } from '../store/app';
 function BufferSummary() {
     const { activeToast, resetToasts } = useBufferFocus();
 
-    const plotRef = useRef<HTMLHeadingElement>(null);
-    const tableRef = useRef<HTMLHeadingElement>(null);
-    const [activeSection, setActiveSection] = useState<SECTION_IDS>(SECTION_IDS.PLOT);
+    const activeSection = useActiveSection([SECTION_IDS.PLOT, SECTION_IDS.TABLE]);
     const [selectedTabId, setSelectedTabId] = useAtom(selectedBufferSummaryTabAtom);
-
-    useEffect(() => {
-        const scrollRefs = [plotRef, tableRef];
-
-        function navHighlighter() {
-            const { scrollY } = window;
-
-            scrollRefs.forEach((ref) => {
-                if (ref?.current?.offsetHeight && ref?.current?.offsetTop) {
-                    const sectionHeight = ref.current.offsetHeight;
-                    const sectionTop = ref.current.offsetTop - 250;
-                    const sectionId = ref.current.getAttribute('id') as SECTION_IDS | null;
-
-                    if (sectionId && scrollY > sectionTop && scrollY <= sectionTop + sectionHeight) {
-                        setActiveSection(sectionId);
-                    }
-                }
-            });
-        }
-
-        window.addEventListener('scroll', navHighlighter);
-        return () => window.removeEventListener('scroll', navHighlighter);
-    }, []);
 
     return (
         <div className='buffer-summary data-padding'>
@@ -90,24 +65,14 @@ function BufferSummary() {
                     id={TAB_IDS.L1}
                     title='L1'
                     icon={IconNames.PAGE_LAYOUT}
-                    panel={
-                        <BufferSummaryTab
-                            plotRef={plotRef}
-                            tableRef={tableRef}
-                        />
-                    }
+                    panel={<BufferSummaryTab />}
                 />
 
                 <Tab
                     id={TAB_IDS.DRAM}
                     title='DRAM'
                     icon={IconNames.PAGE_LAYOUT}
-                    panel={
-                        <BufferSummaryTab
-                            plotRef={plotRef}
-                            tableRef={tableRef}
-                        />
-                    }
+                    panel={<BufferSummaryTab />}
                 />
             </Tabs>
         </div>

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -25,10 +25,8 @@ import {
     selectedPerfRowIdAtom,
     selectedPerformanceRangeAtom,
 } from '../store/app';
-import PerfCharts from '../components/performance/PerfCharts';
-import PerfChartFilter from '../components/performance/PerfChartFilter';
+import PerformanceChartsTab from '../components/performance/PerformanceChartsTab';
 import { Marker, MarkerColours, PerfTableRow, TypedPerfTableRow } from '../definitions/PerfTable';
-import NonFilterablePerfCharts from '../components/performance/NonFilterablePerfCharts';
 import ComparisonReportSelector from '../components/performance/ComparisonReportSelector';
 import 'styles/routes/Performance.scss';
 import getServerConfig from '../functions/getServerConfig';
@@ -277,33 +275,15 @@ export default function Performance() {
                             <h3 className='title'>Performance charts</h3>
 
                             {perfData ? (
-                                <>
-                                    <div className='charts-container'>
-                                        <PerfChartFilter
-                                            opCodeOptions={opCodeOptions}
-                                            selectedOpCodes={selectedOpCodes}
-                                            updateOpCodes={setSelectedOpCodesFromUser}
-                                        />
-
-                                        <PerfCharts
-                                            filteredPerfData={filteredEnrichedData}
-                                            comparisonData={filteredEnrichedComparisonData}
-                                            selectedOpCodes={selectedOpCodes}
-                                        />
-                                    </div>
-
-                                    <div className='charts-container non-filterable-charts'>
-                                        <span />
-
-                                        <div>
-                                            <NonFilterablePerfCharts
-                                                chartData={enrichedData}
-                                                secondaryData={enrichedComparisonData || []}
-                                                opCodeOptions={opCodeOptions}
-                                            />
-                                        </div>
-                                    </div>
-                                </>
+                                <PerformanceChartsTab
+                                    filteredPerfData={filteredEnrichedData}
+                                    filteredComparisonData={filteredEnrichedComparisonData}
+                                    enrichedData={enrichedData}
+                                    enrichedComparisonData={enrichedComparisonData}
+                                    selectedOpCodes={selectedOpCodes}
+                                    opCodeOptions={opCodeOptions}
+                                    updateOpCodes={setSelectedOpCodesFromUser}
+                                />
                             ) : null}
                         </div>
                     }

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+@use '../definitions/variables' as variables;
 
 .charts-container {
     display: grid;
@@ -15,6 +16,13 @@
     .charts {
         min-width: 800px; // Ensures charts are wide enough to display properly and allows overflow
         overflow: auto;
+    }
+
+    // Anchored chart targets sit below the sticky "Jump to chart" nav bar, so their
+    // titles would otherwise land hidden underneath it when navigated to via hash link.
+    .chart-container,
+    .operation-types-chart {
+        scroll-margin-top: variables.$perf-charts-index-scroll-offset;
     }
 }
 

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -8,6 +8,10 @@
     position: relative;
     gap: 30px;
 
+    .charts-column {
+        min-width: 0; // Allow the column to shrink below content width so .charts can scroll horizontally
+    }
+
     .charts {
         min-width: 800px; // Ensures charts are wide enough to display properly and allows overflow
         overflow: auto;

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI UL
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 // Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart
 $perf-charts-index-scroll-offset: 60px;

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 // Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart.
-// Keep in sync with PERF_CHARTS_NAV_OFFSET_PX (PerformanceCharts.ts).
+// Keep in sync with PERF_CHARTS_NAV_OFFSET_PX (PerformanceChartsTab.tsx).
 $perf-charts-nav-offset: 60px;
 
 .charts-container {

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-@use '../definitions/variables' as variables;
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI UL
+
+// Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart
+$perf-charts-index-scroll-offset: 60px;
 
 .charts-container {
     display: grid;
@@ -22,7 +24,7 @@
     // titles would otherwise land hidden underneath it when navigated to via hash link.
     .chart-container,
     .operation-types-chart {
-        scroll-margin-top: variables.$perf-charts-index-scroll-offset;
+        scroll-margin-top: $perf-charts-index-scroll-offset;
     }
 }
 

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -2,8 +2,9 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-// Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart
-$perf-charts-index-scroll-offset: 60px;
+// Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart.
+// Keep in sync with PERF_CHARTS_NAV_OFFSET_PX (PerformanceCharts.ts).
+$perf-charts-nav-offset: 60px;
 
 .charts-container {
     display: grid;
@@ -24,7 +25,7 @@ $perf-charts-index-scroll-offset: 60px;
     // titles would otherwise land hidden underneath it when navigated to via hash link.
     .chart-container,
     .operation-types-chart {
-        scroll-margin-top: $perf-charts-index-scroll-offset;
+        scroll-margin-top: $perf-charts-nav-offset;
     }
 }
 

--- a/src/scss/components/PerfChartsIndex.scss
+++ b/src/scss/components/PerfChartsIndex.scss
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+@use '../definitions/colours' as *;
+@use '../definitions/variables' as variables;
+
+.perf-charts-index {
+    position: sticky;
+    top: 0;
+    z-index: variables.$z-index-2-interactive;
+    margin-bottom: 10px;
+    padding: 5px;
+    background-color: $tt-background;
+    background-color: #4b456e;
+    border-radius: 2px;
+    box-shadow: 6px 6px 8px 0 rgb(0 0 0 / 25%);
+
+    .perf-charts-index-trigger {
+        max-width: 100%;
+
+        .perf-charts-index-trigger-label {
+            display: inline-flex;
+            gap: 6px;
+            align-items: baseline;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+}
+
+.perf-charts-index-menu {
+    max-height: calc(100vh - 80px);
+    overflow-y: auto;
+}
+
+.charts-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    position: sticky;
+    top: 0;
+    align-self: start;
+    max-height: calc(100vh - 20px);
+    overflow-y: auto;
+}

--- a/src/scss/components/PerfChartsIndex.scss
+++ b/src/scss/components/PerfChartsIndex.scss
@@ -10,8 +10,7 @@
     z-index: variables.$z-index-2-interactive; // Above base content and allows internal dropdown to be fully visible
     margin-bottom: 10px;
     padding: 5px;
-    background-color: $tt-background;
-    background-color: #4b456e;
+    background-color: $tt-purple-shade;
     border-radius: 2px;
     box-shadow: 6px 6px 8px 0 rgb(0 0 0 / 25%);
 

--- a/src/scss/components/PerfChartsIndex.scss
+++ b/src/scss/components/PerfChartsIndex.scss
@@ -7,7 +7,7 @@
 .perf-charts-index {
     position: sticky;
     top: 0;
-    z-index: variables.$z-index-2-interactive;
+    z-index: variables.$z-index-2-interactive; // Above base content and allows internal dropdown to be fully visible
     margin-bottom: 10px;
     padding: 5px;
     background-color: $tt-background;

--- a/src/scss/definitions/_variables.scss
+++ b/src/scss/definitions/_variables.scss
@@ -36,3 +36,6 @@ $z-index-3-overlay: 1000;
 
 // Component-specific variables
 $active-transfer-width: 380px;
+
+// Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart
+$perf-charts-index-scroll-offset: 60px;

--- a/src/scss/definitions/_variables.scss
+++ b/src/scss/definitions/_variables.scss
@@ -36,6 +36,3 @@ $z-index-3-overlay: 1000;
 
 // Component-specific variables
 $active-transfer-width: 380px;
-
-// Clears the sticky "Jump to chart" nav bar when scrolling to an anchored chart
-$perf-charts-index-scroll-offset: 60px;

--- a/tests/PerfChartsIndex.spec.tsx
+++ b/tests/PerfChartsIndex.spec.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import PerfChartsIndex from '../src/components/performance/PerfChartsIndex';
+import { PerfChartId } from '../src/definitions/PerformanceCharts';
+import ROUTES from '../src/definitions/Routes';
+
+afterEach(cleanup);
+
+const entries = [
+    { id: PerfChartId.OpCountVsRuntime, label: 'Operation Count vs Device Time' },
+    { id: PerfChartId.CoreCountKernelRuntime, label: 'Core Count + Device Kernel Runtime' },
+];
+
+function openMenu() {
+    fireEvent.click(screen.getByRole('button'));
+}
+
+describe('PerfChartsIndex', () => {
+    it('renders nothing when there are no entries', () => {
+        const { container } = render(
+            <PerfChartsIndex
+                entries={[]}
+                activeId={null}
+            />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('shows the active entry label on the trigger button', () => {
+        render(
+            <PerfChartsIndex
+                entries={entries}
+                activeId={PerfChartId.CoreCountKernelRuntime}
+            />,
+        );
+
+        const trigger = screen.getByRole('button');
+        expect(trigger.textContent).toContain(entries[1].label);
+    });
+
+    it('renders menu items with performance route hashes when opened', () => {
+        render(
+            <PerfChartsIndex
+                entries={entries}
+                activeId={PerfChartId.OpCountVsRuntime}
+            />,
+        );
+
+        openMenu();
+
+        expect(screen.getByRole('menuitem', { name: entries[0].label })).toHaveAttribute(
+            'href',
+            `${ROUTES.PERFORMANCE}#${PerfChartId.OpCountVsRuntime}`,
+        );
+        expect(screen.getByRole('menuitem', { name: entries[1].label })).toHaveAttribute(
+            'href',
+            `${ROUTES.PERFORMANCE}#${PerfChartId.CoreCountKernelRuntime}`,
+        );
+    });
+
+    it('marks the active entry as active in the menu', () => {
+        render(
+            <PerfChartsIndex
+                entries={entries}
+                activeId={PerfChartId.CoreCountKernelRuntime}
+            />,
+        );
+
+        openMenu();
+
+        const activeItem = screen.getByRole('menuitem', { name: entries[1].label });
+        const inactiveItem = screen.getByRole('menuitem', { name: entries[0].label });
+
+        expect(activeItem.className).toContain('bp6-active');
+        expect(inactiveItem.className).not.toContain('bp6-active');
+    });
+});

--- a/tests/PerformanceCharts.spec.ts
+++ b/tests/PerformanceCharts.spec.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import {
+    CONV_CHART_ENTRIES,
+    FILTERABLE_CHART_ENTRIES,
+    MATMUL_CHART_ENTRIES,
+    buildChartIndexEntries,
+    getOperationTypesChartId,
+    getOperationTypesChartLabel,
+} from '../src/definitions/PerformanceCharts';
+
+const idsOf = (entries: { id: string }[]): string[] => entries.map((entry) => entry.id);
+
+const FILTERABLE_IDS = idsOf(FILTERABLE_CHART_ENTRIES);
+const MATMUL_IDS = idsOf(MATMUL_CHART_ENTRIES);
+const CONV_IDS = idsOf(CONV_CHART_ENTRIES);
+
+describe('buildChartIndexEntries', () => {
+    it('returns only the filterable charts when there is no matmul/conv data and no report', () => {
+        const entries = buildChartIndexEntries({
+            hasMatmulData: false,
+            hasConvData: false,
+            activeReportName: null,
+            comparisonReportNames: null,
+        });
+
+        expect(idsOf(entries)).toEqual(FILTERABLE_IDS);
+    });
+
+    it('appends matmul then conv groups in order, only when each has data', () => {
+        expect(
+            idsOf(
+                buildChartIndexEntries({
+                    hasMatmulData: true,
+                    hasConvData: false,
+                    activeReportName: null,
+                    comparisonReportNames: null,
+                }),
+            ),
+        ).toEqual([...FILTERABLE_IDS, ...MATMUL_IDS]);
+
+        expect(
+            idsOf(
+                buildChartIndexEntries({
+                    hasMatmulData: false,
+                    hasConvData: true,
+                    activeReportName: null,
+                    comparisonReportNames: null,
+                }),
+            ),
+        ).toEqual([...FILTERABLE_IDS, ...CONV_IDS]);
+
+        expect(
+            idsOf(
+                buildChartIndexEntries({
+                    hasMatmulData: true,
+                    hasConvData: true,
+                    activeReportName: null,
+                    comparisonReportNames: null,
+                }),
+            ),
+        ).toEqual([...FILTERABLE_IDS, ...MATMUL_IDS, ...CONV_IDS]);
+    });
+
+    it('adds a single Operation Types entry without a report name when there is no comparison', () => {
+        const entries = buildChartIndexEntries({
+            hasMatmulData: false,
+            hasConvData: false,
+            activeReportName: 'report-a',
+            comparisonReportNames: null,
+        });
+
+        expect(entries).toContainEqual({
+            id: getOperationTypesChartId('active'),
+            label: getOperationTypesChartLabel(''),
+        });
+        // Exactly one Operation Types entry (the active one), no comparison entries.
+        expect(entries.filter((entry) => entry.id.includes('operation-types'))).toHaveLength(1);
+    });
+
+    it('labels the active and comparison Operation Types entries with report names while comparing', () => {
+        const entries = buildChartIndexEntries({
+            hasMatmulData: false,
+            hasConvData: false,
+            activeReportName: 'report-a',
+            comparisonReportNames: ['report-b', 'report-c'],
+        });
+
+        expect(entries).toContainEqual({
+            id: getOperationTypesChartId('active'),
+            label: getOperationTypesChartLabel('report-a'),
+        });
+        expect(entries).toContainEqual({
+            id: getOperationTypesChartId('comparison-0'),
+            label: getOperationTypesChartLabel('report-b'),
+        });
+        expect(entries).toContainEqual({
+            id: getOperationTypesChartId('comparison-1'),
+            label: getOperationTypesChartLabel('report-c'),
+        });
+    });
+
+    it('omits the active entry and drops comparison report names when there is no active report', () => {
+        const entries = buildChartIndexEntries({
+            hasMatmulData: false,
+            hasConvData: false,
+            activeReportName: null,
+            comparisonReportNames: ['report-b'],
+        });
+
+        expect(entries.find((entry) => entry.id === getOperationTypesChartId('active'))).toBeUndefined();
+        expect(entries).toContainEqual({
+            id: getOperationTypesChartId('comparison-0'),
+            label: getOperationTypesChartLabel(''),
+        });
+    });
+});

--- a/tests/useActiveSection.spec.ts
+++ b/tests/useActiveSection.spec.ts
@@ -23,6 +23,19 @@ function mockElement(top: number, height: number): HTMLDivElement {
     return element;
 }
 
+// Mirrors a real scroll: move the viewport, then fire the event the hook listens for.
+function scrollTo(scrollY: number): void {
+    Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        value: scrollY,
+        writable: true,
+    });
+
+    act(() => {
+        window.dispatchEvent(new Event('scroll'));
+    });
+}
+
 describe('useActiveSection', () => {
     beforeEach(() => {
         Object.defineProperty(window, 'scrollY', {
@@ -67,31 +80,37 @@ describe('useActiveSection', () => {
             return null;
         });
 
-        const { result, rerender } = renderHook(
-            ({ scrollY }) => {
-                Object.defineProperty(window, 'scrollY', {
-                    configurable: true,
-                    value: scrollY,
-                    writable: true,
-                });
+        const { result } = renderHook(() => useActiveSection(['first', 'second']));
 
-                return useActiveSection(['first', 'second']);
-            },
-            { initialProps: { scrollY: 200 } },
-        );
-
-        act(() => {
-            rerender({ scrollY: 200 });
-            window.dispatchEvent(new Event('scroll'));
-        });
-
+        // 'first' spans (150, 350] once the 250px offset is applied.
+        scrollTo(200);
         expect(result.current).toBe('first');
 
-        act(() => {
-            rerender({ scrollY: 500 });
-            window.dispatchEvent(new Event('scroll'));
+        // 'second' spans (450, 650].
+        scrollTo(500);
+        expect(result.current).toBe('second');
+    });
+
+    it('does not change the active section when scrollY falls outside every section range', () => {
+        vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+            if (id === 'first') {
+                return mockElement(400, 200);
+            }
+
+            if (id === 'second') {
+                return mockElement(700, 200);
+            }
+
+            return null;
         });
 
+        const { result } = renderHook(() => useActiveSection(['first', 'second']));
+
+        scrollTo(500);
+        expect(result.current).toBe('second');
+
+        // 5000 is past both ranges; the hook keeps the last matched section rather than clearing it.
+        scrollTo(5000);
         expect(result.current).toBe('second');
     });
 
@@ -104,24 +123,10 @@ describe('useActiveSection', () => {
             return null;
         });
 
-        const { result, rerender } = renderHook(
-            ({ scrollY }) => {
-                Object.defineProperty(window, 'scrollY', {
-                    configurable: true,
-                    value: scrollY,
-                    writable: true,
-                });
+        const { result } = renderHook(() => useActiveSection(['section'], SCROLL_OFFSET_PX));
 
-                return useActiveSection(['section'], SCROLL_OFFSET_PX);
-            },
-            { initialProps: { scrollY: SCROLL_OFFSET_PX + 100 } },
-        );
-
-        act(() => {
-            rerender({ scrollY: SCROLL_OFFSET_PX + 100 });
-            window.dispatchEvent(new Event('scroll'));
-        });
-
+        // With a 250px offset the section spans (150, 350]; 350 is the inclusive upper bound.
+        scrollTo(SCROLL_OFFSET_PX + 100);
         expect(result.current).toBe('section');
     });
 });

--- a/tests/useActiveSection.spec.ts
+++ b/tests/useActiveSection.spec.ts
@@ -114,6 +114,70 @@ describe('useActiveSection', () => {
         expect(result.current).toBe('second');
     });
 
+    it('activates a section that sits flush with the top of the page (offsetTop === 0)', () => {
+        vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+            if (id === 'first') {
+                return mockElement(0, 400);
+            }
+
+            if (id === 'second') {
+                return mockElement(700, 400);
+            }
+
+            return null;
+        });
+
+        const { result } = renderHook(() => useActiveSection(['first', 'second'], 60));
+
+        // 'second' spans (640, 1040] once the 60px offset is applied.
+        scrollTo(800);
+        expect(result.current).toBe('second');
+
+        // Back to the top: 'first' spans (-60, 340] and must still be reachable despite offsetTop === 0.
+        scrollTo(0);
+        expect(result.current).toBe('first');
+    });
+
+    it('drops a stale active id and re-seeds when the id set changes', () => {
+        vi.spyOn(document, 'getElementById').mockReturnValue(null);
+
+        const { result, rerender } = renderHook(({ ids }) => useActiveSection(ids), {
+            initialProps: { ids: ['first', 'second'] },
+        });
+
+        expect(result.current).toBe('first');
+
+        // The previous active id is gone from the new set, so it falls back to the new first section.
+        rerender({ ids: ['third', 'fourth'] });
+        expect(result.current).toBe('third');
+    });
+
+    it('keeps the current active id when it survives a change to the id set', () => {
+        vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+            if (id === 'first') {
+                return mockElement(400, 200);
+            }
+
+            if (id === 'second') {
+                return mockElement(700, 200);
+            }
+
+            return null;
+        });
+
+        const { result, rerender } = renderHook(({ ids }) => useActiveSection(ids), {
+            initialProps: { ids: ['first', 'second'] },
+        });
+
+        // 'second' spans (450, 650]; make it the active section before the id set grows.
+        scrollTo(500);
+        expect(result.current).toBe('second');
+
+        // 'second' is still present, so adding a new section must not reset the active id.
+        rerender({ ids: ['first', 'second', 'third'] });
+        expect(result.current).toBe('second');
+    });
+
     it('uses the provided scroll offset when determining the active section', () => {
         vi.spyOn(document, 'getElementById').mockImplementation((id) => {
             if (id === 'section') {

--- a/tests/useActiveSection.spec.ts
+++ b/tests/useActiveSection.spec.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useActiveSection } from '../src/hooks/useActiveSection';
+
+const SCROLL_OFFSET_PX = 250;
+
+function mockElement(top: number, height: number): HTMLDivElement {
+    const element = document.createElement('div');
+
+    Object.defineProperty(element, 'offsetTop', {
+        configurable: true,
+        value: top,
+    });
+    Object.defineProperty(element, 'offsetHeight', {
+        configurable: true,
+        value: height,
+    });
+
+    return element;
+}
+
+describe('useActiveSection', () => {
+    beforeEach(() => {
+        Object.defineProperty(window, 'scrollY', {
+            configurable: true,
+            value: 0,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the first section id by default', () => {
+        vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+            if (id === 'first') {
+                return mockElement(400, 200);
+            }
+
+            if (id === 'second') {
+                return mockElement(700, 200);
+            }
+
+            return null;
+        });
+
+        const { result } = renderHook(() => useActiveSection(['first', 'second']));
+
+        expect(result.current).toBe('first');
+    });
+
+    it('selects the section whose scroll range contains scrollY', () => {
+        vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+            if (id === 'first') {
+                return mockElement(400, 200);
+            }
+
+            if (id === 'second') {
+                return mockElement(700, 200);
+            }
+
+            return null;
+        });
+
+        const { result, rerender } = renderHook(
+            ({ scrollY }) => {
+                Object.defineProperty(window, 'scrollY', {
+                    configurable: true,
+                    value: scrollY,
+                    writable: true,
+                });
+
+                return useActiveSection(['first', 'second']);
+            },
+            { initialProps: { scrollY: 200 } },
+        );
+
+        act(() => {
+            rerender({ scrollY: 200 });
+            window.dispatchEvent(new Event('scroll'));
+        });
+
+        expect(result.current).toBe('first');
+
+        act(() => {
+            rerender({ scrollY: 500 });
+            window.dispatchEvent(new Event('scroll'));
+        });
+
+        expect(result.current).toBe('second');
+    });
+
+    it('uses the provided scroll offset when determining the active section', () => {
+        vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+            if (id === 'section') {
+                return mockElement(400, 200);
+            }
+
+            return null;
+        });
+
+        const { result, rerender } = renderHook(
+            ({ scrollY }) => {
+                Object.defineProperty(window, 'scrollY', {
+                    configurable: true,
+                    value: scrollY,
+                    writable: true,
+                });
+
+                return useActiveSection(['section'], SCROLL_OFFSET_PX);
+            },
+            { initialProps: { scrollY: SCROLL_OFFSET_PX + 100 } },
+        );
+
+        act(() => {
+            rerender({ scrollY: SCROLL_OFFSET_PX + 100 });
+            window.dispatchEvent(new Event('scroll'));
+        });
+
+        expect(result.current).toBe('section');
+    });
+});


### PR DESCRIPTION
Adds a sticky navigation bar for charts. The bar code itself isn't complicated but it required some code reorganisation.

<img width="1277" height="878" alt="Screenshot 2026-06-03 at 12 46 11" src="https://github.com/user-attachments/assets/62cae848-73ca-48e3-9e33-940dada3bee4" />

<img width="1277" height="878" alt="Screenshot 2026-06-03 at 12 46 01" src="https://github.com/user-attachments/assets/c4a20b9c-210a-47b7-97c2-327c2e0109a1" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1608.