### PR TITLE
Support profiler report files with and without rank suffixes

### DIFF
--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -30,6 +30,7 @@ from ttnn_visualizer.sockets import FileProgress, FileStatus, emit_file_status
 from ttnn_visualizer.ssh_client import SSHClient, raise_for_ssh_subprocess_error
 from ttnn_visualizer.utils import (
     PROFILER_CONFIG_BASENAME,
+    pick_cluster_descriptor_path,
     ranked_profiler_config_basenames,
     update_last_synced,
 )
@@ -212,17 +213,16 @@ def resolve_file_path(remote_connection, file_path: str) -> str:
     return file_path
 
 
-def get_cluster_desc(instance: Instance):
+def get_cluster_desc(instance: Instance, logical_rank: int = 0):
     if not instance.profiler_path:
         return None
     report_path = Path(instance.profiler_path).parent
-    cluster_path = report_path / "cluster_descriptor.yaml"
-
-    if cluster_path.exists():
-        with open(cluster_path, "r", encoding="utf-8") as cluster_desc_file:
-            return yaml.safe_load(cluster_desc_file)
-    else:
+    cluster_path, _err = pick_cluster_descriptor_path(report_path, logical_rank)
+    if cluster_path is None:
         return None
+
+    with open(cluster_path, "r", encoding="utf-8") as cluster_desc_file:
+        return yaml.safe_load(cluster_desc_file)
 
 
 def is_excluded(file_path, exclude_patterns):

