### PR TITLE
Avoid overlap of device operation data

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -485,18 +485,19 @@ function useDeviceOperationsFullRenderModel(args: {
                                     </div>
                                 </>
                             )}
-                            <MemoryLegendElement
-                                numCores={numCores}
-                                chunk={{ address: parseInt(cb.address, 10), size: parseInt(cb.size, 10) }}
-                                memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
-                                selectedTensorAddress={selectedAddress}
-                                operationDetails={details}
-                                onLegendClick={onLegendClick}
-                                colorVariance={variance}
-                                isGloballyAllocated={isGloballyAllocated}
-                            />
-                            {memoryInfo}
-                            <br />
+                            <div className='cb-legend-row'>
+                                <MemoryLegendElement
+                                    numCores={numCores}
+                                    chunk={{ address: parseInt(cb.address, 10), size: parseInt(cb.size, 10) }}
+                                    memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
+                                    selectedTensorAddress={selectedAddress}
+                                    operationDetails={details}
+                                    onLegendClick={onLegendClick}
+                                    colorVariance={variance}
+                                    isGloballyAllocated={isGloballyAllocated}
+                                />
+                                {memoryInfo}
+                            </div>
                         </Fragment>
                     );
 

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -214,8 +214,8 @@ export const MemoryLegendElement = ({
             <div className='shape-info-slot'>
                 {derivedTensor && (
                     <>
-                        {toReadableShape(derivedTensor.shape)} &nbsp; {toReadableType(derivedTensor.dtype)} &nbsp;{' '}
-                        {isMultiDeviceBuffer && `Device ${chunk?.device_id ?? derivedTensor.device_id}`}
+                        {toReadableShape(derivedTensor.shape)} &nbsp; {toReadableType(derivedTensor.dtype)}
+                        {isMultiDeviceBuffer && ` Device ${chunk?.device_id ?? derivedTensor.device_id}`}
                     </>
                 )}
             </div>

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -471,6 +471,7 @@
     display: flex;
     align-items: baseline;
     gap: 8px;
+    margin-top: 5px;
     margin-bottom: 10px;
 
     h4 {

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -149,7 +149,6 @@
         position: static;
         display: grid;
         margin-left: auto;
-        margin-bottom: 10px;
 
         &.peak {
             border: 1px solid rgb(207 255 90 / 50%);
@@ -165,12 +164,11 @@
         .legend-item {
             flex: 1 1 auto;
             min-width: 0;
-            grid-template-columns: 15px 0.5fr 2fr 10fr 3fr;
+            grid-template-columns: 15px 0.5fr 2fr 10fr 5fr;
         }
 
         .memory-info {
             flex: 0 0 320px;
-            margin-bottom: 5px;
         }
     }
 }

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -141,16 +141,36 @@
 
     .memory-info {
         width: 320px;
-        display: grid;
         gap: 10px;
         font-weight: lighter;
-        margin-left: auto;
-        margin-bottom: 10px;
+        right: 0;
         grid-template-columns: 1fr 1fr 1fr;
         padding: 0 5px;
+        position: static;
+        display: grid;
+        margin-left: auto;
+        margin-bottom: 10px;
 
         &.peak {
             border: 1px solid rgb(207 255 90 / 50%);
+        }
+    }
+
+    // Avoids impacting the legend used below the plots at the top of the page
+    .cb-legend-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+
+        .legend-item {
+            flex: 1 1 auto;
+            min-width: 0;
+            grid-template-columns: 15px 0.5fr 2fr 10fr 3fr;
+        }
+
+        .memory-info {
+            flex: 0 0 320px;
+            margin-bottom: 5px;
         }
     }
 }

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -10,6 +10,7 @@
         justify-content: space-between;
         border-bottom: 1px solid $tt-grey-4;
         font-weight: normal;
+        margin-bottom: 10px;
     }
 }
 
@@ -92,10 +93,11 @@
         .title {
             &.node-type-buffer_allocate,
             &.node-type-buffer_deallocate {
+                display: flex;
                 margin-bottom: 10px;
+                justify-content: space-between;
             }
         }
-
         /* stylelint-enable selector-class-pattern */
 
         .collapsible-controls {
@@ -139,11 +141,11 @@
 
     .memory-info {
         width: 320px;
-        display: inline-grid;
+        display: grid;
         gap: 10px;
         font-weight: lighter;
-        position: absolute;
-        right: 0;
+        margin-left: auto;
+        margin-bottom: 10px;
         grid-template-columns: 1fr 1fr 1fr;
         padding: 0 5px;
 


### PR DESCRIPTION
**Before**
<img width="1317" height="870" alt="Screenshot 2026-06-18 at 13 02 28" src="https://github.com/user-attachments/assets/4a6d1379-e3d8-453d-951b-45317ada6a12" />

**After**
<img width="1317" height="870" alt="Screenshot 2026-06-18 at 13 03 42" src="https://github.com/user-attachments/assets/e070150e-d9a6-4fee-8508-e1fdd3382e76" />


Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1638.