### PR TITLE
Improve sync error messaging and add scp fallback

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -11,6 +11,8 @@ from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
     AuthenticationFailedException,
+    HostKeyVerificationException,
+    HostKeyVerificationFailedException,
     NoReportsException,
     NoValidConnectionsError,
     RemoteConnectionException,
@@ -73,6 +75,17 @@ def remote_exception_handler(func):
             connection = args[0]
         try:
             return func(*args, **kwargs)
+        except HostKeyVerificationException as err:
+            current_app.logger.warning(
+                "SSH host key not trusted for %s@%s:%s",
+                connection.username,
+                connection.host,
+                connection.port,
+            )
+            raise HostKeyVerificationFailedException(
+                message=str(err),
+                status=ConnectionTestStates.FAILED,
+            )
         except AuthenticationException as err:
             current_app.logger.warning(
                 f"SSH authentication failed for {connection.username}@{connection.host}: SSH key authentication required"

--- a/backend/ttnn_visualizer/enums.py
+++ b/backend/ttnn_visualizer/enums.py
@@ -17,3 +17,8 @@ class StackSourceOrigin(str, enum.Enum):
     DATABASE = "database"
     PATH = "path"
     REMAPPED = "remapped"
+
+
+class SyncMethod(str, enum.Enum):
+    SFTP = "sftp"
+    SCP = "scp"

--- a/backend/ttnn_visualizer/exceptions.py
+++ b/backend/ttnn_visualizer/exceptions.py
@@ -54,12 +54,17 @@ class RemoteConnectionException(Exception):
         status: ConnectionTestStates,
         http_status_code: Optional[HTTPStatus] = None,
         detail: Optional[str] = None,
+        sync_method: Optional[str] = None,
     ):
         super().__init__(message)
         self.message = message
         self.status = status
         self.detail = detail
         self._http_status_code = http_status_code
+        # Transport actually used for the failed run, when known (sftp/scp).
+        # Lets callers report the real method instead of re-reading the
+        # process-global fallback cache, which can be stale for this run.
+        self.sync_method = sync_method
 
     @property
     def http_status(self):

--- a/backend/ttnn_visualizer/exceptions.py
+++ b/backend/ttnn_visualizer/exceptions.py
@@ -10,11 +10,16 @@ from ttnn_visualizer.enums import ConnectionTestStates
 
 
 def error_response(
-    status: HTTPStatus, message: Optional[str] = None, detail: Optional[str] = None
+    status: HTTPStatus,
+    message: Optional[str] = None,
+    detail: Optional[str] = None,
+    sync_method: Optional[str] = None,
 ):
     payload = {"error": message or status.phrase}
     if detail:
         payload["detail"] = detail
+    if sync_method:
+        payload["syncMethod"] = sync_method
     return jsonify(payload), status
 
 
@@ -88,6 +93,23 @@ class AuthenticationFailedException(RemoteConnectionException):
         )
 
 
+class HostKeyVerificationFailedException(RemoteConnectionException):
+    """Exception for untrusted SSH host keys that should return HTTP 422."""
+
+    def __init__(
+        self,
+        message,
+        status: ConnectionTestStates = ConnectionTestStates.FAILED,
+        detail: Optional[str] = None,
+    ):
+        super().__init__(
+            message=message,
+            status=status,
+            http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=detail,
+        )
+
+
 class NoReportsException(RemoteConnectionException):
     pass
 
@@ -144,6 +166,12 @@ class SSHException(Exception):
 
 class AuthenticationException(SSHException):
     """Raised when SSH authentication fails"""
+
+    pass
+
+
+class HostKeyVerificationException(SSHException):
+    """Raised when SSH rejects an unknown host key (BatchMode cannot prompt)."""
 
     pass
 

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -429,8 +429,9 @@ def sync_files_and_directories(
             NoValidConnectionsError,
             SSHException,
         ):
-            # Fatal SSH errors must not be swallowed — the decorator maps these to
-            # actionable 422 responses (host key, auth, connectivity).
+            # Fatal SSH errors must not be swallowed — the decorator maps host-key
+            # and auth failures to actionable 422 responses; connectivity
+            # (NoValidConnectionsError) surfaces as a 500.
             raise
         except Exception as e:
             last_download_error = f"{remote_file}: {e}"
@@ -693,7 +694,8 @@ def download_single_file_scp(
         )
         if e.returncode == 255:
             handle_ssh_subprocess_error(e, remote_connection)  # always raises
-        raise RuntimeError(f"Failed to download {remote_file}")
+        detail = (e.stderr or "").strip() or "no stderr"
+        raise RuntimeError(f"Failed to download {remote_file}: {detail}")
     except subprocess.TimeoutExpired:
         logger.error("Timeout downloading file via scp: %s", remote_file)
         raise RuntimeError(f"Timeout downloading {remote_file}")
@@ -748,7 +750,8 @@ def download_single_file_sftp(
         )
         if e.returncode == 255:  # SSH protocol errors
             handle_ssh_subprocess_error(e, remote_connection)  # always raises
-        raise RuntimeError(f"Failed to download {remote_file}")
+        detail = stderr.strip() or "no stderr"
+        raise RuntimeError(f"Failed to download {remote_file}: {detail}")
     except subprocess.TimeoutExpired:
         logger.error("Timeout downloading file: %s", remote_file)
         raise RuntimeError(f"Timeout downloading {remote_file}")
@@ -759,7 +762,7 @@ def download_single_file_sftp(
             type(e).__name__,
             e,
         )