--- a/backend/ttnn_visualizer/tests/test_utils.py
+++ b/backend/ttnn_visualizer/tests/test_utils.py
@@ -10,6 +10,8 @@ from ttnn_visualizer.utils import (
     get_app_data_directory,
     get_report_data_directory,
     is_running_in_container,
+    pick_cluster_descriptor_path,
+    pick_mesh_descriptor_path,
     pick_profiler_config_paths,
     ranked_profiler_config_basenames,
     read_profiler_config_api_payload,
@@ -550,3 +552,68 @@ def test_read_profiler_config_api_payload_missing_directory(tmp_path):
     payload, err = read_profiler_config_api_payload(missing)
     assert payload is None
     assert err is None
+
+
+# Mesh / cluster descriptor YAML with and without _<n>_of_<world> suffix
+
+
+def test_pick_mesh_descriptor_prefers_unsuffixed_file(tmp_path):
+    (tmp_path / "physical_chip_mesh_coordinate_mapping.yaml").write_text(
+        "chips: []\n", encoding="utf-8"
+    )
+    (tmp_path / "physical_chip_mesh_coordinate_mapping_1_of_2.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=1)
+    assert err is None
+    assert path is not None
+    assert path.name == "physical_chip_mesh_coordinate_mapping.yaml"
+
+
+def test_pick_mesh_descriptor_ranked_files(tmp_path):
+    (tmp_path / "physical_chip_mesh_coordinate_mapping_2_of_2.yaml").write_text(
+        "chips: [2]\n", encoding="utf-8"
+    )
+    (tmp_path / "physical_chip_mesh_coordinate_mapping_1_of_2.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None
+    assert path.name == "physical_chip_mesh_coordinate_mapping_1_of_2.yaml"
+
+
+def test_pick_mesh_descriptor_rank_out_of_range(tmp_path):
+    (tmp_path / "physical_chip_mesh_coordinate_mapping_1_of_2.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+    (tmp_path / "physical_chip_mesh_coordinate_mapping_2_of_2.yaml").write_text(
+        "chips: [2]\n", encoding="utf-8"
+    )
+    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=2)
+    assert path is None
+    assert err == "rank_out_of_range"
+
+
+def test_pick_cluster_descriptor_prefers_unsuffixed_file(tmp_path):
+    (tmp_path / "cluster_descriptor.yaml").write_text("chips: []\n", encoding="utf-8")
+    (tmp_path / "cluster_descriptor_1_of_2.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=1)
+    assert err is None
+    assert path is not None
+    assert path.name == "cluster_descriptor.yaml"
+
+
+def test_pick_cluster_descriptor_ranked_files(tmp_path):
+    (tmp_path / "cluster_descriptor_2_of_2.yaml").write_text(
+        "chips: [2]\n", encoding="utf-8"
+    )
+    (tmp_path / "cluster_descriptor_1_of_2.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=1)
+    assert err is None
+    assert path is not None
+    assert path.name == "cluster_descriptor_2_of_2.yaml"

--- a/backend/ttnn_visualizer/tests/views/test_descriptor_endpoints.py
+++ b/backend/ttnn_visualizer/tests/views/test_descriptor_endpoints.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from ttnn_visualizer.extensions import db
+from ttnn_visualizer.models import InstanceTable
+
+
+def _create_instance_without_profiler(app, instance_id: str) -> None:
+    with app.app_context():
+        instance = InstanceTable(
+            instance_id=instance_id,
+            active_report={},
+            profiler_path=None,
+        )
+        db.session.add(instance)
+        db.session.commit()
+
+
+def test_cluster_descriptor_returns_404_when_no_profiler_path(app, client):
+    instance_id = "test-no-profiler-cluster"
+    _create_instance_without_profiler(app, instance_id)
+
+    response = client.get(
+        "/api/cluster-descriptor",
+        query_string={"instanceId": instance_id},
+    )
+
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data is not None
+    assert "cluster_descriptor.yaml not found" in data["error"]
+
+
+def test_mesh_descriptor_returns_404_when_no_profiler_path(app, client):
+    instance_id = "test-no-profiler-mesh"
+    _create_instance_without_profiler(app, instance_id)
+
+    response = client.get(
+        "/api/mesh-descriptor",
+        query_string={"instanceId": instance_id},
+    )
+
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data is not None
+    assert "physical_chip_mesh_coordinate_mapping.yaml not found" in data["error"]

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -16,7 +16,7 @@ from collections import Counter
 from functools import wraps
 from pathlib import Path
 from timeit import default_timer
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Pattern, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -28,20 +28,67 @@ LAST_SYNCED_FILE_NAME = ".last-synced"
 PROFILER_CONFIG_BASENAME = "config.json"
 PROFILER_CONFIG_RANKED_RE = re.compile(r"^config_(\d+)_of_(\d+)\.json$")
 
+MESH_DESCRIPTOR_BASENAME = "physical_chip_mesh_coordinate_mapping.yaml"
+MESH_DESCRIPTOR_RANKED_RE = re.compile(
+    r"^physical_chip_mesh_coordinate_mapping_(\d+)_of_(\d+)\.yaml$"
+)
 
-def parse_ranked_profiler_config_basename(
-    filename: str,
+CLUSTER_DESCRIPTOR_BASENAME = "cluster_descriptor.yaml"
+CLUSTER_DESCRIPTOR_RANKED_RE = re.compile(r"^cluster_descriptor_(\d+)_of_(\d+)\.yaml$")
+
+
+def parse_ranked_basename(
+    filename: str, ranked_re: Pattern[str]
 ) -> Optional[Tuple[int, int]]:
-    """If filename matches config_<n>_of_<world>.json, return (n, world)."""
-    match = PROFILER_CONFIG_RANKED_RE.match(filename)
+    """If filename matches <prefix>_<n>_of_<world>.<ext>, return (n, world)."""
+    match = ranked_re.match(filename)
     if not match:
         return None
     return int(match.group(1)), int(match.group(2))
 
 
+def parse_ranked_profiler_config_basename(
+    filename: str,
+) -> Optional[Tuple[int, int]]:
+    """If filename matches config_<n>_of_<world>.json, return (n, world)."""
+    return parse_ranked_basename(filename, PROFILER_CONFIG_RANKED_RE)
+
+
 def is_valid_profiler_ranked_entry(index_one_based: int, world: int) -> bool:
     """True when the filename indices match TTNN output (1..world inclusive)."""
     return 1 <= index_one_based <= world
+
+
+def ranked_report_basenames(
+    file_names: Iterable[str],
+    ranked_re: Pattern[str],
+    malformed_label: str,
+) -> List[str]:
+    """
+    Select per-rank report files that share the same world_size (majority wins).
+
+    Only filenames whose first number is in 1..world (inclusive) are considered.
+    Returns basenames sorted by ascending 1-based index.
+    """
+    meta: List[Tuple[int, int, str]] = []
+    for name in file_names:
+        parsed = parse_ranked_basename(name, ranked_re)
+        if parsed:
+            index_one_based, world = parsed
+            if not is_valid_profiler_ranked_entry(index_one_based, world):
+                logger.warning(
+                    "Skipping malformed report filename %s (expected %s)",
+                    name,
+                    malformed_label,
+                )
+                continue
+            meta.append((world, index_one_based, name))
+    if not meta:
+        return []
+    common_world = Counter(w for w, _, _ in meta).most_common(1)[0][0]
+    filtered = [(idx, n) for w, idx, n in meta if w == common_world]
+    filtered.sort(key=lambda x: x[0])
+    return [n for _, n in filtered]
 
 
 def ranked_profiler_config_basenames(file_names: Iterable[str]) -> List[str]:
@@ -52,25 +99,53 @@ def ranked_profiler_config_basenames(file_names: Iterable[str]) -> List[str]:
     Returns basenames sorted by ascending 1-based index (config_1_of_*, then
     config_2_of_*, ...).
     """
-    meta: List[Tuple[int, int, str]] = []
-    for name in file_names:
-        parsed = parse_ranked_profiler_config_basename(name)
-        if parsed:
-            index_one_based, world = parsed
-            if not is_valid_profiler_ranked_entry(index_one_based, world):
-                logger.warning(
-                    "Skipping malformed profiler config filename %s "
-                    "(expected config_<n>_of_<world>.json with 1 <= n <= world)",
-                    name,
-                )
-                continue
-            meta.append((world, index_one_based, name))
-    if not meta:
-        return []
-    common_world = Counter(w for w, _, _ in meta).most_common(1)[0][0]
-    filtered = [(idx, n) for w, idx, n in meta if w == common_world]
-    filtered.sort(key=lambda x: x[0])
-    return [n for _, n in filtered]
+    return ranked_report_basenames(
+        file_names,
+        PROFILER_CONFIG_RANKED_RE,
+        "config_<n>_of_<world>.json with 1 <= n <= world",
+    )
+
+
+def _pick_single_or_ranked_report_path(
+    report_dir: Path,
+    *,
+    single_basename: str,
+    ranked_re: Pattern[str],
+    ranked_basename_for: Callable[[int, int], str],
+    malformed_label: str,
+    logical_rank: int = 0,
+) -> tuple[Optional[Path], Optional[str]]:
+    """
+    Prefer ``single_basename`` when present; otherwise pick the ranked file for
+    ``logical_rank``. Returns ``(path, None)`` or ``(None, error)`` where error
+    is ``rank_out_of_range``, ``missing_rank_file``, or ``None`` when absent.
+    """
+    if not report_dir.is_dir():
+        return None, None
+    single = report_dir / single_basename
+    if single.is_file():
+        return single, None
+
+    ranked_names = ranked_report_basenames(
+        (p.name for p in report_dir.iterdir() if p.is_file()),
+        ranked_re,
+        malformed_label,
+    )
+    if not ranked_names:
+        return None, None
+
+    parsed0 = parse_ranked_basename(ranked_names[0], ranked_re)
+    if not parsed0:
+        return None, None
+    _, world_size = parsed0
+
+    if logical_rank < 0 or logical_rank >= world_size:
+        return None, "rank_out_of_range"
+
+    path = report_dir / ranked_basename_for(logical_rank + 1, world_size)
+    if not path.is_file():
+        return None, "missing_rank_file"
+    return path, None
 
 
 def pick_profiler_config_paths(report_dir: Path) -> List[Path]:
@@ -829,28 +904,65 @@ def get_mlir_path(mlir_name, current_app, **_kwargs):
     return str(mlir_path)
 
 
-def get_cluster_descriptor_path(instance):
+def pick_cluster_descriptor_path(
+    report_dir: Path, logical_rank: int = 0
+) -> tuple[Optional[Path], Optional[str]]:
+    """Resolve cluster_descriptor.yaml or cluster_descriptor_<n>_of_<world>.yaml."""
+    return _pick_single_or_ranked_report_path(
+        report_dir,
+        single_basename=CLUSTER_DESCRIPTOR_BASENAME,
+        ranked_re=CLUSTER_DESCRIPTOR_RANKED_RE,
+        ranked_basename_for=lambda index, world: (
+            f"cluster_descriptor_{index}_of_{world}.yaml"
+        ),
+        malformed_label="cluster_descriptor_<n>_of_<world>.yaml with 1 <= n <= world",
+        logical_rank=logical_rank,
+    )
+
+
+def pick_mesh_descriptor_path(
+    report_dir: Path, logical_rank: int = 0
+) -> tuple[Optional[Path], Optional[str]]:
+    """Resolve mesh mapping YAML with or without per-rank suffix."""
+    return _pick_single_or_ranked_report_path(
+        report_dir,
+        single_basename=MESH_DESCRIPTOR_BASENAME,
+        ranked_re=MESH_DESCRIPTOR_RANKED_RE,
+        ranked_basename_for=lambda index, world: (
+            f"physical_chip_mesh_coordinate_mapping_{index}_of_{world}.yaml"
+        ),
+        malformed_label=(
+            "physical_chip_mesh_coordinate_mapping_<n>_of_<world>.yaml "
+            "with 1 <= n <= world"
+        ),
+        logical_rank=logical_rank,
+    )
+
+
+def get_cluster_descriptor_path(instance, logical_rank: int = 0):
     if not instance.profiler_path:
         return None
 
-    cluster_descriptor_path = Path(instance.profiler_path).parent / Path(
-        "cluster_descriptor.yaml"
+    path, _err = pick_cluster_descriptor_path(
+        Path(instance.profiler_path).parent, logical_rank
     )
-
-    if not cluster_descriptor_path.exists():
+    if path is None:
         return None
 
-    return str(cluster_descriptor_path)
+    return str(path)
 
 
-def get_mesh_descriptor_paths(instance):
+def get_mesh_descriptor_paths(instance, logical_rank: int = 0):
     if not instance.profiler_path:
         return []
 
-    parent = Path(instance.profiler_path).parent
-    glob_pattern = "physical_chip_mesh_coordinate_mapping_[0-9]_of_[0-9].yaml"
+    path, _err = pick_mesh_descriptor_path(
+        Path(instance.profiler_path).parent, logical_rank
+    )
+    if path is None:
+        return []
 
-    return sorted(str(path) for path in parent.glob(glob_pattern) if path.is_file())
+    return [str(path)]
 
 
 def read_last_synced_file(directory: str) -> Optional[int]:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1610,7 +1610,10 @@ def list_remote_reports_performance():
 @api.route("/cluster-descriptor", methods=["GET"])
 @with_instance
 def get_cluster_descriptor(instance: Instance):
-    report_dir = Path(str(instance.profiler_path)).parent
+    if not instance.profiler_path:
+        return response_not_found("cluster_descriptor.yaml not found")
+
+    report_dir = Path(instance.profiler_path).parent
     rank_param = _optional_rank_query_param()
     logical_rank = 0 if rank_param is None else rank_param
 
@@ -1642,7 +1645,12 @@ def get_cluster_descriptor(instance: Instance):
 @api.route("/mesh-descriptor", methods=["GET"])
 @with_instance
 def get_mesh_descriptor(instance: Instance):
-    report_dir = Path(str(instance.profiler_path)).parent
+    if not instance.profiler_path:
+        return response_not_found(
+            "physical_chip_mesh_coordinate_mapping.yaml not found"
+        )
+
+    report_dir = Path(instance.profiler_path).parent
     rank_param = _optional_rank_query_param()
     logical_rank = 0 if rank_param is None else rank_param
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -73,7 +73,6 @@ from ttnn_visualizer.sftp_operations import (
     check_remote_path_exists,
     check_remote_path_for_reports,
     get_active_sync_method,
-    get_cluster_desc,
     get_remote_performance_folders,
     get_remote_profiler_folders,
     sync_remote_performance_folders,
@@ -89,7 +88,8 @@ from ttnn_visualizer.stack_trace_source import (
 )
 from ttnn_visualizer.utils import (
     create_path_resolver,
-    get_mesh_descriptor_paths,
+    pick_cluster_descriptor_path,
+    pick_mesh_descriptor_path,
     pick_profiler_config_paths,
     read_last_synced_file,
     read_profiler_config_api_payload,
@@ -1610,12 +1610,26 @@ def list_remote_reports_performance():
 @api.route("/cluster-descriptor", methods=["GET"])
 @with_instance
 def get_cluster_descriptor(instance: Instance):
+    report_dir = Path(str(instance.profiler_path)).parent
+    rank_param = _optional_rank_query_param()
+    logical_rank = 0 if rank_param is None else rank_param
+
+    path, err = pick_cluster_descriptor_path(report_dir, logical_rank)
+    if err == "rank_out_of_range":
+        return response_bad_request(
+            f"Invalid rank for this report: {logical_rank}. "
+            "Rank must be within the world size for this report's cluster descriptor files."
+        )
+    if err == "missing_rank_file":
+        return response_not_found(
+            f"No cluster descriptor file for rank {logical_rank}."
+        )
+    if path is None:
+        return response_not_found("cluster_descriptor.yaml not found")
+
     try:
-        cluster_desc = get_cluster_desc(instance)
-
-        if not cluster_desc:
-            return response_not_found("cluster_descriptor.yaml not found")
-
+        with open(path, "r", encoding="utf-8") as cluster_desc_file:
+            cluster_desc = yaml.safe_load(cluster_desc_file)
         return jsonify(cluster_desc), HTTPStatus.OK
 
     except yaml.YAMLError as e:
@@ -1628,15 +1642,25 @@ def get_cluster_descriptor(instance: Instance):
 @api.route("/mesh-descriptor", methods=["GET"])
 @with_instance
 def get_mesh_descriptor(instance: Instance):
-    paths = get_mesh_descriptor_paths(instance)
+    report_dir = Path(str(instance.profiler_path)).parent
+    rank_param = _optional_rank_query_param()
+    logical_rank = 0 if rank_param is None else rank_param
 
-    if not paths:
+    path, err = pick_mesh_descriptor_path(report_dir, logical_rank)
+    if err == "rank_out_of_range":
+        return response_bad_request(
+            f"Invalid rank for this report: {logical_rank}. "
+            "Rank must be within the world size for this report's mesh descriptor files."
+        )
+    if err == "missing_rank_file":
+        return response_not_found(f"No mesh descriptor file for rank {logical_rank}.")
+    if path is None:
         return response_not_found(
-            "physical_chip_mesh_coordinate_mapping_1_of_1.yaml not found"
+            "physical_chip_mesh_coordinate_mapping.yaml not found"
         )
 
     try:
-        with open(paths[0], "r", encoding="utf-8") as mesh_descriptor_path:
+        with open(path, "r", encoding="utf-8") as mesh_descriptor_path:
             yaml_data = yaml.safe_load(mesh_descriptor_path)
             return jsonify(yaml_data)  # yaml_data is not compatible with orjson
     except yaml.YAMLError as e:


### PR DESCRIPTION
## Summary

- Load cluster and mesh descriptor YAML files with or without `_<rank>_of_<world>` suffixes, matching tt-metal's single-host vs multi-host naming.
- Reuse the same ranked-file resolution pattern already used for `config.json` / `config_<n>_of_<world>.json`.
- Expose optional `?rank=` on `/api/cluster-descriptor` and `/api/mesh-descriptor` for multi-host debugging.

Closes #1641

## Test plan

- [x] `pytest backend/ttnn_visualizer/tests/test_utils.py -k "mesh_descriptor or cluster_descriptor or profiler_config"`
- [ ] Load a single-host report with `cluster_descriptor.yaml` and `physical_chip_mesh_coordinate_mapping.yaml` and confirm topology view works
- [ ] Load a multi-host report with ranked YAML files and confirm topology view works


Made with [Cursor](https://cursor.com)