### PR TITLE
Support per-core CB allocation calculation and core range parsing 

### DIFF
--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -76,7 +76,9 @@ export const MemoryLegendElement = ({
     );
 
     const derivedTensor = operationDetails.getTensorForAddress(chunk.address);
-    const numCoresLabel = numCores && numCores > 1 ? ` x ${numCores} cores` : '';
+    const isPerCoreBuffer = bufferType !== StringBufferType.DRAM && bufferType !== StringBufferType.SYSTEM_MEMORY;
+    const numCoresLabel =
+        isPerCoreBuffer && numCores && numCores > 0 ? ` x ${numCores} ${numCores === 1 ? 'core' : 'cores'}` : '';
 
     const memorySquare = {
         ...(!chunk.empty &&

--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -115,24 +115,52 @@ export const isEqual = <T>(value: T, other: T): boolean => {
     });
 };
 
+export interface CoreCoord {
+    x: number;
+    y: number;
+}
+
+const CORE_RANGE_RECT_RE = /\[([^\]]+)\]/g;
+const CORE_COORD_RE = /\(x=(\d+),y=(\d+)\)|(\d+)-(\d+)/g;
+
 /**
- @description Count the number of cores in a range string
- @param {string} rangeString - The range string to parse {[(x=0,y=0) - (x=7,y=7)]}
- @returns {number} The number of cores
+ * Expand a core_range_set string to the deduplicated list of (x,y) cores it covers.
+ * Accepts both `{[(x=N,y=N) - (x=N,y=N)]}` (legacy) and `{[N-N - N-N]}` (modern),
+ * multi-rectangle unions, and `{}`.
  */
