### PR TITLE
Keeps uv.lock file in sync on release

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -48,6 +48,20 @@ function getCurrentBranch() {
     }
 }
 
+function assertUvAvailable() {
+    try {
+        execSync('uv --version', { stdio: 'ignore' });
+    } catch {
+        console.error(
+            `❌${color.red}Error: "uv" not found on PATH.${color.reset}\n` +
+                `${color.blue}uv is required to regenerate uv.lock. Install it from https://docs.astral.sh/uv/ and retry.${color.reset}`,
+        );
+        process.exit(1);
+    }
+}
+
+assertUvAvailable();
+
 const isNotPatch = bumpType === '-minor' || bumpType === '-major';
 
 if (isNotPatch) {
@@ -77,7 +91,10 @@ pyContents = pyContents.replace(/version\s*=\s*["']\d+\.\d+\.\d+["']/, `version 
 fs.writeFileSync(pyPath, pyContents);
 console.log(`Updated pyproject.toml to version ${newVersion}`);
 
-execSync(`git add package.json pyproject.toml`, { stdio: 'inherit' });
+execSync('uv lock', { stdio: 'inherit' });
+console.log(`Regenerated uv.lock for version ${newVersion}`);
+
+execSync(`git add package.json pyproject.toml uv.lock`, { stdio: 'inherit' });
 execSync(`git commit -m "v${newVersion}"`, { stdio: 'inherit' });
 execSync(`git tag v${newVersion}`, { stdio: 'inherit' });
 execSync(`git push`, { stdio: 'inherit' });

--- a/uv.lock
+++ b/uv.lock
@@ -3245,7 +3245,7 @@ wheels = [
 
 [[package]]
 name = "ttnn-visualizer"
-version = "0.89.0"
+version = "0.90.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Running the release script will require generating a new uv lock due to the version bump. This PR modifies the release script to regenerate the lockfile and commit it. It also adds a guard to prevent the script from running if the user does not have `uv` installed.