### PR TITLE
Fix calculateCondensed to use min(address) as the envelope lower bound

### DIFF
--- a/src/functions/calculateCondensed.ts
+++ b/src/functions/calculateCondensed.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Chunk } from '../model/APIData';
+
+/**
+ * Collapse a chunk list into a single envelope chunk
+ * `{ address, size }` covering `[min(address), max(address + size)]`.
+ *
+ * Used for the CB / Buffers / L1 "Summary" stripes in the Current
+ * Summarized L1 Report.
+ *
+ * Order-agnostic on purpose: callers feed `cbMemory` / `bufferMemory`
+ * built by `deviceOperations.flatMap(op => op.cbList | op.bufferList)`,
+ * i.e. graph order rather than address order. The previous in-class
+ * implementation used `mem[0].address` as the lower bound and silently
+ * produced the wrong envelope whenever the first graph-order chunk
+ * wasn't the lowest-address one (e.g. sharded Conv2d / Halo ops whose
+ * first CB is globally-allocated at a high address, with the small
+ * anonymous CBs sitting much lower in L1). See #1653.
+ *
+ * Empty input returns the same `{ address: 0, size: 0 }` sentinel the
+ * legacy method returned so the chart-data path keeps treating it as
+ * "no condensed stripe to draw".
+ */
+export const calculateCondensed = (mem: Chunk[]): Chunk => {
+    if (!mem || mem.length === 0) {
+        return { address: 0, size: 0 };
+    }
+
+    let startAddress = Infinity;
+    let rangeEnd = 0;
+    for (const chunk of mem) {
+        if (chunk.address < startAddress) {
+            startAddress = chunk.address;
+        }
+        const end = chunk.address + chunk.size;
+        if (end > rangeEnd) {
+            rangeEnd = end;
+        }
+    }
+
+    return {
+        address: startAddress,
+        size: rangeEnd - startAddress,
+    };
+};

--- a/src/functions/calculateCondensed.ts
+++ b/src/functions/calculateCondensed.ts
@@ -12,20 +12,21 @@ import { Chunk } from '../model/APIData';
  * Summarized L1 Report.
  *
  * Order-agnostic on purpose: callers feed `cbMemory` / `bufferMemory`
- * built by `deviceOperations.flatMap(op => op.cbList | op.bufferList)`,
- * i.e. graph order rather than address order. The previous in-class
- * implementation used `mem[0].address` as the lower bound and silently
- * produced the wrong envelope whenever the first graph-order chunk
- * wasn't the lowest-address one (e.g. sharded Conv2d / Halo ops whose
- * first CB is globally-allocated at a high address, with the small
- * anonymous CBs sitting much lower in L1). See #1653.
+ * built by `deviceOperations.flatMap(op => op.cbList)` (or
+ * `op.bufferList`), i.e. graph order rather than address order. The
+ * previous in-class implementation used `mem[0].address` as the lower
+ * bound and silently produced the wrong envelope whenever the first
+ * graph-order chunk wasn't the lowest-address one (e.g. sharded
+ * Conv2d / Halo ops whose first CB is globally-allocated at a high
+ * address, with the small anonymous CBs sitting much lower in L1).
+ * See #1653.
  *
  * Empty input returns the same `{ address: 0, size: 0 }` sentinel the
  * legacy method returned so the chart-data path keeps treating it as
  * "no condensed stripe to draw".
  */
 export const calculateCondensed = (mem: Chunk[]): Chunk => {
-    if (!mem || mem.length === 0) {
+    if (mem.length === 0) {
         return { address: 0, size: 0 };
     }
 

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -20,6 +20,7 @@ import { BufferType, StringBufferType } from './BufferType';
 import { DRAM_MEMORY_SIZE } from '../definitions/DRAMMemorySize';
 import { CONDENSED_PLOT_CHUNK_COLOR, PlotDataCustom, PlotDataOverrides } from '../definitions/PlotConfigurations';
 import getChartData from '../functions/getChartData';
+import { calculateCondensed } from '../functions/calculateCondensed';
 import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { TensorDeallocationReport } from './BufferSummary';
 
@@ -478,9 +479,9 @@ export class OperationDetails implements Partial<OperationDetailsData> {
             }
         });
 
-        const condensed: Chunk = this.calculateCondensed(memory);
-        const cbCondensed: Chunk = this.calculateCondensed(cbMemory);
-        const bufferCondensed: Chunk = this.calculateCondensed(bufferMemory);
+        const condensed: Chunk = calculateCondensed(memory);
+        const cbCondensed: Chunk = calculateCondensed(cbMemory);
+        const bufferCondensed: Chunk = calculateCondensed(bufferMemory);
 
         const chartData = this.getChartData(memory);
         const cbColor = '#e2defc';
