### PR TITLE
Add uv lock --check to backend lint-and-test workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -67,10 +67,12 @@ jobs:
 
       - name: Verify lockfile is up to date
         run: |
-          if ! uv lock --check; then
-            echo "::error::uv.lock is out of date with pyproject.toml. Run 'uv lock' locally and commit the updated uv.lock."
-            exit 1
-          fi
+          set -euo pipefail
+          uv lock --check || {
+            status=$?
+            echo "::error file=uv.lock::'uv lock --check' failed (uv.lock may be out of date with pyproject.toml). Run 'uv lock' locally and commit the updated uv.lock. See logs above for details."
+            exit "${status}"
+          }
 
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -65,6 +65,13 @@ jobs:
           python-version: ${{ steps.python.outputs.PYTHON_VERSION }}
           enable-cache: true
 
+      - name: Verify lockfile is up to date
+        run: |
+          if ! uv lock --check; then
+            echo "::error::uv.lock is out of date with pyproject.toml. Run 'uv lock' locally and commit the updated uv.lock."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: uv sync --frozen
 


### PR DESCRIPTION
## Summary

Adds a CI check to the `backend-lint-and-test` job that fails when `uv.lock` is out of date with `pyproject.toml`.

Previously the backend job ran only `uv sync --frozen`, which enforces installing from the committed lockfile but does not verify the lockfile is current. A PR could change `pyproject.toml` without updating `uv.lock` and CI would still pass.

The new step runs `uv lock --check` before `uv sync --frozen`. It exits non-zero if running `uv lock` would modify `uv.lock`, and emits a clear GitHub error annotation telling contributors to run `uv lock` and commit the updated lockfile.

## Acceptance criteria

- [x] `backend-lint-and-test` fails when `uv.lock` would change after dependency edits.
- [x] Job still passes when `uv.lock` is committed and matches `pyproject.toml` (verified locally: `uv lock --check` resolves cleanly).
- [x] Failure message makes it obvious contributors should run `uv lock` and commit `uv.lock`.

Closes #1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)