### PR TITLE
Add linked node locate capability

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -49,6 +49,7 @@ import type {
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
+import { getNamespaceSegments } from './mlirGraphHelpers';
 
 // Re-uses `WorkerNode['data']` (the canonical shape produced by the layout
 // worker) and tacks on `highlight` — a view-layer-only flag. Set when this
@@ -287,6 +288,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
         toNodeId: string;
         fromPosition: { x: number; y: number };
     } | null>(null);
+    // Set by `navigateToNode` when the target lives inside one or more
+    // collapsed namespaces and we have to wait for the worker to rebuild
+    // before we can fitView on it. Consumed once the rebuilt graph lands.
+    const pendingFocusNodeIdRef = useRef<string | null>(null);
     const hasFitInitiallyRef = useRef(false);
 
     // No graph-id reset effect: `MlGraphInner` is keyed by `graph.id` in
@@ -337,6 +342,27 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     );
                 }
                 viewportAnchorRef.current = null;
+            }
+
+            // Locate-from-panel: the user clicked the "locate" button next to
+            // a producer/consumer reference and the target wasn't visible
+            // pre-rebuild (collapsed namespace). Now that the rebuilt graph
+            // has landed, recenter on it. Skip silently if the target still
+            // isn't in the build (e.g. synthetic id that never reaches the
+            // canvas) — selection is harmless and the missing fitView is
+            // preferable to a noisy error.
+            const pendingFocusId = pendingFocusNodeIdRef.current;
+            if (pendingFocusId) {
+                pendingFocusNodeIdRef.current = null;
+                if (rf.nodes.some((n) => n.id === pendingFocusId)) {
+                    requestAnimationFrame(() => {
+                        void fitView({
+                            nodes: [{ id: pendingFocusId }],
+                            padding: 0.3,
+                            duration: 200,
+                        });
+                    });
+                }
             }
 
             if (!hasFitInitiallyRef.current) {
@@ -765,6 +791,51 @@ const MlGraphInner = ({ data }: ViewProps) => {
         void fitView({ nodes: [{ id: selectedNodeId }], padding: 0.3, duration: 200 });
     }, [fitView, selectedNodeId]);
 
+    // Click handler for the "locate" affordance next to each producer /
+    // consumer reference in the details panel. This is a peek — it pans
+    // the viewport to the linked node without changing the current
+    // selection, so the panel stays on the originating op and the
+    // input/output highlighting on the canvas doesn't churn.
+    //
+    // The target may live inside one or more collapsed namespaces, so we:
+    //   1. Look it up in the source-data map. If unknown (e.g. a synthetic
+    //      arg-node id that never appears as a SourceNode), bail.
+    //   2. Walk the namespace chain and queue any ancestor prefixes — and
+    //      the target's own namespace — that aren't already expanded. Every
+    //      level must be expanded for the node to actually be rendered.
+    //   3. If no expansion was needed, fitView straight away. Otherwise
+    //      stash the id in `pendingFocusNodeIdRef` so the post-rebuild path
+    //      in `applyBuiltGraph` recenters once the new nodes land.
+    const navigateToNode = useCallback(
+        (targetNodeId: string) => {
+            const target = sourceNodeById.get(targetNodeId);
+            if (!target) {
+                return;
+            }
+            const segments = getNamespaceSegments(target.namespace);
+            const prefixesToAdd: string[] = [];
+            for (let i = 1; i <= segments.length; i++) {
+                const prefix = segments.slice(0, i).join('/');
+                if (!expandedNamespaces.has(prefix)) {
+                    prefixesToAdd.push(prefix);
+                }
+            }
+            if (prefixesToAdd.length === 0) {
+                void fitView({ nodes: [{ id: targetNodeId }], padding: 0.3, duration: 200 });
+                return;
+            }
+            pendingFocusNodeIdRef.current = targetNodeId;
+            setExpandedNamespaces((prev) => {
+                const next = new Set(prev);
+                for (const prefix of prefixesToAdd) {
+                    next.add(prefix);
+                }
+                return next;
+            });
+        },
+        [expandedNamespaces, fitView, sourceNodeById],
+    );
+
     // Edge display rules:
     // 1. Drop edges where either endpoint is a real-namespace group node.
     //    The worker's internal-edges loop emits these for nested expanded
@@ -1043,6 +1114,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     outputsMetadata={selectedOutputsMetadata}
                     onClose={closeDetailsPanel}
                     onRecenter={recenterOnSelected}
