### PR TITLE
Relax pinned uv version to a minimum bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ profile = "black"
 line_length = 88
 
 [tool.uv]
-# Single source of truth for the uv version across local dev and CI.
-# astral-sh/setup-uv reads this when no explicit `version:` input is set,
-# and uv itself enforces it on every local invocation.
-required-version = "==0.11.20"
+# Minimum uv version for local dev and CI (astral-sh/setup-uv reads this when no
+# explicit `version:` input is set). Use a lower bound rather than an exact pin so
+# package managers like Homebrew can ship newer patch releases without blocking
+# contributors.
+required-version = ">=0.11.0"


### PR DESCRIPTION
## Summary

- Replaces the exact `required-version = "==0.11.20"` pin with `>=0.11.0` in `pyproject.toml`
- Updates the comment to explain why we use a lower bound instead of an exact patch version
- Allows contributors who install uv via Homebrew (or other package managers that ship the latest stable) to work without manually downgrading uv

Closes #1657

## Test plan

- [x] Verified `uv 0.11.21` (Homebrew) accepts the new constraint locally
- [ ] CI passes (lint-and-test, build-docs, etc.)


Made with [Cursor](https://cursor.com)