### PR TITLE
More gracefully (re)load performance table data

### DIFF
--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -124,6 +124,7 @@ const PerformanceReport = ({
     );
 
     const isSignpostsDisabled = !signposts || signposts.length === 0;
+    const isTableLoading = isLoading || isComparisonLoading;
     const comparisonIndex = (activeComparisonReportList ?? []).findIndex((value) => value === selectedTabId);
     const isGroupedByMemory = stackedGroupBy === StackedGroupBy.MEMORY;
     const filterScopeHelperText =
@@ -625,7 +626,7 @@ const PerformanceReport = ({
                                     filters={filters}
                                     stackedComparisonData={filteredComparisonStackedRowsList}
                                     reportName={activePerformanceReport?.reportName || null}
-                                    isLoading={isLoading}
+                                    isLoading={isTableLoading}
                                 />
                             ) : (
                                 <PerfTable
@@ -637,7 +638,7 @@ const PerformanceReport = ({
                                     reportName={activePerformanceReport?.reportName || null}
                                     showHashColumn={false}
                                     hasL1PressureData={hasL1PressureData}
-                                    isLoading={isLoading}
+                                    isLoading={isTableLoading}
                                 />
                             )
                         }
@@ -676,7 +677,7 @@ const PerformanceReport = ({
                                         ]}
                                         filters={filters}
                                         reportName={report}
-                                        isLoading={isComparisonLoading}
+                                        isLoading={isTableLoading}
                                     />
                                 ) : (
                                     <PerfTable
@@ -692,7 +693,7 @@ const PerformanceReport = ({
                                         showHashColumn={false}
                                         hasL1PressureData={hasL1PressureData}
                                         activeReportComparisonIndex={0}
-                                        isLoading={isComparisonLoading}
+                                        isLoading={isTableLoading}
                                     />
                                 )
                             }

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -71,6 +71,7 @@ interface PerformanceReportProps {
     signposts?: Signpost[];
     hasL1PressureData?: boolean;
     isLoading?: boolean;
+    isComparisonLoading?: boolean;
 }
 
 const INITIAL_TAB_ID = 'perf-table-0'; // `perf-table-${index}`
@@ -84,6 +85,7 @@ const PerformanceReport = ({
     signposts,
     hasL1PressureData = false,
     isLoading = false,
+    isComparisonLoading = false,
 }: PerformanceReportProps) => {
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const activeComparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
@@ -674,7 +676,7 @@ const PerformanceReport = ({
                                         ]}
                                         filters={filters}
                                         reportName={report}
-                                        isLoading={isLoading}
+                                        isLoading={isComparisonLoading}
                                     />
                                 ) : (
                                     <PerfTable
@@ -690,7 +692,7 @@ const PerformanceReport = ({
                                         showHashColumn={false}
                                         hasL1PressureData={hasL1PressureData}
                                         activeReportComparisonIndex={0}
-                                        isLoading={isLoading}
+                                        isLoading={isComparisonLoading}
                                     />
                                 )
                             }

--- a/src/components/performance/PerfReport.tsx
+++ b/src/components/performance/PerfReport.tsx
@@ -70,6 +70,7 @@ interface PerformanceReportProps {
     comparisonStackedData: TypedStackedPerfRow[][];
     signposts?: Signpost[];
     hasL1PressureData?: boolean;
+    isLoading?: boolean;
 }
 
 const INITIAL_TAB_ID = 'perf-table-0'; // `perf-table-${index}`
@@ -82,6 +83,7 @@ const PerformanceReport = ({
     comparisonStackedData,
     signposts,
     hasL1PressureData = false,
+    isLoading = false,
 }: PerformanceReportProps) => {
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const activeComparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
@@ -621,6 +623,7 @@ const PerformanceReport = ({
                                     filters={filters}
                                     stackedComparisonData={filteredComparisonStackedRowsList}
                                     reportName={activePerformanceReport?.reportName || null}
+                                    isLoading={isLoading}
                                 />
                             ) : (
                                 <PerfTable
@@ -632,6 +635,7 @@ const PerformanceReport = ({
                                     reportName={activePerformanceReport?.reportName || null}
                                     showHashColumn={false}
                                     hasL1PressureData={hasL1PressureData}
+                                    isLoading={isLoading}
                                 />
                             )
                         }
@@ -670,6 +674,7 @@ const PerformanceReport = ({
                                         ]}
                                         filters={filters}
                                         reportName={report}
+                                        isLoading={isLoading}
                                     />
                                 ) : (
                                     <PerfTable
@@ -685,6 +690,7 @@ const PerformanceReport = ({
                                         showHashColumn={false}
                                         hasL1PressureData={hasL1PressureData}
                                         activeReportComparisonIndex={0}
+                                        isLoading={isLoading}
                                     />
                                 )
                             }

--- a/src/components/performance/PerfTable.tsx
+++ b/src/components/performance/PerfTable.tsx
@@ -28,9 +28,9 @@ import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList } from '../
 import useSortTable, { SortingDirection } from '../../hooks/useSortTable';
 import { OperationDescription } from '../../model/APIData';
 import { hideHostOpsAtom, mergeDevicesAtom, selectedPerfRowIdAtom } from '../../store/app';
-import LoadingSpinner from '../LoadingSpinner';
 import PerfDeviceArchitecture from './PerfDeviceArchitecture';
 import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
+import PerfTableSkeleton from './PerfTableSkeleton';
 import PerfTensorDrawer from './PerfTensorDrawer';
 
 interface PerformanceTableProps {
@@ -42,6 +42,7 @@ interface PerformanceTableProps {
     reportName: string | null;
     showHashColumn: boolean;
     hasL1PressureData?: boolean;
+    isLoading?: boolean;
     // Identifies which comparison dataset holds the active profiler report's rows. The
     // tensor-drawer trigger only renders on those rows, since op-id sync from
     // `useOpToPerfIdFiltered()` and tensor lookups in `useOperationsList()` are both
@@ -64,6 +65,7 @@ const PerformanceTable = ({
     reportName,
     showHashColumn,
     hasL1PressureData = false,
+    isLoading = false,
     activeReportComparisonIndex = null,
 }: PerformanceTableProps) => {
     const hideHostOps = useAtomValue(hideHostOpsAtom);
@@ -231,9 +233,212 @@ const PerformanceTable = ({
         return formatCell(row, column, operations, highlight, isFirstOfOpRun);
     };
 
-    if (!data) {
-        return <LoadingSpinner />;
-    }
+    const renderTable = () => {
+        if (isLoading) {
+            return (
+                <PerfTableSkeleton
+                    headers={visibleColumns.map((column) => column.name)}
+                    hasLeadingColumn
+                />
+            );
+        }
+
+        if (!data?.length) {
+            return (
+                <p>
+                    <em>No data to display</em>
+                </p>
+            );
+        }
+
+        return (
+            <table className='perf-table monospace'>
+                <thead className='table-header'>
+                    <tr>
+                        <th
+                            className='cell-header'
+                            aria-label='Tensor details'
+                        />
+                        {visibleColumns.map((h) => {
+                            const targetSortDirection =
+                                // eslint-disable-next-line no-nested-ternary
+                                sortingColumn === h.key
+                                    ? sortDirection === SortingDirection.ASC
+                                        ? SortingDirection.DESC
+                                        : SortingDirection.ASC
+                                    : sortDirection;
+
+                            return (
+                                <th
+                                    key={h.key}
+                                    className='cell-header'
+                                >
+                                    {h.sortable ? (
+                                        <Button
+                                            onClick={() => changeSorting(h.key)(targetSortDirection)}
+                                            variant={ButtonVariant.MINIMAL}
+                                            size={Size.SMALL}
+                                        >
+                                            <span className='header-label'>{h.name}</span>
+
+                                            {sortingColumn === h.key ? (
+                                                <Icon
+                                                    className={classNames(
+                                                        {
+                                                            'is-active': sortingColumn === h.key,
+                                                        },
+                                                        'sort-icon',
+                                                    )}
+                                                    icon={
+                                                        sortDirection === SortingDirection.ASC
+                                                            ? IconNames.CARET_UP
+                                                            : IconNames.CARET_DOWN
+                                                    }
+                                                />
+                                            ) : (
+                                                <Icon
+                                                    className={classNames('sort-icon')}
+                                                    icon={IconNames.CARET_DOWN}
+                                                />
+                                            )}
+                                        </Button>
+                                    ) : (
+                                        <span className='header-label no-button'>{h.name}</span>
+                                    )}
+
+                                    {/* TODO: May want this in the near future */}
+                                    {/* {h?.filterable && (
+                                                <div className='column-filter'>
+                                                    <InputGroup
+                                                        asyncControl
+                                                        size={Size.SMALL}
+                                                        onValueChange={(value) => updateColumnFilter(h.key, value)}
+                                                        placeholder='Filter...'
+                                                        value={filters?.[h.key]}
+                                                    />
+                                                </div>
+                                            )} */}
+                                </th>
+                            );
+                        })}
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {tableFields?.map((row, i) => {
+                        const isFirstOfOpRun = row.op === undefined || firstRowOfOpRun.has(row);
+                        const isSignpost = row.op_type === OpType.SIGNPOST;
+                        const isPrimarySelected = isPrimaryActiveReport && row.id === selectedPerfRowId;
+
+                        return (
+                            <Fragment key={i}>
+                                <tr
+                                    className={classNames({
+                                        'missing-data': row.raw_op_code.includes('MISSING'),
+                                        'signpost-op': isSignpost,
+                                        'is-selected': isPrimarySelected,
+                                    })}
+                                >
+                                    <td className='cell'>{isPrimaryActiveReport && renderTensorDrawerTrigger(row)}</td>
+                                    {visibleColumns.map((h) => (
+                                        <td
+                                            key={h.key}
+                                            className={classNames('cell', {
+                                                'align-right': h.key === ColumnKeys.MathFidelity,
+                                            })}
+                                        >
+                                            {cellFormattingProxy(
+                                                row,
+                                                h,
+                                                operationsList,
+                                                filters?.[h.key],
+                                                isFirstOfOpRun,
+                                            )}
+                                        </td>
+                                    ))}
+                                </tr>
+
+                                {comparisonDataTableFields?.length > 0 &&
+                                    comparisonDataTableFields.map((dataset, index) => {
+                                        const subRow = dataset[i];
+                                        const isActiveReportRow = index === activeReportComparisonIndex;
+                                        const isSubRowSelected = isActiveReportRow && subRow?.id === selectedPerfRowId;
+
+                                        return (
+                                            <tr
+                                                key={`comparison-${i}-${index}`}
+                                                className={classNames(
+                                                    {
+                                                        'missing-data': subRow?.raw_op_code?.includes('MISSING'),
+                                                        'signpost-op': subRow?.op_type === OpType.SIGNPOST,
+                                                        'is-selected': isSubRowSelected,
+                                                    },
+                                                    'comparison-row',
+                                                    `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
+                                                )}
+                                            >
+                                                <td className='cell'>
+                                                    {isActiveReportRow && subRow
+                                                        ? renderTensorDrawerTrigger(subRow)
+                                                        : null}
+                                                </td>
+                                                {visibleColumns.map((h) => (
+                                                    <td
+                                                        key={h.key}
+                                                        className={classNames('cell', {
+                                                            'align-right': h.key === ColumnKeys.MathFidelity,
+                                                        })}
+                                                    >
+                                                        {comparisonKeys.includes(h.key) &&
+                                                            subRow &&
+                                                            formatCell(subRow, h, operationsList, filters?.[h.key])}
+                                                    </td>
+                                                ))}
+                                            </tr>
+                                        );
+                                    })}
+                                {provideMatmulAdvice && row.op_code.includes('Matmul') && (
+                                    <tr>
+                                        <td
+                                            colSpan={visibleColumns.length + 1}
+                                            className='cell advice'
+                                        >
+                                            <ul>
+                                                {row?.advice.map((advice, j) => (
+                                                    <li key={`advice-${j}`}>{advice}</li>
+                                                ))}
+                                            </ul>
+                                        </td>
+                                    </tr>
+                                )}
+                            </Fragment>
+                        );
+                    })}
+                </tbody>
+
+                <tfoot className='table-footer'>
+                    <tr>
+                        <td />
+                        {visibleColumns.length > 0 &&
+                            data?.length > 0 &&
+                            visibleColumns
+                                .filter((header) => header?.footerSpan !== 0)
+                                .map((header) => (
+                                    <td
+                                        key={header.key}
+                                        className={classNames({
+                                            'pre-wrap': header.key === ColumnKeys.OpCode,
+                                        })}
+                                        colSpan={header.footerSpan ?? undefined}
+                                    >
+                                        {getTotalsForFooter(header, data, hideHostOps)}
+                                    </td>
+                                ))}
+                    </tr>
+                </tfoot>
+            </table>
+        );
+    };
 
     return (
         <>
@@ -255,200 +460,7 @@ const PerformanceTable = ({
 
             {mergeDevices && <PerfMultiDeviceNotice />}
 
-            {data?.length > 0 ? (
-                <table className='perf-table monospace'>
-                    <thead className='table-header'>
-                        <tr>
-                            <th
-                                className='cell-header'
-                                aria-label='Tensor details'
-                            />
-                            {visibleColumns.map((h) => {
-                                const targetSortDirection =
-                                    // eslint-disable-next-line no-nested-ternary
-                                    sortingColumn === h.key
-                                        ? sortDirection === SortingDirection.ASC
-                                            ? SortingDirection.DESC
-                                            : SortingDirection.ASC
-                                        : sortDirection;
-
-                                return (
-                                    <th
-                                        key={h.key}
-                                        className='cell-header'
-                                    >
-                                        {h.sortable ? (
-                                            <Button
-                                                onClick={() => changeSorting(h.key)(targetSortDirection)}
-                                                variant={ButtonVariant.MINIMAL}
-                                                size={Size.SMALL}
-                                            >
-                                                <span className='header-label'>{h.name}</span>
-
-                                                {sortingColumn === h.key ? (
-                                                    <Icon
-                                                        className={classNames(
-                                                            {
-                                                                'is-active': sortingColumn === h.key,
-                                                            },
-                                                            'sort-icon',
-                                                        )}
-                                                        icon={
-                                                            sortDirection === SortingDirection.ASC
-                                                                ? IconNames.CARET_UP
-                                                                : IconNames.CARET_DOWN
-                                                        }
-                                                    />
-                                                ) : (
-                                                    <Icon
-                                                        className={classNames('sort-icon')}
-                                                        icon={IconNames.CARET_DOWN}
-                                                    />
-                                                )}
-                                            </Button>
-                                        ) : (
-                                            <span className='header-label no-button'>{h.name}</span>
-                                        )}
-
-                                        {/* TODO: May want this in the near future */}
-                                        {/* {h?.filterable && (
-                                                <div className='column-filter'>
-                                                    <InputGroup
-                                                        asyncControl
-                                                        size={Size.SMALL}
-                                                        onValueChange={(value) => updateColumnFilter(h.key, value)}
-                                                        placeholder='Filter...'
-                                                        value={filters?.[h.key]}
-                                                    />
-                                                </div>
-                                            )} */}
-                                    </th>
-                                );
-                            })}
-                        </tr>
-                    </thead>
-
-                    <tbody>
-                        {tableFields?.map((row, i) => {
-                            const isFirstOfOpRun = row.op === undefined || firstRowOfOpRun.has(row);
-                            const isSignpost = row.op_type === OpType.SIGNPOST;
-                            const isPrimarySelected = isPrimaryActiveReport && row.id === selectedPerfRowId;
-
-                            return (
-                                <Fragment key={i}>
-                                    <tr
-                                        className={classNames({
-                                            'missing-data': row.raw_op_code.includes('MISSING'),
-                                            'signpost-op': isSignpost,
-                                            'is-selected': isPrimarySelected,
-                                        })}
-                                    >
-                                        <td className='cell'>
-                                            {isPrimaryActiveReport && renderTensorDrawerTrigger(row)}
-                                        </td>
-                                        {visibleColumns.map((h) => (
-                                            <td
-                                                key={h.key}
-                                                className={classNames('cell', {
-                                                    'align-right': h.key === ColumnKeys.MathFidelity,
-                                                })}
-                                            >
-                                                {cellFormattingProxy(
-                                                    row,
-                                                    h,
-                                                    operationsList,
-                                                    filters?.[h.key],
-                                                    isFirstOfOpRun,
-                                                )}
-                                            </td>
-                                        ))}
-                                    </tr>
-
-                                    {comparisonDataTableFields?.length > 0 &&
-                                        comparisonDataTableFields.map((dataset, index) => {
-                                            const subRow = dataset[i];
-                                            const isActiveReportRow = index === activeReportComparisonIndex;
-                                            const isSubRowSelected =
-                                                isActiveReportRow && subRow?.id === selectedPerfRowId;
-
-                                            return (
-                                                <tr
-                                                    key={`comparison-${i}-${index}`}
-                                                    className={classNames(
-                                                        {
-                                                            'missing-data': subRow?.raw_op_code?.includes('MISSING'),
-                                                            'signpost-op': subRow?.op_type === OpType.SIGNPOST,
-                                                            'is-selected': isSubRowSelected,
-                                                        },
-                                                        'comparison-row',
-                                                        `pattern-${index >= PATTERN_COUNT ? index - PATTERN_COUNT : index}`,
-                                                    )}
-                                                >
-                                                    <td className='cell'>
-                                                        {isActiveReportRow && subRow
-                                                            ? renderTensorDrawerTrigger(subRow)
-                                                            : null}
-                                                    </td>
-                                                    {visibleColumns.map((h) => (
-                                                        <td
-                                                            key={h.key}
-                                                            className={classNames('cell', {
-                                                                'align-right': h.key === ColumnKeys.MathFidelity,
-                                                            })}
-                                                        >
-                                                            {comparisonKeys.includes(h.key) &&
-                                                                subRow &&
-                                                                formatCell(subRow, h, operationsList, filters?.[h.key])}
-                                                        </td>
-                                                    ))}
-                                                </tr>
-                                            );
-                                        })}
-                                    {provideMatmulAdvice && row.op_code.includes('Matmul') && (
-                                        <tr>
-                                            <td
-                                                colSpan={visibleColumns.length + 1}
-                                                className='cell advice'
-                                            >
-                                                <ul>
-                                                    {row?.advice.map((advice, j) => (
-                                                        <li key={`advice-${j}`}>{advice}</li>
-                                                    ))}
-                                                </ul>
-                                            </td>
-                                        </tr>
-                                    )}
-                                </Fragment>
-                            );
-                        })}
-                    </tbody>
-
-                    <tfoot className='table-footer'>
-                        <tr>
-                            <td />
-                            {visibleColumns.length > 0 &&
-                                data?.length > 0 &&
-                                visibleColumns
-                                    .filter((header) => header?.footerSpan !== 0)
-                                    .map((header) => (
-                                        <td
-                                            key={header.key}
-                                            className={classNames({
-                                                'pre-wrap': header.key === ColumnKeys.OpCode,
-                                            })}
-                                            colSpan={header.footerSpan ?? undefined}
-                                        >
-                                            {getTotalsForFooter(header, data, hideHostOps)}
-                                        </td>
-                                    ))}
-                        </tr>
-                    </tfoot>
-                </table>
-            ) : (
-                <p>
-                    <em>No data to display</em>
-                </p>
-            )}
+            {renderTable()}
 
             {canShowTensorDrawer && <PerfTensorDrawer rows={activeReportRows} />}
         </>

--- a/src/components/performance/PerfTableSkeleton.tsx
+++ b/src/components/performance/PerfTableSkeleton.tsx
@@ -4,6 +4,7 @@
 
 import { Classes } from '@blueprintjs/core';
 import classNames from 'classnames';
+import { TEST_IDS } from '../../definitions/TestIds';
 
 const SKELETON_ROW_COUNT = 12;
 
@@ -23,6 +24,7 @@ function PerfTableSkeleton({
             className='perf-table monospace'
             aria-busy='true'
             aria-label='Loading performance data'
+            data-testid={TEST_IDS.PERF_TABLE_SKELETON}
         >
             <thead className='table-header'>
                 <tr>

--- a/src/components/performance/PerfTableSkeleton.tsx
+++ b/src/components/performance/PerfTableSkeleton.tsx
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Classes } from '@blueprintjs/core';
+import classNames from 'classnames';
+
+const SKELETON_ROW_COUNT = 12;
+
+interface PerfTableSkeletonProps {
+    headers: string[];
+    rowCount?: number;
+    hasLeadingColumn?: boolean;
+}
+
+function PerfTableSkeleton({
+    headers,
+    rowCount = SKELETON_ROW_COUNT,
+    hasLeadingColumn = false,
+}: PerfTableSkeletonProps) {
+    return (
+        <table
+            className='perf-table monospace'
+            aria-busy='true'
+            aria-label='Loading performance data'
+        >
+            <thead className='table-header'>
+                <tr>
+                    {hasLeadingColumn && (
+                        <th
+                            className='cell-header'
+                            aria-hidden='true'
+                        />
+                    )}
+                    {headers.map((header) => (
+                        <th
+                            key={header}
+                            className='cell-header'
+                        >
+                            <span className='header-label no-button'>{header}</span>
+                        </th>
+                    ))}
+                </tr>
+            </thead>
+
+            <tbody>
+                {Array.from({ length: rowCount }, (_, rowIndex) => (
+                    <tr key={rowIndex}>
+                        {hasLeadingColumn && (
+                            <td className='cell'>
+                                <span className={classNames('skeleton-cell', Classes.SKELETON)} />
+                            </td>
+                        )}
+                        {headers.map((header) => (
+                            <td
+                                key={header}
+                                className='cell'
+                            >
+                                <span className={classNames('skeleton-cell', Classes.SKELETON)} />
+                            </td>
+                        ))}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}
+
+export default PerfTableSkeleton;

--- a/src/components/performance/StackedPerfTable.tsx
+++ b/src/components/performance/StackedPerfTable.tsx
@@ -20,7 +20,7 @@ import { formatStackedCell } from '../../functions/stackedPerfFunctions';
 import { TypedPerfTableRow } from '../../definitions/PerfTable';
 import { formatSize } from '../../functions/math';
 import PerfDeviceArchitecture from './PerfDeviceArchitecture';
-import LoadingSpinner from '../LoadingSpinner';
+import PerfTableSkeleton from './PerfTableSkeleton';
 import { PATTERN_COUNT } from '../../definitions/Performance';
 import { mergeDevicesAtom } from '../../store/app';
 import PerfMultiDeviceNotice from './PerfMultiDeviceNotice';
@@ -31,6 +31,7 @@ interface StackedPerformanceTableProps {
     stackedComparisonData: TypedStackedPerfRow[][];
     filters: Record<string, string> | null;
     reportName: string | null;
+    isLoading?: boolean;
 }
 
 const StackedPerformanceTable = ({
@@ -39,6 +40,7 @@ const StackedPerformanceTable = ({
     stackedComparisonData,
     filters,
     reportName,
+    isLoading = false,
 }: StackedPerformanceTableProps) => {
     const { sortTableFields, changeSorting, sortingColumn, sortDirection } = useSortTable(null);
     const { error: npeManifestError } = useGetNPEManifest();
@@ -56,9 +58,138 @@ const StackedPerformanceTable = ({
         [mergeDevices],
     );
 
-    if (!data) {
-        return <LoadingSpinner />;
-    }
+    const renderTable = () => {
+        if (isLoading) {
+            return <PerfTableSkeleton headers={computedTableColumns.map((column) => column.label)} />;
+        }
+
+        if (!stackedData?.length) {
+            return (
+                <p>
+                    <em>No data to display</em>
+                </p>
+            );
+        }
+
+        return (
+            <table className='perf-table monospace'>
+                <thead className='table-header'>
+                    <tr>
+                        {computedTableColumns.map((column) => {
+                            const targetSortDirection =
+                                // eslint-disable-next-line no-nested-ternary
+                                sortingColumn === column.key
+                                    ? sortDirection === SortingDirection.ASC
+                                        ? SortingDirection.DESC
+                                        : SortingDirection.ASC
+                                    : sortDirection;
+
+                            return (
+                                <th
+                                    key={column.key}
+                                    className='cell-header'
+                                >
+                                    {column.sortable ? (
+                                        <Button
+                                            onClick={() => changeSorting(column.key)(targetSortDirection)}
+                                            variant={ButtonVariant.MINIMAL}
+                                            size={Size.SMALL}
+                                        >
+                                            <span className='header-label'>{column.label}</span>
+                                            {sortingColumn === column.key ? (
+                                                <Icon
+                                                    className={classNames(
+                                                        {
+                                                            'is-active': sortingColumn === column.key,
+                                                        },
+                                                        'sort-icon',
+                                                    )}
+                                                    icon={
+                                                        sortDirection === SortingDirection.ASC
+                                                            ? IconNames.CARET_UP
+                                                            : IconNames.CARET_DOWN
+                                                    }
+                                                />
+                                            ) : (
+                                                <Icon
+                                                    className={classNames('sort-icon')}
+                                                    icon={IconNames.CARET_DOWN}
+                                                />
+                                            )}
+                                        </Button>
+                                    ) : (
+                                        <span className='header-label no-button'>{column.label}</span>
+                                    )}
+                                </th>
+                            );
+                        })}
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {tableFields?.map((row, i) => (
+                        <Fragment key={`row-${i}`}>
+                            <tr>
+                                {computedTableColumns.map((column: StackedTableColumn) => (
+                                    <td
+                                        key={column.key}
+                                        className={classNames('cell')}
+                                    >
+                                        {formatStackedCell(row, column, filters?.[column.key])}
+                                    </td>
+                                ))}
+                            </tr>
+
+                            {stackedComparisonData.map((comparisonDataset, datasetIndex) => {
+                                const matchingRow = comparisonDataset.find(
+                                    (stackedRow) =>
+                                        stackedRow[StackedColumnKeys.OpCode] === row[StackedColumnKeys.OpCode],
+                                );
+
+                                return (
+                                    <tr
+                                        key={`comparison-${i}-${datasetIndex}`}
+                                        className={classNames(
+                                            'comparison-row',
+                                            `pattern-${datasetIndex >= PATTERN_COUNT ? datasetIndex - PATTERN_COUNT : datasetIndex}`,
+                                        )}
+                                    >
+                                        {computedTableColumns.map((column: StackedTableColumn) => (
+                                            <td
+                                                key={`comparison-${column.key}`}
+                                                className='cell'
+                                            >
+                                                {matchingRow
+                                                    ? formatStackedCell(matchingRow, column, filters?.[column.key])
+                                                    : ''}
+                                            </td>
+                                        ))}
+                                    </tr>
+                                );
+                            })}
+                        </Fragment>
+                    ))}
+                </tbody>
+
+                <tfoot className='table-footer'>
+                    <tr>
+                        {stackedData &&
+                            stackedData?.length > 0 &&
+                            computedTableColumns.map((column) => (
+                                <td
+                                    key={`footer-${column.key}`}
+                                    className={classNames({
+                                        'no-wrap': column.key === StackedColumnKeys.OpCode,
+                                    })}
+                                >
+                                    {getTotalsForFooter(column, stackedData)}
+                                </td>
+                            ))}
+                    </tr>
+                </tfoot>
+            </table>
+        );
+    };
 
     return (
         <>
@@ -80,128 +211,7 @@ const StackedPerformanceTable = ({
 
             {mergeDevices && <PerfMultiDeviceNotice />}
 
-            {stackedData && stackedData?.length > 0 ? (
-                <table className='perf-table monospace'>
-                    <thead className='table-header'>
-                        <tr>
-                            {computedTableColumns.map((column) => {
-                                const targetSortDirection =
-                                    // eslint-disable-next-line no-nested-ternary
-                                    sortingColumn === column.key
-                                        ? sortDirection === SortingDirection.ASC
-                                            ? SortingDirection.DESC
-                                            : SortingDirection.ASC
-                                        : sortDirection;
-
-                                return (
-                                    <th
-                                        key={column.key}
-                                        className='cell-header'
-                                    >
-                                        {column.sortable ? (
-                                            <Button
-                                                onClick={() => changeSorting(column.key)(targetSortDirection)}
-                                                variant={ButtonVariant.MINIMAL}
-                                                size={Size.SMALL}
-                                            >
-                                                <span className='header-label'>{column.label}</span>
-                                                {sortingColumn === column.key ? (
-                                                    <Icon
-                                                        className={classNames(
-                                                            {
-                                                                'is-active': sortingColumn === column.key,
-                                                            },
-                                                            'sort-icon',
-                                                        )}
-                                                        icon={
-                                                            sortDirection === SortingDirection.ASC
-                                                                ? IconNames.CARET_UP
-                                                                : IconNames.CARET_DOWN
-                                                        }
-                                                    />
-                                                ) : (
-                                                    <Icon
-                                                        className={classNames('sort-icon')}
-                                                        icon={IconNames.CARET_DOWN}
-                                                    />
-                                                )}
-                                            </Button>
-                                        ) : (
-                                            <span className='header-label no-button'>{column.label}</span>
-                                        )}
-                                    </th>
-                                );
-                            })}
-                        </tr>
-                    </thead>
-
-                    <tbody>
-                        {tableFields?.map((row, i) => (
-                            <Fragment key={`row-${i}`}>
-                                <tr>
-                                    {computedTableColumns.map((column: StackedTableColumn) => (
-                                        <td
-                                            key={column.key}
-                                            className={classNames('cell')}
-                                        >
-                                            {formatStackedCell(row, column, filters?.[column.key])}
-                                        </td>
-                                    ))}
-                                </tr>
-
-                                {stackedComparisonData.map((comparisonDataset, datasetIndex) => {
-                                    const matchingRow = comparisonDataset.find(
-                                        (stackedRow) =>
-                                            stackedRow[StackedColumnKeys.OpCode] === row[StackedColumnKeys.OpCode],
-                                    );
-
-                                    return (
-                                        <tr
-                                            key={`comparison-${i}-${datasetIndex}`}
-                                            className={classNames(
-                                                'comparison-row',
-                                                `pattern-${datasetIndex >= PATTERN_COUNT ? datasetIndex - PATTERN_COUNT : datasetIndex}`,
-                                            )}
-                                        >
-                                            {computedTableColumns.map((column: StackedTableColumn) => (
-                                                <td
-                                                    key={`comparison-${column.key}`}
-                                                    className='cell'
-                                                >
-                                                    {matchingRow
-                                                        ? formatStackedCell(matchingRow, column, filters?.[column.key])
-                                                        : ''}
-                                                </td>
-                                            ))}
-                                        </tr>
-                                    );
-                                })}
-                            </Fragment>
-                        ))}
-                    </tbody>
-
-                    <tfoot className='table-footer'>
-                        <tr>
-                            {stackedData &&
-                                stackedData?.length > 0 &&
-                                computedTableColumns.map((column) => (
-                                    <td
-                                        key={`footer-${column.key}`}
-                                        className={classNames({
-                                            'no-wrap': column.key === StackedColumnKeys.OpCode,
-                                        })}
-                                    >
-                                        {getTotalsForFooter(column, stackedData)}
-                                    </td>
-                                ))}
-                        </tr>
-                    </tfoot>
-                </table>
-            ) : (
-                <p>
-                    <em>No data to display</em>
-                </p>
-            )}
+            {renderTable()}
         </>
     );
 };

--- a/src/definitions/TestIds.ts
+++ b/src/definitions/TestIds.ts
@@ -29,6 +29,7 @@ export const TEST_IDS = Object.freeze({
     PERFORMANCE_TABLE: 'performance-table',
     PERF_TENSOR_DRAWER: 'perf-tensor-drawer',
     PERF_TENSOR_DRAWER_OPEN_BUTTON: 'perf-tensor-drawer-open-button',
+    PERF_TABLE_SKELETON: 'perf-table-skeleton',
 
     // General UI
     LOADING_SPINNER: 'loading-spinner',

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -59,7 +59,7 @@ export default function Performance() {
         isLoading: isLoadingPerformance,
         error: perfDataError,
     } = usePerformanceReport(activePerformanceReport?.reportName || null);
-    const { data: comparisonData } = usePerformanceComparisonReport();
+    const { data: comparisonData, isLoading: isLoadingComparison } = usePerformanceComparisonReport();
     const { data: folderList } = usePerfFolderList();
     const perfRange = usePerformanceRange();
     const opIdsMap = useOpToPerfIdFiltered();
@@ -271,6 +271,7 @@ export default function Performance() {
                             signposts={data?.signposts}
                             hasL1PressureData={hasL1PressureData}
                             isLoading={isLoadingPerformance}
+                            isComparisonLoading={isLoadingComparison}
                         />
                     }
                 />

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -208,10 +208,6 @@ export default function Performance() {
         }
     }, [appliedOpCodeOptionsKey, opCodeOptionsKey, opCodeOptions]);
 
-    if (isLoadingPerformance && !perfDataError) {
-        return <LoadingSpinner />;
-    }
-
     if (perfDataError?.status === HttpStatusCode.UnprocessableEntity) {
         return (
             <>
@@ -274,6 +270,7 @@ export default function Performance() {
                             comparisonStackedData={enrichedComparisonStackedData}
                             signposts={data?.signposts}
                             hasL1PressureData={hasL1PressureData}
+                            isLoading={isLoadingPerformance}
                         />
                     }
                 />

--- a/src/scss/components/PerfReport.scss
+++ b/src/scss/components/PerfReport.scss
@@ -46,6 +46,12 @@ $header-footer-border: 2px solid colours.$tt-grey-5;
     .perf-table {
         border-collapse: collapse;
         width: 100%;
+
+        .skeleton-cell {
+            display: block;
+            height: 14px;
+            min-width: 40px;
+        }
     }
 
     .header-aside {

--- a/tests/PerfReport.spec.tsx
+++ b/tests/PerfReport.spec.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PerformanceReport from '../src/components/performance/PerfReport';
+import { TypedPerfTableRow } from '../src/definitions/PerfTable';
+import { OpType } from '../src/definitions/Performance';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList, usePerfMeta } from '../src/hooks/useAPI';
+import { comparisonPerformanceReportListAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useGetNPEManifest: vi.fn(),
+    useOpToPerfIdFiltered: vi.fn(),
+    useOperationsList: vi.fn(),
+    usePerfMeta: vi.fn(),
+}));
+
+const COMPARISON_REPORT = 'report-b';
+
+const row = (opCode: string): TypedPerfTableRow =>
+    ({
+        op_type: OpType.DEVICE_OP,
+        op_code: opCode,
+        raw_op_code: opCode,
+        advice: [],
+        bound: null,
+        isFirstHashOccurrence: true,
+        id: 1,
+    }) as unknown as TypedPerfTableRow;
+
+interface RenderOptions {
+    isLoading?: boolean;
+    isComparisonLoading?: boolean;
+    comparisonData?: TypedPerfTableRow[][];
+    comparisonReports?: string[] | null;
+}
+
+function renderReport({
+    isLoading = false,
+    isComparisonLoading = false,
+    comparisonData = [],
+    comparisonReports = null,
+}: RenderOptions = {}) {
+    return render(
+        <TestProviders
+            initialAtomValues={comparisonReports ? [[comparisonPerformanceReportListAtom, comparisonReports]] : []}
+        >
+            <PerformanceReport
+                data={[row('Matmul')]}
+                comparisonData={comparisonData}
+                stackedData={[]}
+                comparisonStackedData={[]}
+                isLoading={isLoading}
+                isComparisonLoading={isComparisonLoading}
+            />
+        </TestProviders>,
+    );
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    (useGetNPEManifest as Mock).mockReturnValue({ data: [], error: null });
+    (useOpToPerfIdFiltered as Mock).mockReturnValue([]);
+    (useOperationsList as Mock).mockReturnValue({ data: [] });
+    (usePerfMeta as Mock).mockReturnValue({ data: null, isLoading: false });
+});
+
+describe('PerformanceReport loading state', () => {
+    it('skeletons the active tab while a comparison dataset loads, even though active rows are present', () => {
+        renderReport({ isComparisonLoading: true });
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeInTheDocument();
+        // The already-loaded active rows are hidden behind the skeleton rather than popping in alongside
+        // the incoming comparison sub-rows.
+        expect(screen.queryByText('Matmul')).not.toBeInTheDocument();
+    });
+
+    it('renders active rows without a skeleton once both datasets are loaded', () => {
+        renderReport();
+
+        expect(screen.queryByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeNull();
+        expect(screen.getAllByText('Matmul').length).toBeGreaterThan(0);
+    });
+
+    it('skeletons a comparison tab while its dataset loads instead of flashing the empty state', () => {
+        renderReport({
+            isComparisonLoading: true,
+            comparisonData: [[row('Matmul')]],
+            comparisonReports: [COMPARISON_REPORT],
+        });
+
+        fireEvent.click(screen.getByRole('tab', { name: COMPARISON_REPORT }));
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeInTheDocument();
+        expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+    });
+});

--- a/tests/PerfTable.spec.tsx
+++ b/tests/PerfTable.spec.tsx
@@ -264,6 +264,75 @@ describe('PerfTable tensor-drawer trigger column', () => {
     });
 });
 
+describe('PerfTable loading state', () => {
+    beforeEach(() => {
+        (useOpToPerfIdFiltered as Mock).mockReturnValue([]);
+    });
+
+    it('renders the skeleton instead of data rows while loading', () => {
+        render(
+            <TestProviders>
+                <PerfTable
+                    data={[matmulRow]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                    isLoading
+                />
+            </TestProviders>,
+        );
+
+        const skeleton = screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON);
+        expect(skeleton).toBeInTheDocument();
+        expect(skeleton).toHaveAttribute('aria-busy', 'true');
+        // No real data rows or footer totals leak through while loading
+        expect(screen.queryByText('Matmul')).not.toBeInTheDocument();
+        expect(screen.queryByTestId(TEST_IDS.PERF_TENSOR_DRAWER_OPEN_BUTTON)).toBeNull();
+    });
+
+    it('keeps the device-architecture strip mounted while loading (scoped skeleton)', () => {
+        render(
+            <TestProviders>
+                <PerfTable
+                    data={[]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                    isLoading
+                />
+            </TestProviders>,
+        );
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeInTheDocument();
+        expect(screen.getByText('Arch:')).toBeInTheDocument();
+    });
+
+    it('shows the empty state rather than the skeleton when not loading and there are no rows', () => {
+        render(
+            <TestProviders>
+                <PerfTable
+                    data={[]}
+                    comparisonData={[]}
+                    filters={null}
+                    provideMatmulAdvice={false}
+                    hiliteHighDispatch={false}
+                    reportName='unit-test'
+                    showHashColumn={false}
+                />
+            </TestProviders>,
+        );
+
+        expect(screen.queryByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeNull();
+        expect(screen.getByText('No data to display')).toBeInTheDocument();
+    });
+});
+
 function SelectedRowProbe() {
     const selected = useAtomValue(selectedPerfRowIdAtom);
 

--- a/tests/PerfTableSkeleton.spec.tsx
+++ b/tests/PerfTableSkeleton.spec.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { Classes } from '@blueprintjs/core';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import PerfTableSkeleton from '../src/components/performance/PerfTableSkeleton';
+import { TEST_IDS } from '../src/definitions/TestIds';
+
+const HEADERS = ['ID', 'OP Code', 'Device Time'];
+
+afterEach(cleanup);
+
+describe('PerfTableSkeleton', () => {
+    it('renders the provided headers as real text', () => {
+        render(<PerfTableSkeleton headers={HEADERS} />);
+
+        HEADERS.forEach((header) => {
+            expect(screen.getByText(header)).toBeInTheDocument();
+        });
+    });
+
+    it('renders the requested number of skeleton rows and one skeleton cell per header', () => {
+        const rowCount = 5;
+        render(
+            <PerfTableSkeleton
+                headers={HEADERS}
+                rowCount={rowCount}
+            />,
+        );
+
+        const body = screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON).querySelector('tbody')!;
+        const rows = within(body).getAllByRole('row');
+        expect(rows).toHaveLength(rowCount);
+
+        rows.forEach((row) => {
+            expect(row.querySelectorAll(`.${Classes.SKELETON}`)).toHaveLength(HEADERS.length);
+        });
+    });
+
+    it('adds a leading column to the header and every body row when hasLeadingColumn is set', () => {
+        render(
+            <PerfTableSkeleton
+                headers={HEADERS}
+                rowCount={3}
+                hasLeadingColumn
+            />,
+        );
+
+        const table = screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON);
+        // The leading column header is aria-hidden, so query the DOM directly rather than by role.
+        const headerCells = table.querySelector('thead')!.querySelectorAll('th');
+        expect(headerCells).toHaveLength(HEADERS.length + 1);
+
+        const body = table.querySelector('tbody')!;
+        within(body)
+            .getAllByRole('row')
+            .forEach((row) => {
+                expect(row.querySelectorAll(`.${Classes.SKELETON}`)).toHaveLength(HEADERS.length + 1);
+            });
+    });
+
+    it('exposes an accessible busy state for screen readers', () => {
+        render(<PerfTableSkeleton headers={HEADERS} />);
+
+        const skeleton = screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON);
+        expect(skeleton).toHaveAttribute('aria-busy', 'true');
+        expect(skeleton).toHaveAccessibleName('Loading performance data');
+    });
+});

--- a/tests/Performance.spec.tsx
+++ b/tests/Performance.spec.tsx
@@ -32,6 +32,13 @@ vi.mock('../src/functions/getServerConfig', () => ({
     default: () => ({ SERVER_MODE: true }),
 }));
 
+// Stub the report shell so these tests exercise only the route's own
+// active-report effects, not PerfTable's selection cleanup effect (which would
+// otherwise clear selectedPerfRowIdAtom while the skeleton is mounted).
+vi.mock('../src/components/performance/PerfReport', () => ({
+    default: () => <div data-testid='perf-report-stub' />,
+}));
+
 const REPORT_A = { path: '/reports/a', reportName: 'report-a' };
 const REPORT_B = { path: '/reports/b', reportName: 'report-b' };
 const SELECTED_ROW_ID = 100;
@@ -39,9 +46,8 @@ const SELECTED_ROW_ID = 100;
 afterEach(cleanup);
 
 beforeEach(() => {
-    // Keep Performance in its loading-spinner early-return path so the test does
-    // not have to mount the full table/chart subtree. Effects still run after
-    // commit, which is exactly what we want to exercise.
+    // Loading state: the route keeps its shell mounted (no full-page spinner) and the
+    // report shell is stubbed, so only the route's active-report effects run here.
     (usePerformanceReport as Mock).mockReturnValue({ data: undefined, isLoading: true, error: null });
     (usePerformanceComparisonReport as Mock).mockReturnValue({ data: undefined });
     (usePerfFolderList as Mock).mockReturnValue({ data: undefined });

--- a/tests/StackedPerfTable.spec.tsx
+++ b/tests/StackedPerfTable.spec.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import StackedPerformanceTable from '../src/components/performance/StackedPerfTable';
+import { StackedColumnKeys, TypedStackedPerfRow } from '../src/definitions/StackedPerfTable';
+import { OpType } from '../src/definitions/Performance';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import { useGetNPEManifest, usePerfMeta } from '../src/hooks/useAPI';
+import { TestProviders } from './helpers/TestProviders';
+
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useGetNPEManifest: vi.fn(),
+    usePerfMeta: vi.fn(),
+}));
+
+const stackedRow = (opCode: string): TypedStackedPerfRow =>
+    ({
+        [StackedColumnKeys.Percent]: 100,
+        [StackedColumnKeys.OpCode]: opCode,
+        [StackedColumnKeys.Device]: 0,
+        [StackedColumnKeys.DeviceTimeSumUs]: 1,
+        [StackedColumnKeys.OpsCount]: 1,
+        op_type: OpType.DEVICE_OP,
+    }) as unknown as TypedStackedPerfRow;
+
+interface RenderOptions {
+    stackedData?: TypedStackedPerfRow[];
+    isLoading?: boolean;
+}
+
+function renderStacked({ stackedData = [], isLoading = false }: RenderOptions = {}) {
+    return render(
+        <TestProviders>
+            <StackedPerformanceTable
+                data={[]}
+                stackedData={stackedData}
+                stackedComparisonData={[]}
+                filters={null}
+                reportName='unit-test'
+                isLoading={isLoading}
+            />
+        </TestProviders>,
+    );
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    (useGetNPEManifest as Mock).mockReturnValue({ data: [], error: null });
+    (usePerfMeta as Mock).mockReturnValue({ data: null, isLoading: false });
+});
+
+describe('StackedPerformanceTable loading state', () => {
+    it('renders the skeleton instead of data rows while loading', () => {
+        renderStacked({ stackedData: [stackedRow('Matmul')], isLoading: true });
+
+        const skeleton = screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON);
+        expect(skeleton).toBeInTheDocument();
+        expect(skeleton).toHaveAttribute('aria-busy', 'true');
+        expect(screen.queryByText('Matmul')).not.toBeInTheDocument();
+    });
+
+    it('keeps the device-architecture strip mounted while loading (scoped skeleton)', () => {
+        renderStacked({ isLoading: true });
+
+        expect(screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeInTheDocument();
+        expect(screen.getByText('Arch:')).toBeInTheDocument();
+    });
+
+    it('shows the empty state rather than the skeleton when not loading and there are no rows', () => {
+        renderStacked();
+
+        expect(screen.queryByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeNull();
+        expect(screen.getByText('No data to display')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Adds lightly animated skeletal UI when the perf table is loading its data instead of reloading the entire view.

<img width="1728" height="879" alt="Screenshot 2026-06-08 at 11 29 25" src="https://github.com/user-attachments/assets/4eb5fc5f-e169-493a-be40-292f2657d6da" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1629.