+                    onNavigateToNode={navigateToNode}
                 />
             )}
         </div>

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -349,8 +349,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
             // pre-rebuild (collapsed namespace). Now that the rebuilt graph
             // has landed, recenter on it. Skip silently if the target still
             // isn't in the build (e.g. synthetic id that never reaches the
-            // canvas) — selection is harmless and the missing fitView is
-            // preferable to a noisy error.
+            // canvas) — a missing fitView is preferable to a noisy error,
+            // and the surrounding state stays consistent because navigation
+            // never touches selection.
             const pendingFocusId = pendingFocusNodeIdRef.current;
             if (pendingFocusId) {
                 pendingFocusNodeIdRef.current = null;

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -29,9 +29,11 @@ interface MlirNodeDetailsPanelProps {
     onRecenter: () => void;
     /**
      * Invoked when the user clicks the "locate" affordance next to a producer
-     * (Inputs) or consumer (Outputs) reference. The view handles selecting
-     * the target, auto-expanding any namespaces it sits inside, and
-     * recentering the canvas on it.
+     * (Inputs) or consumer (Outputs) reference. The view auto-expands any
+     * namespaces the target sits inside and recenters the canvas on it; the
+     * current selection — and therefore the panel itself — is intentionally
+     * left untouched so the user can keep exploring the originating op's
+     * I/O while peeking at where its neighbours live.
      */
     onNavigateToNode: (nodeId: string) => void;
 }

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -168,7 +168,7 @@ const MlirNodeDetailsPanel = ({
     outputsMetadata,
     onClose,
     onRecenter,
-    onNavigateToNode,
+    onNavigateToNode: handleNavigateToNode,
 }: MlirNodeDetailsPanelProps) => {
     const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
 
@@ -293,7 +293,7 @@ const MlirNodeDetailsPanel = ({
                             <LinkedNodeRef
                                 label={edge.sourceNodeLabel}
                                 id={edge.sourceNodeId}
-                                onNavigate={onNavigateToNode}
+                                onNavigate={handleNavigateToNode}
                             />
                             <span className='mlir-node-details-io-port'>
                                 out {edge.sourceNodeOutputId} → in {edge.targetNodeInputId}
@@ -343,7 +343,7 @@ const MlirNodeDetailsPanel = ({
                                             <LinkedNodeRef
                                                 label={consumer.targetNodeLabel}
                                                 id={consumer.targetNodeId}
-                                                onNavigate={onNavigateToNode}
+                                                onNavigate={handleNavigateToNode}
                                             />
                                             <span className='mlir-node-details-io-port'>
                                                 in {consumer.targetNodeInputId}

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -27,6 +27,13 @@ interface MlirNodeDetailsPanelProps {
     outputsMetadata: IndexedPortMetadata[];
     onClose: () => void;
     onRecenter: () => void;
+    /**
+     * Invoked when the user clicks the "locate" affordance next to a producer
+     * (Inputs) or consumer (Outputs) reference. The view handles selecting
+     * the target, auto-expanding any namespaces it sits inside, and
+     * recentering the canvas on it.
+     */
+    onNavigateToNode: (nodeId: string) => void;
 }
 
 interface OutputPortView {
@@ -68,6 +75,41 @@ const NodeRef = ({ label, id }: NodeRefProps) => {
     }
     return <span className='mlir-node-details-io-id'>{id}</span>;
 };
+
+interface LinkedNodeRefProps {
+    label: string | null;
+    id: string;
+    onNavigate: (nodeId: string) => void;
+}
+
+// Pairs a NodeRef with a small "locate" icon button. The button is the click
+// target — keeping it discrete (vs. making the whole label clickable) keeps
+// drag-to-select on the label text working and matches the recenter icon
+// already in the panel header so the affordance reads as the same gesture
+// scoped to a single linked node.
+const LinkedNodeRef = ({ label, id, onNavigate }: LinkedNodeRefProps) => (
+    <div className='mlir-node-details-io-ref'>
+        <div className='mlir-node-details-io-names'>
+            <NodeRef
+                label={label}
+                id={id}
+            />
+        </div>
+        <Tooltip
+            content='Locate'
+            compact
+        >
+            <Button
+                className='mlir-node-details-io-locate'
+                size={Size.SMALL}
+                variant={ButtonVariant.MINIMAL}
+                icon={IconNames.LOCATE}
+                aria-label={`Locate ${label ?? id}`}
+                onClick={() => onNavigate(id)}
+            />
+        </Tooltip>
+    </div>
+);
 
 interface DetailsSectionProps {
     title: string;
@@ -124,6 +166,7 @@ const MlirNodeDetailsPanel = ({
     outputsMetadata,
     onClose,
     onRecenter,
+    onNavigateToNode,
 }: MlirNodeDetailsPanelProps) => {
     const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
 
@@ -183,12 +226,12 @@ const MlirNodeDetailsPanel = ({
                     </p>
                 </div>
                 <div className='mlir-node-details-actions'>
-                    <Tooltip content='Recenter on this node'>
+                    <Tooltip content='Recenter'>
                         <Button
                             size={Size.SMALL}
                             variant={ButtonVariant.MINIMAL}
                             icon={IconNames.LOCATE}
-                            aria-label='Recenter on this node'
+                            aria-label='Recenter'
                             onClick={onRecenter}
                         />
                     </Tooltip>
@@ -245,9 +288,10 @@ const MlirNodeDetailsPanel = ({
                             key={`${edge.sourceNodeId}:${edge.sourceNodeOutputId}->${edge.targetNodeInputId}:${idx}`}
                             className='mlir-node-details-io-row'
                         >
-                            <NodeRef
+                            <LinkedNodeRef
                                 label={edge.sourceNodeLabel}
                                 id={edge.sourceNodeId}
+                                onNavigate={onNavigateToNode}
                             />
                             <span className='mlir-node-details-io-port'>
                                 out {edge.sourceNodeOutputId} → in {edge.targetNodeInputId}
@@ -294,9 +338,10 @@ const MlirNodeDetailsPanel = ({
                                             key={`${consumer.targetNodeId}:${consumer.targetNodeInputId}:${idx}`}
                                             className='mlir-node-details-consumer-row'
                                         >
-                                            <NodeRef
+                                            <LinkedNodeRef
                                                 label={consumer.targetNodeLabel}
                                                 id={consumer.targetNodeId}
+                                                onNavigate={onNavigateToNode}
                                             />
                                             <span className='mlir-node-details-io-port'>
                                                 in {consumer.targetNodeInputId}

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -960,6 +960,7 @@ export default function Styleguide() {
                         outputsMetadata={MLIR_RICH_NODE.outputsMetadata}
                         onClose={() => {}}
                         onRecenter={() => {}}
+                        onNavigateToNode={() => {}}
                     />
                 </div>
 
@@ -972,6 +973,7 @@ export default function Styleguide() {
                         outputsMetadata={MLIR_TERMINATOR_NODE.outputsMetadata}
                         onClose={() => {}}
                         onRecenter={() => {}}
+                        onNavigateToNode={() => {}}
                     />
                 </div>
 
@@ -984,6 +986,7 @@ export default function Styleguide() {
                         outputsMetadata={[]}
                         onClose={() => {}}
                         onRecenter={() => {}}
+                        onNavigateToNode={() => {}}
                     />
                 </div>
             </div>

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -240,6 +240,41 @@
     }
 }
 
+// Horizontal pairing of a producer/consumer name block with its "locate"
+// icon button. The names stack vertically (label over raw id) inside
+// `.mlir-node-details-io-names`; the button is vertically centred against
+// that block so single- and two-line refs both look aligned.
+.mlir-node-details-io-ref {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+.mlir-node-details-io-names {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+// Per-row "locate" icon. Blueprint's MINIMAL/SMALL Button still ships with
+// padding sized for body buttons; trim it down so the icon sits inline with
+// the name block without inflating the row height.
+.mlir-node-details-io-locate {
+    flex: 0 0 auto;
+    min-height: 0;
+    padding: 2px;
+
+    .bp6-icon {
+        color: $tt-grey-7;
+    }
+
+    &:hover .bp6-icon {
+        color: $tt-white;
+    }
+}
+
 .mlir-node-details-io-id {
     font-family: monospace;
     font-size: 11px;

--- a/tests/MlirNodeDetailsPanel.spec.tsx
+++ b/tests/MlirNodeDetailsPanel.spec.tsx
@@ -207,6 +207,26 @@ describe('MlirNodeDetailsPanel Inputs section', () => {
         renderPanel({ incomingEdges: incoming });
         expect(screen.getByText('out 2 → in 1')).toBeInTheDocument();
     });
+
+    it('calls onNavigateToNode with the producer id when the row locate button is clicked', () => {
+        const incoming: IncomingEdgeView[] = [
+            {
+                sourceNodeId: 'loc("-":3:8)__0',
+                sourceNodeLabel: 'stablehlo.broadcast_in_dim',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                sourcePortMetadata: null,
+            },
+        ];
+        const onNavigateToNode = vi.fn();
+        const { container } = renderPanel({ incomingEdges: incoming, onNavigateToNode });
+        const inputsBody = container.querySelector(
+            '.mlir-node-details-inputs .mlir-node-details-section-body',
+        ) as HTMLElement;
+        fireEvent.click(within(inputsBody).getByRole('button', { name: 'Locate stablehlo.broadcast_in_dim' }));
+        expect(onNavigateToNode).toHaveBeenCalledTimes(1);
+        expect(onNavigateToNode).toHaveBeenCalledWith('loc("-":3:8)__0');
+    });
 });
 
 describe('MlirNodeDetailsPanel Outputs section', () => {
@@ -270,6 +290,28 @@ describe('MlirNodeDetailsPanel Outputs section', () => {
         expect(screen.getByText('port 0')).toBeInTheDocument();
         const consumerList = container.querySelector('.mlir-node-details-consumer-list');
         expect(within(consumerList as HTMLElement).getByText('stablehlo.reshape')).toBeInTheDocument();
+    });
+
+    it('calls onNavigateToNode with the consumer id when the row locate button is clicked', () => {
+        const outgoing: OutgoingEdge[] = [
+            {
+                targetNodeId: 'loc("-":7:4)__2',
+                targetNodeLabel: 'stablehlo.add',
+                sourceNodeOutputId: '0',
+                targetNodeInputId: '0',
+                label: '[4, 8] f32',
+            },
+        ];
+        const onNavigateToNode = vi.fn();
+        const { container } = renderPanel({
+            outputsMetadata: [SHAPE_DTYPE_PORT],
+            outgoingEdges: outgoing,
+            onNavigateToNode,
+        });
+        const consumerList = container.querySelector('.mlir-node-details-consumer-list') as HTMLElement;
+        fireEvent.click(within(consumerList).getByRole('button', { name: 'Locate stablehlo.add' }));
+        expect(onNavigateToNode).toHaveBeenCalledTimes(1);
+        expect(onNavigateToNode).toHaveBeenCalledWith('loc("-":7:4)__2');
     });
 
     it('renders an explicit port that carries empty attrs as a bare `port X` row with no metadata block', () => {

--- a/tests/MlirNodeDetailsPanel.spec.tsx
+++ b/tests/MlirNodeDetailsPanel.spec.tsx
@@ -54,6 +54,7 @@ interface RenderPanelOverrides {
     outputsMetadata?: IndexedPortMetadata[];
     onClose?: () => void;
     onRecenter?: () => void;
+    onNavigateToNode?: (nodeId: string) => void;
 }
 
 function renderPanel(overrides: RenderPanelOverrides = {}) {
@@ -67,6 +68,7 @@ function renderPanel(overrides: RenderPanelOverrides = {}) {
                 outputsMetadata={overrides.outputsMetadata ?? node.outputsMetadata}
                 onClose={overrides.onClose ?? (() => {})}
                 onRecenter={overrides.onRecenter ?? (() => {})}
+                onNavigateToNode={overrides.onNavigateToNode ?? (() => {})}
             />
         </TestProviders>,
     );
@@ -89,7 +91,7 @@ describe('MlirNodeDetailsPanel header', () => {
     it('calls onRecenter when the recenter button is clicked', () => {
         const onRecenter = vi.fn();
         renderPanel({ onRecenter });
-        fireEvent.click(screen.getByRole('button', { name: 'Recenter on this node' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Recenter' }));
         expect(onRecenter).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Add a per-row "Locate" button for producer/consumer references in the MLIR node details panel. Introduces LinkedNodeRef (UI + SCSS) and a new onNavigateToNode prop that the MLIR view implements as navigateToNode: it expands any collapsed namespace prefixes (using getNamespaceSegments), schedules a pending focus id, and recenters the canvas once the rebuilt graph lands. Also add pendingFocusNodeIdRef and post-rebuild fitView handling in MLIRViewReactFlow, update the panel recenter button aria-label, wire examples in the styleguide, and update tests accordingly.

<img width="1568" height="1108" alt="image" src="https://github.com/user-attachments/assets/e82c47c2-43d1-4575-90ae-09dfb62a6140" />


closes #1549 