### PR TITLE
Support pre-aggregated buffer-pages chunks for new and legacy formats

### DIFF
--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -98,6 +98,29 @@ class BufferPage(SerializeableDataclass):
 
 
 @dataclasses.dataclass
+class BufferChunk(SerializeableDataclass):
+    """
+    Per-(operation, device, address, bank, core) collapsed view of buffer pages.
+
+    Sourced either from a pre-aggregated ``buffer_chunks`` table or by
+    aggregating the legacy ``buffer_pages`` table on the fly.
+    """
+
+    operation_id: int
+    device_id: int
+    address: int
+    bank_id: int
+    core_x: int
+    core_y: int
+    chunk_address: int
+    chunk_size: int
+    page_size: int
+    num_pages: int
+    buffer_type: BufferType
+    rank: int = 0
+
+
+@dataclasses.dataclass
 class ProducersConsumers(SerializeableDataclass):
     tensor_id: int
     producers: list[int]

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -26,6 +26,7 @@ from ttnn_visualizer.exceptions import (
 )
 from ttnn_visualizer.models import (
     Buffer,
+    BufferChunk,
     BufferPage,
     Device,
     DeviceOperation,
@@ -390,6 +391,100 @@ class DatabaseQueries:
         rows = self._query_table("buffer_pages", filters, select_clause=select_clause)
         for row in rows:
             yield BufferPage(*row)
+
+    def buffer_chunks_source_table(self) -> Optional[str]:
+        """
+        Pick the source table for per-(op, addr, bank, core) chunk reads.
+
+        Returns ``"buffer_chunks"`` when the new pre-aggregated table is
+        present, ``"buffer_pages"`` when only the legacy table exists, and
+        ``None`` when neither is available.
+        """
+        if self._check_table_exists("buffer_chunks"):
+            return "buffer_chunks"
+        if self._check_table_exists("buffer_pages"):
+            return "buffer_pages"
+        return None
+
+    def query_buffer_chunks(
+        self, filters: Optional[Dict[str, Any]] = None
+    ) -> Generator[BufferChunk, None, None]:
+        """
+        Yield ``BufferChunk`` rows from whichever source table is available.
+
+        Prefers a pre-aggregated ``buffer_chunks`` table; falls back to a
+        ``GROUP BY`` aggregation over the legacy ``buffer_pages`` table.
+        """
+        source = self.buffer_chunks_source_table()
+        if source == "buffer_chunks":
+            select_clause = self._dataclass_select_clause("buffer_chunks", BufferChunk)
+            rows = self._query_table(
+                "buffer_chunks", filters, select_clause=select_clause
+            )
+            for row in rows:
+                yield BufferChunk(*row)
+            return
+        if source == "buffer_pages":
+            yield from self._aggregate_buffer_pages_to_chunks(filters)
+
+    def _aggregate_buffer_pages_to_chunks(
+        self, filters: Optional[Dict[str, Any]] = None
+    ) -> Generator[BufferChunk, None, None]:
+        """
+        Group ``buffer_pages`` rows into ``BufferChunk`` rows on the fly.
+
+        Matches the historical FE collapse in ``pageDataToChunkArray``:
+        ``chunk_address = MIN(page_address)`` and
+        ``chunk_size = MAX(page_address + page_size) - MIN(page_address)``
+        per ``(operation_id, device_id, address, bank_id, core_x, core_y)``.
+        """
+        page_columns = set(self._get_table_columns("buffer_pages"))
+        has_rank = "rank" in page_columns
+
+        where_parts: List[str] = ["1=1"]
+        params: List[Any] = []
+        if filters:
+            for column, value in filters.items():
+                if value is None:
+                    continue
+                if isinstance(value, list):
+                    if not value:
+                        continue
+                    placeholders = ", ".join(["?"] * len(value))
+                    where_parts.append(f"{column} IN ({placeholders})")
+                    params.extend(value)
+                else:
+                    where_parts.append(f"{column} = ?")
+                    params.append(value)
+        where_clause = " AND ".join(where_parts)
+
+        rank_select = "rank" if has_rank else "0"
+        rank_group = ", rank" if has_rank else ""
+
+        query = f"""
+            SELECT
+                operation_id,
+                device_id,
+                address,
+                bank_id,
+                core_x,
+                core_y,
+                MIN(page_address) AS chunk_address,
+                MAX(page_address + page_size) - MIN(page_address) AS chunk_size,
+                MAX(page_size) AS page_size,
+                COUNT(*) AS num_pages,
+                buffer_type,
+                {rank_select} AS rank
+            FROM buffer_pages
+            WHERE {where_clause}
+            GROUP BY
+                operation_id, device_id, address,
+                bank_id, core_x, core_y, buffer_type{rank_group}
+        """
+
+        rows = self.query_runner.execute_query(query, params)
+        for row in rows:
+            yield BufferChunk(*row)
 
     def query_tensors(
         self, filters: Optional[Dict[str, Any]] = None

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -433,10 +433,12 @@ class DatabaseQueries:
         """
         Group ``buffer_pages`` rows into ``BufferChunk`` rows on the fly.
 
-        Matches the historical FE collapse in ``pageDataToChunkArray``:
-        ``chunk_address = MIN(page_address)`` and
+        Mirrors the client-side ``aggregatePagesToChunks`` fallback in
+        ``src/functions/normalizeBufferPagesResponse.ts`` so both paths emit
+        identical chunks: ``chunk_address = MIN(page_address)`` and
         ``chunk_size = MAX(page_address + page_size) - MIN(page_address)``
-        per ``(operation_id, device_id, address, bank_id, core_x, core_y)``.
+        per ``(operation_id, device_id, address, bank_id, core_x, core_y,
+        buffer_type[, rank])``.
         """
         page_columns = set(self._get_table_columns("buffer_pages"))
         has_rank = "rank" in page_columns

--- a/backend/ttnn_visualizer/serializers.py
+++ b/backend/ttnn_visualizer/serializers.py
@@ -186,6 +186,24 @@ def serialize_buffer_pages(buffer_pages):
     return buffer_pages_list
 
 
+def serialize_buffer_chunks(buffer_chunks):
+    """
+    Serialize ``BufferChunk`` rows for the ``/api/buffer-pages`` response.
+
+    The synthetic ``id`` field combines the grouping key so each row stays
+    stable across re-fetches even though ``page_index`` no longer exists.
+    """
+    result = [chunk.to_dict() for chunk in buffer_chunks]
+    for chunk in result:
+        chunk["id"] = (
+            f"{chunk['operation_id']}_{chunk['address']}_{chunk['bank_id']}_"
+            f"{chunk['core_x']}_{chunk['core_y']}"
+        )
+        if "buffer_type" in chunk and isinstance(chunk["buffer_type"], BufferType):
+            chunk["buffer_type"] = chunk["buffer_type"].value
+    return result
+
+
 def comparisons_by_tensor_id(
     local_comparisons: List[TensorComparisonRecord],
     global_comparisons: List[TensorComparisonRecord],

--- a/backend/ttnn_visualizer/serializers.py
+++ b/backend/ttnn_visualizer/serializers.py
@@ -190,17 +190,20 @@ def serialize_buffer_chunks(buffer_chunks):
     """
     Serialize ``BufferChunk`` rows for the ``/api/buffer-pages`` response.
 
-    The synthetic ``id`` field combines the grouping key so each row stays
-    stable across re-fetches even though ``page_index`` no longer exists.
+    The synthetic ``id`` encodes the full GROUP BY tuple — ``operation_id``,
+    ``device_id``, ``address``, ``bank_id``, ``core_x``, ``core_y``,
+    ``buffer_type``, ``rank`` — so rows from multi-device / mixed-rank /
+    mixed-type responses cannot collide on the same id. ``BufferChunk.to_dict``
+    already unwraps the ``buffer_type`` enum to its int value, so the f-string
+    embeds the same scalar the client sees.
     """
     result = [chunk.to_dict() for chunk in buffer_chunks]
     for chunk in result:
         chunk["id"] = (
-            f"{chunk['operation_id']}_{chunk['address']}_{chunk['bank_id']}_"
-            f"{chunk['core_x']}_{chunk['core_y']}"
+            f"{chunk['operation_id']}_{chunk['device_id']}_{chunk['address']}_"
+            f"{chunk['bank_id']}_{chunk['core_x']}_{chunk['core_y']}_"
+            f"{chunk['buffer_type']}_{chunk['rank']}"
         )
-        if "buffer_type" in chunk and isinstance(chunk["buffer_type"], BufferType):
-            chunk["buffer_type"] = chunk["buffer_type"].value
     return result
 
 

--- a/backend/ttnn_visualizer/tests/test_queries.py
+++ b/backend/ttnn_visualizer/tests/test_queries.py
@@ -9,7 +9,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from ttnn_visualizer.exceptions import ProfilerReportNotLoadedException
-from ttnn_visualizer.models import DeviceOperation, TensorComparisonRecord
+from ttnn_visualizer.models import BufferChunk, DeviceOperation, TensorComparisonRecord
 from ttnn_visualizer.queries import DatabaseQueries, LocalQueryRunner
 
 
@@ -401,6 +401,53 @@ class TestDatabaseQueries(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].address, 100)
 
+    def test_buffer_chunks_source_table_prefers_legacy_when_no_new_table(self):
+        self.assertEqual(self.db_queries.buffer_chunks_source_table(), "buffer_pages")
+
+    def test_query_buffer_chunks_aggregates_legacy_buffer_pages(self):
+        # Two pages on bank 1 / (0,0) at address 100, contiguous: 1000..1024 and 1024..1048.
+        # One page on bank 2 / (1,0) at address 200.
+        self.connection.executemany(
+            "INSERT INTO buffer_pages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (1, 0, 100, 0, 0, 1, 0, 1000, 24, 0),
+                (1, 0, 100, 0, 0, 1, 1, 1024, 24, 0),
+                (1, 0, 200, 0, 1, 2, 0, 2000, 16, 1),
+                # Different op_id should not bleed into the op_id=1 group.
+                (2, 0, 100, 0, 0, 1, 0, 5000, 8, 0),
+            ],
+        )
+
+        chunks = sorted(
+            self.db_queries.query_buffer_chunks(filters={"operation_id": 1}),
+            key=lambda c: (c.address, c.bank_id),
+        )
+
+        self.assertEqual(len(chunks), 2)
+
+        first, second = chunks
+        self.assertEqual(first.address, 100)
+        self.assertEqual(first.bank_id, 1)
+        self.assertEqual(first.core_x, 0)
+        self.assertEqual(first.core_y, 0)
+        self.assertEqual(first.chunk_address, 1000)
+        # max(page_address + page_size) - min(page_address) = (1024+24) - 1000 = 48
+        self.assertEqual(first.chunk_size, 48)
+        self.assertEqual(first.page_size, 24)
+        self.assertEqual(first.num_pages, 2)
+
+        self.assertEqual(second.address, 200)
+        self.assertEqual(second.bank_id, 2)
+        self.assertEqual(second.chunk_address, 2000)
+        self.assertEqual(second.chunk_size, 16)
+        self.assertEqual(second.num_pages, 1)
+
+    def test_query_buffer_chunks_returns_empty_when_no_source_table(self):
+        self.connection.execute("DROP TABLE buffer_pages")
+        chunks = list(self.db_queries.query_buffer_chunks())
+        self.assertEqual(chunks, [])
+        self.assertIsNone(self.db_queries.buffer_chunks_source_table())
+
     def test_query_tensors(self):
         self.connection.execute(
             "INSERT INTO tensors VALUES (1, '(2,2)', 'float32', 'NCHW', 'default', 1, 100, 0)"
@@ -452,6 +499,92 @@ class TestDatabaseQueries(unittest.TestCase):
         result = self.db_queries.query_next_buffer(operation_id=1, address=100)
         self.assertIsNotNone(result)
         self.assertEqual(result.operation_id, 2)
+
+
+class TestBufferChunksSourceSelection(unittest.TestCase):
+    """
+    Covers the dispatch in ``query_buffer_chunks`` between the new
+    pre-aggregated ``buffer_chunks`` table and the legacy ``buffer_pages``
+    fallback.
+    """
+
+    def _setup_connection_with_chunks_table(self):
+        connection = sqlite3.connect(":memory:")
+        connection.executescript("""
+            CREATE TABLE buffer_chunks (
+                operation_id INTEGER,
+                device_id INTEGER,
+                address INTEGER,
+                bank_id INTEGER,
+                core_x INTEGER,
+                core_y INTEGER,
+                chunk_address INTEGER,
+                chunk_size INTEGER,
+                page_size INTEGER,
+                num_pages INTEGER,
+                buffer_type INTEGER,
+                rank INTEGER DEFAULT 0
+            );
+            """)
+        return connection
+
+    def test_prefers_buffer_chunks_when_present(self):
+        connection = self._setup_connection_with_chunks_table()
+        # Also create buffer_pages with bogus content; we must NOT read it.
+        connection.executescript("""
+            CREATE TABLE buffer_pages (
+                operation_id INTEGER, device_id INTEGER, address INTEGER,
+                core_y INTEGER, core_x INTEGER, bank_id INTEGER,
+                page_index INTEGER, page_address INTEGER, page_size INTEGER,
+                buffer_type INTEGER
+            );
+            """)
+        connection.execute(
+            "INSERT INTO buffer_pages VALUES (99, 99, 999, 9, 9, 9, 0, 99999, 99999, 0)"
+        )
+        connection.execute(
+            "INSERT INTO buffer_chunks "
+            "(operation_id, device_id, address, bank_id, core_x, core_y, "
+            "chunk_address, chunk_size, page_size, num_pages, buffer_type, rank) "
+            "VALUES (1, 0, 100, 1, 0, 0, 1000, 48, 24, 2, 0, 0)"
+        )
+
+        db = DatabaseQueries(connection=connection)
+        self.assertEqual(db.buffer_chunks_source_table(), "buffer_chunks")
+
+        chunks = list(db.query_buffer_chunks(filters={"operation_id": 1}))
+        self.assertEqual(len(chunks), 1)
+        chunk = chunks[0]
+        self.assertIsInstance(chunk, BufferChunk)
+        self.assertEqual(chunk.address, 100)
+        self.assertEqual(chunk.chunk_size, 48)
+        self.assertEqual(chunk.num_pages, 2)
+        # Verify nothing leaked from buffer_pages.
+        self.assertNotEqual(chunk.address, 999)
+        connection.close()
+
+    def test_falls_back_to_buffer_pages_aggregation(self):
+        connection = sqlite3.connect(":memory:")
+        connection.executescript("""
+            CREATE TABLE buffer_pages (
+                operation_id INTEGER, device_id INTEGER, address INTEGER,
+                core_y INTEGER, core_x INTEGER, bank_id INTEGER,
+                page_index INTEGER, page_address INTEGER, page_size INTEGER,
+                buffer_type INTEGER
+            );
+            """)
+        connection.execute(
+            "INSERT INTO buffer_pages VALUES (1, 0, 100, 0, 0, 1, 0, 1000, 24, 0)"
+        )
+
+        db = DatabaseQueries(connection=connection)
+        self.assertEqual(db.buffer_chunks_source_table(), "buffer_pages")
+
+        chunks = list(db.query_buffer_chunks(filters={"operation_id": 1}))
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].chunk_size, 24)
+        self.assertEqual(chunks[0].num_pages, 1)
+        connection.close()
 
 
 if __name__ == "__main__":

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -586,15 +586,43 @@ class TestSerializers(unittest.TestCase):
         result = serialize_buffer_chunks(chunks)
 
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "1_100_1_0_0")
+        self.assertEqual(result[0]["id"], "1_0_100_1_0_0_0_0")
         self.assertEqual(result[0]["buffer_type"], BufferType.DRAM.value)
         self.assertEqual(result[0]["chunk_size"], 48)
         self.assertEqual(result[0]["num_pages"], 2)
         self.assertEqual(result[0]["rank"], 0)
