### PR TITLE
Align buffer and CB legend columns under a single legend row

### DIFF
--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -378,20 +378,31 @@ function useDeviceOperationsFullRenderModel(args: {
                             key={index}
                             title='Buffer allocate'
                         >
-                            <MemoryLegendElement
-                                chunk={{
-                                    address: parseInt(buffer.address, 10),
-                                    size: bufferSize,
-                                }}
-                                numCores={cores}
-                                key={buffer.address}
-                                memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
-                                selectedTensorAddress={selectedAddress}
-                                operationDetails={details}
-                                onLegendClick={onLegendClick}
-                                bufferType={buffer.type}
-                                layout={buffer.layout}
-                            />
+                            {/* Same flex wrapper as CB rows below: pairs the legend
+                                with a 320px placeholder so its grid columns are
+                                computed against the same width as the CB legend.
+                                The running totals live in the h4 above, so we
+                                use an invisible spacer instead of `memoryInfo`. */}
+                            <div className='cb-legend-row'>
+                                <MemoryLegendElement
+                                    chunk={{
+                                        address: parseInt(buffer.address, 10),
+                                        size: bufferSize,
+                                    }}
+                                    numCores={cores}
+                                    key={buffer.address}
+                                    memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
+                                    selectedTensorAddress={selectedAddress}
+                                    operationDetails={details}
+                                    onLegendClick={onLegendClick}
+                                    bufferType={buffer.type}
+                                    layout={buffer.layout}
+                                />
+                                <div
+                                    className='memory-info-placeholder'
+                                    aria-hidden='true'
+                                />
+                            </div>
                         </DeviceOperationNodeComponent>
                     );
                 } else if (nodeType === NodeType.buffer_deallocate) {
@@ -408,19 +419,25 @@ function useDeviceOperationsFullRenderModel(args: {
                             key={index}
                             title='Buffer deallocate'
                         >
-                            <MemoryLegendElement
-                                chunk={{
-                                    address: buffer.address !== undefined ? parseInt(buffer.address, 10) : NaN,
-                                    size: bufferSize,
-                                }}
-                                numCores={cores}
-                                key={buffer.address}
-                                memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
-                                selectedTensorAddress={selectedAddress}
-                                operationDetails={details}
-                                onLegendClick={onLegendClick}
-                                bufferType={buffer.type}
-                            />
+                            <div className='cb-legend-row'>
+                                <MemoryLegendElement
+                                    chunk={{
+                                        address: buffer.address !== undefined ? parseInt(buffer.address, 10) : NaN,
+                                        size: bufferSize,
+                                    }}
+                                    numCores={cores}
+                                    key={buffer.address}
+                                    memSize={details.l1_sizes[0] || L1_DEFAULT_MEMORY_SIZE}
+                                    selectedTensorAddress={selectedAddress}
+                                    operationDetails={details}
+                                    onLegendClick={onLegendClick}
+                                    bufferType={buffer.type}
+                                />
+                                <div
+                                    className='memory-info-placeholder'
+                                    aria-hidden='true'
+                                />
+                            </div>
                             <hr />
                         </DeviceOperationNodeComponent>
                     );

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -383,7 +383,7 @@ function useDeviceOperationsFullRenderModel(args: {
                                 computed against the same width as the CB legend.
                                 The running totals live in the h4 above, so we
                                 use an invisible spacer instead of `memoryInfo`. */}
-                            <div className='cb-legend-row'>
+                            <div className='memory-legend-row'>
                                 <MemoryLegendElement
                                     chunk={{
                                         address: parseInt(buffer.address, 10),
@@ -419,7 +419,7 @@ function useDeviceOperationsFullRenderModel(args: {
                             key={index}
                             title='Buffer deallocate'
                         >
-                            <div className='cb-legend-row'>
+                            <div className='memory-legend-row'>
                                 <MemoryLegendElement
                                     chunk={{
                                         address: buffer.address !== undefined ? parseInt(buffer.address, 10) : NaN,
@@ -502,7 +502,7 @@ function useDeviceOperationsFullRenderModel(args: {
                                     </div>
                                 </>
                             )}
-                            <div className='cb-legend-row'>
+                            <div className='memory-legend-row'>
                                 <MemoryLegendElement
                                     numCores={numCores}
                                     chunk={{ address: parseInt(cb.address, 10), size: parseInt(cb.size, 10) }}

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -155,7 +155,17 @@
         }
     }
 
-    // Avoids impacting the legend used below the plots at the top of the page
+    // Shared row layout for buffer and CB legend entries. Reserving a fixed
+    // 320px right gutter (either the in-flow `.memory-info` for CB rows, or
+    // the invisible `.memory-info-placeholder` for buffer rows where totals
+    // live in the h4 above) keeps every legend grid computed against the
+    // same available width. Combined with the default `.legend-item` grid
+    // templates (5-col `15px 0.5fr 2fr 13fr 3fr` and 6-col extra-info
+    // `15px 0.5fr 2fr 10fr 3fr 3fr` — both sum to 18.5fr after the swatch),
+    // this makes swatch / address / size / shape columns line up
+    // column-for-column across buffer and CB rows. Scoped under
+    // `.device-operations-full-render` so it doesn't bleed into the L1 /
+    // DRAM plot legends.
     .cb-legend-row {
         display: flex;
         align-items: flex-start;
@@ -164,10 +174,10 @@
         .legend-item {
             flex: 1 1 auto;
             min-width: 0;
-            grid-template-columns: 15px 0.5fr 2fr 10fr 5fr;
         }
 
-        .memory-info {
+        .memory-info,
+        .memory-info-placeholder {
             flex: 0 0 320px;
         }
     }

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -166,7 +166,7 @@
     // column-for-column across buffer and CB rows. Scoped under
     // `.device-operations-full-render` so it doesn't bleed into the L1 /
     // DRAM plot legends.
-    .cb-legend-row {
+    .memory-legend-row {
         display: flex;
         align-items: flex-start;
         gap: 10px;


### PR DESCRIPTION
## Summary

Follow-up polish to #1664 / #1638. The CB rows now sit in a `.cb-legend-row` flex (legend width = `parent - 330px`) with a custom 5-col grid (`15px 0.5fr 2fr 10fr 5fr`, sum 17.5fr), while buffer-allocate / buffer-deallocate rows still render their `<MemoryLegendElement>` at full parent width with the default grids. Different available widths *and* different fr totals meant the swatch / address / size / shape columns never lined up between buffer and CB rows.

This PR makes them share one grid:

1. **Buffer rows reuse `.cb-legend-row`.** Each buffer-allocate / buffer-deallocate `<MemoryLegendElement>` is now wrapped in the same flex container, paired with an invisible `.memory-info-placeholder` (the running totals stay in the h4 above; the spacer just reserves the matching 320px right gutter so the legend grid is computed against the same width as CB rows).
2. **Drop the CB-only grid override.** Both row types fall back to the default `.legend-item` grids:
   - CB rows (no `extra-info`): `15px 0.5fr 2fr 13fr 3fr`
   - Buffer rows (`extra-info`):  `15px 0.5fr 2fr 10fr 3fr 3fr`

   Both sum to **18.5fr** after the 15px swatch, so swatch / address / size / shape-info columns line up column-for-column at every viewport width. CB col 4 (tensor id, 13fr) still occupies the combined width of buffer cols 4+5 (tensor id + bufferType+layout), so the inner boundaries differ semantically but the eye reads them as one shared grid.

Scoped under `.device-operations-full-render` so it doesn't bleed into the L1 / DRAM plot legends at the top of the page.

## What this fixes vs. what it doesn't

This is purely the visual-alignment polish that #1664 didn't cover. The original overlap regression that #1664 / #1638 targeted stays fixed.

## Test plan

- [ ] `pnpm exec tsc -p tsconfig.json --noEmit` — clean.
- [ ] `pnpm exec eslint src/components/operation-details/DeviceOperationsFullRender.tsx` — clean.
- [ ] `pnpm exec vitest run tests/MemoryLegendElement.spec.tsx tests/CircularBufferPressureModal.spec.tsx` — 37 / 37 passing.
- [ ] Visual: open the operation details view on a CB-heavy op (the resnet50 report from #1651 reproduces it well). Swatch / address / size columns line up between buffer-allocate, buffer-deallocate, and CB rows. Shape / dtype column lines up too. Running totals on the right stay anchored to the same 320px gutter as before. No new horizontal scroll.
