### PR TITLE
Stop mutating cached BufferChunk objects in TensorVisualisationComponent

### DIFF
--- a/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
+++ b/src/components/tensor-sharding-visualization/SVGBufferRenderer.tsx
@@ -2,11 +2,11 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { BufferChunk } from '../../model/APIData';
+import { DecoratedBufferChunk } from '../../model/APIData';
 
 interface SVGBufferRendererProps {
     height: number;
-    data: BufferChunk[];
+    data: DecoratedBufferChunk[];
     memoryStart: number;
     memoryEnd: number;
 }
@@ -31,7 +31,7 @@ const SVGBufferRenderer = ({ height, data, memoryStart, memoryEnd }: SVGBufferRe
                             y={0}
                             width={`${widthPercent}%`}
                             height={height}
-                            fill={chunk.color || 'red'}
+                            fill={chunk.color}
                         />
                     );
                 })}

--- a/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
+++ b/src/components/tensor-sharding-visualization/TensorVisualisationComponent.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button, ButtonVariant, Card, Overlay2, Size } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { PlotData } from 'plotly.js';
@@ -11,7 +11,7 @@ import { useAtomValue } from 'jotai';
 import { BufferType } from '../../model/BufferType';
 import { useBufferChunks, useDevices } from '../../hooks/useAPI';
 import 'styles/components/TensorVisualizationComponent.scss';
-import { BufferChunk, Tensor } from '../../model/APIData';
+import { DecoratedBufferChunk, Tensor } from '../../model/APIData';
 import SVGBufferRenderer from './SVGBufferRenderer';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import getChartData, { bufferChunksToColoredChunks } from '../../functions/getChartData';