-        self.assertEqual(result[1]["id"], "1_200_2_1_0")
+        self.assertEqual(result[1]["id"], "1_0_200_2_1_0_1_0")
         self.assertEqual(result[1]["buffer_type"], BufferType.L1.value)
-        # The synthetic id must round-trip through orjson cleanly.
-        self.assertEqual(orjson.loads(orjson.dumps(result))[0]["id"], "1_100_1_0_0")
+        self.assertEqual(
+            orjson.loads(orjson.dumps(result))[0]["id"], "1_0_100_1_0_0_0_0"
+        )
+
+    def test_serialize_buffer_chunks_id_disambiguates_device_rank_and_buffer_type(self):
+        # Two chunks that share (op, addr, bank, core_x, core_y) but differ on
+        # device, rank, or buffer_type must produce distinct ids. Regression
+        # check for the legacy id format which only encoded the first five
+        # fields and would collide across devices.
+        base = dict(
+            operation_id=7,
+            address=2048,
+            bank_id=3,
+            core_x=4,
+            core_y=5,
+            chunk_address=2048,
+            chunk_size=64,
+            page_size=32,
+            num_pages=2,
+        )
+        chunks = [
+            BufferChunk(device_id=0, buffer_type=BufferType.DRAM, rank=0, **base),
+            BufferChunk(device_id=1, buffer_type=BufferType.DRAM, rank=0, **base),
+            BufferChunk(device_id=0, buffer_type=BufferType.L1, rank=0, **base),
+            BufferChunk(device_id=0, buffer_type=BufferType.DRAM, rank=1, **base),
+        ]
+
+        ids = [row["id"] for row in serialize_buffer_chunks(chunks)]
+
+        self.assertEqual(len(set(ids)), 4)
 
     def test_serialize_buffer_pages(self):
         buffer_pages = [

--- a/backend/ttnn_visualizer/tests/test_serializers.py
+++ b/backend/ttnn_visualizer/tests/test_serializers.py
@@ -7,6 +7,7 @@ import unittest
 import orjson
 from ttnn_visualizer.models import (
     Buffer,
+    BufferChunk,
     BufferPage,
     BufferType,
     Device,
@@ -20,6 +21,7 @@ from ttnn_visualizer.models import (
     Tensor,
 )
 from ttnn_visualizer.serializers import (
+    serialize_buffer_chunks,
     serialize_buffer_pages,
     serialize_devices,
     serialize_inputs_outputs,
@@ -550,6 +552,49 @@ class TestSerializers(unittest.TestCase):
         )
         self.assertEqual(result["stack_trace"], "trace text")
         self.assertEqual(result["stack_trace_source_file_id"], 7)
+
+    def test_serialize_buffer_chunks(self):
+        chunks = [
+            BufferChunk(
+                operation_id=1,
+                device_id=0,
+                address=100,
+                bank_id=1,
+                core_x=0,
+                core_y=0,
+                chunk_address=1000,
+                chunk_size=48,
+                page_size=24,
+                num_pages=2,
+                buffer_type=BufferType.DRAM,
+            ),
+            BufferChunk(
+                operation_id=1,
+                device_id=0,
+                address=200,
+                bank_id=2,
+                core_x=1,
+                core_y=0,
+                chunk_address=2000,
+                chunk_size=16,
+                page_size=16,
+                num_pages=1,
+                buffer_type=BufferType.L1,
+            ),
+        ]
+
+        result = serialize_buffer_chunks(chunks)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "1_100_1_0_0")
+        self.assertEqual(result[0]["buffer_type"], BufferType.DRAM.value)
+        self.assertEqual(result[0]["chunk_size"], 48)
+        self.assertEqual(result[0]["num_pages"], 2)
+        self.assertEqual(result[0]["rank"], 0)
+        self.assertEqual(result[1]["id"], "1_200_2_1_0")
+        self.assertEqual(result[1]["buffer_type"], BufferType.L1.value)
+        # The synthetic id must round-trip through orjson cleanly.
+        self.assertEqual(orjson.loads(orjson.dumps(result))[0]["id"], "1_100_1_0_0")
 
     def test_serialize_buffer_pages(self):
         buffer_pages = [

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -61,7 +61,7 @@ from ttnn_visualizer.report_source_file import (
 )
 from ttnn_visualizer.serializers import (
     serialize_buffer,
-    serialize_buffer_pages,
+    serialize_buffer_chunks,
     serialize_devices,
     serialize_operation,
     serialize_operation_buffers,
@@ -734,21 +734,19 @@ def buffer_pages(instance: Instance):
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
             return rejected
-        page_filters = {
+
+        source_table = db.buffer_chunks_source_table()
+        chunk_filters = {
             "operation_id": operation_id,
             "device_id": device_id,
             "address": addresses,
             "buffer_type": buffer_type,
         }
-        buffers = list(
-            list(
-                db.query_buffer_pages(
-                    db.merge_rank_filter("buffer_pages", page_filters, rank)
-                )
-            )
-        )
+        if source_table is not None:
+            chunk_filters = db.merge_rank_filter(source_table, chunk_filters, rank)
+        chunks = list(db.query_buffer_chunks(chunk_filters))
         return Response(
-            orjson.dumps(serialize_buffer_pages(buffers)),
+            orjson.dumps(serialize_buffer_chunks(chunks)),
             mimetype="application/json",
         )
 

--- a/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
+++ b/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
@@ -2,19 +2,17 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { BufferPage } from '../../model/APIData';
-import { pageDataToChunkArray } from '../../functions/getChartData';
+import { BufferChunk } from '../../model/APIData';
 
 interface SVGBufferRendererProps {
     height: number;
-    data: BufferPage[];
+    data: BufferChunk[];
     memoryStart: number;
     memoryEnd: number;
 }
 
 const SVGBufferRenderer = ({ height, data, memoryStart, memoryEnd }: SVGBufferRendererProps) => {
     const memoryRange = memoryEnd - memoryStart;
-    const mergedRange = pageDataToChunkArray(data);
 
     return (
         <svg
@@ -22,18 +20,18 @@ const SVGBufferRenderer = ({ height, data, memoryStart, memoryEnd }: SVGBufferRe
             width='100%'
         >
             <g>
-                {mergedRange.map((range) => {
-                    const xPercent = ((range.address - memoryStart) / memoryRange) * 100;
-                    const widthPercent = (range.size / memoryRange) * 100;
+                {data.map((chunk) => {
+                    const xPercent = ((chunk.address - memoryStart) / memoryRange) * 100;
+                    const widthPercent = (chunk.chunk_size / memoryRange) * 100;
 
                     return (
                         <rect
-                            key={range.address}
+                            key={chunk.address}
                             x={`${xPercent}%`}
                             y={0}
                             width={`${widthPercent}%`}
                             height={height}
-                            fill={range.color || 'red'}
+                            fill={chunk.color || 'red'}
                         />
                     );
                 })}

--- a/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
+++ b/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
@@ -26,7 +26,7 @@ const SVGBufferRenderer = ({ height, data, memoryStart, memoryEnd }: SVGBufferRe
 
                     return (
                         <rect
-                            key={chunk.address}
+                            key={chunk.id}
                             x={`${xPercent}%`}
                             y={0}
                             width={`${widthPercent}%`}

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -9,12 +9,12 @@ import { PlotData } from 'plotly.js';
 import classNames from 'classnames';
 import { useAtomValue } from 'jotai';
 import { BufferType } from '../../model/BufferType';
-import { useBufferPages, useDevices } from '../../hooks/useAPI';
+import { useBufferChunks, useDevices } from '../../hooks/useAPI';
 import 'styles/components/TensorVisualizationComponent.scss';
-import { BufferPage, Tensor } from '../../model/APIData';
+import { BufferChunk, Tensor } from '../../model/APIData';
 import SVGBufferRenderer from './SVGBufferRenderer';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
-import getChartData, { pageDataToChunkArray } from '../../functions/getChartData';
+import getChartData, { bufferChunksToColoredChunks } from '../../functions/getChartData';
 import { L1RenderConfiguration } from '../../definitions/PlotConfigurations';
 import MemoryPlotRenderer from '../operation-details/MemoryPlotRenderer';
 import LoadingSpinner from '../LoadingSpinner';
@@ -43,7 +43,7 @@ const TensorVisualisationComponent = ({
     plotZoomRange,
     tensorId,
 }: TensorVisualisationComponentProps) => {
-    const { data } = useBufferPages(operationId, address, bufferType);
+    const { data } = useBufferChunks(operationId, address, bufferType);
     const { data: devices } = useDevices();
     const showHex = useAtomValue(showHexAtom);
 
@@ -80,28 +80,28 @@ const TensorVisualisationComponent = ({
     const tensixSize = 120;
     const tensixHeight = tensixSize / 3;
 
-    const buffersByBankId: BufferPage[][] = [];
+    const buffersByBankId: BufferChunk[][] = [];
     const coordsByBankId: { x: number; y: number }[] = [];
 
-    data.forEach((page: BufferPage) => {
-        if (!buffersByBankId[page.bank_id]) {
-            buffersByBankId[page.bank_id] = [];
+    data.forEach((chunk: BufferChunk) => {
+        if (!buffersByBankId[chunk.bank_id]) {
+            buffersByBankId[chunk.bank_id] = [];
         }
 
         if (tensorByAddress) {
-            const tensor = tensorByAddress?.get(page.address);
-            page.tensor_id = tensor?.id;
-            page.color = getTensorColor(tensor?.id);
+            const tensor = tensorByAddress?.get(chunk.address);
+            chunk.tensor_id = tensor?.id;
+            chunk.color = getTensorColor(tensor?.id);
         } else if (tensorId) {
-            page.tensor_id = tensorId;
-            page.color = getTensorColor(tensorId);
+            chunk.tensor_id = tensorId;
+            chunk.color = getTensorColor(tensorId);
         }
-        if (page.tensor_id === undefined) {
-            page.color = getBufferColor(page.address);
+        if (chunk.tensor_id === undefined) {
+            chunk.color = getBufferColor(chunk.address);
         }
 
-        buffersByBankId[page.bank_id].push(page);
-        coordsByBankId[page.bank_id] = { x: page.core_x, y: page.core_y };
+        buffersByBankId[chunk.bank_id].push(chunk);
+        coordsByBankId[chunk.bank_id] = { x: chunk.core_x, y: chunk.core_y };
     });
 
     return (
@@ -158,7 +158,7 @@ const TensorVisualisationComponent = ({
                                         setSelectedTensix(matchIndex);
                                         setChartData(
                                             getChartData(
-                                                pageDataToChunkArray(buffersByBankId[matchIndex]),
+                                                bufferChunksToColoredChunks(buffersByBankId[matchIndex]),
                                                 (id) => tensorByAddress?.get(id) || null,
                                                 undefined,
                                                 { showHex },

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -5,7 +5,7 @@
 import { getBufferColor, getTensorColor } from './colorGenerator';
 import { formatMemorySize, getMemoryAddress } from './math';
 import { toReadableShape, toReadableType } from './formatting';
-import { BufferPage, Chunk, ColoredChunk, Tensor } from '../model/APIData';
+import { BufferChunk, Chunk, ColoredChunk, Tensor } from '../model/APIData';
 import { PlotDataCustom } from '../definitions/PlotConfigurations';
 import { TensorMemoryLayout } from './parseMemoryConfig';
 
@@ -118,25 +118,17 @@ export default function getChartData(
     });
 }
 
-export const pageDataToChunkArray = (data: BufferPage[]): ColoredChunk[] => {
-    const mergedRangeByAddress: Map<number, { start: number; end: number; color: string | undefined }> = new Map();
-
-    data.forEach((page: BufferPage) => {
-        const { address } = page;
-        const defaultRange = { start: Infinity, end: 0, color: page.color };
-        const currentRange = mergedRangeByAddress.get(address) || defaultRange;
-        currentRange.start = Math.min(currentRange.start, page.page_address);
-        currentRange.end = Math.max(currentRange.end, page.page_address + page.page_size);
-        mergedRangeByAddress.set(address, currentRange);
-    });
-    return Array.from(mergedRangeByAddress.entries()).map(([address, range]) => {
-        return {
-            address,
-            size: range.end - range.start,
-            color: range.color,
-        };
-    });
-};
+/**
+ * Project pre-aggregated buffer chunks onto the renderer-friendly
+ * ``{address, size, color}`` shape. Aggregation already happened on the
+ * backend (or in the legacy GROUP BY adapter), so this is a trivial map.
+ */
+export const bufferChunksToColoredChunks = (data: BufferChunk[]): ColoredChunk[] =>
+    data.map((chunk) => ({
+        address: chunk.address,
+        size: chunk.chunk_size,
+        color: chunk.color,
+    }));
 
 const createHoverTemplate = (
     address: number,

--- a/src/functions/normalizeBufferPagesResponse.ts
+++ b/src/functions/normalizeBufferPagesResponse.ts
@@ -65,7 +65,7 @@ export const aggregatePagesToChunks = (pages: LegacyBufferPage[]): BufferChunk[]
                     core_y: page.core_y,
                     buffer_type: page.buffer_type,
                     rank,
-                    id: `${page.operation_id}_${page.address}_${page.bank_id}_${page.core_x}_${page.core_y}`,
+                    id: `${page.operation_id}_${page.device_id}_${page.address}_${page.bank_id}_${page.core_x}_${page.core_y}_${page.buffer_type}_${rank}`,
                 },
                 start: page.page_address,
                 end: pageEnd,

--- a/src/functions/normalizeBufferPagesResponse.ts
+++ b/src/functions/normalizeBufferPagesResponse.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { BufferChunk, LegacyBufferPage } from '../model/APIData';
+
+/**
+ * Client-side fallback for backends that have not been upgraded to return
+ * pre-aggregated ``BufferChunk`` rows from ``/api/buffer-pages``.
+ *
+ * The aggregation mirrors the server-side ``GROUP BY`` in
+ * ``_aggregate_buffer_pages_to_chunks`` so the two paths produce identical
+ * data: one row per ``(operation_id, device_id, address, bank_id, core_x,
+ * core_y, buffer_type)`` group, with ``chunk_address = MIN(page_address)``
+ * and ``chunk_size = MAX(page_address + page_size) - MIN(page_address)``.
+ */
+export const aggregatePagesToChunks = (pages: LegacyBufferPage[]): BufferChunk[] => {
+    const groups = new Map<
+        string,
+        {
+            chunk: Omit<BufferChunk, 'chunk_address' | 'chunk_size' | 'page_size' | 'num_pages'> & {
+                rank: number;
+            };
+            start: number;
+            end: number;
+            maxPageSize: number;
+            count: number;
+        }
+    >();
+
+    for (const page of pages) {
+        const rank = page.rank ?? 0;
+        const key = [
+            page.operation_id,
+            page.device_id,
+            page.address,
+            page.bank_id,
+            page.core_x,
+            page.core_y,
+            page.buffer_type,
+            rank,
+        ].join('|');
+
+        const pageEnd = page.page_address + page.page_size;
+        const existing = groups.get(key);
+        if (existing) {
+            if (page.page_address < existing.start) {
+                existing.start = page.page_address;
+            }
+            if (pageEnd > existing.end) {
+                existing.end = pageEnd;
+            }
+            if (page.page_size > existing.maxPageSize) {
+                existing.maxPageSize = page.page_size;
+            }
+            existing.count += 1;
+        } else {
+            groups.set(key, {
+                chunk: {
+                    operation_id: page.operation_id,
+                    device_id: page.device_id,
+                    address: page.address,
+                    bank_id: page.bank_id,
+                    core_x: page.core_x,
+                    core_y: page.core_y,
+                    buffer_type: page.buffer_type,
+                    rank,
+                    id: `${page.operation_id}_${page.address}_${page.bank_id}_${page.core_x}_${page.core_y}`,
+                },
+                start: page.page_address,
+                end: pageEnd,
+                maxPageSize: page.page_size,
+                count: 1,
+            });
+        }
+    }
+
+    return Array.from(groups.values()).map(({ chunk, start, end, maxPageSize, count }) => ({
+        ...chunk,
+        chunk_address: start,
+        chunk_size: end - start,
+        page_size: maxPageSize,
+        num_pages: count,
+    }));
+};
+
+/**
+ * Return ``true`` when a row from ``/api/buffer-pages`` was emitted by a
+ * legacy backend (per-page rows) rather than an aggregating backend
+ * (per-chunk rows). The discriminator is the presence of ``page_index``,
+ * which only exists on legacy rows.
+ */
+export const isLegacyBufferPageRow = (row: unknown): row is LegacyBufferPage =>
+    typeof row === 'object' && row !== null && 'page_index' in row && !('chunk_address' in row);
+
+/**
+ * Normalize a heterogeneous ``/api/buffer-pages`` response into
+ * ``BufferChunk[]``. New backends already return chunks; old backends
+ * return raw pages and we collapse them in the browser.
+ */
+export const normalizeBufferPagesResponse = (rows: unknown[]): BufferChunk[] => {
+    if (rows.length === 0) {
+        return [];
+    }
+    const sample = rows[0];
+    if (isLegacyBufferPageRow(sample)) {
+        return aggregatePagesToChunks(rows as LegacyBufferPage[]);
+    }
+    return rows as BufferChunk[];
+};

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -11,8 +11,8 @@ import Ajv from 'ajv';
 import axiosInstance from '../libs/axiosInstance';
 import {
     Buffer,
+    BufferChunk,
     BufferData,
-    BufferPage,
     BuffersByOperation,
     DeviceInfo,
     DeviceOperationParams,
@@ -33,6 +33,7 @@ import { PerfTableRow } from '../definitions/PerfTable';
 import { L1PressureResult, buildL1PressureResult } from '../functions/l1Pressure';
 import { StackedGroupBy, StackedPerfRow } from '../definitions/StackedPerfTable';
 import { isDeviceOperation } from '../functions/filterOperations';
+import { normalizeBufferPagesResponse } from '../functions/normalizeBufferPagesResponse';
 import {
     activeNpeOpTraceAtom,
     activePerformanceReportAtom,
@@ -116,12 +117,12 @@ export const updateInstance = async (payload: Partial<Instance>): Promise<Instan
     return response?.data ?? null;
 };
 
-export const fetchBufferPages = async (
+export const fetchBufferChunks = async (
     operationId: number,
     address?: number | string,
     bufferType?: BufferType,
-): Promise<BufferPage[]> => {
-    const response = await axiosInstance.get<BufferPage[]>(Endpoints.BUFFER_PAGES, {
+): Promise<BufferChunk[]> => {
+    const response = await axiosInstance.get<unknown[]>(Endpoints.BUFFER_PAGES, {
         params: {
             operation_id: operationId,
             address,
@@ -129,7 +130,7 @@ export const fetchBufferPages = async (
         },
     });
 
-    return response.data;
+    return normalizeBufferPagesResponse(response.data ?? []);
 };
 
 const fetchOperationDetails = async (id: number | null): Promise<OperationDetailsData> => {
@@ -806,10 +807,10 @@ export const useReportMetadata = () => {
     });
 };
 
-export const useBufferPages = (operationId: number, address?: number | string, bufferType?: BufferType) => {
-    return useQuery<BufferPage[], AxiosError>({
-        queryKey: ['get-buffer-pages', operationId, address, bufferType],
-        queryFn: () => fetchBufferPages(operationId, address, bufferType),
+export const useBufferChunks = (operationId: number, address?: number | string, bufferType?: BufferType) => {
+    return useQuery<BufferChunk[], AxiosError>({
+        queryKey: ['get-buffer-chunks', operationId, address, bufferType],
+        queryFn: () => fetchBufferChunks(operationId, address, bufferType),
         staleTime: Infinity,
     });
 };

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -370,21 +370,44 @@ export interface TensorBuffer extends Chunk {
     type: StringBufferType;
 }
 
-export interface BufferPage {
+export interface BufferChunk {
+    operation_id: number;
+    device_id: number;
     address: number;
     bank_id: number;
-    buffer_type: BufferType;
     core_x: number;
     core_y: number;
-    device_id: number;
-    operation_id: number;
-    page_address: number;
-    page_index: number;
+    chunk_address: number;
+    chunk_size: number;
     page_size: number;
+    num_pages: number;
+    buffer_type: BufferType;
+    rank?: number;
     id: string;
 
     tensor_id?: number;
     color?: string;
+}
+
+/**
+ * Legacy raw row from a backend that has not yet been updated to return
+ * pre-aggregated chunks. The FE adapter in ``fetchBufferChunks`` collapses
+ * an array of these into ``BufferChunk[]`` so downstream code never sees
+ * the old shape.
+ */
+export interface LegacyBufferPage {
+    operation_id: number;
+    device_id: number;
+    address: number;
+    bank_id: number;
+    core_x: number;
+    core_y: number;
+    page_index: number;
+    page_address: number;
+    page_size: number;
+    buffer_type: BufferType;
+    rank?: number;
+    id?: string;
 }
 
 export interface BuffersByOperation {

--- a/tests/SVGBufferRenderer.spec.tsx
+++ b/tests/SVGBufferRenderer.spec.tsx
@@ -10,7 +10,7 @@ import { BufferChunk } from '../src/model/APIData';
 import { BufferType } from '../src/model/BufferType';
 
 function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
-    return {
+    const merged = {
         operation_id: 1,
         device_id: 0,
         address: 1000,
@@ -23,9 +23,14 @@ function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
         num_pages: 8,
         buffer_type: BufferType.L1,
         rank: 0,
-        id: '1_1000_1_0_0',
         color: '#ff0000',
         ...overrides,
+    };
+    // Derive id from the grouping tuple so chunks that differ on any
+    // collision-relevant field also get distinct React keys.
+    return {
+        ...merged,
+        id: `${merged.operation_id}_${merged.device_id}_${merged.address}_${merged.bank_id}_${merged.core_x}_${merged.core_y}_${merged.buffer_type}_${merged.rank}`,
     };
 }
 

--- a/tests/SVGBufferRenderer.spec.tsx
+++ b/tests/SVGBufferRenderer.spec.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import SVGBufferRenderer from '../src/components/tensor-sharding-visualization/SVGBufferRenderer';
+import { BufferChunk } from '../src/model/APIData';
+import { BufferType } from '../src/model/BufferType';
+
+function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
+    return {
+        operation_id: 1,
+        device_id: 0,
+        address: 1000,
+        bank_id: 1,
+        core_x: 0,
+        core_y: 0,
+        chunk_address: 1000,
+        chunk_size: 256,
+        page_size: 32,
+        num_pages: 8,
+        buffer_type: BufferType.L1,
+        rank: 0,
+        id: '1_1000_1_0_0',
+        color: '#ff0000',
+        ...overrides,
+    };
+}
+
+afterEach(cleanup);
+
+describe('SVGBufferRenderer (pre-aggregated chunks)', () => {
+    it('renders one rect per BufferChunk', () => {
+        const { container } = render(
+            <SVGBufferRenderer
+                height={20}
+                memoryStart={0}
+                memoryEnd={4096}
+                data={[
+                    chunk({ address: 100, chunk_size: 512 }),
+                    chunk({ address: 1024, chunk_size: 256 }),
+                    chunk({ address: 2000, chunk_size: 128 }),
+                ]}
+            />,
+        );
+
+        expect(container.querySelectorAll('rect')).toHaveLength(3);
+    });
+
+    it('positions and sizes rects by (address - memoryStart) / memoryRange and chunk_size / memoryRange', () => {
+        const { container } = render(
+            <SVGBufferRenderer
+                height={20}
+                memoryStart={1000}
+                memoryEnd={5000}
+                data={[chunk({ address: 2000, chunk_size: 1000, color: '#00ff00' })]}
+            />,
+        );
+
+        const rect = container.querySelector('rect');
+        expect(rect).not.toBeNull();
+        // (2000 - 1000) / (5000 - 1000) = 0.25 → "25%"
+        expect(rect!.getAttribute('x')).toBe('25%');
+        // 1000 / 4000 = 0.25 → "25%"
+        expect(rect!.getAttribute('width')).toBe('25%');
+        expect(rect!.getAttribute('fill')).toBe('#00ff00');
+    });
+
+    it('falls back to red when a chunk has no color', () => {
+        const { container } = render(
+            <SVGBufferRenderer
+                height={10}
+                memoryStart={0}
+                memoryEnd={1024}
+                data={[chunk({ address: 0, chunk_size: 1024, color: undefined })]}
+            />,
+        );
+
+        expect(container.querySelector('rect')!.getAttribute('fill')).toBe('red');
+    });
+
+    it('renders an empty group when there are no chunks', () => {
+        const { container } = render(
+            <SVGBufferRenderer
+                height={10}
+                memoryStart={0}
+                memoryEnd={1024}
+                data={[]}
+            />,
+        );
+
+        expect(container.querySelectorAll('rect')).toHaveLength(0);
+    });
+});

--- a/tests/bufferChunksToColoredChunks.spec.ts
+++ b/tests/bufferChunksToColoredChunks.spec.ts
@@ -21,7 +21,7 @@ function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
         num_pages: 2,
         buffer_type: BufferType.L1,
         rank: 0,
-        id: '1_100_1_0_0',
+        id: '1_0_100_1_0_0_1_0',
         ...overrides,
     };
 }

--- a/tests/bufferChunksToColoredChunks.spec.ts
+++ b/tests/bufferChunksToColoredChunks.spec.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { bufferChunksToColoredChunks } from '../src/functions/getChartData';
+import { BufferChunk } from '../src/model/APIData';
+import { BufferType } from '../src/model/BufferType';
+
+function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
+    return {
+        operation_id: 1,
+        device_id: 0,
+        address: 100,
+        bank_id: 1,
+        core_x: 0,
+        core_y: 0,
+        chunk_address: 1000,
+        chunk_size: 48,
+        page_size: 24,
+        num_pages: 2,
+        buffer_type: BufferType.L1,
+        rank: 0,
+        id: '1_100_1_0_0',
+        ...overrides,
+    };
+}
+
+describe('bufferChunksToColoredChunks', () => {
+    it('projects a chunk to {address, size, color}', () => {
+        const result = bufferChunksToColoredChunks([chunk({ address: 200, chunk_size: 1024, color: '#abcdef' })]);
+
+        expect(result).toEqual([{ address: 200, size: 1024, color: '#abcdef' }]);
+    });
+
+    it('preserves chunk order', () => {
+        const result = bufferChunksToColoredChunks([
+            chunk({ address: 300, chunk_size: 16 }),
+            chunk({ address: 100, chunk_size: 8 }),
+            chunk({ address: 200, chunk_size: 32 }),
+        ]);
+
+        expect(result.map((c) => c.address)).toEqual([300, 100, 200]);
+    });
+
+    it('uses chunk_size for the rendered size, not page_size or num_pages', () => {
+        const result = bufferChunksToColoredChunks([chunk({ chunk_size: 4096, page_size: 24, num_pages: 170 })]);
+
+        expect(result[0].size).toBe(4096);
+    });
+
+    it('passes color through unchanged including undefined', () => {
+        const result = bufferChunksToColoredChunks([
+            chunk({ address: 100, color: undefined }),
+            chunk({ address: 200, color: 'rgb(1, 2, 3)' }),
+        ]);
+
+        expect(result[0].color).toBeUndefined();
+        expect(result[1].color).toBe('rgb(1, 2, 3)');
+    });
+
+    it('returns an empty array for empty input', () => {
+        expect(bufferChunksToColoredChunks([])).toEqual([]);
+    });
+});

--- a/tests/normalizeBufferPagesResponse.spec.ts
+++ b/tests/normalizeBufferPagesResponse.spec.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import {
+    aggregatePagesToChunks,
+    isLegacyBufferPageRow,
+    normalizeBufferPagesResponse,
+} from '../src/functions/normalizeBufferPagesResponse';
+import { BufferChunk, LegacyBufferPage } from '../src/model/APIData';
+import { BufferType } from '../src/model/BufferType';
+
+function page(overrides: Partial<LegacyBufferPage> = {}): LegacyBufferPage {
+    return {
+        operation_id: 1,
+        device_id: 0,
+        address: 100,
+        bank_id: 1,
+        core_x: 0,
+        core_y: 0,
+        page_index: 0,
+        page_address: 1000,
+        page_size: 24,
+        buffer_type: BufferType.L1,
+        id: '1_0',
+        ...overrides,
+    };
+}
+
+function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
+    return {
+        operation_id: 1,
+        device_id: 0,
+        address: 100,
+        bank_id: 1,
+        core_x: 0,
+        core_y: 0,
+        chunk_address: 1000,
+        chunk_size: 48,
+        page_size: 24,
+        num_pages: 2,
+        buffer_type: BufferType.L1,
+        rank: 0,
+        id: '1_100_1_0_0',
+        ...overrides,
+    };
+}
+
+describe('isLegacyBufferPageRow', () => {
+    it('returns true for rows with page_index and no chunk_address', () => {
+        expect(isLegacyBufferPageRow(page())).toBe(true);
+    });
+
+    it('returns false for chunk rows', () => {
+        expect(isLegacyBufferPageRow(chunk())).toBe(false);
+    });
+
+    it('returns false for null / non-object input', () => {
+        expect(isLegacyBufferPageRow(null)).toBe(false);
+        expect(isLegacyBufferPageRow(undefined)).toBe(false);
+        expect(isLegacyBufferPageRow(42)).toBe(false);
+    });
+});
+
+describe('aggregatePagesToChunks', () => {
+    it('collapses contiguous pages into one chunk and computes chunk_size by extent', () => {
+        const result = aggregatePagesToChunks([
+            page({ page_index: 0, page_address: 1000, page_size: 24 }),
+            page({ page_index: 1, page_address: 1024, page_size: 24 }),
+        ]);
+
+        expect(result).toHaveLength(1);
+        const c = result[0];
+        expect(c.chunk_address).toBe(1000);
+        // max(page_addr + page_size) - min(page_addr) = (1024+24) - 1000 = 48
+        expect(c.chunk_size).toBe(48);
+        expect(c.page_size).toBe(24);
+        expect(c.num_pages).toBe(2);
+    });
+
+    it('emits separate chunks for different (bank, core) groups', () => {
+        const result = aggregatePagesToChunks([
+            page({ bank_id: 1, core_x: 0, core_y: 0, page_address: 1000 }),
+            page({ bank_id: 2, core_x: 1, core_y: 0, page_address: 2000, page_size: 16 }),
+        ]);
+
+        expect(result).toHaveLength(2);
+        const sorted = result.sort((a, b) => a.bank_id - b.bank_id);
+        expect(sorted[0].bank_id).toBe(1);
+        expect(sorted[0].chunk_address).toBe(1000);
+        expect(sorted[1].bank_id).toBe(2);
+        expect(sorted[1].chunk_address).toBe(2000);
+        expect(sorted[1].chunk_size).toBe(16);
+    });
+
+    it('keeps different operation_ids in separate groups', () => {
+        const result = aggregatePagesToChunks([page({ operation_id: 1 }), page({ operation_id: 2 })]);
+        expect(result).toHaveLength(2);
+        expect(result.map((c) => c.operation_id).sort()).toEqual([1, 2]);
+    });
+
+    it('does not merge rows with different rank values', () => {
+        const result = aggregatePagesToChunks([page({ rank: 0 }), page({ rank: 1 })]);
+        expect(result).toHaveLength(2);
+        expect(result.map((c) => c.rank).sort()).toEqual([0, 1]);
+    });
+
+    it('defaults missing rank to 0', () => {
+        const result = aggregatePagesToChunks([page({ rank: undefined })]);
+        expect(result[0].rank).toBe(0);
+    });
+
+    it('synthesizes the chunk id as op_addr_bank_x_y', () => {
+        const result = aggregatePagesToChunks([
+            page({ operation_id: 5, address: 200, bank_id: 3, core_x: 2, core_y: 4 }),
+        ]);
+        expect(result[0].id).toBe('5_200_3_2_4');
+    });
+
+    it('takes the max page_size when sizes vary within a group', () => {
+        const result = aggregatePagesToChunks([
+            page({ page_address: 1000, page_size: 24 }),
+            page({ page_address: 1024, page_size: 32 }),
+        ]);
+        expect(result[0].page_size).toBe(32);
+    });
+
+    it('returns an empty array for empty input', () => {
+        expect(aggregatePagesToChunks([])).toEqual([]);
+    });
+});
+
+describe('normalizeBufferPagesResponse', () => {
+    it('returns chunks unchanged when the backend already aggregated', () => {
+        const chunks = [chunk({ address: 100 }), chunk({ address: 200, id: '1_200_1_0_0' })];
+        expect(normalizeBufferPagesResponse(chunks)).toEqual(chunks);
+    });
+
+    it('aggregates legacy page rows on the client', () => {
+        const result = normalizeBufferPagesResponse([
+            page({ page_address: 1000, page_size: 24, page_index: 0 }),
+            page({ page_address: 1024, page_size: 24, page_index: 1 }),
+        ]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].chunk_size).toBe(48);
+        expect(result[0].num_pages).toBe(2);
+    });
+
+    it('returns an empty array for an empty response', () => {
+        expect(normalizeBufferPagesResponse([])).toEqual([]);
+    });
+});

--- a/tests/normalizeBufferPagesResponse.spec.ts
+++ b/tests/normalizeBufferPagesResponse.spec.ts
@@ -42,7 +42,7 @@ function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
         num_pages: 2,
         buffer_type: BufferType.L1,
         rank: 0,
-        id: '1_100_1_0_0',
+        id: '1_0_100_1_0_0_1_0',
         ...overrides,
     };
 }
@@ -111,11 +111,25 @@ describe('aggregatePagesToChunks', () => {
         expect(result[0].rank).toBe(0);
     });
 
-    it('synthesizes the chunk id as op_addr_bank_x_y', () => {
+    it('synthesizes the chunk id from the full grouping tuple', () => {
         const result = aggregatePagesToChunks([
             page({ operation_id: 5, address: 200, bank_id: 3, core_x: 2, core_y: 4 }),
         ]);
-        expect(result[0].id).toBe('5_200_3_2_4');
+        // op_device_addr_bank_x_y_buffer-type_rank — page() defaults give
+        // device_id=0, buffer_type=L1(1), rank=0 (the omitted-rank default).
+        expect(result[0].id).toBe(`5_0_200_3_2_4_${BufferType.L1}_0`);
+    });
+
+    it('emits distinct ids for groups that only differ on device, rank, or buffer_type', () => {
+        const result = aggregatePagesToChunks([
+            page({ device_id: 0, buffer_type: BufferType.DRAM, rank: 0 }),
+            page({ device_id: 1, buffer_type: BufferType.DRAM, rank: 0 }),
+            page({ device_id: 0, buffer_type: BufferType.L1, rank: 0 }),
+            page({ device_id: 0, buffer_type: BufferType.DRAM, rank: 1 }),
+        ]);
+
+        const ids = new Set(result.map((c) => c.id));
+        expect(ids.size).toBe(4);
     });
 
     it('takes the max page_size when sizes vary within a group', () => {
@@ -133,7 +147,7 @@ describe('aggregatePagesToChunks', () => {
 
 describe('normalizeBufferPagesResponse', () => {
     it('returns chunks unchanged when the backend already aggregated', () => {
-        const chunks = [chunk({ address: 100 }), chunk({ address: 200, id: '1_200_1_0_0' })];
+        const chunks = [chunk({ address: 100 }), chunk({ address: 200, id: '1_0_200_1_0_0_1_0' })];
         expect(normalizeBufferPagesResponse(chunks)).toEqual(chunks);
     });
 


### PR DESCRIPTION
Add first-class support for pre-aggregated BufferChunk rows while retaining compatibility with legacy per-page rows.

Backend: introduce BufferChunk dataclass, DatabaseQueries.buffer_chunks_source_table(), query_buffer_chunks() and _aggregate_buffer_pages_to_chunks() to prefer a new buffer_chunks table and fall back to GROUP BY on buffer_pages when needed. Add serialize_buffer_chunks() and switch the /api/buffer-pages view to emit chunks. Tests updated/added to cover source selection, aggregation and serialization. Synthetic stable id and rank handling implemented.

Frontend: change API/model to work with BufferChunk (fetchBufferChunks/useBufferChunks), add normalizeBufferPagesResponse client-side aggregator to collapse legacy page rows into chunks when necessary, and update getChartData, SVGBufferRenderer and TensorVisualisationComponent to consume chunk-shaped data. Add unit tests for renderer, mapping and normalization.

This enables a more efficient pre-aggregated backend path while keeping backward compatibility with older backends that return per-page rows.

partial #1258