### PR TITLE
chore: ignore local .pnpm-store/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ dist-ssr
 
 # We use PNPM
 package-lock.json
+# Local pnpm content-addressed store, created by `pnpm install` when the user's
+# global store path resolves inside the workspace (e.g. when `store-dir` is
+# overridden or when running pnpm from a context without a home-dir store).
+# Hundreds-of-thousands of cache files; must never be committed.
+.pnpm-store/
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary

`pnpm install` materializes a workspace-local `.pnpm-store/` when the user's global pnpm store path resolves inside the repo (when `store-dir` is overridden, or when pnpm runs without a writable home-dir store). That produces hundreds of thousands of cache files — caught locally as ~400 untracked entries showing up in a git client, one accidental `git add -A` away from polluting a PR.

Adds `.pnpm-store/` to `.gitignore` under the existing `# We use PNPM` section so related ignores stay together.

## Test plan

- `git check-ignore -v .pnpm-store/` reports the entry from `.gitignore`.
- `git status` no longer lists the directory after `pnpm install` materializes it locally.
- No tracked files inside `.pnpm-store/` (verified pre-merge: `git ls-files .pnpm-store` is empty), so no `git rm --cached` follow-up required.