### PR TITLE
dev: relax deps version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "gevent==25.9.1",
     "gunicorn~=23.0.0",
     "orjson>=3.9.0",
-    "pandas>=2.0.0,<3.0",
+    "pandas>=2.2.0,<3.0",
     "pydantic_core==2.41.5",
     "pydantic==2.12.5",
     "python-dotenv==1.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,21 +8,21 @@ requires-python = ">=3.10"
 dependencies = [
     "alembic~=1.18.0",
     "build",
-    "Flask-Cors==6.0.0",
-    "flask-socketio==5.6.1",
+    "Flask-Cors>=6.0.0,<7.0",
+    "flask-socketio>=5.6.0,<6.0",
     "flask-sqlalchemy==3.1.1",
     "Flask-Static-Digest==0.4.1",
-    "Flask==3.1.3",
+    "Flask>=3.1.0,<4.0",
     "gevent==25.9.1",
     "gunicorn~=23.0.0",
     "orjson>=3.9.0",
-    "pandas==2.2.3",
+    "pandas>=2.0.0,<3.0",
     "pydantic_core==2.41.5",
     "pydantic==2.12.5",
     "python-dotenv==1.2.2",
-    "PyYAML==6.0.2",
+    "PyYAML>=6.0.0,<7.0",
     "tt-perf-report==1.2.4",
-    "zstd==1.5.7.0"
+    "zstd>=1.5.7,<2.0"
 ]
 
 classifiers = [
@@ -59,7 +59,7 @@ where = ["backend"]
 ttnn_visualizer = ["alembic.ini", "alembic/**/*.py"]
 
 [build-system]
-requires = ["setuptools==78.1.1", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ where = ["backend"]
 ttnn_visualizer = ["alembic.ini", "alembic/**/*.py"]
 
 [build-system]
-requires = ["setuptools>=78.1.1", "wheel"]
+requires = ["setuptools>=78.1.1,<81.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]


### PR DESCRIPTION
When running on my nix based environment, the dependency versions were too strict. So, this introduces relaxes some of these too strict versions (most of them pinned to minor versions)

I tested their running based on [here](https://docs.tenstorrent.com/ttnn-visualizer/src/running-from-source.html)

The error log example for versions: 

```sh

       > ERROR Missing dependencies:
       >        setuptools==78.1.1
       For full logs, run:
         nix log /nix/store/xgkwic9vaz63xsp9shkpsslc7f8wgqk6-python3.13-ttnn-visualizer-0.88.0.drv
error: Cannot build '/nix/store/f8z7q779vyn432k56phsdk5pbd8nr8hs-python3-3.13.13-env.drv'.

```
