### PR TITLE
Show circular buffer allocation view per core

### DIFF
--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -110,10 +110,13 @@ const ZoomedCorePlot = ({
     const memoryRange = Math.max(1, memoryEnd - memoryStart);
     const memoryMid = memoryStart + memoryRange / 2;
     const plotHeight = 64;
-    // Pixel threshold above which we surface the inline `addr · size`
-    // label. Below this the rect collapses to colour-only and we lean
-    // on the tooltip / legend for identity.
-    const MIN_PX_FOR_LABEL = 70;
+    // Width threshold for the inline `addr · size` label, expressed as a
+    // percentage of the address window. The `prettyPrintAddress · size`
+    // string needs ~70px in our monospace font, and the zoomed panel sits
+    // in a ~600px column, so anything narrower than ~12% of the window
+    // can't fit the label without clipping. Below this we drop the label
+    // and lean on the tooltip / legend for identity.
+    const MIN_WIDTH_PERCENT_FOR_LABEL = 12;
 
     return (
         <div className='zoomed-core-plot'>
@@ -129,7 +132,7 @@ const ZoomedCorePlot = ({
                     const isSelected = selectedCBNodeId === cb.nodeId;
                     // Width-as-fraction-of-window is enough to decide whether
                     // there's room for a label without forcing a layout pass.
-                    const labelFits = widthPercent > MIN_PX_FOR_LABEL / 6;
+                    const labelFits = widthPercent > MIN_WIDTH_PERCENT_FOR_LABEL;
                     return (
                         <g
                             key={cb.nodeId}
@@ -498,7 +501,7 @@ const CircularBufferPressureBody = ({
                     {snapshot.allocations.length === 0 && (
                         <p className='empty-message'>No live CBs in this DeviceOp.</p>
                     )}
-                    <ul className='cb-list with-total'>
+                    <ul className='cb-list'>
                         {snapshot.allocations.map((cb) => {
                             const isSelected = selectedCBNodeId === cb.nodeId;
                             const swatchColor = getBufferColor(cb.address + (cb.allocateOperationId ?? 0));

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -440,7 +440,11 @@ const CircularBufferPressureBody = ({
                         <div className='axis-caption monospace'>
                             <span>{prettyPrintAddress(memStart, l1Budget)}</span>
                             <span className='axis-range'>
-                                L1 address window · {formatMemorySize(memEnd - memStart, 2)}
+                                {/* "Address range" rather than "L1 address window" so the
+                                    chart-window size doesn't get conflated with the per-core
+                                    L1 capacity shown in the header's `L1 budget` tag — they
+                                    are different quantities measured in different bytes. */}
+                                Address range · {formatMemorySize(memEnd - memStart, 2)}
                             </span>
                             <span>{prettyPrintAddress(memEnd, l1Budget)}</span>
                         </div>

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
     Button,
     ButtonGroup,
@@ -185,6 +185,17 @@ const CircularBufferPressureModal = ({ isOpen, onClose, title, snapshot }: Circu
     const [selectedCBNodeId, setSelectedCBNodeId] = useState<number | null>(null);
     const [normalisation, setNormalisation] = useState<Normalisation>('local');
     const [showAbsolute, setShowAbsolute] = useState<boolean>(true);
+
+    // We render null on close instead of unmounting, so useState slots
+    // persist across open/close cycles. Drop the per-snapshot selections
+    // whenever a new snapshot arrives — they'd otherwise point at stale
+    // nodeIds / cores from the previously-inspected DeviceOp. Normalisation
+    // and the byte-overlay toggle are user preferences, so they're kept.
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setSelectedCore(null);
+        setSelectedCBNodeId(null);
+    }, [snapshot]);
 
     if (!isOpen) {
         return null;
@@ -504,7 +515,7 @@ const CircularBufferPressureBody = ({
                     <ul className='cb-list'>
                         {snapshot.allocations.map((cb) => {
                             const isSelected = selectedCBNodeId === cb.nodeId;
-                            const swatchColor = getBufferColor(cb.address + (cb.allocateOperationId ?? 0));
+                            const swatchColor = cbColor(cb);
                             return (
                                 <li key={cb.nodeId}>
                                     <button

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -1,0 +1,611 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useMemo, useState } from 'react';
+import {
+    Button,
+    ButtonGroup,
+    ButtonVariant,
+    Card,
+    Overlay2,
+    PopoverPosition,
+    Size,
+    Switch,
+    Tag,
+    Tooltip,
+} from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import classNames from 'classnames';
+import { useDevices } from '../../hooks/useAPI';
+import LoadingSpinner from '../LoadingSpinner';
+import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
+import { getBufferColor } from '../../functions/colorGenerator';
+import { CBAllocationSummary, CBPressureSnapshot } from '../../functions/processMemoryAllocations';
+import 'styles/components/CircularBufferPressureModal.scss';
+
+const CORE_KEY = (x: number, y: number) => `${x},${y}`;
+
+type Normalisation = 'local' | 'budget';
+
+// Cell geometry — mirrors the L1 tensix grid (tensixSize=120, /3 height) used
+// by TensorVisualisationComponent so the two visualisations feel like siblings.
+const TENSIX_WIDTH = 120;
+const TENSIX_HEIGHT = TENSIX_WIDTH / 3;
+const STRIP_HEIGHT = 16;
+
+// Fallback grey for the rare case where the palette generator returns
+// undefined (e.g. address falls outside its known bands); keeps the rect
+// visible instead of letting SVG default to black.
+const CB_FALLBACK_COLOR = '#888';
+
+const cbColor = (cb: CBAllocationSummary): string =>
+    getBufferColor(cb.address + (cb.allocateOperationId ?? 0)) ?? CB_FALLBACK_COLOR;
+
+interface MiniCBStripProps {
+    cbs: CBAllocationSummary[];
+    memoryStart: number;
+    memoryEnd: number;
+    selectedCBNodeId: number | null;
+}
+
+/**
+ * Per-core L1 strip showing where each contributing CB sits in the address
+ * space. Inline SVG (rather than reusing SVGBufferRenderer) because we work
+ * with CBAllocationSummary, not BufferChunk, and we want a hover/selection
+ * outline that the existing primitive doesn't expose.
+ */
+const MiniCBStrip = ({ cbs, memoryStart, memoryEnd, selectedCBNodeId }: MiniCBStripProps) => {
+    const memoryRange = Math.max(1, memoryEnd - memoryStart);
+    return (
+        <svg
+            className='cb-strip'
+            height={STRIP_HEIGHT}
+            width='100%'
+            preserveAspectRatio='none'
+        >
+            {cbs.map((cb) => {
+                const xPercent = ((cb.address - memoryStart) / memoryRange) * 100;
+                const widthPercent = (cb.size / memoryRange) * 100;
+                const isSelected = selectedCBNodeId === cb.nodeId;
+                return (
+                    <rect
+                        key={cb.nodeId}
+                        x={`${xPercent}%`}
+                        y={0}
+                        width={`${widthPercent}%`}
+                        height={STRIP_HEIGHT}
+                        fill={cbColor(cb)}
+                        className={classNames('cb-strip-chunk', { selected: isSelected })}
+                    />
+                );
+            })}
+        </svg>
+    );
+};
+
+interface ZoomedCorePlotProps {
+    cbs: CBAllocationSummary[];
+    memoryStart: number;
+    memoryEnd: number;
+    l1Budget: number;
+    selectedCBNodeId: number | null;
+    onSelectCB: (nodeId: number | null) => void;
+}
+
+/**
+ * Wider per-core L1 plot rendered in the details panel when a cell is
+ * selected. Shares its `[memoryStart, memoryEnd]` window with the grid so
+ * the zoom panel is a true magnification — a CB at the same x-offset in
+ * the grid strip lands at the same x-offset down here, just bigger.
+ */
+const ZoomedCorePlot = ({
+    cbs,
+    memoryStart,
+    memoryEnd,
+    l1Budget,
+    selectedCBNodeId,
+    onSelectCB,
+}: ZoomedCorePlotProps) => {
+    const memoryRange = Math.max(1, memoryEnd - memoryStart);
+    const memoryMid = memoryStart + memoryRange / 2;
+    const plotHeight = 64;
+    // Pixel threshold above which we surface the inline `addr · size`
+    // label. Below this the rect collapses to colour-only and we lean
+    // on the tooltip / legend for identity.
+    const MIN_PX_FOR_LABEL = 70;
+
+    return (
+        <div className='zoomed-core-plot'>
+            <svg
+                className='zoomed-core-svg'
+                width='100%'
+                height={plotHeight}
+                preserveAspectRatio='none'
+            >
+                {cbs.map((cb) => {
+                    const xPercent = ((cb.address - memoryStart) / memoryRange) * 100;
+                    const widthPercent = (cb.size / memoryRange) * 100;
+                    const isSelected = selectedCBNodeId === cb.nodeId;
+                    // Width-as-fraction-of-window is enough to decide whether
+                    // there's room for a label without forcing a layout pass.
+                    const labelFits = widthPercent > MIN_PX_FOR_LABEL / 6;
+                    return (
+                        <g
+                            key={cb.nodeId}
+                            className={classNames('zoomed-chunk', { selected: isSelected })}
+                            onClick={() => onSelectCB(isSelected ? null : cb.nodeId)}
+                        >
+                            <title>{`${prettyPrintAddress(cb.address, l1Budget)}  ${formatMemorySize(cb.size, 2)}`}</title>
+                            <rect
+                                x={`${xPercent}%`}
+                                y={0}
+                                width={`${widthPercent}%`}
+                                height={plotHeight}
+                                fill={cbColor(cb)}
+                                className='zoomed-chunk-rect'
+                            />
+                            {labelFits && (
+                                <text
+                                    x={`${xPercent + widthPercent / 2}%`}
+                                    y={plotHeight / 2}
+                                    textAnchor='middle'
+                                    dominantBaseline='central'
+                                    className='zoomed-chunk-label'
+                                >
+                                    {prettyPrintAddress(cb.address, l1Budget)} · {formatMemorySize(cb.size, 2)}
+                                </text>
+                            )}
+                        </g>
+                    );
+                })}
+            </svg>
+            <div className='zoomed-axis monospace'>
+                <span>{prettyPrintAddress(memoryStart, l1Budget)}</span>
+                <span>{prettyPrintAddress(memoryMid, l1Budget)}</span>
+                <span>{prettyPrintAddress(memoryEnd, l1Budget)}</span>
+            </div>
+        </div>
+    );
+};
+
+export interface CircularBufferPressureModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    snapshot: CBPressureSnapshot | null;
+}
+
+const CircularBufferPressureModal = ({ isOpen, onClose, title, snapshot }: CircularBufferPressureModalProps) => {
+    const { data: devices } = useDevices();
+    const [selectedCore, setSelectedCore] = useState<string | null>(null);
+    const [selectedCBNodeId, setSelectedCBNodeId] = useState<number | null>(null);
+    const [normalisation, setNormalisation] = useState<Normalisation>('local');
+    const [showAbsolute, setShowAbsolute] = useState<boolean>(true);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    if (!snapshot || !devices) {
+        return (
+            <Overlay2
+                isOpen={isOpen}
+                enforceFocus
+                hasBackdrop
+                usePortal
+                canEscapeKeyClose
+                transitionDuration={0}
+                onClose={onClose}
+                canOutsideClickClose
+                portalClassName='cb-pressure-overlay'
+            >
+                <Card className='loading-container'>
+                    <LoadingSpinner />
+                </Card>
+            </Overlay2>
+        );
+    }
+
+    if (devices.length === 0) {
+        return null;
+    }
+
+    return (
+        <Overlay2
+            isOpen={isOpen}
+            enforceFocus
+            hasBackdrop
+            usePortal
+            canEscapeKeyClose
+            transitionDuration={0}
+            onClose={onClose}
+            canOutsideClickClose
+            portalClassName='cb-pressure-overlay'
+        >
+            <Card className='cb-pressure'>
+                <CircularBufferPressureBody
+                    title={title}
+                    snapshot={snapshot}
+                    deviceWidth={devices[0].num_x_cores}
+                    deviceHeight={devices[0].num_y_cores}
+                    l1Budget={devices[0].worker_l1_size}
+                    selectedCore={selectedCore}
+                    setSelectedCore={setSelectedCore}
+                    selectedCBNodeId={selectedCBNodeId}
+                    setSelectedCBNodeId={setSelectedCBNodeId}
+                    normalisation={normalisation}
+                    setNormalisation={setNormalisation}
+                    showAbsolute={showAbsolute}
+                    setShowAbsolute={setShowAbsolute}
+                    onClose={onClose}
+                />
+            </Card>
+        </Overlay2>
+    );
+};
+
+interface BodyProps {
+    title: string;
+    snapshot: CBPressureSnapshot;
+    deviceWidth: number;
+    deviceHeight: number;
+    l1Budget: number;
+    selectedCore: string | null;
+    setSelectedCore: (v: string | null) => void;
+    selectedCBNodeId: number | null;
+    setSelectedCBNodeId: (v: number | null) => void;
+    normalisation: Normalisation;
+    setNormalisation: (v: Normalisation) => void;
+    showAbsolute: boolean;
+    setShowAbsolute: (v: boolean) => void;
+    onClose: () => void;
+}
+
+const CircularBufferPressureBody = ({
+    title,
+    snapshot,
+    deviceWidth,
+    deviceHeight,
+    l1Budget,
+    selectedCore,
+    setSelectedCore,
+    selectedCBNodeId,
+    setSelectedCBNodeId,
+    normalisation,
+    setNormalisation,
+    showAbsolute,
+    setShowAbsolute,
+    onClose,
+}: BodyProps) => {
+    // Quick lookup for "is core part of selected CB" highlighting.
+    const selectedCBCores: Set<string> | null = useMemo(() => {
+        if (selectedCBNodeId === null) {
+            return null;
+        }
+        const cb = snapshot.allocations.find((a) => a.nodeId === selectedCBNodeId);
+        if (!cb) {
+            return null;
+        }
+        return new Set(cb.cores.map((c) => CORE_KEY(c.x, c.y)));
+    }, [snapshot.allocations, selectedCBNodeId]);
+
+    // Pre-build a per-core CB list so the grid doesn't filter allocations
+    // for every cell on every render (cells × allocations gets expensive on
+    // big chips). Only cores that actually have a CB get an entry.
+    const cbsByCore: Map<string, CBAllocationSummary[]> = useMemo(() => {
+        const map = new Map<string, CBAllocationSummary[]>();
+        for (const cb of snapshot.allocations) {
+            for (const c of cb.cores) {
+                const key = CORE_KEY(c.x, c.y);
+                const list = map.get(key);
+                if (list) {
+                    list.push(cb);
+                } else {
+                    map.set(key, [cb]);
+                }
+            }
+        }
+        return map;
+    }, [snapshot.allocations]);
+
+    // CBs that contribute to the currently focused core; powers the "core
+    // selected" detail panel without re-walking allocations on every render.
+    const cbsForSelectedCore: CBAllocationSummary[] = useMemo(() => {
+        if (!selectedCore) {
+            return [];
+        }
+        return cbsByCore.get(selectedCore) ?? [];
+    }, [cbsByCore, selectedCore]);
+
+    // Global address-axis clip. Cells share one [memStart, memEnd] so a
+    // CB at the same address lines up across cores at the same x-offset.
+    const [memStart, memEnd] = useMemo(() => {
+        let lo = Number.POSITIVE_INFINITY;
+        let hi = Number.NEGATIVE_INFINITY;
+        // '?' bucket (numCores === 0) is excluded — it doesn't have a
+        // meaningful position on the per-core address axis.
+        for (const cb of snapshot.allocations) {
+            if (cb.numCores > 0) {
+                if (cb.address < lo) {
+                    lo = cb.address;
+                }
+                const end = cb.address + cb.size;
+                if (end > hi) {
+                    hi = end;
+                }
+            }
+        }
+        if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+            return [0, 1];
+        }
+        return [lo, hi];
+    }, [snapshot.allocations]);
+
+    const norm = normalisation === 'budget' ? l1Budget : snapshot.maxBytes || 1;
+
+    return (
+        <>
+            <div className='header'>
+                <h3 className='title'>
+                    <span className='title-text'>{title}</span>
+                    <Button
+                        icon={IconNames.CROSS}
+                        variant={ButtonVariant.MINIMAL}
+                        size={Size.SMALL}
+                        onClick={onClose}
+                    />
+                </h3>
+
+                <div className='summary monospace'>
+                    <Tag
+                        minimal
+                        large
+                    >
+                        Peak: {formatMemorySize(snapshot.maxBytes, 2)}
+                    </Tag>
+                    <Tag
+                        minimal
+                        large
+                    >
+                        L1 budget: {formatMemorySize(l1Budget, 2)}
+                    </Tag>
+                    <Tag
+                        minimal
+                        large
+                    >
+                        CBs: {snapshot.allocations.length}
+                    </Tag>
+                    {snapshot.unattributedBytes > 0 && (
+                        <Tooltip
+                            content={
+                                <span>
+                                    CBs with an empty <code>core_range_set</code> couldn&apos;t be attributed to a
+                                    specific worker core. They&apos;re tracked here as a single bucket.
+                                </span>
+                            }
+                        >
+                            <Tag
+                                intent='warning'
+                                large
+                            >
+                                Unattributed: {formatMemorySize(snapshot.unattributedBytes, 2)}
+                            </Tag>
+                        </Tooltip>
+                    )}
+                </div>
+
+                <div className='controls'>
+                    <ButtonGroup>
+                        <Button
+                            size={Size.SMALL}
+                            intent={normalisation === 'local' ? 'primary' : 'none'}
+                            onClick={() => setNormalisation('local')}
+                        >
+                            Local max
+                        </Button>
+                        <Button
+                            size={Size.SMALL}
+                            intent={normalisation === 'budget' ? 'primary' : 'none'}
+                            onClick={() => setNormalisation('budget')}
+                        >
+                            vs. L1 budget
+                        </Button>
+                    </ButtonGroup>
+                    <Switch
+                        checked={showAbsolute}
+                        label='Show bytes on cells'
+                        onChange={(e) => setShowAbsolute(e.currentTarget.checked)}
+                    />
+                </div>
+            </div>
+
+            <div className='chip-and-legend'>
+                <div className='chip'>
+                    {memEnd > memStart && (
+                        <div className='axis-caption monospace'>
+                            <span>{prettyPrintAddress(memStart, l1Budget)}</span>
+                            <span className='axis-range'>
+                                L1 address window · {formatMemorySize(memEnd - memStart, 2)}
+                            </span>
+                            <span>{prettyPrintAddress(memEnd, l1Budget)}</span>
+                        </div>
+                    )}
+                    <div
+                        className='tensix-grid'
+                        style={{
+                            gridTemplateColumns: `repeat(${deviceWidth || 0}, minmax(0, ${TENSIX_WIDTH}px))`,
+                            gridTemplateRows: `repeat(${deviceHeight || 0}, ${TENSIX_HEIGHT}px)`,
+                        }}
+                    >
+                        {Array.from({ length: deviceWidth * deviceHeight }).map((_, index) => {
+                            const x = index % deviceWidth;
+                            const y = Math.floor(index / deviceWidth);
+                            const key = CORE_KEY(x, y);
+                            const bytes = snapshot.byCore[key] ?? 0;
+                            const intensity = bytes === 0 ? 0 : Math.min(1, bytes / (norm || 1));
+                            const isActive = selectedCore === key;
+                            const isHighlighted = selectedCBCores?.has(key) ?? false;
+                            const overBudget = bytes > l1Budget;
+                            const coreCBs = cbsByCore.get(key) ?? [];
+
+                            return (
+                                <button
+                                    type='button'
+                                    key={key}
+                                    className={classNames('tensix', {
+                                        'has-bytes': bytes > 0,
+                                        active: isActive,
+                                        highlighted: isHighlighted,
+                                        'over-budget': overBudget,
+                                    })}
+                                    style={{
+                                        gridColumn: x + 1,
+                                        gridRow: y + 1,
+                                        // SCSS picks this up to drive the
+                                        // heatmap wash behind the address strip.
+                                        ['--cb-intensity' as string]: intensity.toFixed(3),
+                                    }}
+                                    onClick={() => setSelectedCore(isActive ? null : key)}
+                                    title={`(${x}, ${y})  ${formatMemorySize(bytes, 2)}${
+                                        bytes > 0 ? `  (${((bytes / l1Budget) * 100).toFixed(1)}% of L1)` : ''
+                                    }`}
+                                >
+                                    <span className='tensix-meta'>
+                                        <span className='coord monospace'>
+                                            {x},{y}
+                                        </span>
+                                        {showAbsolute && bytes > 0 && (
+                                            <span className='value monospace'>{formatMemorySize(bytes, 2)}</span>
+                                        )}
+                                    </span>
+                                    {coreCBs.length > 0 && (
+                                        <MiniCBStrip
+                                            cbs={coreCBs}
+                                            memoryStart={memStart}
+                                            memoryEnd={memEnd}
+                                            selectedCBNodeId={selectedCBNodeId}
+                                        />
+                                    )}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <div className='legend'>
+                    <h4>Circular buffers</h4>
+                    {snapshot.allocations.length === 0 && (
+                        <p className='empty-message'>No live CBs in this DeviceOp.</p>
+                    )}
+                    <ul className='cb-list with-total'>
+                        {snapshot.allocations.map((cb) => {
+                            const isSelected = selectedCBNodeId === cb.nodeId;
+                            const swatchColor = getBufferColor(cb.address + (cb.allocateOperationId ?? 0));
+                            return (
+                                <li key={cb.nodeId}>
+                                    <button
+                                        type='button'
+                                        className={classNames('cb-row', { active: isSelected })}
+                                        onClick={() => setSelectedCBNodeId(isSelected ? null : cb.nodeId)}
+                                    >
+                                        <span
+                                            className='swatch'
+                                            style={{ backgroundColor: swatchColor }}
+                                        />
+                                        <span className='cb-row-body monospace'>
+                                            <span className='addr'>{prettyPrintAddress(cb.address, l1Budget)}</span>
+                                            <span className='size'>{formatMemorySize(cb.size, 2)}</span>
+                                            <span className='cores'>
+                                                {cb.numCores > 0 ? `× ${cb.numCores} cores` : 'unattributed'}
+                                            </span>
+                                        </span>
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                    {snapshot.allocations.length > 0 &&
+                        (() => {
+                            const cbSum = snapshot.allocations.reduce((sum, cb) => sum + cb.size, 0);
+                            // Sum only diverges from peak when CBs span disjoint
+                            // core sets (no single core carries the full sum).
+                            // Hiding it in the common case keeps the legend
+                            // uncluttered; surfacing it on divergence makes
+                            // the "CBs don't share core sets" signal explicit.
+                            const showSum = cbSum > snapshot.maxBytes;
+                            return (
+                                <div className='cb-list-totals monospace'>
+                                    <Tooltip
+                                        content={
+                                            <span>
+                                                Highest per-core CB load. Caps L1 budget headroom; matches the Peak tag
+                                                in the header.
+                                            </span>
+                                        }
+                                        position={PopoverPosition.TOP}
+                                    >
+                                        <div className='cb-list-total row-peak'>
+                                            <span className='label'>Peak per core</span>
+                                            <span className='value'>{formatMemorySize(snapshot.maxBytes, 2)}</span>
+                                        </div>
+                                    </Tooltip>
+                                    {showSum && (
+                                        <Tooltip
+                                            content={
+                                                <span>
+                                                    Total CB bytes across the snapshot (sum of each CB&apos;s per-core
+                                                    size). Larger than peak here because CBs land on disjoint core sets
+                                                    &mdash; no single core carries the full total.
+                                                </span>
+                                            }
+                                            position={PopoverPosition.TOP}
+                                        >
+                                            <div className='cb-list-total row-sum'>
+                                                <span className='label'>Total CBs</span>
+                                                <span className='value'>{formatMemorySize(cbSum, 2)}</span>
+                                            </div>
+                                        </Tooltip>
+                                    )}
+                                </div>
+                            );
+                        })()}
+                </div>
+            </div>
+
+            {selectedCore && (
+                <div className='tensix-details'>
+                    <div className='tensix-details-header'>
+                        <h4 className='monospace'>
+                            Core ({selectedCore}) · {formatMemorySize(snapshot.byCore[selectedCore] ?? 0, 2)}
+                            <span className='subtle'>
+                                {' '}
+                                · {cbsForSelectedCore.length} {cbsForSelectedCore.length === 1 ? 'CB' : 'CBs'}
+                            </span>
+                        </h4>
+                        <Button
+                            icon={IconNames.CROSS}
+                            variant={ButtonVariant.MINIMAL}
+                            size={Size.SMALL}
+                            onClick={() => setSelectedCore(null)}
+                        />
+                    </div>
+                    {cbsForSelectedCore.length === 0 ? (
+                        <p className='empty-message'>No CB contributions for this core.</p>
+                    ) : (
+                        <ZoomedCorePlot
+                            cbs={cbsForSelectedCore}
+                            memoryStart={memStart}
+                            memoryEnd={memEnd}
+                            l1Budget={l1Budget}
+                            selectedCBNodeId={selectedCBNodeId}
+                            onSelectCB={setSelectedCBNodeId}
+                        />
+                    )}
+                </div>
+            )}
+        </>
+    );
+};
+
+export default CircularBufferPressureModal;

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -26,8 +26,13 @@ import { MemoryLegendElement } from './MemoryLegendElement';
 import { OperationDetails } from '../../model/OperationDetails';
 import { selectedAddressAtom } from '../../store/app';
 import Collapsible, { COLLAPSIBLE_EMPTY_CLASS } from '../Collapsible';
-import { AllocationDetails, processMemoryAllocations } from '../../functions/processMemoryAllocations';
+import {
+    AllocationDetails,
+    CBPressureSnapshot,
+    processMemoryAllocations,
+} from '../../functions/processMemoryAllocations';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
+import CircularBufferPressureModal from './CircularBufferPressureModal';
 import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1MemorySize';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
@@ -213,18 +218,28 @@ const renderMemoryInfo = (
     );
 };
 
+type CBPressureModalState = { title: string; snapshot: CBPressureSnapshot } | null;
+
 function useDeviceOperationsFullRenderModel(args: {
     deviceOperations: Node[];
     details: OperationDetails;
     onLegendClick: (address: number, tensorId?: number) => void;
     setDeviceOperationsArgsNode: React.Dispatch<React.SetStateAction<DeviceOperationNode | null>>;
     setDeviceOperationsArgsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    setCbPressureModal: React.Dispatch<React.SetStateAction<CBPressureModalState>>;
     colorVariance?: number;
 }) {
-    const { deviceOperations, details, onLegendClick, setDeviceOperationsArgsOpen, setDeviceOperationsArgsNode } = args;
+    const {
+        deviceOperations,
+        details,
+        onLegendClick,
+        setDeviceOperationsArgsOpen,
+        setDeviceOperationsArgsNode,
+        setCbPressureModal,
+    } = args;
 
     const selectedAddress = useAtomValue(selectedAddressAtom);
-    const { memoryAllocationList, peakMemoryLoad } = processMemoryAllocations(deviceOperations);
+    const { memoryAllocationList, peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(deviceOperations);
 
     const formatTensor = useCallback((node: Node) => formatTensorRendering(node, details), [details]);
 
@@ -232,6 +247,10 @@ function useDeviceOperationsFullRenderModel(args: {
         (nodes: Node[]) => {
             const deviceOpList: Node[] = [];
             const stack: JSX.Element[][] = [];
+            // Tracks the innermost open DeviceOp (matching the JSX stack) so
+            // the CB-pressure button rendered at the "<h4>CBs</h4>" heading
+            // knows which DeviceOp snapshot to surface.
+            const deviceOpIdStack: { id: number; name: string }[] = [];
             const output: JSX.Element[] = [];
             let consecutiveCBsOutput = false;
 
@@ -243,11 +262,13 @@ function useDeviceOperationsFullRenderModel(args: {
                 if (nodeType === NodeType.function_start) {
                     deviceOpList.push(node);
                     stack.push([]);
+                    deviceOpIdStack.push({ id: node.id, name: node.params.name });
                     return;
                 }
 
                 if (nodeType === NodeType.function_end) {
                     const innerContent = stack.pop();
+                    deviceOpIdStack.pop();
                     const opName = node.params.name;
 
                     const opArgs = node.operation?.arguments;
@@ -417,12 +438,37 @@ function useDeviceOperationsFullRenderModel(args: {
                     const numCores = parseInt(cb.num_cores, 10) || 1;
 
                     const variance = cb.allocateOperationId;
+                    const currentDeviceOp = deviceOpIdStack[deviceOpIdStack.length - 1];
+                    const cbSnapshot = currentDeviceOp ? cbPressureByOpId.get(currentDeviceOp.id) : undefined;
                     operationContent = (
                         <Fragment key={`${cb.address}-${index}`}>
                             {!consecutiveCBsOutput && (
                                 <>
                                     <hr />
-                                    <h4>CBs</h4>
+                                    <div className='cbs-heading'>
+                                        <h4>CBs</h4>
+                                        {cbSnapshot && currentDeviceOp && (
+                                            <Tooltip
+                                                content='Show per-core CB pressure for this DeviceOp'
+                                                position={PopoverPosition.TOP}
+                                            >
+                                                <Button
+                                                    icon={IconNames.HEAT_GRID}
+                                                    size={Size.SMALL}
+                                                    variant={ButtonVariant.OUTLINED}
+                                                    intent={Intent.PRIMARY}
+                                                    onClick={() =>
+                                                        setCbPressureModal({
+                                                            title: `${currentDeviceOp.name} · per-core CB pressure`,
+                                                            snapshot: cbSnapshot,
+                                                        })
+                                                    }
+                                                >
+                                                    Per-core pressure
+                                                </Button>
+                                            </Tooltip>
+                                        )}
+                                    </div>
                                 </>
                             )}
                             <MemoryLegendElement
@@ -458,12 +504,14 @@ function useDeviceOperationsFullRenderModel(args: {
             return output;
         },
         [
+            cbPressureByOpId,
             details,
             formatTensor,
             memoryAllocationList,
             onLegendClick,
             peakMemoryLoad,
             selectedAddress,
+            setCbPressureModal,
             setDeviceOperationsArgsNode,
             setDeviceOperationsArgsOpen,
         ],
@@ -486,12 +534,14 @@ interface DeviceOperationsFullRenderProps {
 const DeviceOperationsFullRender = ({ deviceOperations, details, onLegendClick }: DeviceOperationsFullRenderProps) => {
     const [deviceOperationsArgsOpen, setDeviceOperationsArgsOpen] = useState(false);
     const [deviceOperationsArgsNode, setDeviceOperationsArgsNode] = useState<DeviceOperationNode | null>(null);
+    const [cbPressureModal, setCbPressureModal] = useState<CBPressureModalState>(null);
     const { peakMemoryLoad, renderOperations } = useDeviceOperationsFullRenderModel({
         deviceOperations,
         details,
         onLegendClick,
         setDeviceOperationsArgsNode,
         setDeviceOperationsArgsOpen,
+        setCbPressureModal,
     });
     return (
         <div className='device-operations-full-render-wrap'>
@@ -499,6 +549,12 @@ const DeviceOperationsFullRender = ({ deviceOperations, details, onLegendClick }
                 node={deviceOperationsArgsNode}
                 open={deviceOperationsArgsOpen}
                 onClose={() => setDeviceOperationsArgsOpen(false)}
+            />
+            <CircularBufferPressureModal
+                isOpen={cbPressureModal !== null}
+                title={cbPressureModal?.title ?? ''}
+                snapshot={cbPressureModal?.snapshot ?? null}
+                onClose={() => setCbPressureModal(null)}
             />
             <h3 className='peak-load monospace'>
                 Peak L1 memory load per core:{' '}

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -448,25 +448,31 @@ function useDeviceOperationsFullRenderModel(args: {
                                     <div className='cbs-heading'>
                                         <h4>CBs</h4>
                                         {cbSnapshot && currentDeviceOp && (
-                                            <Tooltip
-                                                content='Show per-core CB pressure for this DeviceOp'
-                                                position={PopoverPosition.TOP}
-                                            >
-                                                <Button
-                                                    icon={IconNames.HEAT_GRID}
-                                                    size={Size.SMALL}
-                                                    variant={ButtonVariant.OUTLINED}
-                                                    intent={Intent.PRIMARY}
-                                                    onClick={() =>
-                                                        setCbPressureModal({
-                                                            title: `${currentDeviceOp.name} · per-core CB pressure`,
-                                                            snapshot: cbSnapshot,
-                                                        })
-                                                    }
+                                            <>
+                                                <span
+                                                    className='cbs-heading-separator'
+                                                    aria-hidden='true'
                                                 >
-                                                    Per-core pressure
-                                                </Button>
-                                            </Tooltip>
+                                                    ·
+                                                </span>
+                                                <Tooltip
+                                                    content='Show per-core CB allocations for this DeviceOp'
+                                                    position={PopoverPosition.TOP}
+                                                >
+                                                    <button
+                                                        type='button'
+                                                        className='cbs-heading-link'
+                                                        onClick={() =>
+                                                            setCbPressureModal({
+                                                                title: `${currentDeviceOp.name} · per-core CB allocations`,
+                                                                snapshot: cbSnapshot,
+                                                            })
+                                                        }
+                                                    >
+                                                        View per-core allocations
+                                                    </button>
+                                                </Tooltip>
+                                            </>
                                         )}
                                     </div>
                                 </>

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -5,7 +5,7 @@
 import { DeviceOperationNode, Node, NodeType } from '../model/APIData';
 import { L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { StringBufferType } from '../model/BufferType';
-import { getCoresInRangeList } from './math';
+import { CoreCoord, getCoresInRangeList } from './math';
 
 export type AllocationDetails = {
     id: number;
@@ -17,17 +17,88 @@ export type AllocationDetails = {
     deviceId: number;
 };
 
+/**
+ * One circular-buffer allocation summarised at the moment it landed, so the
+ * pressure modal can replay "which CBs contributed to this core" without
+ * re-walking the graph.
+ */
+export type CBAllocationSummary = {
+    /** Node id of the originating `circular_buffer_allocate` event. */
+    nodeId: number;
+    address: number;
+    /** Per-core size in bytes (matches the raw `size` field on the node). */
+    size: number;
+    /** Number of distinct cores the allocation covers (0 if unattributed). */
+    numCores: number;
+    /** Raw `core_range_set` string from the graph node (for display + reproducibility). */
+    coreRangeSet: string;
+    /** Expanded cores; empty when the allocation falls into the `'?'` bucket. */
+    cores: CoreCoord[];
+    /** Op id/name that created the CB, used downstream for color-variance/highlighting. */
+    allocateOperationId?: number;
+    allocateOperationName?: string;
+};
+
+/**
+ * Snapshot of CB pressure for one DeviceOp. Keyed by the innermost open
+ * `function_start.id` at the time the snapshot was taken (either at a
+ * `circular_buffer_deallocate_all` or, as a fallback, at `function_end` when
+ * CBs are still live).
+ */
+export type CBPressureSnapshot = {
+    /** Bytes-per-core, keyed by `"x,y"`. The `'?'` bucket captures unattributed CBs. */
+    byCore: Record<string, number>;
+    /** Convenience: largest attributed (x,y) value in `byCore`. Excludes `'?'`. */
+    maxBytes: number;
+    /** Bucket for CB allocations whose `core_range_set` resolved to zero cores. */
+    unattributedBytes: number;
+    /** Ordered list of CBs that were live when the snapshot was taken. */
+    allocations: CBAllocationSummary[];
+};
+
 export function processMemoryAllocations(
     graph: Node[],
     // _inputs: { id: number; size: number | null }[],
 ): {
     peakMemoryLoad: number;
     memoryAllocationList: AllocationDetails[];
+    cbPressureByOpId: Map<number, CBPressureSnapshot>;
 } {
     let peakMemoryLoad = 0;
     const memoryAllocationList: AllocationDetails[] = [];
     const curOpList: { name: string; id: number; deviceId?: string | number }[] = [];
     const cbBytesByCore = new Map<string, number>();
+    // Live CB allocations since the last `circular_buffer_deallocate_all` (or
+    // since the DeviceOp started, whichever came last). Mirrors `cbBytesByCore`
+    // so the snapshot can attribute pressure back to specific CB events.
+    let liveCBs: CBAllocationSummary[] = [];
+    const cbPressureByOpId = new Map<number, CBPressureSnapshot>();
+
+    const snapshotCBPressure = (opId: number) => {
+        if (liveCBs.length === 0 && cbBytesByCore.size === 0) {
+            return;
+        }
+        const byCore: Record<string, number> = {};
+        let maxBytes = 0;
+        let unattributedBytes = 0;
+        for (const [k, v] of cbBytesByCore.entries()) {
+            byCore[k] = v;
+            if (k === '?') {
+                unattributedBytes = v;
+            } else if (v > maxBytes) {
+                maxBytes = v;
+            }
+        }
+        // Last writer wins if a DeviceOp triggers multiple snapshots. v1
+        // assumption: one `circular_buffer_deallocate_all` per DeviceOp.
+        cbPressureByOpId.set(opId, {
+            byCore,
+            maxBytes,
+            unattributedBytes,
+            allocations: liveCBs.slice(),
+        });
+    };
+
     let totalBuffer = 0;
 
     const maxCbPerCore = (): number => {
@@ -70,10 +141,28 @@ export function processMemoryAllocations(
                     cbBytesByCore.set(k, (cbBytesByCore.get(k) ?? 0) + size);
                 }
             }
+            liveCBs.push({
+                nodeId: node.id,
+                address: parseInt(node.params.address, 10),
+                size,
+                numCores: cores.length,
+                coreRangeSet: node.params.core_range_set,
+                cores,
+                allocateOperationId: currentOp?.id,
+                allocateOperationName: currentOp?.name,
+            });
         }
 
         if (node.node_type === NodeType.circular_buffer_deallocate_all) {
+            // Snapshot before clearing so the modal can recreate the pressure
+            // state seen by the just-completed kernel. Attribute to the
+            // innermost open function_start — that's the DeviceOp whose CBs
+            // are being released.
+            if (currentOp) {
+                snapshotCBPressure(currentOp.id);
+            }
             cbBytesByCore.clear();
+            liveCBs = [];
         }
 
         if (node.node_type === NodeType.buffer_allocate && node.params.type === StringBufferType.L1) {
@@ -83,6 +172,14 @@ export function processMemoryAllocations(
         }
 
         if (node.node_type === NodeType.function_end) {
+            // Safety net: well-behaved DeviceOps end with
+            // `circular_buffer_deallocate_all`, but if a kernel exits with CBs
+            // still live, attribute the lingering pressure to the closing op
+            // before unwinding the stack.
+            const ending = curOpList[curOpList.length - 1];
+            if (ending && liveCBs.length > 0 && !cbPressureByOpId.has(ending.id)) {
+                snapshotCBPressure(ending.id);
+            }
             curOpList.pop();
         }
 
@@ -112,7 +209,7 @@ export function processMemoryAllocations(
         peakMemoryLoad = Math.max(peakMemoryLoad, cbPeak + totalBuffer);
     }
 
-    return { peakMemoryLoad, memoryAllocationList };
+    return { peakMemoryLoad, memoryAllocationList, cbPressureByOpId };
 }
 
 export const processInputsOutputs = (graph: Node[]): DeviceOperationNode[] => {

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -103,8 +103,11 @@ export function processMemoryAllocations(
 
     const maxCbPerCore = (): number => {
         let m = 0;
-        for (const v of cbBytesByCore.values()) {
-            if (v > m) {
+        // Skip the '?' bucket — those bytes have no core attribution so
+        // they don't belong in a per-core peak. Mirrors the same exclusion
+        // in snapshotCBPressure() so cbPeak and snapshot.maxBytes agree.
+        for (const [k, v] of cbBytesByCore.entries()) {
+            if (k !== '?' && v > m) {
                 m = v;
             }
         }

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -391,13 +391,45 @@
     }
 }
 
-// Inline button next to the "CBs" heading inside the DeviceOp render.
+// Inline affordance next to the "CBs" heading inside the DeviceOp render.
+// Plain anchor-style button — no chrome, just colored text + hover-underline.
+// Heavier button chrome (outlined/primary) felt out of place next to the
+// small <h4>; the minimal icon-only variant was too easy to miss. Link text
+// reads as interactive without competing with the heading.
 .cbs-heading {
     display: flex;
-    align-items: center;
-    gap: 12px;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 10px;
 
     h4 {
         margin: 0;
+    }
+
+    .cbs-heading-separator {
+        opacity: 0.5;
+        user-select: none;
+    }
+
+    .cbs-heading-link {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        color: $tt-yellow;
+        cursor: pointer;
+        text-decoration: none;
+
+        &:hover {
+            color: $tt-yellow-tint-1;
+            text-decoration: underline;
+        }
+
+        &:focus-visible {
+            outline: 1px dotted $tt-yellow;
+            outline-offset: 2px;
+            text-decoration: underline;
+        }
     }
 }

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -55,6 +55,7 @@
             .controls {
                 display: flex;
                 align-items: center;
+                justify-content: center;
                 gap: 16px;
             }
         }

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -264,10 +264,6 @@
                             }
                         }
                     }
-
-                    &.compact {
-                        max-height: 200px;
-                    }
                 }
 
                 .cb-list-totals {

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -55,7 +55,6 @@
             .controls {
                 display: flex;
                 align-items: center;
-                justify-content: center;
                 gap: 16px;
             }
         }

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -56,6 +56,14 @@
                 display: flex;
                 align-items: center;
                 gap: 16px;
+
+                // Blueprint switches carry a default `.bp6-control { margin-bottom: 10px }`
+                // which makes `align-items: center` pull the visible toggle upward
+                // relative to the neighbouring button group. Same workaround already
+                // used in OperationGraphComponent / OperationDetailsComponent control rows.
+                .bp6-control {
+                    margin-bottom: 0;
+                }
             }
         }
 

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+@use 'styles/definitions/colours' as *;
+
+.cb-pressure-overlay {
+    .bp6-overlay {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+    }
+
+    .loading-container {
+        background-color: transparent;
+    }
+
+    .cb-pressure {
+        background-color: $tt-grey-4;
+        max-width: 90vw;
+        max-height: 90vh;
+        overflow: auto;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+
+        .header {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+
+            .title {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin: 0;
+
+                .title-text {
+                    font-size: 1.1rem;
+                }
+
+                svg {
+                    fill: $tt-white;
+                }
+            }
+
+            .summary {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .controls {
+                display: flex;
+                align-items: center;
+                gap: 16px;
+            }
+        }
+
+        .chip-and-legend {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) 280px;
+            gap: 16px;
+
+            .chip {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+
+                .axis-caption {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    font-size: 10px;
+                    color: rgba($tt-white, 0.6);
+                    padding: 0 2px;
+
+                    .axis-range {
+                        opacity: 0.5;
+                    }
+                }
+
+                .tensix-grid {
+                    display: grid;
+                    gap: 4px;
+
+                    .tensix {
+                        // Heatmap intensity is driven by inline --cb-intensity
+                        // (0..1) and renders as a thin saturated bar at the top
+                        // of the cell via a ::before pseudo-element. Cell body
+                        // stays neutral so the CB strip remains the dominant
+                        // visual signal.
+                        --cb-intensity: 0;
+
+                        position: relative;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-between;
+                        align-items: stretch;
+                        gap: 2px;
+                        padding: 5px 3px 2px;
+                        border: 1px solid $tt-black;
+                        background-color: $tt-grey-2;
+                        color: $tt-white;
+                        cursor: pointer;
+                        font-size: 9px;
+                        line-height: 1;
+                        overflow: hidden;
+
+                        // Top-of-cell intensity bar. Painted at full saturation
+                        // because it's small and competes with no other colour
+                        // in the slim 3px region.
+                        &::before {
+                            content: '';
+                            position: absolute;
+                            top: 0;
+                            left: 0;
+                            right: 0;
+                            height: 3px;
+                            background-color: rgba($tt-red-accent, var(--cb-intensity));
+                            pointer-events: none;
+                        }
+
+                        &:not(.has-bytes) {
+                            background-color: rgba($tt-grey-2, 0.5);
+                            color: rgba($tt-white, 0.35);
+                            cursor: default;
+                        }
+
+                        &:hover.has-bytes {
+                            border-color: $tt-yellow-tint-2;
+                        }
+
+                        &.active {
+                            border-color: $tt-tensix-active;
+                            box-shadow: 0 0 0 1px $tt-tensix-active inset;
+                        }
+
+                        &.highlighted {
+                            border-color: $tt-yellow;
+                            box-shadow: 0 0 0 2px $tt-yellow inset;
+                        }
+
+                        &.over-budget {
+                            outline: 1px dashed $tt-red;
+                            outline-offset: -1px;
+                        }
+
+                        .tensix-meta {
+                            display: flex;
+                            justify-content: space-between;
+                            align-items: baseline;
+                            gap: 4px;
+                            min-width: 0;
+
+                            .coord {
+                                opacity: 0.7;
+                            }
+
+                            .value {
+                                font-weight: 600;
+                                text-align: right;
+                                white-space: nowrap;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                            }
+                        }
+
+                        .cb-strip {
+                            display: block;
+
+                            // Inline rects are pixel-stable; subtle stroke
+                            // separates touching CBs without faking gaps.
+                            .cb-strip-chunk {
+                                stroke: rgba($tt-black, 0.6);
+                                stroke-width: 0.5;
+                            }
+
+                            .cb-strip-chunk.selected {
+                                stroke: $tt-yellow;
+                                stroke-width: 2;
+                            }
+                        }
+                    }
+                }
+            }
+
+            .legend {
+                background-color: $tt-grey-2;
+                padding: 8px 10px;
+                border-radius: 2px;
+
+                h4 {
+                    margin: 0 0 6px;
+                }
+
+                .empty-message {
+                    color: rgba($tt-white, 0.6);
+                    margin: 0;
+                }
+
+                .cb-list {
+                    list-style: none;
+                    padding: 0;
+                    margin: 0;
+                    max-height: 420px;
+                    overflow-y: auto;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 2px;
+
+                    li {
+                        margin: 0;
+                    }
+
+                    .cb-row {
+                        display: flex;
+                        align-items: center;
+                        gap: 8px;
+                        width: 100%;
+                        padding: 4px 6px;
+                        background: transparent;
+                        border: 1px solid transparent;
+                        color: $tt-white;
+                        cursor: pointer;
+                        text-align: left;
+
+                        &:hover {
+                            background-color: rgba($tt-white, 0.08);
+                        }
+
+                        &.active {
+                            border-color: $tt-yellow;
+                            background-color: rgba($tt-yellow, 0.15);
+                        }
+
+                        .swatch {
+                            display: inline-block;
+                            width: 12px;
+                            height: 12px;
+                            border: 1px solid $tt-black;
+                            flex: 0 0 auto;
+                        }
+
+                        .cb-row-body {
+                            display: grid;
+                            grid-template-columns: 1fr auto auto;
+                            gap: 8px;
+                            flex: 1;
+                            font-size: 12px;
+
+                            .addr {
+                                opacity: 0.85;
+                            }
+
+                            .size {
+                                font-weight: 600;
+                            }
+
+                            .cores {
+                                opacity: 0.7;
+                            }
+                        }
+                    }
+
+                    &.compact {
+                        max-height: 200px;
+                    }
+                }
+
+                .cb-list-totals {
+                    margin-top: 4px;
+                    border-top: 1px solid rgba($tt-white, 0.15);
+                    padding-top: 2px;
+
+                    .cb-list-total {
+                        display: flex;
+                        align-items: baseline;
+                        gap: 8px;
+                        padding: 4px 6px;
+                        font-size: 12px;
+
+                        // Pseudo-element occupies the same slot as the row
+                        // swatch above (12px swatch + 8px gap implied by the
+                        // outer flex), so the label lines up under the first
+                        // address column instead of floating in the middle.
+                        &::before {
+                            content: '';
+                            flex: 0 0 12px;
+                        }
+
+                        .label {
+                            opacity: 0.7;
+                        }
+
+                        .value {
+                            font-weight: 600;
+                        }
+
+                        // The Sum row only renders when it diverges from peak,
+                        // which is the interesting/diagnostic case. Warning
+                        // tint signals "this number is not the L1 budget you
+                        // think it is" without pulling attention from Peak.
+                        &.row-sum {
+                            color: $tt-yellow-tint-1;
+
+                            .label {
+                                opacity: 0.85;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        .tensix-details {
+            background-color: $tt-grey-2;
+            padding: 8px 10px;
+            border-radius: 2px;
+
+            .tensix-details-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-bottom: 6px;
+
+                h4 {
+                    margin: 0;
+
+                    .subtle {
+                        opacity: 0.6;
+                        font-weight: 400;
+                    }
+                }
+
+                svg {
+                    fill: $tt-white;
+                }
+            }
+
+            .zoomed-core-plot {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+
+                .zoomed-core-svg {
+                    display: block;
+                    background-color: rgba($tt-black, 0.35);
+                    border: 1px solid rgba($tt-black, 0.7);
+                    border-radius: 1px;
+
+                    .zoomed-chunk {
+                        cursor: pointer;
+
+                        .zoomed-chunk-rect {
+                            stroke: rgba($tt-black, 0.7);
+                            stroke-width: 0.75;
+                        }
+
+                        .zoomed-chunk-label {
+                            font-family: monospace;
+                            font-size: 11px;
+                            fill: $tt-black;
+                            pointer-events: none;
+                            user-select: none;
+                        }
+
+                        &:hover .zoomed-chunk-rect {
+                            stroke: $tt-yellow-tint-2;
+                            stroke-width: 1.5;
+                        }
+
+                        &.selected .zoomed-chunk-rect {
+                            stroke: $tt-yellow;
+                            stroke-width: 2;
+                        }
+                    }
+                }
+
+                .zoomed-axis {
+                    display: flex;
+                    justify-content: space-between;
+                    font-size: 10px;
+                    color: rgba($tt-white, 0.6);
+                    padding: 0 2px;
+                }
+            }
+        }
+    }
+}
+
+// Inline button next to the "CBs" heading inside the DeviceOp render.
+.cbs-heading {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    h4 {
+        margin: 0;
+    }
+}

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -233,6 +233,58 @@ describe('CircularBufferPressureModal - selection flows', () => {
         // (1,0) carries a different CB so it must NOT be highlighted by this row.
         expect(getTensix(1, 0)).not.toHaveClass('highlighted');
     });
+
+    it('clears core / CB selection when the snapshot prop changes', () => {
+        // Stale selections would otherwise leak across DeviceOps because the
+        // modal renders null on close instead of unmounting.
+        const first = buildSnapshot();
+        const { rerender } = render(
+            <TestProviders>
+                <CircularBufferPressureModal
+                    isOpen
+                    onClose={ON_CLOSE}
+                    title='op A'
+                    snapshot={first}
+                />
+            </TestProviders>,
+        );
+        fireEvent.click(getTensix(0, 0));
+        fireEvent.click(document.querySelectorAll('button.cb-row')[0]);
+        expect(document.querySelector('.tensix-details')).toBeInTheDocument();
+        expect(getTensix(0, 0)).toHaveClass('highlighted');
+
+        // Swap in a different snapshot - say a single CB on (1,1) - and the
+        // previous core/CB selection must drop.
+        const second: CBPressureSnapshot = {
+            byCore: { '1,1': 2048 },
+            maxBytes: 2048,
+            unattributedBytes: 0,
+            allocations: [
+                {
+                    nodeId: 99,
+                    address: 0x9000,
+                    size: 2048,
+                    numCores: 1,
+                    coreRangeSet: '{[(x=1,y=1) - (x=1,y=1)]}',
+                    cores: [{ x: 1, y: 1 }],
+                },
+            ],
+        };
+        rerender(
+            <TestProviders>
+                <CircularBufferPressureModal
+                    isOpen
+                    onClose={ON_CLOSE}
+                    title='op B'
+                    snapshot={second}
+                />
+            </TestProviders>,
+        );
+
+        expect(document.querySelector('.tensix-details')).not.toBeInTheDocument();
+        // No cell should carry the highlighted class anymore.
+        expect(document.querySelectorAll('button.tensix.highlighted')).toHaveLength(0);
+    });
 });
 
 describe('CircularBufferPressureModal - legend totals', () => {

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CircularBufferPressureModal from '../src/components/operation-details/CircularBufferPressureModal';
+import { CBPressureSnapshot } from '../src/functions/processMemoryAllocations';
+import { TestProviders } from './helpers/TestProviders';
+
+// useDevices is the only API hook this modal touches; stub it so we don't
+// need a backing query/router setup just to feed grid dimensions.
+const mockUseDevices = vi.fn();
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useDevices: () => mockUseDevices(),
+}));
+
+// Tiny 2x2 grid keeps the DOM small and makes coverage-vs-bytes assertions
+// trivial to read at the test site.
+const DEVICE_2X2 = {
+    num_x_cores: 2,
+    num_y_cores: 2,
+    worker_l1_size: 1_000_000,
+};
+
+const ON_CLOSE = vi.fn();
+
+function renderModal(snapshot: CBPressureSnapshot | null, title = 'demo_op · per-core CB allocations') {
+    return render(
+        <TestProviders>
+            <CircularBufferPressureModal
+                isOpen
+                onClose={ON_CLOSE}
+                title={title}
+                snapshot={snapshot}
+            />
+        </TestProviders>,
+    );
+}
+
+function getTensix(x: number, y: number): HTMLButtonElement {
+    // Cell label is "x,y" inside the .coord span; grab the enclosing button.
+    const coord = screen.getByText(`${x},${y}`);
+    const tensix = coord.closest('button.tensix');
+    if (!tensix) {
+        throw new Error(`Could not find tensix button for (${x}, ${y})`);
+    }
+    return tensix as HTMLButtonElement;
+}
+
+beforeEach(() => {
+    mockUseDevices.mockReturnValue({ data: [DEVICE_2X2] });
+    ON_CLOSE.mockReset();
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('CircularBufferPressureModal - lifecycle', () => {
+    it('renders nothing when isOpen is false', () => {
+        render(
+            <TestProviders>
+                <CircularBufferPressureModal
+                    isOpen={false}
+                    onClose={ON_CLOSE}
+                    title='hidden'
+                    snapshot={null}
+                />
+            </TestProviders>,
+        );
+
+        expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Peak:/i)).not.toBeInTheDocument();
+    });
+
+    it('shows the loading container when devices are still pending', () => {
+        mockUseDevices.mockReturnValue({ data: undefined });
+
+        renderModal(buildSnapshot());
+
+        // Body never renders without devices; check by absence of the Peak tag
+        // and presence of the spinner container.
+        expect(screen.queryByText(/Peak:/i)).not.toBeInTheDocument();
+        expect(document.querySelector('.loading-container')).toBeInTheDocument();
+    });
+
+    it('shows the loading container when the snapshot is still null', () => {
+        renderModal(null, 'pending op');
+
+        expect(screen.queryByText('pending op')).not.toBeInTheDocument();
+        expect(document.querySelector('.loading-container')).toBeInTheDocument();
+    });
+
+    it('returns null (no portal) when devices payload is empty', () => {
+        mockUseDevices.mockReturnValue({ data: [] });
+
+        renderModal(buildSnapshot(), 'should not render');
+
+        expect(screen.queryByText('should not render')).not.toBeInTheDocument();
+        expect(document.querySelector('.loading-container')).not.toBeInTheDocument();
+    });
+});
+
+describe('CircularBufferPressureModal - header summary', () => {
+    it('renders title, Peak, L1 budget, and CB count tags', () => {
+        renderModal(buildSnapshot());
+
+        expect(screen.getByText('demo_op · per-core CB allocations')).toBeInTheDocument();
+        expect(screen.getByText(/^Peak:/)).toBeInTheDocument();
+        expect(screen.getByText(/^L1 budget:/)).toBeInTheDocument();
+        expect(screen.getByText(/^CBs:\s*2$/)).toBeInTheDocument();
+    });
+
+    it('hides the unattributed tag when no "?" bytes are present', () => {
+        renderModal(buildSnapshot({ unattributedBytes: 0 }));
+
+        expect(screen.queryByText(/^Unattributed:/)).not.toBeInTheDocument();
+    });
+
+    it('renders the unattributed tag when "?" bytes exist', () => {
+        renderModal(
+            buildSnapshot({
+                unattributedBytes: 4096,
+                // Mirror the data layer: the "?" bucket lives in byCore but
+                // not in maxBytes.
+                byCore: { '0,0': 2048, '?': 4096 },
+            }),
+        );
+
+        expect(screen.getByText(/^Unattributed:/)).toBeInTheDocument();
+    });
+});
+
+describe('CircularBufferPressureModal - heatmap grid', () => {
+    it('renders one tensix button per worker core', () => {
+        renderModal(buildSnapshot());
+
+        // 2x2 = 4 cells.
+        const cells = document.querySelectorAll('button.tensix');
+        expect(cells).toHaveLength(4);
+        expect(screen.getByText('0,0')).toBeInTheDocument();
+        expect(screen.getByText('1,1')).toBeInTheDocument();
+    });
+
+    it('marks only cores with bytes as has-bytes', () => {
+        renderModal(buildSnapshot());
+
+        expect(getTensix(0, 0)).toHaveClass('has-bytes');
+        expect(getTensix(1, 0)).toHaveClass('has-bytes');
+        // (0,1) and (1,1) have zero bytes in the fixture.
+        expect(getTensix(0, 1)).not.toHaveClass('has-bytes');
+        expect(getTensix(1, 1)).not.toHaveClass('has-bytes');
+    });
+
+    it('drives --cb-intensity off snapshot.maxBytes in local normalisation', () => {
+        const snapshot = buildSnapshot();
+        renderModal(snapshot);
+
+        // Local normalisation: intensity = bytes / maxBytes.
+        // (0,0) carries the peak (1MiB) → intensity 1.
+        // (1,0) carries 256KiB → intensity 0.25.
+        const peakIntensity = getTensix(0, 0).style.getPropertyValue('--cb-intensity');
+        const partialIntensity = getTensix(1, 0).style.getPropertyValue('--cb-intensity');
+        expect(Number(peakIntensity)).toBeCloseTo(1.0, 3);
+        expect(Number(partialIntensity)).toBeCloseTo((256 * 1024) / (1024 * 1024), 3);
+    });
+
+    it('rescales --cb-intensity against L1 budget when "vs. L1 budget" is selected', () => {
+        renderModal(buildSnapshot());
+
+        fireEvent.click(screen.getByRole('button', { name: 'vs. L1 budget' }));
+
+        // 1 MiB / 1 MB worker_l1_size ≈ 1.048 → clamped to 1.0.
+        // 256 KiB / 1 MB ≈ 0.262.
+        expect(Number(getTensix(0, 0).style.getPropertyValue('--cb-intensity'))).toBeCloseTo(1, 3);
+        expect(Number(getTensix(1, 0).style.getPropertyValue('--cb-intensity'))).toBeCloseTo(
+            (256 * 1024) / 1_000_000,
+            3,
+        );
+    });
+
+    it('shows per-cell byte labels when "Show bytes on cells" is enabled', () => {
+        renderModal(buildSnapshot());
+
+        // The Switch defaults to checked, so the byte value should already
+        // be visible on cells that carry bytes.
+        const labels = document.querySelectorAll('button.tensix .tensix-meta .value');
+        expect(labels).toHaveLength(2);
+
+        // Toggle it off and the byte labels disappear, but the coordinate
+        // labels stay.
+        fireEvent.click(screen.getByLabelText('Show bytes on cells'));
+        expect(document.querySelectorAll('button.tensix .tensix-meta .value')).toHaveLength(0);
+        expect(screen.getByText('0,0')).toBeInTheDocument();
+    });
+});
+
+describe('CircularBufferPressureModal - selection flows', () => {
+    it('opens the zoomed core plot when a cell is clicked and closes it on a second click', () => {
+        renderModal(buildSnapshot());
+
+        // No details panel before selection.
+        expect(document.querySelector('.tensix-details')).not.toBeInTheDocument();
+
+        fireEvent.click(getTensix(0, 0));
+
+        const details = document.querySelector('.tensix-details');
+        expect(details).toBeInTheDocument();
+        // Header should announce the selected core.
+        expect(within(details as HTMLElement).getByText(/Core \(0,0\)/)).toBeInTheDocument();
+        // Default fixture lands one CB on (0,0); the panel uses the singular
+        // "CB" form to gate the count-label pluralisation.
+        expect(within(details as HTMLElement).getByText(/· 1 CB$/)).toBeInTheDocument();
+        // Zoomed plot is rendered as an inline SVG inside the details panel.
+        expect((details as HTMLElement).querySelector('.zoomed-core-plot')).not.toBeNull();
+
+        fireEvent.click(getTensix(0, 0));
+        expect(document.querySelector('.tensix-details')).not.toBeInTheDocument();
+    });
+
+    it('highlights every core covered by a selected CB row', () => {
+        renderModal(buildSnapshot());
+
+        // The 1MiB CB on (0,0) is the first CB in the list. Click its row.
+        const rows = document.querySelectorAll('button.cb-row');
+        expect(rows.length).toBeGreaterThan(0);
+        fireEvent.click(rows[0]);
+
+        expect(getTensix(0, 0)).toHaveClass('highlighted');
+        // (1,0) carries a different CB so it must NOT be highlighted by this row.
+        expect(getTensix(1, 0)).not.toHaveClass('highlighted');
+    });
+});
+
+describe('CircularBufferPressureModal - legend totals', () => {
+    it('hides "Total CBs" when the sum of CB sizes equals the per-core peak', () => {
+        // Two CBs on the same core → sum == peak → only "Peak per core" row.
+        const cb1 = 1024 * 1024;
+        const cb2 = 256 * 1024;
+        const snapshot: CBPressureSnapshot = {
+            byCore: { '0,0': cb1 + cb2 },
+            maxBytes: cb1 + cb2,
+            unattributedBytes: 0,
+            allocations: [
+                {
+                    nodeId: 11,
+                    address: 0x1000,
+                    size: cb1,
+                    numCores: 1,
+                    coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
+                    cores: [{ x: 0, y: 0 }],
+                },
+                {
+                    nodeId: 12,
+                    address: 0x2000,
+                    size: cb2,
+                    numCores: 1,
+                    coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
+                    cores: [{ x: 0, y: 0 }],
+                },
+            ],
+        };
+        renderModal(snapshot);
+
+        expect(screen.getByText('Peak per core')).toBeInTheDocument();
+        expect(screen.queryByText('Total CBs')).not.toBeInTheDocument();
+    });
+
+    it('shows "Total CBs" when CBs land on disjoint cores (sum > peak)', () => {
+        // The default fixture has cb1 on (0,0) and cb2 on (1,0) — disjoint
+        // cores, so sum (1MiB + 256KiB) > peak (1MiB).
+        renderModal(buildSnapshot());
+
+        expect(screen.getByText('Peak per core')).toBeInTheDocument();
+        expect(screen.getByText('Total CBs')).toBeInTheDocument();
+    });
+
+    it('shows the empty-state message when there are no CBs in the snapshot', () => {
+        renderModal({
+            byCore: {},
+            maxBytes: 0,
+            unattributedBytes: 0,
+            allocations: [],
+        });
+
+        expect(screen.getByText(/No live CBs in this DeviceOp\./)).toBeInTheDocument();
+        // No totals row when there's nothing to total.
+        expect(screen.queryByText('Peak per core')).not.toBeInTheDocument();
+    });
+});
+
+// Default fixture: two disjoint CBs (1 MiB on (0,0), 256 KiB on (1,0)).
+// Peak is the per-core max, which equals the bigger CB; sum > peak so the
+// Total CBs row is exercised by default.
+function buildSnapshot(overrides: Partial<CBPressureSnapshot> = {}): CBPressureSnapshot {
+    const cb1 = 1024 * 1024;
+    const cb2 = 256 * 1024;
+    return {
+        byCore: { '0,0': cb1, '1,0': cb2 },
+        maxBytes: cb1,
+        unattributedBytes: 0,
+        allocations: [
+            {
+                nodeId: 1,
+                address: 0x1000,
+                size: cb1,
+                numCores: 1,
+                coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
+                cores: [{ x: 0, y: 0 }],
+                allocateOperationId: 100,
+                allocateOperationName: 'demo_op',
+            },
+            {
+                nodeId: 2,
+                address: 0x2000,
+                size: cb2,
+                numCores: 1,
+                coreRangeSet: '{[(x=1,y=0) - (x=1,y=0)]}',
+                cores: [{ x: 1, y: 0 }],
+                allocateOperationId: 100,
+                allocateOperationName: 'demo_op',
+            },
+        ],
+        ...overrides,
+    };
+}

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -8,6 +8,12 @@ import { Node, NodeType } from '../src/model/APIData';
 import { StringBufferType } from '../src/model/BufferType';
 
 let nextId = 0;
+// Monotonic CB address counter so every cbAllocate() call carries a real numeric
+// address — matches the captured-graph wire format (real `circular_buffer_allocate`
+// nodes always include `address`) and surfaces any future regression in code that
+// assumes a numeric address rather than silently producing NaN. Reset alongside
+// `nextId` in `beforeEach`.
+let nextCbAddress = 0x1000;
 function mkNode<T extends Partial<Node>>(node: T): Node {
     nextId += 1;
     return {
@@ -42,12 +48,17 @@ function functionEnd(name: string): Node {
 }
 
 function cbAllocate(coreRangeSet: string, size: number, address?: number): Node {
+    // Default to the next slot in our monotonic CB address counter so every node
+    // round-trips through `processMemoryAllocations()` with a real numeric address.
+    // Bump after read so the next CB starts past this one's end.
+    const resolvedAddress = address ?? nextCbAddress;
+    nextCbAddress = Math.max(nextCbAddress, resolvedAddress + size);
     return mkNode({
         node_type: NodeType.circular_buffer_allocate,
         params: {
             core_range_set: coreRangeSet,
             size: String(size),
-            ...(address !== undefined && { address: String(address) }),
+            address: String(resolvedAddress),
         },
     } as unknown as Partial<Node>);
 }
@@ -76,6 +87,7 @@ function bufferDeallocate(type: StringBufferType, size: number, numCores: number
 describe('processMemoryAllocations - CB per-core accounting', () => {
     beforeEach(() => {
         nextId = 0;
+        nextCbAddress = 0x1000;
     });
 
     it('returns zero peak for a graph with no allocations', () => {
@@ -211,14 +223,17 @@ describe('processMemoryAllocations - CB per-core accounting', () => {
 
         processMemoryAllocations(graph);
 
-        expect((cbNode.params as Record<string, unknown>).allocateOperationName).toBe('demo_op');
-        expect((cbNode.params as Record<string, unknown>).allocateOperationId).toBe(graph[1].id);
+        // Cast via `unknown` first — the discriminated-union narrowing on
+        // `Node.params` rejects a direct `Record<string, unknown>` cast.
+        expect((cbNode.params as unknown as Record<string, unknown>).allocateOperationName).toBe('demo_op');
+        expect((cbNode.params as unknown as Record<string, unknown>).allocateOperationId).toBe(graph[1].id);
     });
 });
 
 describe('processMemoryAllocations - L1 buffer accounting', () => {
     beforeEach(() => {
         nextId = 0;
+        nextCbAddress = 0x1000;
     });
 
     it('amortizes L1 buffer_allocate over num_cores and reverses on deallocate', () => {
@@ -258,6 +273,7 @@ describe('processMemoryAllocations - L1 buffer accounting', () => {
 describe('processMemoryAllocations - cbPressureByOpId snapshots', () => {
     beforeEach(() => {
         nextId = 0;
+        nextCbAddress = 0x1000;
     });
 
     it('emits no snapshot for ops that never allocate a CB', () => {

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -183,13 +183,21 @@ describe('processMemoryAllocations - CB per-core accounting', () => {
         expect(peakMemoryLoad).toBe(size);
     });
 
-    it('accounts for size even when core_range_set is empty', () => {
+    it('keeps unattributed-only CBs out of the per-core peak but still tracks their bytes', () => {
+        // CBs with an empty core_range_set land in the "?" bucket - they
+        // have no core attribution, so they must not inflate peakMemoryLoad
+        // (which is a per-core quantity). The snapshot still surfaces them
+        // through unattributedBytes so the UI can flag them.
         const size = 4096;
-        const graph = [captureStart(), functionStart('op'), cbAllocate('{}', size), functionEnd('op')];
+        const opStart = functionStart('op');
+        const graph = [captureStart(), opStart, cbAllocate('{}', size), functionEnd('op')];
 
-        const { peakMemoryLoad } = processMemoryAllocations(graph);
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
 
-        expect(peakMemoryLoad).toBe(size);
+        expect(peakMemoryLoad).toBe(0);
+        const snap = cbPressureByOpId.get(opStart.id);
+        expect(snap?.unattributedBytes).toBe(size);
+        expect(snap?.maxBytes).toBe(0);
     });
 
     it('annotates CB allocations with the enclosing function for color variance', () => {

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -41,10 +41,14 @@ function functionEnd(name: string): Node {
     } as unknown as Partial<Node>);
 }
 
-function cbAllocate(coreRangeSet: string, size: number): Node {
+function cbAllocate(coreRangeSet: string, size: number, address?: number): Node {
     return mkNode({
         node_type: NodeType.circular_buffer_allocate,
-        params: { core_range_set: coreRangeSet, size: String(size) },
+        params: {
+            core_range_set: coreRangeSet,
+            size: String(size),
+            ...(address !== undefined && { address: String(address) }),
+        },
     } as unknown as Partial<Node>);
 }
 
@@ -240,5 +244,244 @@ describe('processMemoryAllocations - L1 buffer accounting', () => {
         const { peakMemoryLoad } = processMemoryAllocations(graph);
 
         expect(peakMemoryLoad).toBe(cbSize);
+    });
+});
+
+describe('processMemoryAllocations - cbPressureByOpId snapshots', () => {
+    beforeEach(() => {
+        nextId = 0;
+    });
+
+    it('emits no snapshot for ops that never allocate a CB', () => {
+        const graph = [captureStart(), functionStart('op'), functionEnd('op')];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        expect(cbPressureByOpId.size).toBe(0);
+    });
+
+    it('snapshots on circular_buffer_deallocate_all keyed by the innermost function_start id', () => {
+        const cb1 = 1024 * 1024;
+        const cb2 = 750 * 1024;
+        const opStart = functionStart('memory_repro');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[0-0 - 0-0]}', cb1, 0x1000),
+            cbAllocate('{[1-0 - 1-0]}', cb2, 0x2000),
+            cbDeallocateAll(),
+            functionEnd('memory_repro'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id);
+        expect(snap).toBeDefined();
+        // Disjoint cores: each carries its own CB only - no summation across them.
+        expect(snap!.byCore).toEqual({ '0,0': cb1, '1,0': cb2 });
+        // Peak is per-core, so it should equal the larger of the two CBs.
+        expect(snap!.maxBytes).toBe(cb1);
+        expect(snap!.unattributedBytes).toBe(0);
+        expect(snap!.allocations).toHaveLength(2);
+        expect(snap!.allocations.map((a) => a.size)).toEqual([cb1, cb2]);
+        expect(snap!.allocations.map((a) => a.address)).toEqual([0x1000, 0x2000]);
+    });
+
+    it('sums sizes for CBs that share a core', () => {
+        const cb1 = 1024 * 1024;
+        const cb2 = 256 * 1024;
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb1),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb2),
+            cbDeallocateAll(),
+            functionEnd('op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.byCore).toEqual({ '0,0': cb1 + cb2 });
+        expect(snap.maxBytes).toBe(cb1 + cb2);
+    });
+
+    it('routes empty core_range_set into the "?" bucket and keeps it out of maxBytes', () => {
+        const attributed = 1024 * 1024;
+        const unattributed = 200 * 1024;
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', attributed),
+            cbAllocate('{}', unattributed),
+            cbDeallocateAll(),
+            functionEnd('op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.byCore['0,0']).toBe(attributed);
+        expect(snap.byCore['?']).toBe(unattributed);
+        expect(snap.unattributedBytes).toBe(unattributed);
+        // The "?" bucket would dwarf the per-core peak if it leaked in.
+        expect(snap.maxBytes).toBe(attributed);
+    });
+
+    it('expands a multi-rect CB across every covered core', () => {
+        const size = 128;
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=2,y=2)]}', size),
+            cbDeallocateAll(),
+            functionEnd('op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        const entries = Object.entries(snap.byCore);
+        expect(entries).toHaveLength(9);
+        expect(entries.every(([, v]) => v === size)).toBe(true);
+        expect(snap.allocations[0].numCores).toBe(9);
+        expect(snap.allocations[0].cores).toHaveLength(9);
+        expect(snap.maxBytes).toBe(size);
+    });
+
+    it('does not double-count overlapping rectangles inside a single CB', () => {
+        const size = 100;
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=2,y=2)], [(x=1,y=1) - (x=3,y=3)]}', size),
+            cbDeallocateAll(),
+            functionEnd('op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        // Every covered core counts the CB exactly once, even where the
+        // rectangles overlap - otherwise byCore would stack 2x size.
+        expect(Object.values(snap.byCore).every((v) => v === size)).toBe(true);
+        expect(snap.maxBytes).toBe(size);
+    });
+
+    it('produces a snapshot at function_end when CBs are still live', () => {
+        // Safety net for kernels that never emit circular_buffer_deallocate_all.
+        const size = 4096;
+        const opStart = functionStart('op');
+        const graph = [captureStart(), opStart, cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', size), functionEnd('op')];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id);
+        expect(snap).toBeDefined();
+        expect(snap!.byCore['0,0']).toBe(size);
+        expect(snap!.allocations).toHaveLength(1);
+    });
+
+    it('prefers the deallocate_all snapshot over the function_end safety net', () => {
+        // First CB is captured by dealloc_all; the second batch survives past
+        // function_end but the explicit snapshot should not be overwritten.
+        const cb1 = 1024;
+        const cb2 = 2048;
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb1),
+            cbDeallocateAll(),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', cb2),
+            functionEnd('op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.allocations).toHaveLength(1);
+        expect(snap.allocations[0].size).toBe(cb1);
+    });
+
+    it('attributes nested CBs to the innermost open function_start', () => {
+        const outerStart = functionStart('outer');
+        const innerStart = functionStart('inner');
+        const size = 512;
+        const graph = [
+            captureStart(),
+            outerStart,
+            innerStart,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', size),
+            cbDeallocateAll(),
+            functionEnd('inner'),
+            functionEnd('outer'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        expect(cbPressureByOpId.has(innerStart.id)).toBe(true);
+        expect(cbPressureByOpId.has(outerStart.id)).toBe(false);
+    });
+
+    it('preserves allocation order in the snapshot', () => {
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', 100),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', 200),
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', 300),
+            cbDeallocateAll(),
+            functionEnd('op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const sizes = cbPressureByOpId.get(opStart.id)!.allocations.map((a) => a.size);
+        expect(sizes).toEqual([100, 200, 300]);
+    });
+
+    it('carries the enclosing op id and name on each allocation summary', () => {
+        const opStart = functionStart('demo_op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', 1024),
+            cbDeallocateAll(),
+            functionEnd('demo_op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const [alloc] = cbPressureByOpId.get(opStart.id)!.allocations;
+        expect(alloc.allocateOperationId).toBe(opStart.id);
+        expect(alloc.allocateOperationName).toBe('demo_op');
+    });
+
+    it('emits an independent snapshot per DeviceOp', () => {
+        const op1Start = functionStart('op1');
+        const op2Start = functionStart('op2');
+        const graph = [
+            captureStart(),
+            op1Start,
+            cbAllocate('{[(x=0,y=0) - (x=0,y=0)]}', 1024),
+            cbDeallocateAll(),
+            functionEnd('op1'),
+            op2Start,
+            cbAllocate('{[(x=1,y=1) - (x=1,y=1)]}', 4096),
+            cbDeallocateAll(),
+            functionEnd('op2'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        expect(cbPressureByOpId.size).toBe(2);
+        expect(cbPressureByOpId.get(op1Start.id)!.byCore).toEqual({ '0,0': 1024 });
+        expect(cbPressureByOpId.get(op2Start.id)!.byCore).toEqual({ '1,1': 4096 });
     });
 });


### PR DESCRIPTION
This pull request adds a new feature to display per-core circular buffer (CB) memory allocations for each DeviceOp, accessible via a modal dialog. It introduces a mechanism to snapshot CB allocations and pressure by DeviceOp, exposes this data in the UI, and provides a button to view detailed per-core allocations. The main changes are grouped as follows:

These changes collectively enable users to inspect, for each DeviceOp, which CBs were live and how much memory pressure they contributed per core at key execution points.

<img width="1674" height="823" alt="image" src="https://github.com/user-attachments/assets/e08f85e4-3561-4f91-833e-71b5f43e99a9" />

<img width="1669" height="823" alt="image" src="https://github.com/user-attachments/assets/c7949fda-4305-4a11-b6f4-029eee8d67f4" />


closes #1604 