### PR TITLE
Scope operation-detail caches by active report path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ Open pull requests with **`dev`** as the base branch by default.
 
 - Type every hook as **`useQuery<Data, AxiosError>`** — don't let the error parameter fall back to `unknown`. Call sites depend on `AxiosError` shape (e.g. `error?.status === HttpStatusCode.UnprocessableEntity`).
 - Query keys are tuples of `['kebab-string-name', ...reactiveDeps]` (e.g. `['fetch-all-buffers', bufferType, activeProfilerReport?.path]`). Report-bound queries use `staleTime: Infinity`. Keys that need invalidation from another module are exported as `*_QUERY_KEY` constants.
+- Report-bound query keys must include the active report's identity — typically **`activeProfilerReport?.path`** or **`activePerformanceReport?.path`**. Operation ids reset per report, so a key like `['get-operation-detail', operationId]` collides across reports and serves stale payloads when the same id is revisited under a different report. See #1674.
 
 ### Errors and toasts
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -422,10 +422,12 @@ return useQuery<Buffer[], AxiosError>({
 
 The first element is the human-readable name, then every reactive value the query depends on. Re-used keys (invalidated from another module) are exported as `*_QUERY_KEY` constants.
 
+Report-bound queries must include the active report's identity in the key (typically `activeProfilerReport?.path` or `activePerformanceReport?.path`). Operation ids reset per report, so a key like `['get-operation-detail', operationId]` collides across reports and serves stale payloads when the same id is revisited under a different report. See #1674.
+
 `src/hooks/useAPI.tsx`
 
 ```tsx
-queryKey: ['get-operation-buffers', operationId],
+queryKey: ['get-operation-buffers', operationId, activeProfilerReport?.path],
 ```
 
 ### `staleTime: Infinity` for report-bound queries
@@ -449,7 +451,7 @@ When a query depends on another query's result (e.g. only fetch detail when a li
 ```ts
 return useQuery({
     queryFn: () => fetchOperationDetails(operationId),
-    queryKey: ['get-operation-detail', operationId],
+    queryKey: ['get-operation-detail', operationId, activeProfilerReport?.path],
     enabled: operationId !== null,
 });
 ```

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -324,8 +324,13 @@ export const fetchOperationBuffers = async (operationId: number) => {
 };
 
 export const useOperationBuffers = (operationId: number) => {
+    // Scope the cache by the active report's path. Operation ids reset per
+    // report, so a key of `[..., operationId]` collides across reports and
+    // serves the previously-loaded report's payload when the same id is
+    // revisited under the new one. See #1674.
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
     return useQuery<BuffersByOperation, AxiosError>({
-        queryKey: ['get-operation-buffers', operationId],
+        queryKey: ['get-operation-buffers', operationId, activeProfilerReport?.path],
         queryFn: () => fetchOperationBuffers(operationId),
         retry: false,
         staleTime: Infinity,
@@ -521,19 +526,22 @@ export const useMlir = (fileName: string | null) => {
 
 export const useOperationDetails = (operationId: number | null) => {
     const { data: operations } = useOperationsList();
+    // Scope the cache by the active report's path. Operation ids reset per
+    // report, so a key of `[..., operationId]` collides across reports and
+    // serves the previously-loaded report's payload when the same id is
+    // revisited under the new one. See #1674.
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
 
-    // Memoize the operation lookup
     const operation = useMemo(
         () => operations?.find((_operation) => _operation.id === operationId) || null,
         [operations, operationId],
     );
 
-    // Memoized function for fetching operation details
     const fetchDetails = useCallback(() => fetchOperationDetails(operationId), [operationId]);
 
     const operationDetails = useQuery<OperationDetailsData>({
         queryFn: () => fetchDetails(),
-        queryKey: ['get-operation-detail', operationId],
+        queryKey: ['get-operation-detail', operationId, activeProfilerReport?.path],
         retry: 2,
         retryDelay: (retryAttempt) => Math.min(retryAttempt * 100, 500),
         staleTime: Infinity,
@@ -785,8 +793,13 @@ export const useReportMetadata = () => {
 };
 
 export const useBufferChunks = (operationId: number, address?: number | string, bufferType?: BufferType) => {
+    // Scope the cache by the active report's path. Operation ids reset per
+    // report, so a key of `[..., operationId, ...]` collides across reports
+    // and serves the previously-loaded report's payload when the same id is
+    // revisited under the new one. See #1674.
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
     return useQuery<BufferChunk[], AxiosError>({
-        queryKey: ['get-buffer-chunks', operationId, address, bufferType],
+        queryKey: ['get-buffer-chunks', operationId, address, bufferType, activeProfilerReport?.path],
         queryFn: () => fetchBufferChunks(operationId, address, bufferType),
         staleTime: Infinity,
     });


### PR DESCRIPTION
## Summary

Fixes #1674. Operation ids reset per report, so the React Query keys for `useOperationDetails`, `useOperationBuffers`, and `useBufferChunks` collided across reports and served the previously loaded report's payload when the same id was revisited under the new one.

Appends `activeProfilerReport?.path` to each affected key, matching the convention already used by `get-operations`, `get-cluster-description`, `get-devices`, `get-tensors`, `get-report-metadata`, and `fetch-all-buffers` in the same file. Pure surgical change — no backend, no data layer, no other call sites depend on these key tuples.

Also updates `CONVENTIONS.md` to document the report-scoping rule so the same regression isn't reintroduced.

## Why this fix vs. alternatives

- Adding the report path to the key is the React Query ‘canonical’ isolation pattern — same as every other report-bound query in `useAPI.tsx`.
- Alternative (`queryClient.invalidateQueries` on report switch) would require coupling every report-switch entry point to the cache, would silently break if a new entry point lands without the invalidation, and would still leave the cache populated until reset.

## Test plan

- [ ] Load report A, navigate to operation id 5, note the displayed tensors / buffers.
- [ ] Switch to report B (must share the operation id, e.g. id 5).
- [ ] Navigate to operation id 5 in report B; details should show report B's payload immediately, not report A's.
- [ ] Switch back to report A and confirm report A's payload returns from cache (no extra refetch).
- [ ] `pnpm exec tsc -p tsconfig.json --noEmit` — clean.
- [ ] `pnpm exec eslint src/hooks/useAPI.tsx` — clean.
- [ ] `pnpm exec vitest run tests/TensorVisualisationComponent.spec.tsx` (the one test that touches `useBufferChunks`) — passes; the mock doesn't care about the new key shape.

## Out of scope

- `useNextBuffer` has the same caller-controlled `queryKey: [queryKey]` shape but is dead code (no callers). Leaving it alone here; worth a follow-up to delete or rework.
- NPE / MLIR / device-log queries keyed by `fileName` may have an analogous collision risk if two reports share file names. Out of scope for this issue/PR.
