### PR TITLE
Show/hide globally allocated CBs in the Circular Buffer Pressure modal

### DIFF
--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -52,6 +52,29 @@ const CB_FALLBACK_COLOR = '#888';
 const cbColor = (cb: CBAllocationSummary): string =>
     getBufferColor(cb.address + (cb.allocateOperationId ?? 0)) ?? CB_FALLBACK_COLOR;
 
+/**
+ * SVG paints siblings in document order, so the *last* rect in a sibling group
+ * wins at shared boundaries. The selected rect wears a thicker, brighter
+ * (2px yellow) stroke that must not be covered by an adjacent rect's stroke
+ * at a shared address edge — otherwise the selection outline drops on the
+ * shared side and the user sees only three of four edges. Pulling the
+ * selected rect to the end of the list guarantees its outline survives on
+ * every side. No-op when nothing is selected or the rect isn't in the list.
+ */
+const reorderSelectedLast = (cbs: CBAllocationSummary[], selectedNodeId: number | null): CBAllocationSummary[] => {
+    if (selectedNodeId === null) {
+        return cbs;
+    }
+    const idx = cbs.findIndex((c) => c.nodeId === selectedNodeId);
+    if (idx === -1 || idx === cbs.length - 1) {
+        return cbs;
+    }
+    const next = cbs.slice();
+    const [selected] = next.splice(idx, 1);
+    next.push(selected);
+    return next;
+};
+
 interface MiniCBStripProps {
     cbs: CBAllocationSummary[];
     memoryStart: number;
@@ -73,6 +96,7 @@ interface MiniCBStripProps {
  */
 const MiniCBStrip = ({ cbs, memoryStart, memoryEnd, selectedCBNodeId }: MiniCBStripProps) => {
     const memoryRange = Math.max(1, memoryEnd - memoryStart);
+    const orderedCbs = useMemo(() => reorderSelectedLast(cbs, selectedCBNodeId), [cbs, selectedCBNodeId]);
     return (
         <svg
             className='cb-strip'
@@ -80,7 +104,7 @@ const MiniCBStrip = ({ cbs, memoryStart, memoryEnd, selectedCBNodeId }: MiniCBSt
             width='100%'
             preserveAspectRatio='none'
         >
-            {cbs.map((cb) => {
+            {orderedCbs.map((cb) => {
                 const xPercent = ((cb.address - memoryStart) / memoryRange) * 100;
                 const widthPercent = (cb.size / memoryRange) * 100;
                 const isSelected = selectedCBNodeId === cb.nodeId;
@@ -143,6 +167,7 @@ const ZoomedCorePlot = ({
     // can't fit the label without clipping. Below this we drop the label
     // and lean on the tooltip / legend for identity.
     const MIN_WIDTH_PERCENT_FOR_LABEL = 12;
+    const orderedCbs = useMemo(() => reorderSelectedLast(cbs, selectedCBNodeId), [cbs, selectedCBNodeId]);
 
     return (
         <div className='zoomed-core-plot'>
@@ -163,7 +188,7 @@ const ZoomedCorePlot = ({
                     preserveAspectRatio='none'
                     overflow='visible'
                 >
-                    {cbs.map((cb) => {
+                    {orderedCbs.map((cb) => {
                         const xPercent = ((cb.address - memoryStart) / memoryRange) * 100;
                         const widthPercent = (cb.size / memoryRange) * 100;
                         const isSelected = selectedCBNodeId === cb.nodeId;

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -212,6 +212,11 @@ const CircularBufferPressureModal = ({ isOpen, onClose, title, snapshot }: Circu
     const [selectedCBNodeId, setSelectedCBNodeId] = useState<number | null>(null);
     const [normalisation, setNormalisation] = useState<Normalisation>('local');
     const [showAbsolute, setShowAbsolute] = useState<boolean>(true);
+    // Default-on per the #1655 spec: aliased CBs are visible until the user
+    // explicitly hides them. Sticky across snapshot changes (same as
+    // showAbsolute / normalisation) - it's a viewing preference, not a
+    // per-DeviceOp selection.
+    const [showAliasedCBs, setShowAliasedCBs] = useState<boolean>(true);
 
     // We render null on close instead of unmounting, so useState slots
     // persist across open/close cycles. Drop the per-snapshot selections
@@ -279,6 +284,8 @@ const CircularBufferPressureModal = ({ isOpen, onClose, title, snapshot }: Circu
                     setNormalisation={setNormalisation}
                     showAbsolute={showAbsolute}
                     setShowAbsolute={setShowAbsolute}
+                    showAliasedCBs={showAliasedCBs}
+                    setShowAliasedCBs={setShowAliasedCBs}
                     onClose={onClose}
                 />
             </Card>
@@ -300,6 +307,8 @@ interface BodyProps {
     setNormalisation: (v: Normalisation) => void;
     showAbsolute: boolean;
     setShowAbsolute: (v: boolean) => void;
+    showAliasedCBs: boolean;
+    setShowAliasedCBs: (v: boolean) => void;
     onClose: () => void;
 }
 
@@ -317,26 +326,50 @@ const CircularBufferPressureBody = ({
     setNormalisation,
     showAbsolute,
     setShowAbsolute,
+    showAliasedCBs,
+    setShowAliasedCBs,
     onClose,
 }: BodyProps) => {
-    // Quick lookup for "is core part of selected CB" highlighting.
+    // #1655: Aliased (`globallyAllocated`) CBs can flood dense ops where most
+    // CBs are tensor views. The toggle filters them out at render time only -
+    // the data layer (snapshot.maxBytes, byCore, etc.) already excludes them
+    // from pressure totals per #1651, so peak / total numbers stay anchored
+    // to the anonymous bytes regardless of toggle state.
+    const aliasedCount = useMemo(
+        () => snapshot.allocations.reduce((n, cb) => n + (cb.globallyAllocated ? 1 : 0), 0),
+        [snapshot.allocations],
+    );
+
+    const visibleAllocations: CBAllocationSummary[] = useMemo(() => {
+        if (showAliasedCBs) {
+            return snapshot.allocations;
+        }
+        return snapshot.allocations.filter((cb) => !cb.globallyAllocated);
+    }, [snapshot.allocations, showAliasedCBs]);
+
+    const hiddenAliasedCount = showAliasedCBs ? 0 : aliasedCount;
+
+    // Quick lookup for "is core part of selected CB" highlighting. Looking
+    // up against `visibleAllocations` means a selected aliased CB stops
+    // highlighting when its row is filtered out, then comes back when the
+    // toggle is flipped on again (the nodeId itself is preserved).
     const selectedCBCores: Set<string> | null = useMemo(() => {
         if (selectedCBNodeId === null) {
             return null;
         }
-        const cb = snapshot.allocations.find((a) => a.nodeId === selectedCBNodeId);
+        const cb = visibleAllocations.find((a) => a.nodeId === selectedCBNodeId);
         if (!cb) {
             return null;
         }
         return new Set(cb.cores.map((c) => CORE_KEY(c.x, c.y)));
-    }, [snapshot.allocations, selectedCBNodeId]);
+    }, [visibleAllocations, selectedCBNodeId]);
 
     // Pre-build a per-core CB list so the grid doesn't filter allocations
     // for every cell on every render (cells × allocations gets expensive on
     // big chips). Only cores that actually have a CB get an entry.
     const cbsByCore: Map<string, CBAllocationSummary[]> = useMemo(() => {
         const map = new Map<string, CBAllocationSummary[]>();
-        for (const cb of snapshot.allocations) {
+        for (const cb of visibleAllocations) {
             for (const c of cb.cores) {
                 const key = CORE_KEY(c.x, c.y);
                 const list = map.get(key);
@@ -348,7 +381,7 @@ const CircularBufferPressureBody = ({
             }
         }
         return map;
-    }, [snapshot.allocations]);
+    }, [visibleAllocations]);
 
     // CBs that contribute to the currently focused core; powers the "core
     // selected" detail panel without re-walking allocations on every render.
@@ -361,12 +394,15 @@ const CircularBufferPressureBody = ({
 
     // Global address-axis clip. Cells share one [memStart, memEnd] so a
     // CB at the same address lines up across cores at the same x-offset.
+    // Derives from `visibleAllocations` so that hiding aliased CBs tightens
+    // the address window around the anonymous (pressure-contributing) CBs
+    // instead of leaving a sparsely-populated strip.
     const [memStart, memEnd] = useMemo(() => {
         let lo = Number.POSITIVE_INFINITY;
         let hi = Number.NEGATIVE_INFINITY;
         // '?' bucket (numCores === 0) is excluded — it doesn't have a
         // meaningful position on the per-core address axis.
-        for (const cb of snapshot.allocations) {
+        for (const cb of visibleAllocations) {
             if (cb.numCores > 0) {
                 if (cb.address < lo) {
                     lo = cb.address;
@@ -381,7 +417,7 @@ const CircularBufferPressureBody = ({
             return [0, 1];
         }
         return [lo, hi];
-    }, [snapshot.allocations]);
+    }, [visibleAllocations]);
 
     const norm = normalisation === 'budget' ? l1Budget : snapshot.maxBytes || 1;
 
@@ -415,7 +451,7 @@ const CircularBufferPressureBody = ({
                         minimal
                         large
                     >
-                        CBs: {snapshot.allocations.length}
+                        CBs: {visibleAllocations.length}
                     </Tag>
                     {snapshot.unattributedBytes > 0 && (
                         <Tooltip
@@ -458,6 +494,23 @@ const CircularBufferPressureBody = ({
                         label='Show bytes on cells'
                         onChange={(e) => setShowAbsolute(e.currentTarget.checked)}
                     />
+                    {/* The aliased-CB toggle only renders when this snapshot
+                        has aliased CBs to hide - otherwise it's a no-op
+                        affordance that just adds noise to the control row.
+                        See #1655 for the design rationale (default-on,
+                        per-snapshot opt-out, sibling to "Show bytes"). */}
+                    {aliasedCount > 0 && (
+                        <div className='aliased-toggle'>
+                            <Switch
+                                checked={showAliasedCBs}
+                                label='Show globally allocated CBs'
+                                onChange={(e) => setShowAliasedCBs(e.currentTarget.checked)}
+                            />
+                            {hiddenAliasedCount > 0 && (
+                                <span className='aliased-hidden-hint monospace'>({hiddenAliasedCount} hidden)</span>
+                            )}
+                        </div>
+                    )}
                 </div>
             </div>
 
@@ -544,7 +597,7 @@ const CircularBufferPressureBody = ({
                         <p className='empty-message'>No live CBs in this DeviceOp.</p>
                     )}
                     <ul className='cb-list'>
-                        {snapshot.allocations.map((cb) => {
+                        {visibleAllocations.map((cb) => {
                             const isSelected = selectedCBNodeId === cb.nodeId;
                             const swatchColor = cbColor(cb);
                             const isAliased = cb.globallyAllocated;

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -331,16 +331,22 @@ const CircularBufferPressureBody = ({
     onClose,
 }: BodyProps) => {
     // #1655: Aliased (`globallyAllocated`) CBs can flood dense ops where most
-    // CBs are tensor views. The toggle filters them out at render time only -
-    // the data layer (snapshot.maxBytes, byCore, etc.) already excludes them
-    // from pressure totals per #1651, so peak / total numbers stay anchored
-    // to the anonymous bytes regardless of toggle state.
+    // CBs are tensor views. The toggle relieves grid-density only - the
+    // legend keeps all rows always so the right panel stays informationally
+    // complete; aliased rows just dim when the toggle is off. The data
+    // layer (snapshot.maxBytes, byCore, etc.) already excludes aliased
+    // bytes from pressure totals per #1651, so peak / total numbers stay
+    // anchored to the anonymous bytes regardless of toggle state.
     const aliasedCount = useMemo(
         () => snapshot.allocations.reduce((n, cb) => n + (cb.globallyAllocated ? 1 : 0), 0),
         [snapshot.allocations],
     );
 
-    const visibleAllocations: CBAllocationSummary[] = useMemo(() => {
+    // `gridVisibleAllocations` powers the per-core grid strip, zoomed
+    // plot, and address-axis window - the surfaces where rendering aliased
+    // CBs clutters the dense kernel-side view. The legend deliberately
+    // does NOT consume this; it always renders the full list.
+    const gridVisibleAllocations: CBAllocationSummary[] = useMemo(() => {
         if (showAliasedCBs) {
             return snapshot.allocations;
         }
@@ -349,27 +355,27 @@ const CircularBufferPressureBody = ({
 
     const hiddenAliasedCount = showAliasedCBs ? 0 : aliasedCount;
 
-    // Quick lookup for "is core part of selected CB" highlighting. Looking
-    // up against `visibleAllocations` means a selected aliased CB stops
-    // highlighting when its row is filtered out, then comes back when the
-    // toggle is flipped on again (the nodeId itself is preserved).
+    // Quick lookup for "is core part of selected CB" highlighting. Uses
+    // the full snapshot so clicking a dimmed aliased row still lights up
+    // the cores it touches in the grid - the row stays interactive even
+    // when its strip rect is hidden.
     const selectedCBCores: Set<string> | null = useMemo(() => {
         if (selectedCBNodeId === null) {
             return null;
         }
-        const cb = visibleAllocations.find((a) => a.nodeId === selectedCBNodeId);
+        const cb = snapshot.allocations.find((a) => a.nodeId === selectedCBNodeId);
         if (!cb) {
             return null;
         }
         return new Set(cb.cores.map((c) => CORE_KEY(c.x, c.y)));
-    }, [visibleAllocations, selectedCBNodeId]);
+    }, [snapshot.allocations, selectedCBNodeId]);
 
     // Pre-build a per-core CB list so the grid doesn't filter allocations
     // for every cell on every render (cells × allocations gets expensive on
     // big chips). Only cores that actually have a CB get an entry.
     const cbsByCore: Map<string, CBAllocationSummary[]> = useMemo(() => {
         const map = new Map<string, CBAllocationSummary[]>();
-        for (const cb of visibleAllocations) {
+        for (const cb of gridVisibleAllocations) {
             for (const c of cb.cores) {
                 const key = CORE_KEY(c.x, c.y);
                 const list = map.get(key);
@@ -381,7 +387,7 @@ const CircularBufferPressureBody = ({
             }
         }
         return map;
-    }, [visibleAllocations]);
+    }, [gridVisibleAllocations]);
 
     // CBs that contribute to the currently focused core; powers the "core
     // selected" detail panel without re-walking allocations on every render.
@@ -394,15 +400,15 @@ const CircularBufferPressureBody = ({
 
     // Global address-axis clip. Cells share one [memStart, memEnd] so a
     // CB at the same address lines up across cores at the same x-offset.
-    // Derives from `visibleAllocations` so that hiding aliased CBs tightens
-    // the address window around the anonymous (pressure-contributing) CBs
-    // instead of leaving a sparsely-populated strip.
+    // Derives from `gridVisibleAllocations` so that hiding aliased CBs
+    // tightens the address window around the anonymous (pressure-
+    // contributing) CBs instead of leaving a sparsely-populated strip.
     const [memStart, memEnd] = useMemo(() => {
         let lo = Number.POSITIVE_INFINITY;
         let hi = Number.NEGATIVE_INFINITY;
         // '?' bucket (numCores === 0) is excluded — it doesn't have a
         // meaningful position on the per-core address axis.
-        for (const cb of visibleAllocations) {
+        for (const cb of gridVisibleAllocations) {
             if (cb.numCores > 0) {
                 if (cb.address < lo) {
                     lo = cb.address;
@@ -417,7 +423,7 @@ const CircularBufferPressureBody = ({
             return [0, 1];
         }
         return [lo, hi];
-    }, [visibleAllocations]);
+    }, [gridVisibleAllocations]);
 
     const norm = normalisation === 'budget' ? l1Budget : snapshot.maxBytes || 1;
 
@@ -451,7 +457,7 @@ const CircularBufferPressureBody = ({
                         minimal
                         large
                     >
-                        CBs: {visibleAllocations.length}
+                        CBs: {snapshot.allocations.length}
                     </Tag>
                     {snapshot.unattributedBytes > 0 && (
                         <Tooltip
@@ -597,10 +603,16 @@ const CircularBufferPressureBody = ({
                         <p className='empty-message'>No live CBs in this DeviceOp.</p>
                     )}
                     <ul className='cb-list'>
-                        {visibleAllocations.map((cb) => {
+                        {snapshot.allocations.map((cb) => {
                             const isSelected = selectedCBNodeId === cb.nodeId;
                             const swatchColor = cbColor(cb);
                             const isAliased = cb.globallyAllocated;
+                            // Dim aliased rows when the toggle is off.
+                            // Visual demotion only - the row stays clickable
+                            // (selection still highlights cores in the grid),
+                            // it just reads as secondary to the anonymous CBs
+                            // the user is currently focused on.
+                            const isDimmed = isAliased && !showAliasedCBs;
                             // Outline-only fill for aliased CBs ("border" instead of "background")
                             // mirrors the in-cell strip treatment and keeps the colour signal
                             // tied to the tensor they alias. See #1651.
@@ -616,7 +628,11 @@ const CircularBufferPressureBody = ({
                             const row = (
                                 <button
                                     type='button'
-                                    className={classNames('cb-row', { active: isSelected, aliased: isAliased })}
+                                    className={classNames('cb-row', {
+                                        active: isSelected,
+                                        aliased: isAliased,
+                                        'aliased-dimmed': isDimmed,
+                                    })}
                                     onClick={() => setSelectedCBNodeId(isSelected ? null : cb.nodeId)}
                                 >
                                     <span

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -183,7 +183,14 @@ const ZoomedCorePlot = ({
                                 y={RECT_STROKE_INSET}
                                 width={`${widthPercent}%`}
                                 height={plotHeight - RECT_STROKE_INSET * 2}
-                                fill={isAliased ? 'none' : colour}
+                                // `transparent` (rgba(0,0,0,0)) keeps the
+                                // visual identical to `none` but counts as
+                                // "painted" under the default `pointer-events:
+                                // visiblePainted`, so the whole interior of
+                                // outline-only (aliased) rects routes clicks
+                                // up to the `<g>` onClick handler instead of
+                                // only the 1.5px stroke being hit-testable.
+                                fill={isAliased ? 'transparent' : colour}
                                 className='zoomed-chunk-rect'
                             />
                             {labelFits && (

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -37,14 +37,12 @@ const STRIP_HEIGHT = 16;
 
 // SVG strokes are centered on the geometric edge of the rect by default, so a
 // rect at `y=0, height=H` with a 1.5px stroke would have its bottom 0.75px
-// rendered *outside* the SVG viewport and clipped. That's invisible on the
-// strip but obvious on the zoomed plot, where the dark `border: 1px solid` on
-// `.zoomed-core-svg` visually merges with the clipped stroke and makes the
-// bottom edge of outline-only (aliased) rects look cut off. Insetting by 1px
-// on each side keeps the geometric edge 1px inside the SVG, which fully
-// contains the max 2px stroke (selected state) — sized to the worst case so
-// the rect placement is stroke-state-agnostic.
-const RECT_STROKE_INSET = 1;
+// rendered *outside* the SVG viewport and clipped. Insetting by 1px on each
+// side keeps the geometric edge 1px inside the SVG, fully containing the max
+// 2px stroke (selected state). Only applies to the per-core strip — the
+// zoomed plot uses a frame-wrapper + `overflow="visible"` approach instead
+// (see `ZoomedCorePlot`) so its rects don't need a y-inset.
+const STRIP_STROKE_INSET = 1;
 
 // Fallback grey for the rare case where the palette generator returns
 // undefined (e.g. address falls outside its known bands); keeps the rect
@@ -92,9 +90,9 @@ const MiniCBStrip = ({ cbs, memoryStart, memoryEnd, selectedCBNodeId }: MiniCBSt
                     <rect
                         key={cb.nodeId}
                         x={`${xPercent}%`}
-                        y={RECT_STROKE_INSET}
+                        y={STRIP_STROKE_INSET}
                         width={`${widthPercent}%`}
-                        height={STRIP_HEIGHT - RECT_STROKE_INSET * 2}
+                        height={STRIP_HEIGHT - STRIP_STROKE_INSET * 2}
                         fill={isAliased ? 'none' : colour}
                         // SVG `stroke` attribute would be clobbered by CSS rules
                         // on `.cb-strip-chunk`, so we surface the per-chunk colour
@@ -148,66 +146,82 @@ const ZoomedCorePlot = ({
 
     return (
         <div className='zoomed-core-plot'>
-            <svg
-                className='zoomed-core-svg'
-                width='100%'
-                height={plotHeight}
-                preserveAspectRatio='none'
-            >
-                {cbs.map((cb) => {
-                    const xPercent = ((cb.address - memoryStart) / memoryRange) * 100;
-                    const widthPercent = (cb.size / memoryRange) * 100;
-                    const isSelected = selectedCBNodeId === cb.nodeId;
-                    // Width-as-fraction-of-window is enough to decide whether
-                    // there's room for a label without forcing a layout pass.
-                    const labelFits = widthPercent > MIN_WIDTH_PERCENT_FOR_LABEL;
-                    const colour = cbColor(cb);
-                    const isAliased = cb.globallyAllocated;
-                    const titleText = isAliased
-                        ? `${prettyPrintAddress(cb.address, l1Budget)}  ${formatMemorySize(cb.size, 2)} · Aliased to tensor @ ${prettyPrintAddress(cb.address, l1Budget)} — no new allocation`
-                        : `${prettyPrintAddress(cb.address, l1Budget)}  ${formatMemorySize(cb.size, 2)}`;
-                    return (
-                        <g
-                            key={cb.nodeId}
-                            className={classNames('zoomed-chunk', { selected: isSelected, aliased: isAliased })}
-                            // CSS variable lets the `.aliased` rule provide the
-                            // outline colour at higher specificity than the base
-                            // `.zoomed-chunk-rect` stroke. Same pattern as the
-                            // per-core strip above.
-                            style={isAliased ? ({ '--cb-color': colour } as React.CSSProperties) : undefined}
-                            onClick={() => onSelectCB(isSelected ? null : cb.nodeId)}
-                        >
-                            <title>{titleText}</title>
-                            <rect
-                                x={`${xPercent}%`}
-                                y={RECT_STROKE_INSET}
-                                width={`${widthPercent}%`}
-                                height={plotHeight - RECT_STROKE_INSET * 2}
-                                // `transparent` (rgba(0,0,0,0)) keeps the
-                                // visual identical to `none` but counts as
-                                // "painted" under the default `pointer-events:
-                                // visiblePainted`, so the whole interior of
-                                // outline-only (aliased) rects routes clicks
-                                // up to the `<g>` onClick handler instead of
-                                // only the 1.5px stroke being hit-testable.
-                                fill={isAliased ? 'transparent' : colour}
-                                className='zoomed-chunk-rect'
-                            />
-                            {labelFits && (
-                                <text
-                                    x={`${xPercent + widthPercent / 2}%`}
-                                    y={plotHeight / 2}
-                                    textAnchor='middle'
-                                    dominantBaseline='central'
-                                    className='zoomed-chunk-label'
-                                >
-                                    {prettyPrintAddress(cb.address, l1Budget)} · {formatMemorySize(cb.size, 2)}
-                                </text>
-                            )}
-                        </g>
-                    );
-                })}
-            </svg>
+            {/* Frame wrapper owns the border + background + a 2px inner
+                padding. Rect strokes that spill past the SVG viewport (top,
+                bottom, *and* the left/right edges where x/width are in `%`
+                and we can't easily inset in pixels) render into that padding
+                area instead of being clipped — combined with the SVG's
+                `overflow="visible"` below. Without this, Firefox in
+                particular clips the bottom/right strokes of outline-only
+                (aliased) rects that land flush against the SVG bounds,
+                leaving the border looking cut off. */}
+            <div className='zoomed-core-svg-frame'>
+                <svg
+                    className='zoomed-core-svg'
+                    width='100%'
+                    height={plotHeight}
+                    preserveAspectRatio='none'
+                    overflow='visible'
+                >
+                    {cbs.map((cb) => {
+                        const xPercent = ((cb.address - memoryStart) / memoryRange) * 100;
+                        const widthPercent = (cb.size / memoryRange) * 100;
+                        const isSelected = selectedCBNodeId === cb.nodeId;
+                        // Width-as-fraction-of-window is enough to decide
+                        // whether there's room for a label without forcing
+                        // a layout pass.
+                        const labelFits = widthPercent > MIN_WIDTH_PERCENT_FOR_LABEL;
+                        const colour = cbColor(cb);
+                        const isAliased = cb.globallyAllocated;
+                        const titleText = isAliased
+                            ? `${prettyPrintAddress(cb.address, l1Budget)}  ${formatMemorySize(cb.size, 2)} · Aliased to tensor @ ${prettyPrintAddress(cb.address, l1Budget)} — no new allocation`
+                            : `${prettyPrintAddress(cb.address, l1Budget)}  ${formatMemorySize(cb.size, 2)}`;
+                        return (
+                            <g
+                                key={cb.nodeId}
+                                className={classNames('zoomed-chunk', { selected: isSelected, aliased: isAliased })}
+                                // CSS variable lets the `.aliased` rule
+                                // provide the outline colour at higher
+                                // specificity than the base
+                                // `.zoomed-chunk-rect` stroke. Same pattern
+                                // as the per-core strip above.
+                                style={isAliased ? ({ '--cb-color': colour } as React.CSSProperties) : undefined}
+                                onClick={() => onSelectCB(isSelected ? null : cb.nodeId)}
+                            >
+                                <title>{titleText}</title>
+                                <rect
+                                    x={`${xPercent}%`}
+                                    y={0}
+                                    width={`${widthPercent}%`}
+                                    height={plotHeight}
+                                    // `transparent` (rgba(0,0,0,0)) keeps
+                                    // the visual identical to `none` but
+                                    // counts as "painted" under the default
+                                    // `pointer-events: visiblePainted`, so
+                                    // the whole interior of outline-only
+                                    // (aliased) rects routes clicks up to
+                                    // the `<g>` onClick handler instead of
+                                    // only the 1.5px stroke being
+                                    // hit-testable.
+                                    fill={isAliased ? 'transparent' : colour}
+                                    className='zoomed-chunk-rect'
+                                />
+                                {labelFits && (
+                                    <text
+                                        x={`${xPercent + widthPercent / 2}%`}
+                                        y={plotHeight / 2}
+                                        textAnchor='middle'
+                                        dominantBaseline='central'
+                                        className='zoomed-chunk-label'
+                                    >
+                                        {prettyPrintAddress(cb.address, l1Budget)} · {formatMemorySize(cb.size, 2)}
+                                    </text>
+                                )}
+                            </g>
+                        );
+                    })}
+                </svg>
+            </div>
             <div className='zoomed-axis monospace'>
                 <span>{prettyPrintAddress(memoryStart, l1Budget)}</span>
                 <span>{prettyPrintAddress(memoryMid, l1Budget)}</span>

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -35,6 +35,17 @@ const TENSIX_WIDTH = 120;
 const TENSIX_HEIGHT = TENSIX_WIDTH / 3;
 const STRIP_HEIGHT = 16;
 
+// SVG strokes are centered on the geometric edge of the rect by default, so a
+// rect at `y=0, height=H` with a 1.5px stroke would have its bottom 0.75px
+// rendered *outside* the SVG viewport and clipped. That's invisible on the
+// strip but obvious on the zoomed plot, where the dark `border: 1px solid` on
+// `.zoomed-core-svg` visually merges with the clipped stroke and makes the
+// bottom edge of outline-only (aliased) rects look cut off. Insetting by 1px
+// on each side keeps the geometric edge 1px inside the SVG, which fully
+// contains the max 2px stroke (selected state) — sized to the worst case so
+// the rect placement is stroke-state-agnostic.
+const RECT_STROKE_INSET = 1;
+
 // Fallback grey for the rare case where the palette generator returns
 // undefined (e.g. address falls outside its known bands); keeps the rect
 // visible instead of letting SVG default to black.
@@ -81,9 +92,9 @@ const MiniCBStrip = ({ cbs, memoryStart, memoryEnd, selectedCBNodeId }: MiniCBSt
                     <rect
                         key={cb.nodeId}
                         x={`${xPercent}%`}
-                        y={0}
+                        y={RECT_STROKE_INSET}
                         width={`${widthPercent}%`}
-                        height={STRIP_HEIGHT}
+                        height={STRIP_HEIGHT - RECT_STROKE_INSET * 2}
                         fill={isAliased ? 'none' : colour}
                         // SVG `stroke` attribute would be clobbered by CSS rules
                         // on `.cb-strip-chunk`, so we surface the per-chunk colour
@@ -169,9 +180,9 @@ const ZoomedCorePlot = ({
                             <title>{titleText}</title>
                             <rect
                                 x={`${xPercent}%`}
-                                y={0}
+                                y={RECT_STROKE_INSET}
                                 width={`${widthPercent}%`}
-                                height={plotHeight}
+                                height={plotHeight - RECT_STROKE_INSET * 2}
                                 fill={isAliased ? 'none' : colour}
                                 className='zoomed-chunk-rect'
                             />

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -455,11 +455,27 @@
                 flex-direction: column;
                 gap: 4px;
 
-                .zoomed-core-svg {
-                    display: block;
+                // Frame wraps the SVG so that strokes overflowing the SVG
+                // viewport (especially at x=0%/x=100% where we can't inset
+                // in pixel space) render into the frame's 2px padding
+                // instead of being clipped by the SVG's own border. Fixes
+                // the Firefox "bottom/right border cut off" rendering on
+                // outline-only (aliased) rects flush against the edge.
+                // `overflow: visible` on the SVG itself lets the strokes
+                // escape the viewport in the first place.
+                .zoomed-core-svg-frame {
                     background-color: rgba($tt-black, 0.35);
                     border: 1px solid rgba($tt-black, 0.7);
                     border-radius: 1px;
+
+                    // 2px is enough for the widest stroke (selected = 2px,
+                    // half-spilling = 1px each side); 1px would be tight
+                    // for subpixel rounding in Firefox.
+                    padding: 2px;
+                }
+
+                .zoomed-core-svg {
+                    display: block;
 
                     .zoomed-chunk {
                         cursor: pointer;

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -64,6 +64,21 @@
                 .bp6-control {
                     margin-bottom: 0;
                 }
+
+                // Grouped switch + "(N hidden)" hint for the aliased CB toggle
+                // (#1655). The 8px gap inside this group is tighter than the
+                // surrounding 16px so the hint reads as belonging to the
+                // toggle rather than as a standalone control row item.
+                .aliased-toggle {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+
+                    .aliased-hidden-hint {
+                        font-size: 11px;
+                        color: rgba($tt-white, 0.6);
+                    }
+                }
             }
         }
 

--- a/src/scss/components/CircularBufferPressureModal.scss
+++ b/src/scss/components/CircularBufferPressureModal.scss
@@ -250,9 +250,17 @@
                     }
 
                     .cb-row {
-                        display: flex;
+                        // Grid (rather than flex) so the optional aliased
+                        // marker can drop to its own row underneath the
+                        // data columns instead of competing horizontally
+                        // with `addr / size / cores`. Without this the
+                        // marker pushes the data grid narrow enough that
+                        // wide values like "98 KiB" wrap mid-row, breaking
+                        // alignment between aliased and anonymous rows.
+                        display: grid;
+                        grid-template-columns: 12px 1fr;
+                        gap: 2px 8px;
                         align-items: center;
-                        gap: 8px;
                         width: 100%;
                         padding: 4px 6px;
                         background: transparent;
@@ -275,7 +283,13 @@
                             width: 12px;
                             height: 12px;
                             border: 1px solid $tt-black;
-                            flex: 0 0 auto;
+
+                            // Span both grid rows so the swatch stays
+                            // vertically centred against the full visible
+                            // row height — including the marker line on
+                            // aliased rows.
+                            grid-row: 1 / -1;
+                            align-self: center;
                         }
 
                         // Outline-only treatment for aliased CBs: keep the
@@ -289,18 +303,20 @@
                             background-color: transparent;
                         }
 
-                        // The aliased marker sits at the end of the row,
-                        // visually grouping the icon and the label so the row
-                        // reads as `[swatch] addr  size  cores  [link icon]
-                        // Globally allocated`. Push it to the right edge with
-                        // `margin-left: auto` rather than a dedicated grid
-                        // column so the layout still degrades gracefully in
-                        // narrower viewports.
+                        // The aliased marker drops onto a second grid row
+                        // under `.cb-row-body` and aligns to the same start
+                        // edge as the addr column, so the row reads as
+                        // `[swatch] addr  size  cores`
+                        // `         [link icon] Globally allocated`. This
+                        // keeps the data columns aligned with anonymous
+                        // rows in the legend.
                         .aliased-marker {
                             display: inline-flex;
                             align-items: center;
                             gap: 4px;
-                            margin-left: auto;
+                            grid-column: 2;
+                            grid-row: 2;
+                            justify-self: start;
                             padding: 1px 6px;
                             border: 1px solid rgba($tt-white, 0.35);
                             border-radius: 8px;
@@ -319,7 +335,8 @@
                             display: grid;
                             grid-template-columns: 1fr auto auto;
                             gap: 8px;
-                            flex: 1;
+                            grid-column: 2;
+                            grid-row: 1;
                             font-size: 12px;
 
                             .addr {
@@ -343,6 +360,22 @@
                         &.aliased .cb-row-body .addr {
                             text-decoration: underline dotted rgba($tt-white, 0.4);
                             text-underline-offset: 2px;
+                        }
+
+                        // #1655: When the "Show globally allocated CBs"
+                        // toggle is off, aliased rows stay in the legend as
+                        // a reference panel but visually demote. Opacity
+                        // (rather than a colour shift) is reversible by
+                        // hover / active so the row still reads as
+                        // interactive — clicking a dimmed row continues to
+                        // highlight its cores in the grid.
+                        &.aliased-dimmed {
+                            opacity: 0.4;
+
+                            &:hover,
+                            &.active {
+                                opacity: 1;
+                            }
                         }
                     }
                 }

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -482,6 +482,152 @@ describe('CircularBufferPressureModal - globally_allocated CBs (#1651)', () => {
     });
 });
 
+describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)', () => {
+    it('renders the aliased-CB toggle only when the snapshot has aliased CBs', () => {
+        // No aliased CBs in the default fixture → the affordance must stay
+        // hidden; the existing "Show bytes on cells" toggle is the only
+        // Switch in the controls row.
+        renderModal(buildSnapshot());
+        expect(screen.queryByLabelText('Show globally allocated CBs')).not.toBeInTheDocument();
+
+        cleanup();
+
+        // Aliased fixture has one globally_allocated CB → toggle appears.
+        renderModal(buildAliasedSnapshot());
+        expect(screen.getByLabelText('Show globally allocated CBs')).toBeInTheDocument();
+    });
+
+    it('defaults to on - aliased CBs are visible until the user opts out', () => {
+        renderModal(buildAliasedSnapshot());
+
+        const toggle = screen.getByLabelText('Show globally allocated CBs') as HTMLInputElement;
+        expect(toggle).toBeChecked();
+
+        // Sanity-check the rendered state matches the toggle: aliased row
+        // present in the legend, header CBs count includes both CBs.
+        expect(document.querySelectorAll('button.cb-row')).toHaveLength(2);
+        expect(screen.getByText(/^CBs:\s*2$/)).toBeInTheDocument();
+        // "(N hidden)" hint only renders when something is hidden.
+        expect(screen.queryByText(/\(\d+ hidden\)/)).not.toBeInTheDocument();
+    });
+
+    it('filters aliased CBs from the legend, grid strip, and zoomed plot when toggled off', () => {
+        renderModal(buildAliasedSnapshot());
+
+        fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
+
+        // Legend: only the anonymous row survives.
+        const rows = document.querySelectorAll('button.cb-row');
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).not.toHaveClass('aliased');
+        expect(screen.queryByText('Globally allocated')).not.toBeInTheDocument();
+
+        // Header CBs count reflects the visible set, not the full snapshot.
+        expect(screen.getByText(/^CBs:\s*1$/)).toBeInTheDocument();
+        // Hint surfaces the count of CBs the user is currently hiding.
+        expect(screen.getByText(/^\(1 hidden\)$/)).toBeInTheDocument();
+
+        // Per-core strip on (0,0) - the aliased-only core in the fixture -
+        // no longer has any CB rects to render. (1,0) still has the
+        // anonymous CB rect.
+        expect(getTensix(0, 0).querySelectorAll('.cb-strip-chunk')).toHaveLength(0);
+        expect(getTensix(1, 0).querySelectorAll('.cb-strip-chunk')).toHaveLength(1);
+
+        // Zoomed plot on the aliased-only core renders the empty-state copy
+        // (no contributions) instead of the outline-only rect that was there
+        // when the toggle was on.
+        fireEvent.click(getTensix(0, 0));
+        const details = document.querySelector('.tensix-details') as HTMLElement | null;
+        expect(details).not.toBeNull();
+        expect(within(details!).getByText(/No CB contributions for this core\./)).toBeInTheDocument();
+        expect(details!.querySelector('.zoomed-core-plot')).toBeNull();
+    });
+
+    it('keeps Peak per core and Total CBs anchored to the anonymous bytes when toggled off', () => {
+        // Build a fixture where Total CBs would visibly diverge if we
+        // accidentally driven it off the visible set: one anonymous CB on
+        // (0,0) and another anonymous CB on (1,0) (disjoint cores → sum >
+        // peak), plus an aliased CB on (0,0). Toggling the aliased CB off
+        // must NOT change either total.
+        const anonA = 1024;
+        const anonB = 2048;
+        const aliasedSize = 100_000;
+        const snapshot: CBPressureSnapshot = {
+            byCore: { '0,0': anonA, '1,0': anonB },
+            maxBytes: anonB,
+            unattributedBytes: 0,
+            allocations: [
+                {
+                    nodeId: 1,
+                    address: 0x1000,
+                    size: aliasedSize,
+                    numCores: 1,
+                    coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
+                    cores: [{ x: 0, y: 0 }],
+                    globallyAllocated: true,
+                },
+                {
+                    nodeId: 2,
+                    address: 0x2000,
+                    size: anonA,
+                    numCores: 1,
+                    coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
+                    cores: [{ x: 0, y: 0 }],
+                    globallyAllocated: false,
+                },
+                {
+                    nodeId: 3,
+                    address: 0x3000,
+                    size: anonB,
+                    numCores: 1,
+                    coreRangeSet: '{[(x=1,y=0) - (x=1,y=0)]}',
+                    cores: [{ x: 1, y: 0 }],
+                    globallyAllocated: false,
+                },
+            ],
+        };
+
+        renderModal(snapshot);
+
+        const peakRow = document.querySelector('.cb-list-total.row-peak') as HTMLElement;
+        const sumRow = document.querySelector('.cb-list-total.row-sum') as HTMLElement;
+        // Total CBs is visible because the two anonymous CBs sit on disjoint
+        // cores, so sum (3 KiB) > peak (2 KiB).
+        expect(peakRow).not.toBeNull();
+        expect(sumRow).not.toBeNull();
+        const peakValueBefore = peakRow.querySelector('.value')!.textContent;
+        const sumValueBefore = sumRow.querySelector('.value')!.textContent;
+        expect(peakValueBefore).toMatch(/^2\s*KiB/);
+        expect(sumValueBefore).toMatch(/^3\s*KiB/);
+
+        fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
+
+        // Values do not move when the aliased CB is filtered out - they're
+        // anchored to snapshot.maxBytes and the non-aliased sum, neither of
+        // which depends on the toggle.
+        const peakRowAfter = document.querySelector('.cb-list-total.row-peak') as HTMLElement;
+        const sumRowAfter = document.querySelector('.cb-list-total.row-sum') as HTMLElement;
+        expect(peakRowAfter.querySelector('.value')!.textContent).toBe(peakValueBefore);
+        expect(sumRowAfter.querySelector('.value')!.textContent).toBe(sumValueBefore);
+    });
+
+    it('restores aliased CBs when the toggle is flipped back on', () => {
+        renderModal(buildAliasedSnapshot());
+
+        fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
+        expect(document.querySelectorAll('button.cb-row')).toHaveLength(1);
+        expect(screen.getByText(/^\(1 hidden\)$/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
+
+        // Aliased row is back and the hint is gone again.
+        expect(document.querySelectorAll('button.cb-row')).toHaveLength(2);
+        expect(document.querySelectorAll('button.cb-row.aliased')).toHaveLength(1);
+        expect(screen.queryByText(/\(\d+ hidden\)/)).not.toBeInTheDocument();
+        expect(getTensix(0, 0).querySelectorAll('.cb-strip-chunk.aliased')).toHaveLength(1);
+    });
+});
+
 // Two CBs, one aliased (globally_allocated=1) on (0,0), one anonymous on (1,0).
 // Matches the resnet50 op-8 pattern where the aliased CB at the tensor's
 // address must not advance the per-core peak.

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -511,20 +511,31 @@ describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)
         expect(screen.queryByText(/\(\d+ hidden\)/)).not.toBeInTheDocument();
     });
 
-    it('filters aliased CBs from the legend, grid strip, and zoomed plot when toggled off', () => {
+    it('dims aliased legend rows and filters them from the grid strip + zoomed plot when toggled off', () => {
         renderModal(buildAliasedSnapshot());
 
         fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
 
-        // Legend: only the anonymous row survives.
+        // Legend still shows both rows - the right panel is a reference
+        // surface, so we don't strip aliased CBs out of it. The aliased
+        // row picks up the `aliased-dimmed` class which drives the opacity
+        // demotion in SCSS.
         const rows = document.querySelectorAll('button.cb-row');
-        expect(rows).toHaveLength(1);
-        expect(rows[0]).not.toHaveClass('aliased');
-        expect(screen.queryByText('Globally allocated')).not.toBeInTheDocument();
+        expect(rows).toHaveLength(2);
+        const aliasedRow = rows[0];
+        const anonymousRow = rows[1];
+        expect(aliasedRow).toHaveClass('aliased');
+        expect(aliasedRow).toHaveClass('aliased-dimmed');
+        expect(anonymousRow).not.toHaveClass('aliased-dimmed');
+        // The "Globally allocated" marker stays visible on the dimmed row
+        // so the reason for the demotion is still legible.
+        expect(within(aliasedRow as HTMLElement).getByText('Globally allocated')).toBeInTheDocument();
 
-        // Header CBs count reflects the visible set, not the full snapshot.
-        expect(screen.getByText(/^CBs:\s*1$/)).toBeInTheDocument();
-        // Hint surfaces the count of CBs the user is currently hiding.
+        // Header CBs count still reflects the full snapshot - the rows are
+        // dimmed, not removed.
+        expect(screen.getByText(/^CBs:\s*2$/)).toBeInTheDocument();
+        // Hint is grid-focused: "hidden" refers to the strip/zoomed plot,
+        // not to the legend.
         expect(screen.getByText(/^\(1 hidden\)$/)).toBeInTheDocument();
 
         // Per-core strip on (0,0) - the aliased-only core in the fixture -
@@ -541,6 +552,28 @@ describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)
         expect(details).not.toBeNull();
         expect(within(details!).getByText(/No CB contributions for this core\./)).toBeInTheDocument();
         expect(details!.querySelector('.zoomed-core-plot')).toBeNull();
+    });
+
+    it('keeps dimmed aliased rows interactive: clicking still highlights the cores they touch', () => {
+        // The dim-but-keep-in-legend trade-off only makes sense if the row
+        // is still useful as a reference. The selection lookup uses the
+        // full snapshot (not the grid-visible subset) so a dimmed row can
+        // still light up its cores even though no strip rect is rendered.
+        renderModal(buildAliasedSnapshot());
+
+        fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
+
+        const aliasedRow = document.querySelector('button.cb-row.aliased-dimmed') as HTMLButtonElement | null;
+        expect(aliasedRow).not.toBeNull();
+        fireEvent.click(aliasedRow!);
+
+        // Aliased CB in the fixture lives on (0,0) only.
+        expect(getTensix(0, 0)).toHaveClass('highlighted');
+        expect(getTensix(1, 0)).not.toHaveClass('highlighted');
+        // The strip on (0,0) still shows no rects - selection only drives
+        // the cell-level highlight, it does NOT re-introduce the filtered
+        // strip rect.
+        expect(getTensix(0, 0).querySelectorAll('.cb-strip-chunk')).toHaveLength(0);
     });
 
     it('keeps Peak per core and Total CBs anchored to the anonymous bytes when toggled off', () => {
@@ -611,17 +644,19 @@ describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)
         expect(sumRowAfter.querySelector('.value')!.textContent).toBe(sumValueBefore);
     });
 
-    it('restores aliased CBs when the toggle is flipped back on', () => {
+    it('restores aliased CB rendering when the toggle is flipped back on', () => {
         renderModal(buildAliasedSnapshot());
 
+        // Off: row stays in the legend but dimmed, strip rect drops.
         fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
-        expect(document.querySelectorAll('button.cb-row')).toHaveLength(1);
+        expect(document.querySelectorAll('button.cb-row.aliased-dimmed')).toHaveLength(1);
         expect(screen.getByText(/^\(1 hidden\)$/)).toBeInTheDocument();
+        expect(getTensix(0, 0).querySelectorAll('.cb-strip-chunk')).toHaveLength(0);
 
+        // On: dim class clears, hint disappears, strip rect comes back.
         fireEvent.click(screen.getByLabelText('Show globally allocated CBs'));
-
-        // Aliased row is back and the hint is gone again.
         expect(document.querySelectorAll('button.cb-row')).toHaveLength(2);
+        expect(document.querySelectorAll('button.cb-row.aliased-dimmed')).toHaveLength(0);
         expect(document.querySelectorAll('button.cb-row.aliased')).toHaveLength(1);
         expect(screen.queryByText(/\(\d+ hidden\)/)).not.toBeInTheDocument();
         expect(getTensix(0, 0).querySelectorAll('.cb-strip-chunk.aliased')).toHaveLength(1);

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -467,12 +467,17 @@ describe('CircularBufferPressureModal - globally_allocated CBs (#1651)', () => {
         const details = document.querySelector('.tensix-details') as HTMLElement | null;
         expect(details).not.toBeNull();
 
-        // Zoomed plot mirrors the strip: aliased CBs render outline-only.
+        // Zoomed plot mirrors the strip: aliased CBs render outline-only. Per
+        // #1665 the aliased rect uses `fill="transparent"` rather than
+        // `fill="none"` so the whole interior is hit-testable under the
+        // default `pointer-events: visiblePainted` — without this the only
+        // clickable surface is the 1.5px stroke. Visually identical because
+        // `transparent` is `rgba(0,0,0,0)`.
         const zoomedChunks = details!.querySelectorAll('.zoomed-chunk');
         const aliasedChunks = Array.from(zoomedChunks).filter((c) => c.classList.contains('aliased'));
         expect(aliasedChunks.length).toBeGreaterThan(0);
         const aliasedRect = aliasedChunks[0].querySelector('.zoomed-chunk-rect');
-        expect(aliasedRect).toHaveAttribute('fill', 'none');
+        expect(aliasedRect).toHaveAttribute('fill', 'transparent');
 
         // Tooltip <title> for the aliased zoomed chunk surfaces the "aliased
         // to tensor" framing the issue asks for.


### PR DESCRIPTION
Closes #1655.
<img width="1307" height="642" alt="image" src="https://github.com/user-attachments/assets/69455ba0-89f8-435a-82f0-94cc2195d508" />

Adds a default-on `Show globally allocated CBs` switch to the Circular Buffer Pressure modal controls row. The toggle relieves grid density on dense ops (e.g. `HaloDeviceOperation` on the `resnet50_main_jun10_2110` op-8 fixture, where 6 of 8 CBs are aliased) without losing the reference panel on the right.

## Behaviour

**Toggle ON (default)** — unchanged from before.

**Toggle OFF:**
- Aliased CBs are filtered out of the per-core grid strip, the zoomed core plot, and the address-axis window (the surfaces where the kernel-side view gets noisy).
- Aliased CB rows stay in the legend but dim to ~40% opacity, so the right panel stays informationally complete. The outline-only swatch and `Globally allocated` marker remain visible on dimmed rows.
- A small `(N hidden)` hint surfaces next to the toggle so users know how many aliased CBs exist on this DeviceOp.
- Dimmed rows stay interactive — clicking one still highlights the cores it touches in the grid (no strip rect, just the cell-level highlight), and the row's opacity restores while it's hovered or active.
- `Peak per core` and `Total CBs` stay anchored to `snapshot.maxBytes` / the non-aliased CB sum, matching the #1651 data semantics — neither value moves with the toggle.

The toggle is only rendered when the snapshot actually has aliased CBs to hide; on ops without any, the controls row stays at one switch.

## Drive-by layout fix

The legend rows now use CSS grid (instead of flex with `margin-left: auto` for the marker), so the `Globally allocated` badge drops to its own row beneath `addr / size / cores` instead of competing horizontally with the data columns. This fixes the wrap of wider size values (`98 KiB`, `112 KiB`) and aligns the data columns across aliased and anonymous rows.

## Tests

30 specs total in `CircularBufferPressureModal.spec.tsx`. Six new tests cover the AC:
- Toggle only renders when the snapshot has aliased CBs.
- Defaults to on; no hint when nothing is hidden.
- Off state dims aliased legend rows, filters them from the grid strip + zoomed plot, and surfaces the `(N hidden)` hint.
- `Peak per core` and `Total CBs` values are identical before/after toggling.
- Dimmed rows stay interactive — clicking still highlights the cores they touch in the grid.
- Toggle restoration (back on clears the dim class and brings the strip rect back).