### PR TITLE
MLIR: clear pendingFocusNodeIdRef when selection changes

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -307,10 +307,12 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // `pendingFocusNodeIdRef` is a one-shot baton armed by `navigateToNode`
     // when the locate target lives in a collapsed namespace and consumed by
     // `applyBuiltGraph` after the worker rebuild. If the user changes the
-    // selection in the meantime (clicks another node, clicks empty space,
-    // clicks a different "Locate"), the user's intent has moved on — drop
-    // the baton so the rebuild doesn't jerk the viewport to a stale target.
-    // Safe because `navigateToNode` never touches selection itself.
+    // selection in the meantime (clicks another node, clicks empty space),
+    // the user's intent has moved on — drop the baton so the rebuild
+    // doesn't jerk the viewport to a stale target. Back-to-back "Locate"
+    // clicks don't go through here: `navigateToNode` overwrites the ref
+    // directly and doesn't touch selection, so the latest target wins
+    // without any effect firing.
     useEffect(() => {
         pendingFocusNodeIdRef.current = null;
     }, [selectedNodeId]);

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -304,6 +304,17 @@ const MlGraphInner = ({ data }: ViewProps) => {
         selectedNodeIdRef.current = selectedNodeId;
     }, [selectedNodeId]);
 
+    // `pendingFocusNodeIdRef` is a one-shot baton armed by `navigateToNode`
+    // when the locate target lives in a collapsed namespace and consumed by
+    // `applyBuiltGraph` after the worker rebuild. If the user changes the
+    // selection in the meantime (clicks another node, clicks empty space,
+    // clicks a different "Locate"), the user's intent has moved on — drop
+    // the baton so the rebuild doesn't jerk the viewport to a stale target.
+    // Safe because `navigateToNode` never touches selection itself.
+    useEffect(() => {
+        pendingFocusNodeIdRef.current = null;
+    }, [selectedNodeId]);
+
     // Reflect selectedNodeId onto each node's `selected` flag so React Flow
     // applies its built-in selected styling.
     useEffect(() => {


### PR DESCRIPTION
Closes #1632.

## Problem

`pendingFocusNodeIdRef` is a one-shot baton armed by `navigateToNode` when the locate target sits inside one or more collapsed namespaces, and consumed by `applyBuiltGraph` once the worker rebuild lands. There is no other clear path. If the user changes selection between the "Locate" click and the rebuild settling (clicking a different node, clicking empty space, clicking another "Locate"), the ref stays armed and the post-rebuild `fitView` jerks the viewport to a target the user has moved on from. The window is short but not zero — namespace expansion forces a full worker rebuild, which on non-trivial graphs is tens to a few hundred ms.

## Fix

Drop the baton on every `selectedNodeId` change:

```ts
useEffect(() => {
    pendingFocusNodeIdRef.current = null;
}, [selectedNodeId]);
```

Safe because `navigateToNode` itself never touches selection (per its JSDoc) — so any selection change represents independent user intent and supersedes the queued navigation.

## Test plan

### Manual (per issue repro)

- [x] Open an MLIR graph with at least one node nested in a collapsed namespace.
- [x] Select a node whose Inputs section lists a producer inside a collapsed namespace.
- [x] Click "Locate" on that producer row.
- [x] Immediately click a different node on the canvas before the rebuild settles → viewport stays on the new selection; no jerk to the locate target.
- [x] Repeat with "click empty space to clear selection" → same result.
- [x] Sanity: "Locate" without an intervening selection change still recenters as before.

### Automated

Not included. Unit-testing this end-to-end requires mocking both `@xyflow/react` (`useReactFlow`, `useNodesState`, ...) and `useMlirLayoutWorker` (jsdom doesn't support real `Worker`s), which is roughly 100+ lines of harness for a 3-line effect whose semantics are guaranteed by React itself. The issue's acceptance criteria explicitly allow the manual-repro path here, and the issue out-of-scope guidance argues against extracting a navigation-intent state machine just for testability while there's only one such ref. Existing suite (`pnpm vitest run`) still 364 passed / 1 skipped.