@@ -50,6 +50,44 @@ const TensorVisualisationComponent = ({
     const [selectedTensix, setSelectedTensix] = useState<number | null>(null);
     const [chartData, setChartData] = useState<Partial<PlotData>[]>([]);
 
+    // Project each cached BufferChunk into a DecoratedBufferChunk that
+    // carries the resolved tensor association and the palette colour for
+    // this render. Done off the React Query cache so the cached objects
+    // stay untouched and a future second consumer of useBufferChunks can't
+    // see fields populated by our `tensorByAddress` map. Computed in a
+    // useMemo because both downstream readers (the per-bank grid and the
+    // tensix-detail click handler) need the same shape, and the
+    // address-keyed colour lookups are stable across re-renders.
+    const { buffersByBankId, coordsByBankId } = useMemo(() => {
+        const buckets: DecoratedBufferChunk[][] = [];
+        const coords: { x: number; y: number }[] = [];
+        if (!data) {
+            return { buffersByBankId: buckets, coordsByBankId: coords };
+        }
+        for (const chunk of data) {
+            // Match the original branching exactly: when `tensorByAddress` is
+            // provided we use it (even if it doesn't contain the address —
+            // the `tensorId` prop is then ignored); otherwise fall back to
+            // the explicit `tensorId` prop, treating 0 / undefined as
+            // "no association" the same way the legacy code did.
+            const tensor = tensorByAddress?.get(chunk.address);
+            const resolvedTensorId = tensorByAddress ? tensor?.id : tensorId || undefined;
+            const tensorColor = resolvedTensorId !== undefined ? getTensorColor(resolvedTensorId) : undefined;
+            // 'red' mirrors the SVGBufferRenderer's old `|| 'red'` fallback;
+            // keeping it lets us narrow DecoratedBufferChunk.color to a
+            // required string while preserving the pre-fix render.
+            const color = tensorColor ?? getBufferColor(chunk.address) ?? 'red';
+            const decorated: DecoratedBufferChunk = { ...chunk, tensor_id: resolvedTensorId, color };
+
+            if (!buckets[chunk.bank_id]) {
+                buckets[chunk.bank_id] = [];
+            }
+            buckets[chunk.bank_id].push(decorated);
+            coords[chunk.bank_id] = { x: chunk.core_x, y: chunk.core_y };
+        }
+        return { buffersByBankId: buckets, coordsByBankId: coords };
+    }, [data, tensorByAddress, tensorId]);
+
     if (!data || !devices) {
         return (
             <Overlay2
@@ -79,30 +117,6 @@ const TensorVisualisationComponent = ({
     const [memStart, memEnd] = plotZoomRange;
     const tensixSize = 120;
     const tensixHeight = tensixSize / 3;
-
-    const buffersByBankId: BufferChunk[][] = [];
-    const coordsByBankId: { x: number; y: number }[] = [];
-
-    data.forEach((chunk: BufferChunk) => {
-        if (!buffersByBankId[chunk.bank_id]) {
-            buffersByBankId[chunk.bank_id] = [];
-        }
-
-        if (tensorByAddress) {
-            const tensor = tensorByAddress?.get(chunk.address);
-            chunk.tensor_id = tensor?.id;
-            chunk.color = getTensorColor(tensor?.id);
-        } else if (tensorId) {
-            chunk.tensor_id = tensorId;
-            chunk.color = getTensorColor(tensorId);
-        }
-        if (chunk.tensor_id === undefined) {
-            chunk.color = getBufferColor(chunk.address);
-        }
-
-        buffersByBankId[chunk.bank_id].push(chunk);
-        coordsByBankId[chunk.bank_id] = { x: chunk.core_x, y: chunk.core_y };
-    });
 
     return (
         <Overlay2

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -5,7 +5,7 @@
 import { getBufferColor, getTensorColor } from './colorGenerator';
 import { formatMemorySize, getMemoryAddress } from './math';
 import { toReadableShape, toReadableType } from './formatting';
-import { BufferChunk, Chunk, ColoredChunk, Tensor } from '../model/APIData';
+import { Chunk, ColoredChunk, DecoratedBufferChunk, Tensor } from '../model/APIData';
 import { PlotDataCustom } from '../definitions/PlotConfigurations';
 import { TensorMemoryLayout } from './parseMemoryConfig';
 
@@ -119,11 +119,15 @@ export default function getChartData(
 }
 
 /**
- * Project pre-aggregated buffer chunks onto the renderer-friendly
+ * Project decorated buffer chunks onto the renderer-friendly
  * ``{address, size, color}`` shape. Aggregation already happened on the
  * backend (or in the legacy GROUP BY adapter), so this is a trivial map.
+ *
+ * Takes ``DecoratedBufferChunk`` rather than ``BufferChunk`` so the
+ * colour-resolution step is forced to happen upstream (in the caller's
+ * own ``useMemo``), never on cached API rows.
  */
-export const bufferChunksToColoredChunks = (data: BufferChunk[]): ColoredChunk[] =>
+export const bufferChunksToColoredChunks = (data: DecoratedBufferChunk[]): ColoredChunk[] =>
     data.map((chunk) => ({
         address: chunk.address,
         size: chunk.chunk_size,

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -384,9 +384,22 @@ export interface BufferChunk {
     buffer_type: BufferType;
     rank?: number;
     id: string;
+}
 
+/**
+ * Render-side projection of a ``BufferChunk`` with the tensor association
+ * and palette colour resolved by the consuming component.
+ *
+ * Lives outside the API/cache shape on purpose: ``tensor_id`` and ``color``
+ * are derived from the caller's ``tensorByAddress`` map (or fallback hues),
+ * so they're per-render concerns and don't belong on the React Query cache
+ * entry. Keeping them off ``BufferChunk`` also prevents accidental in-place
+ * mutation of cached objects when more than one consumer of
+ * ``useBufferChunks`` shows up later.
+ */
+export interface DecoratedBufferChunk extends BufferChunk {
     tensor_id?: number;
-    color?: string;
+    color: string;
 }
 
 /**

--- a/tests/SVGBufferRenderer.spec.tsx
+++ b/tests/SVGBufferRenderer.spec.tsx
@@ -6,10 +6,10 @@ import { cleanup, render } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it } from 'vitest';
 import SVGBufferRenderer from '../src/components/tensor-sharding-visualization/SVGBufferRenderer';
-import { BufferChunk } from '../src/model/APIData';
+import { DecoratedBufferChunk } from '../src/model/APIData';
 import { BufferType } from '../src/model/BufferType';
 
-function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
+function chunk(overrides: Partial<DecoratedBufferChunk> = {}): DecoratedBufferChunk {
     const merged = {
         operation_id: 1,
         device_id: 0,
@@ -71,19 +71,6 @@ describe('SVGBufferRenderer (pre-aggregated chunks)', () => {
         // 1000 / 4000 = 0.25 → "25%"
         expect(rect!.getAttribute('width')).toBe('25%');
         expect(rect!.getAttribute('fill')).toBe('#00ff00');
-    });
-
-    it('falls back to red when a chunk has no color', () => {
-        const { container } = render(
-            <SVGBufferRenderer
-                height={10}
-                memoryStart={0}
-                memoryEnd={1024}
-                data={[chunk({ address: 0, chunk_size: 1024, color: undefined })]}
-            />,
-        );
-
-        expect(container.querySelector('rect')!.getAttribute('fill')).toBe('red');
     });
 
     it('renders an empty group when there are no chunks', () => {

--- a/tests/TensorVisualisationComponent.spec.tsx
+++ b/tests/TensorVisualisationComponent.spec.tsx
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TensorVisualisationComponent from '../src/components/tensor-sharding-visualization/TensorVisualisationComponent';
+import { BufferChunk, Tensor } from '../src/model/APIData';
+import { BufferType } from '../src/model/BufferType';
+import { TestProviders } from './helpers/TestProviders';
+
+const mockUseBufferChunks = vi.fn();
+const mockUseDevices = vi.fn();
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useBufferChunks: () => mockUseBufferChunks(),
+    useDevices: () => mockUseDevices(),
+}));
+
+const DEVICE_2X2 = {
+    num_x_cores: 2,
+    num_y_cores: 2,
+    worker_l1_size: 1_000_000,
+};
+
+function makeChunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
+    return {
+        operation_id: 1,
+        device_id: 0,
+        address: 0x1000,
+        bank_id: 0,
+        core_x: 0,
+        core_y: 0,
+        chunk_address: 0x1000,
+        chunk_size: 256,
+        page_size: 32,
+        num_pages: 8,
+        buffer_type: BufferType.L1,
+        rank: 0,
+        id: '1_0_4096_0_0_0_1_0',
+        ...overrides,
+    };
+}
+
+function tensor(id: number): Tensor {
+    return {
+        id,
+        operation_id: 1,
+        device_id: 0,
+        address: 0x1000,
+        shape: '[1, 1]',
+        dtype: 'f32',
+        layout: 'TILE',
+        memory_config: null,
+        producers: [],
+        consumers: [],
+        comparison: null,
+    } as unknown as Tensor;
+}
+
+beforeEach(() => {
+    mockUseDevices.mockReturnValue({ data: [DEVICE_2X2] });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('TensorVisualisationComponent - no mutation of cached BufferChunks', () => {
+    it('does not assign tensor_id / color onto cached chunks (tensorByAddress path)', () => {
+        // Stable reference simulates the React Query cache handing the same
+        // array back on every consumer call. The objects inside are what we
+        // care about — none of them should grow new fields after render.
+        const cached: BufferChunk[] = [
+            makeChunk({ address: 0x1000, bank_id: 0, core_x: 0, core_y: 0 }),
+            makeChunk({ address: 0x2000, bank_id: 1, core_x: 1, core_y: 0, id: '1_0_8192_1_1_0_1_0' }),
+        ];
+        const snapshot = structuredClone(cached);
+        mockUseBufferChunks.mockReturnValue({ data: cached });
+
+        const tensorByAddress = new Map<number, Tensor>([[0x1000, tensor(42)]]);
+
+        render(
+            <TestProviders>
+                <TensorVisualisationComponent
+                    title='unit test'
+                    operationId={1}
+                    isOpen
+                    onClose={() => {}}
+                    tensorByAddress={tensorByAddress}
+                    plotZoomRange={[0, 0x3000]}
+                />
+            </TestProviders>,
+        );
+
+        // No keys added in place; deep equality against the pre-render snapshot.
+        expect(cached).toEqual(snapshot);
+        for (const chunk of cached) {
+            expect(chunk).not.toHaveProperty('tensor_id');
+            expect(chunk).not.toHaveProperty('color');
+        }
+    });
+
+    it('does not mutate cached chunks across a re-render with new props', () => {
+        const cached: BufferChunk[] = [makeChunk({ address: 0x1000, bank_id: 0 })];
+        const snapshot = structuredClone(cached);
+        mockUseBufferChunks.mockReturnValue({ data: cached });
+
+        const { rerender } = render(
+            <TestProviders>
+                <TensorVisualisationComponent
+                    title='first pass'
+                    operationId={1}
+                    isOpen
+                    onClose={() => {}}
+                    tensorId={7}
+                    plotZoomRange={[0, 0x2000]}
+                />
+            </TestProviders>,
+        );
+
+        // Swap the tensor association to a different prop shape: a path
+        // through `tensorByAddress` instead of the plain `tensorId`. Both
+        // branches used to mutate; neither should now.
+        rerender(
+            <TestProviders>
+                <TensorVisualisationComponent
+                    title='second pass'
+                    operationId={1}
+                    isOpen
+                    onClose={() => {}}
+                    tensorByAddress={new Map([[0x1000, tensor(99)]])}
+                    plotZoomRange={[0, 0x2000]}
+                />
+            </TestProviders>,
+        );
+
+        expect(cached).toEqual(snapshot);
+        for (const chunk of cached) {
+            expect(chunk).not.toHaveProperty('tensor_id');
+            expect(chunk).not.toHaveProperty('color');
+        }
+    });
+
+    it('falls through to the buffer palette when no tensor association applies', () => {
+        // Sanity that the no-tensor branch still produces a render rather
+        // than crashing on undefined colour — covers the `?? 'red'` floor
+        // we added to DecoratedBufferChunk.color.
+        const cached: BufferChunk[] = [makeChunk({ address: 0x1000, bank_id: 0 })];
+        mockUseBufferChunks.mockReturnValue({ data: cached });
+
+        const { container } = render(
+            <TestProviders>
+                <TensorVisualisationComponent
+                    title='unit test'
+                    operationId={1}
+                    isOpen
+                    onClose={() => {}}
+                    plotZoomRange={[0, 0x2000]}
+                />
+            </TestProviders>,
+        );
+
+        // SVGBufferRenderer always emits a fill on every rect; if the
+        // projection forgot to provide one, the rect would render with
+        // fill=""/undefined.
+        const rect = container.ownerDocument.querySelector('rect');
+        expect(rect).not.toBeNull();
+        expect(rect!.getAttribute('fill')).toBeTruthy();
+    });
+});

--- a/tests/bufferChunksToColoredChunks.spec.ts
+++ b/tests/bufferChunksToColoredChunks.spec.ts
@@ -4,10 +4,10 @@
 
 import { describe, expect, it } from 'vitest';
 import { bufferChunksToColoredChunks } from '../src/functions/getChartData';
-import { BufferChunk } from '../src/model/APIData';
+import { DecoratedBufferChunk } from '../src/model/APIData';
 import { BufferType } from '../src/model/BufferType';
 
-function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
+function chunk(overrides: Partial<DecoratedBufferChunk> = {}): DecoratedBufferChunk {
     return {
         operation_id: 1,
         device_id: 0,
@@ -22,6 +22,7 @@ function chunk(overrides: Partial<BufferChunk> = {}): BufferChunk {
         buffer_type: BufferType.L1,
         rank: 0,
         id: '1_0_100_1_0_0_1_0',
+        color: '#000000',
         ...overrides,
     };
 }
@@ -49,13 +50,13 @@ describe('bufferChunksToColoredChunks', () => {
         expect(result[0].size).toBe(4096);
     });
 
-    it('passes color through unchanged including undefined', () => {
+    it('passes color through unchanged', () => {
         const result = bufferChunksToColoredChunks([
-            chunk({ address: 100, color: undefined }),
+            chunk({ address: 100, color: '#abcdef' }),
             chunk({ address: 200, color: 'rgb(1, 2, 3)' }),
         ]);
 
-        expect(result[0].color).toBeUndefined();
+        expect(result[0].color).toBe('#abcdef');
         expect(result[1].color).toBe('rgb(1, 2, 3)');
     });
 


### PR DESCRIPTION
## Summary

`TensorVisualisationComponent` was assigning `tensor_id` and `color` in place on the `BufferChunk` objects returned by `useBufferChunks`, i.e. directly on the React Query cache entry. There's only one consumer of that cache key today, so this is currently dormant — but any future caller would see fields populated by another render's `tensorByAddress` map. Same pattern called out in the original PR #1631 review thread.

- Drop `tensor_id?` / `color?` from `BufferChunk` and add a sibling `DecoratedBufferChunk extends BufferChunk` (with `color: string` required, `tensor_id?: number`). Cache type stays pure API data; the render-side projection is the only place those fields live.
- Replace the in-place `data.forEach` mutation with a `useMemo` keyed on `[data, tensorByAddress, tensorId]` that emits `DecoratedBufferChunk[][]` and the existing `coordsByBankId`. Branching matches the original line-for-line (including the `tensorId` falsy-0 skip and the `'red'` final fallback that used to live in `SVGBufferRenderer`).
- Thread `DecoratedBufferChunk` through `SVGBufferRenderer` and `bufferChunksToColoredChunks` — both are only consumed by this component, so no ripple.

Closes #1633.

## Perf

Same O(N) outer pass. One extra shallow spread per chunk (~14-field copy). On re-renders where the memo deps don't change (tensix selection, `showHex` toggle, parent re-renders), the new version skips the per-chunk loop entirely — the original recomputed it every render. Net: equal or faster for any realistic render pattern.

`details.tensorListByAddress` is a class field on `OperationDetails` (set once per `.update()`), so the `tensorByAddress` prop is reference-stable across renders and the memo actually hits.