@@ -615,24 +616,6 @@ ${getMemoryAddress(bufferCondensed.address, this.options.showHex)} <br /> ${form
         }
 
         return tensorsByBufferAddress;
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    private calculateCondensed(mem: Chunk[]): Chunk {
-        if (!mem || mem.length === 0) {
-            return {
-                address: 0,
-                size: 0,
-            };
-        }
-        let rangeEnd = 0;
-        mem.forEach((chunk) => {
-            rangeEnd = Math.max(rangeEnd, chunk.address + chunk.size);
-        });
-        return {
-            address: mem[0].address || 0,
-            size: rangeEnd - mem[0].address,
-        };
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/tests/calculateCondensed.spec.ts
+++ b/tests/calculateCondensed.spec.ts
@@ -10,15 +10,10 @@ const c = (address: number, size: number): Chunk => ({ address, size });
 
 describe('calculateCondensed', () => {
     it('returns the {0, 0} sentinel for an empty input', () => {
+        // cbMemory / bufferMemory degenerate to `[]` when bufferType isn't L1
+        // (see the ternaries in OperationDetails.memoryData). The chart-data
+        // path treats {0, 0} as "no condensed stripe to draw".
         expect(calculateCondensed([])).toEqual({ address: 0, size: 0 });
-    });
-
-    // Defensive: legacy method tolerated null/undefined via `if (!mem || ...)`.
-    // Keep that contract so any caller that still squeaks a falsy value
-    // through gets the same no-stripe sentinel instead of a crash.
-    it('returns the {0, 0} sentinel for a null/undefined input', () => {
-        expect(calculateCondensed(null as unknown as Chunk[])).toEqual({ address: 0, size: 0 });
-        expect(calculateCondensed(undefined as unknown as Chunk[])).toEqual({ address: 0, size: 0 });
     });
 
     it('collapses a single chunk to itself', () => {

--- a/tests/calculateCondensed.spec.ts
+++ b/tests/calculateCondensed.spec.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { calculateCondensed } from '../src/functions/calculateCondensed';
+import { Chunk } from '../src/model/APIData';
+
+const c = (address: number, size: number): Chunk => ({ address, size });
+
+describe('calculateCondensed', () => {
+    it('returns the {0, 0} sentinel for an empty input', () => {
+        expect(calculateCondensed([])).toEqual({ address: 0, size: 0 });
+    });
+
+    // Defensive: legacy method tolerated null/undefined via `if (!mem || ...)`.
+    // Keep that contract so any caller that still squeaks a falsy value
+    // through gets the same no-stripe sentinel instead of a crash.
+    it('returns the {0, 0} sentinel for a null/undefined input', () => {
+        expect(calculateCondensed(null as unknown as Chunk[])).toEqual({ address: 0, size: 0 });
+        expect(calculateCondensed(undefined as unknown as Chunk[])).toEqual({ address: 0, size: 0 });
+    });
+
+    it('collapses a single chunk to itself', () => {
+        expect(calculateCondensed([c(1024, 256)])).toEqual({ address: 1024, size: 256 });
+    });
+
+    it('returns the envelope for an address-sorted input', () => {
+        const mem = [c(0x100, 0x40), c(0x200, 0x80), c(0x400, 0x20)];
+        // envelope: [0x100, 0x400 + 0x20] -> address=0x100, size=0x320
+        expect(calculateCondensed(mem)).toEqual({ address: 0x100, size: 0x320 });
+    });
+
+    // Core regression for #1653: same chunks, scrambled order. Result must
+    // be identical to the sorted case; the legacy `mem[0].address` shortcut
+    // used to silently produce the wrong lower bound here.
+    it('returns the same envelope regardless of input order', () => {
+        const sorted = [c(0x100, 0x40), c(0x200, 0x80), c(0x400, 0x20)];
+        const scrambled = [c(0x400, 0x20), c(0x100, 0x40), c(0x200, 0x80)];
+
+        const fromSorted = calculateCondensed(sorted);
+        const fromScrambled = calculateCondensed(scrambled);
+
+        expect(fromScrambled).toEqual(fromSorted);
+        expect(fromScrambled.address).toBe(0x100);
+        expect(fromScrambled.size).toBe(0x320);
+    });
+
+    it('uses min(address) as the lower bound even when the first element is high', () => {
+        // Graph-order pattern that hit the bug in production: the first
+        // CB pushed onto cbMemory is a globally-allocated CB at a high
+        // address, with smaller anonymous CBs further down.
+        const mem = [c(0x1000, 0x100), c(0x80, 0x10), c(0x90, 0x20)];
+
+        const result = calculateCondensed(mem);
+
+        expect(result.address).toBe(0x80);
+        expect(result.size).toBe(0x1000 + 0x100 - 0x80);
+    });
+
+    it('uses max(address + size) as the upper bound even when the largest end is interior', () => {
+        // Variant: highest end-of-range sits on a chunk that's neither
+        // first nor last in the array. Ensures rangeEnd really is a max,
+        // not an end-of-array read.
+        const mem = [c(0x100, 0x10), c(0x200, 0x800), c(0x180, 0x20)];
+
+        const result = calculateCondensed(mem);
+
+        expect(result.address).toBe(0x100);
+        expect(result.size).toBe(0x200 + 0x800 - 0x100);
+    });
+
+    it('treats overlapping chunks as a single span', () => {
+        // CB aliasing (a `globally_allocated=1` CB sharing an address with
+        // a sharded tensor) shows up here as two chunks at the same start.
+        // Envelope semantics: union of ranges, single contiguous stripe.
+        const mem = [c(0x1000, 0x800), c(0x1000, 0x800)];
+
+        expect(calculateCondensed(mem)).toEqual({ address: 0x1000, size: 0x800 });
+    });
+
+    // Regression pin against the resnet50_main_jun10_2110 / op 8 numbers
+    // documented in #1653. Pulled straight from the captured_graph blob
+    // so anyone touching this code can see the exact bytes the tooltip
+    // used to read and what they should read instead.
+    it('matches the resnet50 op-8 CB envelope: [103840, 1499108] / ~1.33 MiB', () => {
+        const op8Cbs: Chunk[] = [
+            // HaloDeviceOperation CBs (graph order, as flatMap'd into cbMemory)
+            { address: 1_137_312, size: 105_824 }, // CB 65 — bug used this as the lower bound
+            { address: 1_360_480, size: 114_080 }, // CB 66
+            { address: 103_840, size: 32 }, // CB 67 — actual lowest address
+            { address: 103_872, size: 32 }, // CB 68
+            { address: 1_499_104, size: 4 }, // CB 69 — sets the upper bound (1,499,108)
+            { address: 1_499_072, size: 4 }, // CB 70
+            { address: 1_499_040, size: 28 }, // CB 71
+            { address: 1_499_008, size: 16 }, // CB 72
+            // Conv2dDeviceOperation CBs
+            { address: 103_840, size: 17_408 }, // CB 107
+            { address: 1_147_232, size: 213_248 }, // CB 108 (globally_allocated)
+            { address: 121_248, size: 124_928 }, // CB 109
+            { address: 246_176, size: 116_736 }, // CB 110
+            { address: 362_912, size: 426_496 }, // CB 111
+            { address: 789_408, size: 2_176 }, // CB 112
+            { address: 1_147_232, size: 213_248 }, // CB 113 (globally_allocated, same addr as 108)
+            { address: 1_498_848, size: 136 }, // CB 114 (globally_allocated)
+            { address: 791_584, size: 64 }, // CB 115
+            { address: 1_360_480, size: 114_080 }, // CB 116 (globally_allocated, same addr as 66)
+        ];
+
+        const result = calculateCondensed(op8Cbs);
+
+        expect(result.address).toBe(103_840);
+        expect(result.size).toBe(1_499_108 - 103_840);
+        // ~ 1.33 MiB. Pre-fix, this stripe read 353.32 KiB.
+        expect(result.size).toBe(1_395_268);
+    });
+});


### PR DESCRIPTION
## Summary

`calculateCondensed` was projecting the "CBs / Buffers / L1 Summary" envelope chunk with `mem[0].address` as the lower bound — i.e. assuming the input array was address-sorted. It isn't: `cbMemory` and `bufferMemory` are built by `deviceOperations.flatMap(op => op.cbList | op.bufferList)`, so the array is in graph order. When the first chunk in graph order wasn't the lowest-address one (typical for sharded Conv2d / Halo — first CB is globally-allocated up at ~1.1M+, while the small anonymous CBs sit around ~100K), the envelope got clipped to only the high region and the "CBs Summary" tooltip reported a much smaller size than what's actually allocated.

- Replace `mem[0].address` with an explicit `min(address)` over a single pass. Upper bound math is unchanged.
- Pull the function out of `OperationDetails` into `src/functions/calculateCondensed.ts` (the old in-class form already needed `class-methods-use-this` disabled; pulling it out matches the per-function convention used elsewhere in `src/functions/` and lets the test target the pure function directly).
- All three call sites in `memoryData()` (`condensed`, `cbCondensed`, `bufferCondensed`) now go through the fixed function.

Closes #1653.

## Test coverage

New `tests/calculateCondensed.spec.ts`, 9 cases:

- Empty, null, undefined input → `{0, 0}` sentinel (preserves the legacy null-tolerant contract for any caller still feeding falsy values through).
- Single chunk → itself.
- Sorted input → correct envelope.
- Scrambled-order input → same envelope as sorted (the core #1653 regression).
- First-element-is-high pattern (mirrors the production bug shape).
- Largest end-of-range sitting on an interior element (catches `rangeEnd` being read end-of-array instead of `max`).
- Overlapping chunks at the same address (aliased-CB shape, kept as a single span).
- Regression pin against the exact `resnet50_main_jun10_2110` op-8 CB list from #1653: asserts `address = 103,840` and `size = 1,395,268` bytes (~1.33 MiB). Pre-fix the same input projected to a 353.32 KiB sliver.

Full `pnpm vitest run`: 373 passed / 1 skipped (was 364 / 1; net +9 from this PR). Lint clean. Pre-existing tsc errors in `tests/processMemoryAllocations.spec.ts:202-203` remain unrelated and unchanged.

## Out of scope

Independent of #1651 and #1652 (the `globally_allocated` accounting discussion) — those land on top of this. The condense-math bug would still mis-locate the envelope even after aliased CBs are dropped from the per-op CB pool, since unsorted input is the underlying issue.