-export const getCoresInRange = (rangeString: string): number => {
-    const regex = /\(x=(\d+),y=(\d+)\)/g;
-    const matches = [...rangeString.matchAll(regex)];
-
-    if (matches.length !== 2) {
-        return 0;
+export const getCoresInRangeList = (rangeString: string): CoreCoord[] => {
+    const cores = new Map<string, CoreCoord>();
+    for (const rect of rangeString.matchAll(CORE_RANGE_RECT_RE)) {
+        const corners: CoreCoord[] = [];
+        for (const m of rect[1].matchAll(CORE_COORD_RE)) {
+            const x = m[1] !== undefined ? Number(m[1]) : Number(m[3]);
+            const y = m[2] !== undefined ? Number(m[2]) : Number(m[4]);
+            corners.push({ x, y });
+            if (corners.length === 2) {
+                break;
+            }
+        }
+        if (corners.length !== 2) {
+            continue; // eslint-disable-line no-continue
+        }
+        const [a, b] = corners;
+        const xMin = Math.min(a.x, b.x);
+        const xMax = Math.max(a.x, b.x);
+        const yMin = Math.min(a.y, b.y);
+        const yMax = Math.max(a.y, b.y);
+        for (let x = xMin; x <= xMax; x += 1) {
+            for (let y = yMin; y <= yMax; y += 1) {
+                const k = `${x},${y}`;
+                if (!cores.has(k)) {
+                    cores.set(k, { x, y });
+                }
+            }
+        }
     }
-
-    const [x1, y1] = matches[0].slice(1).map(Number);
-    const [x2, y2] = matches[1].slice(1).map(Number);
-
-    return (x2 - x1 + 1) * (y2 - y1 + 1);
+    return Array.from(cores.values());
 };
+
+export const getCoresInRange = (rangeString: string): number => getCoresInRangeList(rangeString).length;
 
 /**
  * Convert bytes to human-readable format using binary units (1024-based)

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -5,6 +5,7 @@
 import { DeviceOperationNode, Node, NodeType } from '../model/APIData';
 import { L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { StringBufferType } from '../model/BufferType';
+import { getCoresInRangeList } from './math';
 
 export type AllocationDetails = {
     id: number;
@@ -26,26 +27,24 @@ export function processMemoryAllocations(
     let peakMemoryLoad = 0;
     const memoryAllocationList: AllocationDetails[] = [];
     const curOpList: { name: string; id: number; deviceId?: string | number }[] = [];
-    let totalCb = 0;
+    const cbBytesByCore = new Map<string, number>();
     let totalBuffer = 0;
+
+    const maxCbPerCore = (): number => {
+        let m = 0;
+        for (const v of cbBytesByCore.values()) {
+            if (v > m) {
+                m = v;
+            }
+        }
+        return m;
+    };
 
     let i = 1;
     while (i < graph.length) {
         const node = graph[i];
         i += 1;
         if (node.node_type === NodeType.function_start) {
-            // logic below calculates inputs sizes. its is deemed unnecessary for now
-            // keeping for a while
-            // if (node.inputs?.length > 0) {
-            //     // eslint-disable-next-line no-loop-func
-            //     node.inputs.forEach((tensor) => {
-            //         const size = inputs.find((x) => x.id === parseInt(String(tensor.params.tensor_id), 10))?.size;
-            //         if (size !== null && size !== undefined) {
-            //             totalBuffer += size;
-            //         }
-            //     });
-            // }
-
             const { name } = node.params;
             curOpList.push({ name, id: node.id, deviceId: node.params.device_id });
         }
@@ -56,16 +55,25 @@ export function processMemoryAllocations(
         }
 
         if (node.node_type === NodeType.circular_buffer_allocate) {
-            // this is the only sane way to track allocation op for color variance. not a fan
+            // tracks allocation op for color variance downstream
             if (currentOp) {
                 node.params.allocateOperationId = currentOp.id;
                 node.params.allocateOperationName = currentOp.name;
             }
-            totalCb += parseInt(node.params.size, 10);
+            const size = parseInt(node.params.size, 10);
+            const cores = getCoresInRangeList(node.params.core_range_set);
+            if (cores.length === 0) {
+                cbBytesByCore.set('?', (cbBytesByCore.get('?') ?? 0) + size);
+            } else {
+                for (const { x, y } of cores) {
+                    const k = `${x},${y}`;
+                    cbBytesByCore.set(k, (cbBytesByCore.get(k) ?? 0) + size);
+                }
+            }
         }
 
         if (node.node_type === NodeType.circular_buffer_deallocate_all) {
-            totalCb = 0;
+            cbBytesByCore.clear();
         }
 
         if (node.node_type === NodeType.buffer_allocate && node.params.type === StringBufferType.L1) {
@@ -86,20 +94,22 @@ export function processMemoryAllocations(
             }
         }
 
+        const cbPeak = maxCbPerCore();
+
         if (curOpList.length > 0) {
             const obj: AllocationDetails = {
                 name: curOpList[curOpList.length - 1].name,
                 deviceId: curOpList[curOpList.length - 1].deviceId as number,
                 id: node.id,
                 type: node.node_type,
-                total_cb: totalCb,
+                total_cb: cbPeak,
                 total_buffer: totalBuffer,
-                total_memory: totalCb + totalBuffer,
+                total_memory: cbPeak + totalBuffer,
             };
             memoryAllocationList.push(obj);
         }
 
-        peakMemoryLoad = Math.max(peakMemoryLoad, totalCb + totalBuffer);
+        peakMemoryLoad = Math.max(peakMemoryLoad, cbPeak + totalBuffer);
     }
 
     return { peakMemoryLoad, memoryAllocationList };

--- a/tests/MemoryLegendElement.spec.tsx
+++ b/tests/MemoryLegendElement.spec.tsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryLegendElement } from '../src/components/operation-details/MemoryLegendElement';
 import { MarkerType } from '../src/model/APIData';
+import { StringBufferType } from '../src/model/BufferType';
 import { OperationDetails } from '../src/model/OperationDetails';
 import { TestProviders } from './helpers/TestProviders';
 
@@ -16,7 +17,9 @@ const operationDetails = {
     getTensorForAddress: () => undefined,
 } as unknown as OperationDetails;
 
-function renderLegendElement(chunk: Parameters<typeof MemoryLegendElement>[0]['chunk']) {
+type LegendProps = Parameters<typeof MemoryLegendElement>[0];
+
+function renderLegendElement(chunk: LegendProps['chunk'], extraProps: Partial<LegendProps> = {}) {
     const { container } = render(
         <TestProviders>
             <MemoryLegendElement
@@ -25,6 +28,7 @@ function renderLegendElement(chunk: Parameters<typeof MemoryLegendElement>[0]['c
                 selectedTensorAddress={null}
                 operationDetails={operationDetails}
                 onLegendClick={onLegendClick}
+                {...extraProps}
             />
         </TestProviders>,
     );
@@ -72,5 +76,45 @@ describe('MemoryLegendElement legend swatches', () => {
         expect(container.querySelector('.memory-color-block')).toBeInTheDocument();
         expect(container.querySelector('.legend-marker-swatch')).not.toBeInTheDocument();
         expect(container.querySelector('.legend-empty-swatch')).not.toBeInTheDocument();
+    });
+});
+
+describe('MemoryLegendElement core count label', () => {
+    const chunk = { address: 0x4000, size: 1024 };
+
+    it('renders "x 1 core" for a single-core CB (no bufferType)', () => {
+        renderLegendElement(chunk, { numCores: 1 });
+        expect(screen.getByText(/x 1 core(?!s)/)).toBeInTheDocument();
+    });
+
+    it('renders "x 64 cores" for a multi-core L1 allocation', () => {
+        renderLegendElement(chunk, { numCores: 64, bufferType: StringBufferType.L1 });
+        expect(screen.getByText(/x 64 cores/)).toBeInTheDocument();
+    });
+
+    it('renders "x 1 core" for a single-core L1 allocation', () => {
+        renderLegendElement(chunk, { numCores: 1, bufferType: StringBufferType.L1 });
+        expect(screen.getByText(/x 1 core(?!s)/)).toBeInTheDocument();
+    });
+
+    it('omits the label for DRAM allocations even when numCores is provided', () => {
+        renderLegendElement(chunk, { numCores: 1, bufferType: StringBufferType.DRAM });
+        expect(screen.queryByText(/x 1 core/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/cores?/)).not.toBeInTheDocument();
+    });
+
+    it('omits the label for SYSTEM_MEMORY allocations', () => {
+        renderLegendElement(chunk, { numCores: 8, bufferType: StringBufferType.SYSTEM_MEMORY });
+        expect(screen.queryByText(/cores?/)).not.toBeInTheDocument();
+    });
+
+    it('omits the label when numCores is unset', () => {
+        renderLegendElement(chunk);
+        expect(screen.queryByText(/cores?/)).not.toBeInTheDocument();
+    });
+
+    it('omits the label when numCores is zero', () => {
+        renderLegendElement(chunk, { numCores: 0 });
+        expect(screen.queryByText(/cores?/)).not.toBeInTheDocument();
     });
 });

--- a/tests/getCoresInRange.spec.ts
+++ b/tests/getCoresInRange.spec.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { getCoresInRange, getCoresInRangeList } from '../src/functions/math';
+
+describe('getCoresInRangeList', () => {
+    describe('legacy (x=N,y=N) format', () => {
+        it('returns a single core for a degenerate rectangle', () => {
+            expect(getCoresInRangeList('{[(x=0,y=0) - (x=0,y=0)]}')).toEqual([{ x: 0, y: 0 }]);
+        });
+
+        it('expands a column rectangle inclusively', () => {
+            const cores = getCoresInRangeList('{[(x=0,y=0) - (x=0,y=7)]}');
+            expect(cores).toHaveLength(8);
+            expect(cores).toContainEqual({ x: 0, y: 0 });
+            expect(cores).toContainEqual({ x: 0, y: 7 });
+        });
+
+        it('expands a full 8x8 grid to 64 cores', () => {
+            expect(getCoresInRangeList('{[(x=0,y=0) - (x=7,y=7)]}')).toHaveLength(64);
+        });
+
+        it('handles a non-origin single core', () => {
+            expect(getCoresInRangeList('{[(x=6,y=7) - (x=6,y=7)]}')).toEqual([{ x: 6, y: 7 }]);
+        });
+    });
+
+    describe('legacy multi-rectangle unions', () => {
+        it('dedupes the union of disjoint rectangles', () => {
+            const cores = getCoresInRangeList('{[(x=0,y=0) - (x=1,y=3)], [(x=0,y=4) - (x=0,y=7)]}');
+            expect(cores).toHaveLength(12);
+            expect(cores).toContainEqual({ x: 0, y: 4 });
+            expect(cores).toContainEqual({ x: 1, y: 3 });
+        });
+
+        it('handles the full-row + tail union pattern from real reports', () => {
+            const cores = getCoresInRangeList('{[(x=0,y=0) - (x=7,y=6)], [(x=0,y=7) - (x=5,y=7)]}');
+            expect(cores).toHaveLength(7 * 8 + 6);
+        });
+
+        it('does not double-count overlapping rectangles', () => {
+            const cores = getCoresInRangeList('{[(x=0,y=0) - (x=2,y=2)], [(x=1,y=1) - (x=3,y=3)]}');
+            const keys = new Set(cores.map(({ x, y }) => `${x},${y}`));
+            expect(keys.size).toBe(cores.length);
+            // 3x3 + 3x3 - 2x2 overlap = 14 unique cores
+            expect(cores).toHaveLength(14);
+        });
+    });
+
+    describe('modern N-N format', () => {
+        it('parses a single-core modern range', () => {
+            expect(getCoresInRangeList('{[0-0 - 0-0]}')).toEqual([{ x: 0, y: 0 }]);
+        });
+
+        it('parses a non-origin single-core modern range', () => {
+            expect(getCoresInRangeList('{[1-0 - 1-0]}')).toEqual([{ x: 1, y: 0 }]);
+        });
+
+        it('expands a multi-cell modern rectangle inclusively', () => {
+            const cores = getCoresInRangeList('{[2-0 - 5-7]}');
+            expect(cores).toHaveLength(4 * 8);
+            expect(cores).toContainEqual({ x: 2, y: 0 });
+            expect(cores).toContainEqual({ x: 5, y: 7 });
+        });
+
+        it('handles multi-digit coordinates without splitting digits', () => {
+            const cores = getCoresInRangeList('{[10-2 - 12-2]}');
+            expect(cores).toEqual([
+                { x: 10, y: 2 },
+                { x: 11, y: 2 },
+                { x: 12, y: 2 },
+            ]);
+        });
+    });
+
+    describe('empty and malformed input', () => {
+        it('returns an empty list for {}', () => {
+            expect(getCoresInRangeList('{}')).toEqual([]);
+        });
+
+        it('returns an empty list for a rectangle with only one corner', () => {
+            expect(getCoresInRangeList('{[(x=0,y=0)]}')).toEqual([]);
+        });
+
+        it('returns an empty list for a non-matching string', () => {
+            expect(getCoresInRangeList('garbage')).toEqual([]);
+        });
+    });
+});
+
+describe('getCoresInRange', () => {
+    it('returns the number of cores covered by the union', () => {
+        expect(getCoresInRange('{[(x=0,y=0) - (x=0,y=0)]}')).toBe(1);
+        expect(getCoresInRange('{[(x=0,y=0) - (x=7,y=7)]}')).toBe(64);
+        expect(getCoresInRange('{[(x=0,y=0) - (x=1,y=3)], [(x=0,y=4) - (x=0,y=7)]}')).toBe(12);
+        expect(getCoresInRange('{[0-0 - 0-0]}')).toBe(1);
+        expect(getCoresInRange('{}')).toBe(0);
+    });
+});

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { processMemoryAllocations } from '../src/functions/processMemoryAllocations';
+import { Node, NodeType } from '../src/model/APIData';
+import { StringBufferType } from '../src/model/BufferType';
+
+let nextId = 0;
+function mkNode<T extends Partial<Node>>(node: T): Node {
+    nextId += 1;
+    return {
+        id: nextId,
+        connections: [],
+        inputs: [],
+        outputs: [],
+        stacking_level: 0,
+        ...node,
+    } as Node;
+}
+
+function captureStart(): Node {
+    return mkNode({
+        node_type: NodeType.capture_start,
+        params: { name: 'capture', device_id: 0 },
+    } as unknown as Partial<Node>);
+}
+
+function functionStart(name: string, deviceId: number | undefined = 0): Node {
+    return mkNode({
+        node_type: NodeType.function_start,
+        params: { name, device_id: deviceId },
+    } as unknown as Partial<Node>);
+}
+
+function functionEnd(name: string): Node {
+    return mkNode({
+        node_type: NodeType.function_end,
+        params: { name },
+    } as unknown as Partial<Node>);
+}
+
+function cbAllocate(coreRangeSet: string, size: number): Node {
+    return mkNode({
+        node_type: NodeType.circular_buffer_allocate,
+        params: { core_range_set: coreRangeSet, size: String(size) },
+    } as unknown as Partial<Node>);
+}
+
+function cbDeallocateAll(): Node {
+    return mkNode({
+        node_type: NodeType.circular_buffer_deallocate_all,
+        params: {},
+    } as unknown as Partial<Node>);
+}
+
+function bufferAllocate(type: StringBufferType, size: number, numCores: number): Node {
+    return mkNode({
+        node_type: NodeType.buffer_allocate,
+        params: { type, size: String(size), num_cores: String(numCores) },
+    } as unknown as Partial<Node>);
+}
+
+function bufferDeallocate(type: StringBufferType, size: number, numCores: number): Node {
+    return mkNode({
+        node_type: NodeType.buffer_deallocate,
+        params: { type, size: String(size), num_cores: String(numCores) },
+    } as unknown as Partial<Node>);
+}
+
+describe('processMemoryAllocations - CB per-core accounting', () => {
+    beforeEach(() => {
+        nextId = 0;
+    });
+
+    it('returns zero peak for a graph with no allocations', () => {
+        const graph = [captureStart(), functionStart('op'), functionEnd('op')];
+
+        const { peakMemoryLoad, memoryAllocationList } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(0);
+        expect(memoryAllocationList.every((row) => row.total_cb === 0 && row.total_buffer === 0)).toBe(true);
+    });
+
+    it('reports total_cb = size for a single CB on a single core', () => {
+        const size = 1024 * 1024;
+        const graph = [
+            captureStart(),
+            functionStart('op'),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', size),
+            functionEnd('op'),
+        ];
+
+        const { peakMemoryLoad, memoryAllocationList } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(size);
+        const cbRow = memoryAllocationList.find((row) => row.type === NodeType.circular_buffer_allocate);
+        expect(cbRow?.total_cb).toBe(size);
+    });
+
+    it('takes the max-per-core when two CBs live on disjoint cores (issue #1622)', () => {
+        const cb1 = 1024 * 1024;
+        const cb2 = 750 * 1024;
+        const graph = [
+            captureStart(),
+            functionStart('memory_repro'),
+            cbAllocate('{[0-0 - 0-0]}', cb1),
+            cbAllocate('{[1-0 - 1-0]}', cb2),
+            functionEnd('memory_repro'),
+        ];
+
+        const { peakMemoryLoad, memoryAllocationList } = processMemoryAllocations(graph);
+
+        const [, firstCb, secondCb] = memoryAllocationList;
+        expect(firstCb.total_cb).toBe(cb1);
+        expect(secondCb.total_cb).toBe(cb1);
+        expect(peakMemoryLoad).toBe(cb1);
+        expect(peakMemoryLoad).toBeLessThan(cb1 + cb2);
+    });
+
+    it('sums per-core when two CBs share the same core', () => {
+        const cb1 = 1024 * 1024;
+        const cb2 = 256 * 1024;
+        const graph = [
+            captureStart(),
+            functionStart('op'),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb1),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb2),
+            functionEnd('op'),
+        ];
+
+        const { peakMemoryLoad, memoryAllocationList } = processMemoryAllocations(graph);
+
+        const [, , afterSecond] = memoryAllocationList;
+        expect(afterSecond.total_cb).toBe(cb1 + cb2);
+        expect(peakMemoryLoad).toBe(cb1 + cb2);
+    });
+
+    it('does not double-count overlapping multi-rectangle CB allocations', () => {
+        const size = 100;
+        const graph = [
+            captureStart(),
+            functionStart('op'),
+            cbAllocate('{[(x=0,y=0) - (x=2,y=2)], [(x=1,y=1) - (x=3,y=3)]}', size),
+            functionEnd('op'),
+        ];
+
+        const { peakMemoryLoad } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(size);
+    });
+
+    it('clears per-core CB tracking on circular_buffer_deallocate_all', () => {
+        const cb1 = 500_000;
+        const cb2 = 800_000;
+        const graph = [
+            captureStart(),
+            functionStart('op'),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb1),
+            cbDeallocateAll(),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb2),
+            functionEnd('op'),
+        ];
+
+        const { peakMemoryLoad, memoryAllocationList } = processMemoryAllocations(graph);
+
+        const dealloc = memoryAllocationList.find((row) => row.type === NodeType.circular_buffer_deallocate_all);
+        expect(dealloc?.total_cb).toBe(0);
+        expect(peakMemoryLoad).toBe(Math.max(cb1, cb2));
+    });
+
+    it('handles modern N-N core_range_set syntax', () => {
+        const size = 2048;
+        const graph = [captureStart(), functionStart('op'), cbAllocate('{[0-0 - 0-0]}', size), functionEnd('op')];
+
+        const { peakMemoryLoad } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(size);
+    });
+
+    it('accounts for size even when core_range_set is empty', () => {
+        const size = 4096;
+        const graph = [captureStart(), functionStart('op'), cbAllocate('{}', size), functionEnd('op')];
+
+        const { peakMemoryLoad } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(size);
+    });
+
+    it('annotates CB allocations with the enclosing function for color variance', () => {
+        const graph = [
+            captureStart(),
+            functionStart('demo_op'),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', 1024),
+            functionEnd('demo_op'),
+        ];
+        const cbNode = graph[2];
+
+        processMemoryAllocations(graph);
+
+        expect((cbNode.params as Record<string, unknown>).allocateOperationName).toBe('demo_op');
+        expect((cbNode.params as Record<string, unknown>).allocateOperationId).toBe(graph[1].id);
+    });
+});
+
+describe('processMemoryAllocations - L1 buffer accounting', () => {
+    beforeEach(() => {
+        nextId = 0;
+    });
+
+    it('amortizes L1 buffer_allocate over num_cores and reverses on deallocate', () => {
+        const size = 64 * 64; // amortizes cleanly across 64 cores
+        const graph = [
+            captureStart(),
+            functionStart('op'),
+            bufferAllocate(StringBufferType.L1, size, 64),
+            bufferDeallocate(StringBufferType.L1, size, 64),
+            functionEnd('op'),
+        ];
+
+        const { memoryAllocationList } = processMemoryAllocations(graph);
+
+        const afterAlloc = memoryAllocationList.find((row) => row.type === NodeType.buffer_allocate);
+        const afterDealloc = memoryAllocationList.find((row) => row.type === NodeType.buffer_deallocate);
+        expect(afterAlloc?.total_buffer).toBe(size / 64);
+        expect(afterDealloc?.total_buffer).toBe(0);
+    });
+
+    it('ignores DRAM allocations when computing L1 peak', () => {
+        const cbSize = 1024;
+        const graph = [
+            captureStart(),
+            functionStart('op'),
+            bufferAllocate(StringBufferType.DRAM, 99_999_999, 1),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cbSize),
+            functionEnd('op'),
+        ];
+
+        const { peakMemoryLoad } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(cbSize);
+    });
+});


### PR DESCRIPTION
Track circular buffer (CB) allocations per core and compute peak CB usage per-core. Added getCoresInRangeList (and getCoresInRange wrapper) to math.ts to parse and expand core_range_set strings (supports legacy and modern formats, multi-rect unions, and deduplicates cores). processMemoryAllocations.ts now accumulates CB bytes by core, computes the per-core peak (cbPeak) for total_cb/total_memory and global peakMemoryLoad, and clears per-core state on deallocation. MemoryLegendElement.tsx was updated to only show core counts for per-core buffers (not DRAM/SYSTEM_MEMORY) and to pluralize "core/cores" correctly.

<img width="1527" height="897" alt="image" src="https://github.com/user-attachments/assets/a5df241b-293b-4f5d-8a06-15bf64b064f8" />

closes #1622 