-        raise RuntimeError(f"Failed to download {remote_file}")
+        raise RuntimeError(f"Failed to download {remote_file}: {type(e).__name__}: {e}")
 
 
 def get_remote_profiler_folder_from_config_path(

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -27,12 +27,7 @@ from ttnn_visualizer.exceptions import (
 )
 from ttnn_visualizer.models import Instance, RemoteConnection, RemoteReportFolder
 from ttnn_visualizer.sockets import FileProgress, FileStatus, emit_file_status
-from ttnn_visualizer.ssh_client import (
-    SSH_AUTH_FAILURE_MESSAGE,
-    SSHClient,
-    is_ssh_host_key_verification_error,
-    ssh_host_key_failure_message,
-)
+from ttnn_visualizer.ssh_client import SSHClient, raise_for_ssh_subprocess_error
 from ttnn_visualizer.utils import (
     PROFILER_CONFIG_BASENAME,
     ranked_profiler_config_basenames,
@@ -41,7 +36,12 @@ from ttnn_visualizer.utils import (
 
 logger = logging.getLogger(__name__)
 
-# Hosts where the SFTP subsystem is unavailable but scp over SSH still works.
+# Hosts where the SFTP subsystem is unavailable but scp over SSH still works,
+# keyed by (username, host, port). Process-global and never evicted: a single
+# subsystem failure pins that endpoint to scp for the rest of the process
+# lifetime (across users under SERVER_MODE). That's an intentional tradeoff —
+# scp is a safe superset fallback, so a stale entry only costs an unnecessary
+# scp where sftp might now work, never a failed sync. A restart clears it.
 _sftp_subsystem_unavailable: set[tuple[str, str, int]] = set()
 
 
@@ -62,10 +62,6 @@ def get_active_sync_method(remote_connection: RemoteConnection) -> SyncMethod:
     if _remote_transfer_key(remote_connection) in _sftp_subsystem_unavailable:
         return SyncMethod.SCP
     return SyncMethod.SFTP
-
-
-# Backwards-compatible private alias.
-_active_sync_method = get_active_sync_method
 
 
 def _ssh_subprocess_timeout_seconds() -> int:
@@ -148,42 +144,11 @@ def handle_ssh_subprocess_error(
     a call to this helper as unreachable, which keeps the call sites tidy
     and prevents accidental fall-through.
     """
-    stderr = (e.stderr or "").lower()
     raw_error = (e.stderr or "").strip() or "No stderr output"
     logger.warning(
         f"SSH error for {remote_connection.username}@{remote_connection.host}: {raw_error}"
     )
-    if is_ssh_host_key_verification_error(stderr):
-        raise HostKeyVerificationException(
-            ssh_host_key_failure_message(remote_connection)
-        )
-
-    if any(
-        auth_err in stderr
-        for auth_err in [
-            "permission denied",
-            "authentication failed",
-            "publickey",
-            "password",
-        ]
-    ):
-        raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)
-    if any(
-        conn_err in stderr
-        for conn_err in [
-            "connection refused",
-            "network is unreachable",
-            "no route to host",
-            "name or service not known",
-            "could not resolve hostname",
-            "connection timed out",
-            "nodename nor servname provided",
-        ]
-    ):
-        raise NoValidConnectionsError(f"SSH connection failed: {e.stderr}")
-    if "ssh:" in stderr or "protocol" in stderr:
-        raise SSHException(f"SSH protocol error: {e.stderr}")
-    raise SSHException(f"SSH command failed: {e.stderr}")
+    raise_for_ssh_subprocess_error(e, remote_connection)
 
 
 def start_background_task(task, *args):

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -16,9 +16,10 @@ from typing import List, NoReturn, Optional
 import yaml
 from flask import current_app
 from ttnn_visualizer.decorators import remote_exception_handler
-from ttnn_visualizer.enums import ConnectionTestStates
+from ttnn_visualizer.enums import ConnectionTestStates, SyncMethod
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
+    HostKeyVerificationException,
     NoReportsException,
     NoValidConnectionsError,
     RemoteConnectionException,
@@ -26,7 +27,12 @@ from ttnn_visualizer.exceptions import (
 )
 from ttnn_visualizer.models import Instance, RemoteConnection, RemoteReportFolder
 from ttnn_visualizer.sockets import FileProgress, FileStatus, emit_file_status
-from ttnn_visualizer.ssh_client import SSH_AUTH_FAILURE_MESSAGE, SSHClient
+from ttnn_visualizer.ssh_client import (
+    SSH_AUTH_FAILURE_MESSAGE,
+    SSHClient,
+    is_ssh_host_key_verification_error,
+    ssh_host_key_failure_message,
+)
 from ttnn_visualizer.utils import (
     PROFILER_CONFIG_BASENAME,
     ranked_profiler_config_basenames,
@@ -34,6 +40,32 @@ from ttnn_visualizer.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Hosts where the SFTP subsystem is unavailable but scp over SSH still works.
+_sftp_subsystem_unavailable: set[tuple[str, str, int]] = set()
+
+
+def _remote_transfer_key(remote_connection: RemoteConnection) -> tuple[str, str, int]:
+    return (
+        remote_connection.username,
+        remote_connection.host,
+        remote_connection.port,
+    )
+
+
+def _is_sftp_subsystem_unavailable(stderr: str) -> bool:
+    return "subsystem request failed" in (stderr or "").lower()
+
+
+def get_active_sync_method(remote_connection: RemoteConnection) -> SyncMethod:
+    """Which transport this host is currently using (scp once SFTP has failed)."""
+    if _remote_transfer_key(remote_connection) in _sftp_subsystem_unavailable:
+        return SyncMethod.SCP
+    return SyncMethod.SFTP
+
+
+# Backwards-compatible private alias.
+_active_sync_method = get_active_sync_method
 
 
 def _ssh_subprocess_timeout_seconds() -> int:
@@ -87,6 +119,25 @@ def _sftp_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
     return cmd
 
 
+def _scp_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
+    """Build scp command prefix (never prompts for password). Mirrors ssh/sftp options.
+
+    `-O` forces the legacy SCP/rcp transfer protocol. OpenSSH 9+ defaults scp to
+    the SFTP subsystem, which is exactly the subsystem that's unavailable on the
+    hosts this fallback targets; `-O` transfers over a plain remote exec instead.
+    """
+    cmd = ["scp", "-O"]
+    identity = (getattr(remote_connection, "identityFile", None) or "").strip()
+    if identity:
+        cmd.extend(["-F", os.devnull])
+    cmd.extend(["-o", "BatchMode=yes", "-o", "PasswordAuthentication=no"])
+    if identity:
+        cmd.extend(["-o", "IdentitiesOnly=yes", "-i", identity])
+    if remote_connection.port != 22:
+        cmd.extend(["-P", str(remote_connection.port)])
+    return cmd
+
+
 def handle_ssh_subprocess_error(
     e: subprocess.CalledProcessError, remote_connection: RemoteConnection
 ) -> NoReturn:
@@ -102,6 +153,11 @@ def handle_ssh_subprocess_error(
     logger.warning(
         f"SSH error for {remote_connection.username}@{remote_connection.host}: {raw_error}"
     )
+    if is_ssh_host_key_verification_error(stderr):
+        raise HostKeyVerificationException(
+            ssh_host_key_failure_message(remote_connection)
+        )
+
     if any(
         auth_err in stderr
         for auth_err in [
@@ -109,7 +165,6 @@ def handle_ssh_subprocess_error(
             "authentication failed",
             "publickey",
             "password",
-            "host key verification failed",
         ]
     ):
         raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)
@@ -238,8 +293,12 @@ def sync_files_and_directories(
     destination_dir: Path,
     exclude_patterns=None,
     sid=None,
-):
-    """Download files and directories using SFTP with progress reporting."""
+) -> SyncMethod:
+    """Download files and directories using SFTP with progress reporting.
+
+    Returns the transport actually used (``sftp``, or ``scp`` when the remote
+    SFTP subsystem was unavailable and we fell back).
+    """
     exclude_patterns = exclude_patterns or []
 
     # Ensure the destination directory exists
@@ -319,6 +378,11 @@ def sync_files_and_directories(
     finished_files = 0
     failed_count = 0
     bytes_transferred = 0
+    last_download_error: Optional[str] = None
+    # Track the transport actually used this run rather than reading the
+    # process-global fallback cache, so the reported method reflects *this*
+    # sync (and this port), not a stale guess from a prior host.
+    methods_used: set[SyncMethod] = set()
 
     logger.info(f"Starting download of {total_files} files...")
 
@@ -364,8 +428,10 @@ def sync_files_and_directories(
                     sid,
                 )
 
-            # Download the file using SFTP
-            download_single_file_sftp(remote_connection, remote_file, local_file)
+            # Download the file using SFTP (or scp fallback)
+            methods_used.add(
+                download_single_file_sftp(remote_connection, remote_file, local_file)
+            )
 
             finished_files += 1
             bytes_transferred += remote_file_size
@@ -392,19 +458,37 @@ def sync_files_and_directories(
             # Skip if remote_file is not relative to remote_profiler_folder
             logger.warning(f"Skipping file outside base folder: {remote_file}")
             continue
+        except (
+            HostKeyVerificationException,
+            AuthenticationException,
+            NoValidConnectionsError,
+            SSHException,
+        ):
+            # Fatal SSH errors must not be swallowed — the decorator maps these to
+            # actionable 422 responses (host key, auth, connectivity).
+            raise
         except Exception as e:
-            logger.error(f"Failed to download {remote_file}: {e}")
+            last_download_error = f"{remote_file}: {e}"
+            logger.error("Failed to download %s: %s", remote_file, e)
             failed_count += 1
             # Best-effort: try remaining files, but do not report success if any fail.
             continue
 
+    # scp wins the label if any file needed the fallback; otherwise sftp.
+    run_sync_method = (
+        SyncMethod.SCP if SyncMethod.SCP in methods_used else SyncMethod.SFTP
+    )
+
     sync_incomplete = total_files > 0 and finished_files < total_files
     if sync_incomplete:
+        sync_method = run_sync_method
         logger.error(
-            "SFTP sync incomplete: downloaded %s/%s files (%s failed).",
+            "%s sync incomplete: downloaded %s/%s files (%s failed). Last error: %s",
+            sync_method.value,
             finished_files,
             total_files,
             failed_count,
+            last_download_error or "unknown",
         )
         if current_app.config["USE_WEBSOCKETS"]:
             emit_file_status(
@@ -420,13 +504,17 @@ def sync_files_and_directories(
                 ),
                 sid,
             )
+        message = (
+            f"Sync incomplete: downloaded {finished_files} of {total_files} "
+            f"file(s) ({failed_count} failed) via {sync_method.value}."
+        )
+        if last_download_error:
+            message = f"{message} Last error: {last_download_error}"
         raise RemoteConnectionException(
-            message=(
-                f"Sync incomplete: downloaded {finished_files} of {total_files} "
-                f"file(s) ({failed_count} failed). Check logs for per-file errors."
-            ),
+            message=message,
             status=ConnectionTestStates.FAILED,
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=last_download_error,
         )
 
     # Only stamp success after every queued file downloaded.
@@ -447,8 +535,12 @@ def sync_files_and_directories(
         emit_file_status(final_progress, sid)
 
     logger.info(
-        f"SFTP sync completed. Downloaded {finished_files}/{total_files} files."
+        "%s sync completed. Downloaded %s/%s files.",
+        run_sync_method.value,
+        finished_files,
+        total_files,
     )
+    return run_sync_method
 
 
 def get_remote_file_list(
@@ -604,21 +696,63 @@ def get_remote_directory_list(
         return []
 
 
+def _scp_remote_target(remote_connection: RemoteConnection, remote_file: str) -> str:
+    """Build scp remote target for argv (no shell quoting — subprocess passes it verbatim)."""
+    return f"{remote_connection.username}@{remote_connection.host}:{remote_file}"
+
+
+def download_single_file_scp(
+    remote_connection: RemoteConnection, remote_file: str, local_file: Path
+) -> SyncMethod:
+    """Download a single file using scp (when the remote SFTP subsystem is disabled)."""
+    local_file.parent.mkdir(parents=True, exist_ok=True)
+    remote_spec = _scp_remote_target(remote_connection, remote_file)
+    scp_cmd = _scp_cmd_prefix(remote_connection) + [remote_spec, str(local_file)]
+    try:
+        subprocess.run(
+            scp_cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=300,
+        )
+        logger.debug("Downloaded via scp: %s -> %s", remote_file, local_file)
+        return SyncMethod.SCP
+    except subprocess.CalledProcessError as e:
+        logger.error(
+            "scp download failed for %s (rc=%s): %s",
+            remote_file,
+            e.returncode,
+            (e.stderr or "").strip() or "no stderr",
+        )
+        if e.returncode == 255:
+            handle_ssh_subprocess_error(e, remote_connection)  # always raises
+        raise RuntimeError(f"Failed to download {remote_file}")
+    except subprocess.TimeoutExpired:
+        logger.error("Timeout downloading file via scp: %s", remote_file)
+        raise RuntimeError(f"Timeout downloading {remote_file}")
+
+
 def download_single_file_sftp(
     remote_connection: RemoteConnection, remote_file: str, local_file: Path
-):
-    """Download a single file using SFTP."""
-    # Ensure local directory exists
+) -> SyncMethod:
+    """Download a single file using SFTP, falling back to scp when needed.
+
+    Returns the transport actually used for this file.
+    """
+    transfer_key = _remote_transfer_key(remote_connection)
+    if transfer_key in _sftp_subsystem_unavailable:
+        return download_single_file_scp(remote_connection, remote_file, local_file)
+
     local_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Build SFTP command (never prompts for password)
     sftp_cmd = _sftp_cmd_prefix(remote_connection)
-
-    # SFTP commands to execute
-    sftp_commands = f"get '{remote_file}' '{local_file}'\nquit\n"
+    # Batch script is parsed by sftp, not the shell — quote paths for spaces/special chars.
+    sftp_commands = (
+        f"get {shlex.quote(remote_file)} {shlex.quote(str(local_file))}\nquit\n"
+    )
 
     try:
-        result = subprocess.run(
+        subprocess.run(
             sftp_cmd,
             input=sftp_commands,
             capture_output=True,
@@ -626,19 +760,39 @@ def download_single_file_sftp(
             check=True,
             timeout=300,  # 5 minute timeout per file
         )
-
-        logger.debug(f"Downloaded: {remote_file} -> {local_file}")
+        logger.debug("Downloaded via sftp: %s -> %s", remote_file, local_file)
+        return SyncMethod.SFTP
 
     except subprocess.CalledProcessError as e:
+        stderr = e.stderr or ""
+        if _is_sftp_subsystem_unavailable(stderr):
+            logger.warning(
+                "SFTP subsystem unavailable on %s@%s:%s; using scp for remaining files",
+                remote_connection.username,
+                remote_connection.host,
+                remote_connection.port,
+            )
+            _sftp_subsystem_unavailable.add(transfer_key)
+            return download_single_file_scp(remote_connection, remote_file, local_file)
+        logger.error(
+            "Error downloading file %s (rc=%s): %s",
+            remote_file,
+            e.returncode,
+            stderr.strip() or "no stderr",
+        )
         if e.returncode == 255:  # SSH protocol errors
             handle_ssh_subprocess_error(e, remote_connection)  # always raises
-        logger.error(f"Error downloading file {remote_file}: {e.stderr}")
         raise RuntimeError(f"Failed to download {remote_file}")
     except subprocess.TimeoutExpired:
-        logger.error(f"Timeout downloading file: {remote_file}")
+        logger.error("Timeout downloading file: %s", remote_file)
         raise RuntimeError(f"Timeout downloading {remote_file}")
     except Exception as e:
-        logger.error(f"Error downloading file {remote_file}: {e}")
+        logger.error(
+            "Error downloading file %s: %s: %s",
+            remote_file,
+            type(e).__name__,
+            e,
+        )
         raise RuntimeError(f"Failed to download {remote_file}")
 
 
@@ -1040,7 +1194,7 @@ def sync_remote_profiler_folders(
     path_prefix: str,
     exclude_patterns: Optional[List[str]] = None,
     sid=None,
-):
+) -> SyncMethod:
     """Main function to sync test folders, handles both compressed and individual syncs."""
     profiler_folder = Path(remote_folder_path).name
     destination_dir = Path(
@@ -1052,7 +1206,7 @@ def sync_remote_profiler_folders(
     )
     destination_dir.mkdir(parents=True, exist_ok=True)
 
-    sync_files_and_directories(
+    return sync_files_and_directories(
         remote_connection, remote_folder_path, destination_dir, exclude_patterns, sid
     )
 
@@ -1064,7 +1218,7 @@ def sync_remote_performance_folders(
     performance: RemoteReportFolder,
     exclude_patterns: Optional[List[str]] = None,
     sid=None,
-):
+) -> SyncMethod:
     remote_folder_path = performance.remotePath
     profile_folder = Path(remote_folder_path).name
     destination_dir = Path(
@@ -1075,6 +1229,6 @@ def sync_remote_performance_folders(
         profile_folder,
     )
     destination_dir.mkdir(parents=True, exist_ok=True)
-    sync_files_and_directories(
+    return sync_files_and_directories(
         remote_connection, remote_folder_path, destination_dir, exclude_patterns, sid
     )

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -480,6 +480,7 @@ def sync_files_and_directories(
             status=ConnectionTestStates.FAILED,
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             detail=last_download_error,
+            sync_method=sync_method.value,
         )
 
     # Only stamp success after every queued file downloaded.

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -33,13 +33,31 @@ SSH_AUTH_FAILURE_MESSAGE = (
 )
 
 
+# stderr fragments (lowercase) that classify an SSH/SFTP subprocess failure.
+_SSH_AUTH_ERROR_FRAGMENTS = (
+    "permission denied",
+    "authentication failed",
+    "publickey",
+    "password",
+)
+_SSH_CONNECTION_ERROR_FRAGMENTS = (
+    "connection refused",
+    "network is unreachable",
+    "no route to host",
+    "name or service not known",
+    "could not resolve hostname",
+    "connection timed out",
+    "nodename nor servname provided",
+)
+
+
 def is_ssh_host_key_verification_error(stderr: str) -> bool:
     """True when OpenSSH rejected an unknown/untrusted host key."""
     lowered = (stderr or "").lower()
     if "host key verification failed" in lowered:
         return True
     # e.g. "No ED25519 host key is known for [host]:port and you have requested strict checking."
-    return "host key is known" in lowered and "no " in lowered
+    return "host key is known" in lowered and "strict checking" in lowered
 
 
 def ssh_host_key_failure_message(connection: RemoteConnection) -> str:
@@ -53,6 +71,26 @@ def ssh_host_key_failure_message(connection: RemoteConnection) -> str:
         "~/.ssh/known_hosts. Remote sync cannot prompt to accept new keys. "
         f"Run {ssh_example} once in a terminal, accept the host key, then retry."
     )
+
+
+def raise_for_ssh_subprocess_error(
+    e: subprocess.CalledProcessError, connection: RemoteConnection
+) -> NoReturn:
+    """Classify an SSH/SFTP subprocess failure and raise the matching exception.
+
+    Shared by both the SFTP/scp subprocess path and ``SSHClient`` so the two
+    stay in lockstep. Always raises (``NoReturn``).
+    """
+    stderr = (e.stderr or "").lower()
+    if is_ssh_host_key_verification_error(stderr):
+        raise HostKeyVerificationException(ssh_host_key_failure_message(connection))
+    if any(auth_err in stderr for auth_err in _SSH_AUTH_ERROR_FRAGMENTS):
+        raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)
+    if any(conn_err in stderr for conn_err in _SSH_CONNECTION_ERROR_FRAGMENTS):
+        raise NoValidConnectionsError(f"SSH connection failed: {e.stderr}")
+    if "ssh:" in stderr or "protocol" in stderr:
+        raise SSHException(f"SSH protocol error: {e.stderr}")
+    raise SSHException(f"SSH command failed: {e.stderr}")
 
 
 class SSHClient:
@@ -108,7 +146,6 @@ class SSHClient:
         :param e: The subprocess.CalledProcessError
         :raises: SSHException, AuthenticationException, or NoValidConnectionsError
         """
-        stderr = e.stderr.lower() if e.stderr else ""
         raw_error = e.stderr.strip() if e.stderr else "No stderr output"
 
         # Log the raw SSH error for debugging
@@ -119,45 +156,7 @@ class SSHClient:
         # Store raw error for exceptions that need it
         self._last_raw_error = raw_error
 
-        if is_ssh_host_key_verification_error(stderr):
-            raise HostKeyVerificationException(
-                ssh_host_key_failure_message(self.connection)
-            )
-
-        # Check for authentication failures
-        if any(
-            auth_err in stderr
-            for auth_err in [
-                "permission denied",
-                "authentication failed",
-                "publickey",
-                "password",
-            ]
-        ):
-            raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)
-
-        # Check for connection failures (including DNS resolution failures)
-        elif any(
-            conn_err in stderr
-            for conn_err in [
-                "connection refused",
-                "network is unreachable",
-                "no route to host",
-                "name or service not known",
-                "could not resolve hostname",
-                "connection timed out",
-                "nodename nor servname provided",
-            ]
-        ):
-            raise NoValidConnectionsError(f"SSH connection failed: {e.stderr}")
-
-        # Check for general SSH protocol errors
-        elif "ssh:" in stderr or "protocol" in stderr:
-            raise SSHException(f"SSH protocol error: {e.stderr}")
-
-        # Default to generic SSH exception
-        else:
-            raise SSHException(f"SSH command failed: {e.stderr}")
+        raise_for_ssh_subprocess_error(e, self.connection)
 
     def execute_command(self, command: str, timeout: int = 30) -> str:
         """

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -14,6 +14,7 @@ from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
     AuthenticationFailedException,
+    HostKeyVerificationException,
     NoValidConnectionsError,
     RemoteConnectionException,
     RemoteFileReadException,
@@ -30,6 +31,28 @@ SSH_AUTH_FAILURE_MESSAGE = (
     "Password authentication is not supported. "
     "If your key has a passphrase, add it to ssh-agent once (e.g. ssh-add) so you are not prompted."
 )
+
+
+def is_ssh_host_key_verification_error(stderr: str) -> bool:
+    """True when OpenSSH rejected an unknown/untrusted host key."""
+    lowered = (stderr or "").lower()
+    if "host key verification failed" in lowered:
+        return True
+    # e.g. "No ED25519 host key is known for [host]:port and you have requested strict checking."
+    return "host key is known" in lowered and "no " in lowered
+
+
+def ssh_host_key_failure_message(connection: RemoteConnection) -> str:
+    user_host = f"{connection.username}@{connection.host}"
+    if connection.port != 22:
+        ssh_example = f"ssh -p {connection.port} {user_host}"
+    else:
+        ssh_example = f"ssh {user_host}"
+    return (
+        f"SSH host key for {connection.host} (port {connection.port}) is not in "
+        "~/.ssh/known_hosts. Remote sync cannot prompt to accept new keys. "
+        f"Run {ssh_example} once in a terminal, accept the host key, then retry."
+    )
 
 
 class SSHClient:
@@ -96,6 +119,11 @@ class SSHClient:
         # Store raw error for exceptions that need it
         self._last_raw_error = raw_error
 
+        if is_ssh_host_key_verification_error(stderr):
+            raise HostKeyVerificationException(
+                ssh_host_key_failure_message(self.connection)
+            )
+
         # Check for authentication failures
         if any(
             auth_err in stderr
@@ -104,7 +132,6 @@ class SSHClient:
                 "authentication failed",
                 "publickey",
                 "password",
-                "host key verification failed",
             ]
         ):
             raise AuthenticationException(SSH_AUTH_FAILURE_MESSAGE)

--- a/backend/ttnn_visualizer/tests/test_sftp_download_fallback.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_download_fallback.py
@@ -11,10 +11,10 @@ import pytest
 from ttnn_visualizer.enums import SyncMethod
 from ttnn_visualizer.models import RemoteConnection
 from ttnn_visualizer.sftp_operations import (
-    _active_sync_method,
     _scp_remote_target,
     _sftp_subsystem_unavailable,
     download_single_file_sftp,
+    get_active_sync_method,
 )
 
 
@@ -97,7 +97,7 @@ def test_subsequent_downloads_skip_sftp_after_subsystem_failure(connection, tmp_
 
 
 def test_active_sync_method_reflects_fallback_state(connection, tmp_path):
-    assert _active_sync_method(connection) == SyncMethod.SFTP
+    assert get_active_sync_method(connection) == SyncMethod.SFTP
     sftp_error = subprocess.CalledProcessError(
         returncode=255,
         cmd=["sftp"],
@@ -109,4 +109,4 @@ def test_active_sync_method_reflects_fallback_state(connection, tmp_path):
         side_effect=[sftp_error, _scp_success()],
     ):
         download_single_file_sftp(connection, "/remote/a.txt", tmp_path / "a.txt")
-    assert _active_sync_method(connection) == SyncMethod.SCP
+    assert get_active_sync_method(connection) == SyncMethod.SCP

--- a/backend/ttnn_visualizer/tests/test_sftp_download_fallback.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_download_fallback.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for scp fallback when the remote SFTP subsystem is unavailable."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from ttnn_visualizer.enums import SyncMethod
+from ttnn_visualizer.models import RemoteConnection
+from ttnn_visualizer.sftp_operations import (
+    _active_sync_method,
+    _scp_remote_target,
+    _sftp_subsystem_unavailable,
+    download_single_file_sftp,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_sftp_subsystem_cache():
+    _sftp_subsystem_unavailable.clear()
+    yield
+    _sftp_subsystem_unavailable.clear()
+
+
+@pytest.fixture
+def connection() -> RemoteConnection:
+    return RemoteConnection(
+        name="test",
+        username="user",
+        host="example.test",
+        port=45985,
+        profilerPath="/remote/profiler",
+    )
+
+
+def _scp_success() -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["scp"], returncode=0, stdout="", stderr="")
+
+
+def test_scp_remote_target_has_no_shell_quotes(connection):
+    target = _scp_remote_target(connection, "/remote/report/config.json")
+    assert target == "user@example.test:/remote/report/config.json"
+    assert "'" not in target
+
+
+def test_sftp_subsystem_failure_falls_back_to_scp(connection, tmp_path):
+    local_file = tmp_path / "config.json"
+    sftp_error = subprocess.CalledProcessError(
+        returncode=255,
+        cmd=["sftp"],
+        output="",
+        stderr="subsystem request failed on channel 0\nConnection closed\n",
+    )
+
+    with (
+        patch(
+            "subprocess.run",
+            side_effect=[sftp_error, _scp_success()],
+        ),
+        patch(
+            "ttnn_visualizer.sftp_operations.download_single_file_scp"
+        ) as scp_download,
+    ):
+        download_single_file_sftp(
+            connection,
+            "/remote/config.json",
+            local_file,
+        )
+
+    scp_download.assert_called_once_with(connection, "/remote/config.json", local_file)
+
+
+def test_subsequent_downloads_skip_sftp_after_subsystem_failure(connection, tmp_path):
+    sftp_error = subprocess.CalledProcessError(
+        returncode=255,
+        cmd=["sftp"],
+        output="",
+        stderr="subsystem request failed on channel 0\n",
+    )
+
+    with patch(
+        "subprocess.run",
+        side_effect=[sftp_error, _scp_success(), _scp_success()],
+    ) as run:
+        download_single_file_sftp(connection, "/remote/a.txt", tmp_path / "a.txt")
+        download_single_file_sftp(connection, "/remote/b.txt", tmp_path / "b.txt")
+
+    assert run.call_args_list[0][0][0][0] == "sftp"
+    assert run.call_args_list[1][0][0][0] == "scp"
+    assert run.call_args_list[2][0][0][0] == "scp"
+    # `-O` forces legacy SCP protocol so scp does not reuse the disabled SFTP subsystem.
+    assert run.call_args_list[1][0][0][1] == "-O"
+    assert run.call_args_list[2][0][0][1] == "-O"
+
+
+def test_active_sync_method_reflects_fallback_state(connection, tmp_path):
+    assert _active_sync_method(connection) == SyncMethod.SFTP
+    sftp_error = subprocess.CalledProcessError(
+        returncode=255,
+        cmd=["sftp"],
+        output="",
+        stderr="subsystem request failed on channel 0\n",
+    )
+    with patch(
+        "subprocess.run",
+        side_effect=[sftp_error, _scp_success()],
+    ):
+        download_single_file_sftp(connection, "/remote/a.txt", tmp_path / "a.txt")
+    assert _active_sync_method(connection) == SyncMethod.SCP

--- a/backend/ttnn_visualizer/tests/test_sftp_operations.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_operations.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 import pytest
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
+    HostKeyVerificationException,
     NoValidConnectionsError,
     RemoteConnectionException,
 )
@@ -203,6 +204,20 @@ class TestGetRemoteFileList:
         with patch("subprocess.run", side_effect=auth_error):
             with pytest.raises(AuthenticationException):
                 get_remote_file_list(connection, "/remote", exclude_patterns=[])
+
+    def test_ssh_unknown_host_key_raises_host_key_exception(self, connection):
+        host_key_error = _called_process_error(
+            returncode=255,
+            stderr=(
+                "No ED25519 host key is known for [example.test]:45985 and you have "
+                "requested strict checking.\nHost key verification failed.\n"
+            ),
+        )
+        with patch("subprocess.run", side_effect=host_key_error):
+            with pytest.raises(HostKeyVerificationException) as excinfo:
+                get_remote_file_list(connection, "/remote", exclude_patterns=[])
+        assert "known_hosts" in str(excinfo.value).lower()
+        assert "example.test" in str(excinfo.value)
 
     def test_ssh_protocol_connection_error_raises_no_valid_connections(
         self, connection

--- a/backend/ttnn_visualizer/tests/test_sftp_operations.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_operations.py
@@ -417,7 +417,7 @@ class TestSyncFilesAndDirectoriesPartialFailure:
 class TestSyncFilesAndDirectoriesSyncMethod:
     """The reported sync method must reflect *this* run's transport, not the
     process-global fallback cache (which is keyed by user@host:port and can hold
-    stale entries from a prior host/port).
+    a stale entry from a prior run against the same endpoint).
     """
 
     @pytest.fixture(autouse=True)

--- a/backend/ttnn_visualizer/tests/test_sftp_operations.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_operations.py
@@ -17,6 +17,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
+from ttnn_visualizer.enums import SyncMethod
 from ttnn_visualizer.exceptions import (
     AuthenticationException,
     HostKeyVerificationException,
@@ -26,6 +27,8 @@ from ttnn_visualizer.exceptions import (
 from ttnn_visualizer.models import RemoteConnection
 from ttnn_visualizer.sftp_operations import (
     _get_remote_file_list_without_sizes,
+    _remote_transfer_key,
+    _sftp_subsystem_unavailable,
     get_remote_directory_list,
     get_remote_file_list,
     sync_files_and_directories,
@@ -409,6 +412,98 @@ class TestSyncFilesAndDirectoriesPartialFailure:
         last_synced.assert_called_once_with(tmp_path)
         terminal = emit_status.call_args_list[-1][0][0]
         assert terminal.status == FileStatus.FINISHED
+
+
+class TestSyncFilesAndDirectoriesSyncMethod:
+    """The reported sync method must reflect *this* run's transport, not the
+    process-global fallback cache (which is keyed by user@host:port and can hold
+    stale entries from a prior host/port).
+    """
+
+    @pytest.fixture(autouse=True)
+    def clear_sftp_subsystem_cache(self):
+        _sftp_subsystem_unavailable.clear()
+        yield
+        _sftp_subsystem_unavailable.clear()
+
+    @staticmethod
+    def _patches(connection, files, download_side_effect=None, download_return=None):
+        download_kwargs = {}
+        if download_side_effect is not None:
+            download_kwargs["side_effect"] = download_side_effect
+        else:
+            download_kwargs["return_value"] = download_return
+        return (
+            patch(
+                "ttnn_visualizer.sftp_operations.get_remote_file_list",
+                return_value=files,
+            ),
+            patch(
+                "ttnn_visualizer.sftp_operations.get_remote_directory_list",
+                return_value=["/remote/reports"],
+            ),
+            patch(
+                "ttnn_visualizer.sftp_operations.download_single_file_sftp",
+                **download_kwargs,
+            ),
+            patch("ttnn_visualizer.sftp_operations.update_last_synced"),
+            patch("ttnn_visualizer.sftp_operations.emit_file_status"),
+        )
+
+    def test_returns_sftp_despite_stale_global_scp_entry_for_other_host(
+        self, app, tmp_path, connection
+    ):
+        # A different host fell back to scp earlier in the process lifetime.
+        _sftp_subsystem_unavailable.add(("user", "other.test", 45985))
+        files = [("/remote/reports/a.txt", 10)]
+        list_patch, dir_patch, dl_patch, _, _ = self._patches(
+            connection, files, download_return=SyncMethod.SFTP
+        )
+        with app.app_context(), list_patch, dir_patch, dl_patch:
+            result = sync_files_and_directories(
+                connection, "/remote/reports", tmp_path, exclude_patterns=[]
+            )
+        assert result == SyncMethod.SFTP
+
+    def test_returns_scp_when_any_file_used_fallback(self, app, tmp_path, connection):
+        files = [("/remote/reports/a.txt", 10), ("/remote/reports/b.txt", 20)]
+
+        def download_side_effect(_conn, remote_file, _local_file):
+            # First file goes over sftp, second triggers the scp fallback.
+            return SyncMethod.SCP if remote_file.endswith("b.txt") else SyncMethod.SFTP
+
+        list_patch, dir_patch, dl_patch, _, _ = self._patches(
+            connection, files, download_side_effect=download_side_effect
+        )
+        with app.app_context(), list_patch, dir_patch, dl_patch:
+            result = sync_files_and_directories(
+                connection, "/remote/reports", tmp_path, exclude_patterns=[]
+            )
+        assert result == SyncMethod.SCP
+
+    def test_incomplete_sync_message_uses_run_method_not_global_cache(
+        self, app, tmp_path, connection
+    ):
+        # Poison the global cache for *this* host so the regression (reading the
+        # global instead of the per-run method) would report "via scp".
+        _sftp_subsystem_unavailable.add(_remote_transfer_key(connection))
+        files = [("/remote/reports/a.txt", 10), ("/remote/reports/b.txt", 20)]
+
+        def download_side_effect(_conn, remote_file, _local_file):
+            if remote_file.endswith("b.txt"):
+                raise RuntimeError("SFTP transient failure")
+            return SyncMethod.SFTP
+
+        list_patch, dir_patch, dl_patch, _, _ = self._patches(
+            connection, files, download_side_effect=download_side_effect
+        )
+        with app.app_context(), list_patch, dir_patch, dl_patch:
+            with pytest.raises(RemoteConnectionException) as excinfo:
+                sync_files_and_directories(
+                    connection, "/remote/reports", tmp_path, exclude_patterns=[]
+                )
+        assert "via sftp" in excinfo.value.message
+        assert "via scp" not in excinfo.value.message
 
 
 class TestGetRemoteFileListWithoutSizes:

--- a/backend/ttnn_visualizer/tests/test_sftp_operations.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_operations.py
@@ -504,6 +504,9 @@ class TestSyncFilesAndDirectoriesSyncMethod:
                 )
         assert "via sftp" in excinfo.value.message
         assert "via scp" not in excinfo.value.message
+        # The exception carries the per-run method so callers don't have to
+        # re-read the (poisoned) global cache.
+        assert excinfo.value.sync_method == SyncMethod.SFTP.value
 
 
 class TestGetRemoteFileListWithoutSizes:

--- a/backend/ttnn_visualizer/tests/test_ssh_host_key_errors.py
+++ b/backend/ttnn_visualizer/tests/test_ssh_host_key_errors.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from ttnn_visualizer.models import RemoteConnection
+from ttnn_visualizer.ssh_client import (
+    is_ssh_host_key_verification_error,
+    ssh_host_key_failure_message,
+)
+
+
+def test_is_ssh_host_key_verification_error_matches_strict_check_message():
+    stderr = (
+        "No ED25519 host key is known for [aus-wh-05]:45985 and you have "
+        "requested strict checking.\nHost key verification failed.\n"
+    )
+    assert is_ssh_host_key_verification_error(stderr)
+
+
+def test_is_ssh_host_key_verification_error_does_not_match_auth_failure():
+    assert not is_ssh_host_key_verification_error("Permission denied (publickey).")
+
+
+def test_ssh_host_key_failure_message_includes_non_default_port():
+    connection = RemoteConnection(
+        name="lab",
+        username="user",
+        host="aus-wh-05",
+        port=45985,
+        profilerPath="/remote",
+    )
+    message = ssh_host_key_failure_message(connection)
+    assert "45985" in message
+    assert "ssh -p 45985 user@aus-wh-05" in message

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1780,7 +1780,7 @@ def sync_remote_folder():
                 e.http_status,
                 e.message,
                 detail=e.detail,
-                sync_method=get_active_sync_method(connection).value,
+                sync_method=e.sync_method or get_active_sync_method(connection).value,
             )
 
     try:
@@ -1811,7 +1811,7 @@ def sync_remote_folder():
             e.http_status,
             e.message,
             detail=e.detail,
-            sync_method=get_active_sync_method(connection).value,
+            sync_method=e.sync_method or get_active_sync_method(connection).value,
         )
 
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -72,6 +72,7 @@ from ttnn_visualizer.serializers import (
 from ttnn_visualizer.sftp_operations import (
     check_remote_path_exists,
     check_remote_path_for_reports,
+    get_active_sync_method,
     get_cluster_desc,
     get_remote_performance_folders,
     get_remote_profiler_folders,
@@ -1760,7 +1761,7 @@ def sync_remote_folder():
             performance, strict=False
         )
         try:
-            sync_remote_performance_folders(
+            sync_method = sync_remote_performance_folders(
                 connection,
                 remote_dir,
                 performance=performance_folder,
@@ -1770,17 +1771,24 @@ def sync_remote_folder():
 
             performance_folder.lastSynced = int(time.time())
 
-            return performance_folder.model_dump()
+            response_body = performance_folder.model_dump()
+            response_body["syncMethod"] = sync_method.value
+            return response_body
 
         except RemoteConnectionException as e:
-            return error_response(e.http_status, e.message)
+            return error_response(
+                e.http_status,
+                e.message,
+                detail=e.detail,
+                sync_method=get_active_sync_method(connection).value,
+            )
 
     try:
         remote_profiler_folder = RemoteReportFolder.model_validate(
             profiler, strict=False
         )
 
-        sync_remote_profiler_folders(
+        sync_method = sync_remote_profiler_folders(
             connection,
             remote_profiler_folder.remotePath,
             remote_dir,
@@ -1790,13 +1798,21 @@ def sync_remote_folder():
 
         remote_profiler_folder.lastSynced = int(time.time())
 
+        response_body = remote_profiler_folder.model_dump()
+        response_body["syncMethod"] = sync_method.value
+
         return Response(
-            orjson.dumps(remote_profiler_folder.model_dump()),
+            orjson.dumps(response_body),
             mimetype="application/json",
         )
 
     except RemoteConnectionException as e:
-        return error_response(e.http_status, e.message)
+        return error_response(
+            e.http_status,
+            e.message,
+            detail=e.detail,
+            sync_method=get_active_sync_method(connection).value,
+        )
 
 
 @api.route("/remote/use", methods=["POST"])


### PR DESCRIPTION
Improves error messaging for remote sync and adds a fallback to scp when sftp isn't available.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1619.