### PR TITLE
Show successful linking in report selection 

### DIFF
--- a/src/components/ReportLinkStatus.tsx
+++ b/src/components/ReportLinkStatus.tsx
@@ -5,11 +5,62 @@
 import { Icon, Intent, Position, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useEffect } from 'react';
 import { useGetDeviceOperationListPerf } from '../hooks/useAPI';
+import {
+    activePerformanceReportAtom,
+    activeProfilerReportAtom,
+    performanceReportLocationAtom,
+    profilerReportLocationAtom,
+    successfulReportLinksAtom,
+} from '../store/app';
+import { addReportLink } from '../functions/reportLinks';
+import getServerConfig from '../functions/getServerConfig';
 
 const ReportLinkStatus = () => {
     const useGetDeviceOperationListPerfResult = useGetDeviceOperationListPerf();
     const canMatchOperations = useGetDeviceOperationListPerfResult.length > 0;
+
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
+    const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
+    const profilerLocation = useAtomValue(profilerReportLocationAtom);
+    const performanceLocation = useAtomValue(performanceReportLocationAtom);
+    const setReportLinks = useSetAtom(successfulReportLinksAtom);
+
+    const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
+
+    // Lazily record the active pair whenever it links successfully, so the report
+    // selection lists can later badge known counterparts of the active report.
+    useEffect(() => {
+        if (
+            !isReportLinkingEnabled ||
+            !canMatchOperations ||
+            !activeProfilerReport ||
+            !activePerformanceReport ||
+            !profilerLocation ||
+            !performanceLocation
+        ) {
+            return;
+        }
+
+        setReportLinks((links) =>
+            addReportLink(links, {
+                profilerPath: activeProfilerReport.path,
+                profilerLocation,
+                performancePath: activePerformanceReport.path,
+                performanceLocation,
+            }),
+        );
+    }, [
+        canMatchOperations,
+        activeProfilerReport,
+        activePerformanceReport,
+        profilerLocation,
+        performanceLocation,
+        setReportLinks,
+        isReportLinkingEnabled,
+    ]);
 
     // Compute icon and messaging
     const tooltipContent = canMatchOperations ? (

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -84,7 +84,7 @@ const LocalFolderPicker = ({
                     labelElement={
                         isLinked ? (
                             <Tooltip
-                                content='Previously linked with the active report (matched by operation sequence — may also match similar runs)'
+                                content='Previously linked with the active report'
                                 position={Position.RIGHT}
                             >
                                 <Icon

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -2,8 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useState } from 'react';
-import { Alert, Button, ButtonVariant, Intent, MenuItem, Position, Tooltip } from '@blueprintjs/core';
+import { useMemo, useState } from 'react';
+import { Alert, Button, ButtonVariant, Icon, Intent, MenuItem, Position, Tooltip } from '@blueprintjs/core';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { useInstance } from '../../hooks/useAPI';
@@ -20,6 +20,8 @@ interface LocalFolderPickerProps {
     defaultLabel?: string;
     valueLabel?: string | null;
     showReportName?: boolean;
+    /** Paths of items previously observed to link with the active counterpart report. */
+    linkedPaths?: Set<string>;
 }
 
 const LocalFolderPicker = ({
@@ -30,6 +32,7 @@ const LocalFolderPicker = ({
     defaultLabel = 'Select a report...',
     valueLabel,
     showReportName,
+    linkedPaths,
 }: LocalFolderPickerProps) => {
     const { data: instance } = useInstance();
 
@@ -40,10 +43,22 @@ const LocalFolderPicker = ({
     const activeName = value ? (valueLabel ?? value) : null;
     const isDeleteDisabled = getServerConfig()?.SERVER_MODE;
 
+    // Surface reports that linked with the active counterpart first, preserving the
+    // server-provided order (most-recently-modified) within each group.
+    const sortedItems = useMemo(() => {
+        if (!items || !linkedPaths?.size) {
+            return items ?? [];
+        }
+
+        return [...items].sort((a, b) => Number(linkedPaths.has(b.path)) - Number(linkedPaths.has(a.path)));
+    }, [items, linkedPaths]);
+
     const renderItem: ItemRenderer<ReportFolder> = (folder, { handleClick, handleFocus, modifiers, query }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
+
+        const isLinked = linkedPaths?.has(folder.path) ?? false;
 
         return (
             <div
@@ -66,6 +81,19 @@ const LocalFolderPicker = ({
                     onClick={handleClick}
                     onFocus={handleFocus}
                     icon={folder.path === activePath ? IconNames.SAVED : IconNames.DOCUMENT}
+                    labelElement={
+                        isLinked ? (
+                            <Tooltip
+                                content='Previously linked with the active report (matched by operation sequence — may also match similar runs)'
+                                position={Position.RIGHT}
+                            >
+                                <Icon
+                                    icon={IconNames.LINK}
+                                    intent={Intent.SUCCESS}
+                                />
+                            </Tooltip>
+                        ) : undefined
+                    }
                 />
 
                 {handleDelete && !isDeleteDisabled && (
@@ -107,7 +135,7 @@ const LocalFolderPicker = ({
     return (
         <Select<ReportFolder>
             className='folder-picker'
-            items={items ?? []}
+            items={sortedItems}
             itemPredicate={(query, item) => !query || item.path.toLowerCase().includes(query.toLowerCase())}
             itemRenderer={renderItem}
             noResults={

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -7,14 +7,16 @@ import { IconNames } from '@blueprintjs/icons';
 import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import useLocalConnection from '../../hooks/useLocal';
 import {
     activePerformanceReportAtom,
     activeProfilerReportAtom,
     performanceReportLocationAtom,
     profilerReportLocationAtom,
+    successfulReportLinksAtom,
 } from '../../store/app';
+import { linkedPerformancePaths, linkedProfilerPaths } from '../../functions/reportLinks';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
 import getResponseError from '../../functions/getResponseError';
@@ -136,7 +138,27 @@ const LocalFolderOptions = () => {
         [activePerformanceReport, perfFolderList, isPerformanceLocal],
     );
 
+    const reportLinks = useAtomValue(successfulReportLinksAtom);
+
     const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
+    const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
+
+    // Performance reports that have linked with the active memory report (and vice versa).
+    // Experimental: only surfaced in development builds.
+    const linkedPerfPaths = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? linkedPerformancePaths(reportLinks, activeProfilerReport?.path, profilerReportLocation)
+                : undefined,
+        [reportLinks, activeProfilerReport, profilerReportLocation, isReportLinkingEnabled],
+    );
+    const linkedProfilerReportPaths = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? linkedProfilerPaths(reportLinks, activePerformanceReport?.path, performanceReportLocation)
+                : undefined,
+        [reportLinks, activePerformanceReport, performanceReportLocation, isReportLinkingEnabled],
+    );
 
     const handleReportDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
         if (!e.target.files) {
@@ -285,6 +307,7 @@ const LocalFolderOptions = () => {
                     valueLabel={activeProfilerReport?.reportName ?? null}
                     handleSelect={handleSelectProfiler}
                     handleDelete={handleDeleteProfiler}
+                    linkedPaths={linkedProfilerReportPaths}
                     showReportName
                 />
             </FormGroup>
@@ -333,6 +356,7 @@ const LocalFolderOptions = () => {
                     valueLabel={activePerformanceReport?.reportName ?? null}
                     handleSelect={handleSelectPerformance}
                     handleDelete={handleDeletePerformance}
+                    linkedPaths={linkedPerfPaths}
                 />
             </FormGroup>
 

--- a/src/functions/getServerConfig.ts
+++ b/src/functions/getServerConfig.ts
@@ -13,6 +13,7 @@ interface ServerConfig {
     BASE_PATH?: string;
     TT_METAL_HOME?: string;
     REPORT_DATA_DIRECTORY?: string;
+    REPORT_LINKING_ENABLED?: boolean;
 }
 
 const getServerConfig = (): ServerConfig => {
@@ -23,6 +24,7 @@ const getServerConfig = (): ServerConfig => {
             SERVER_MODE: !!import.meta.env.VITE_SERVER_MODE || false,
             TT_METAL_HOME: import.meta.env.VITE_TT_METAL_HOME,
             REPORT_DATA_DIRECTORY: import.meta.env.VITE_REPORT_DATA_DIRECTORY || '/path/to/data/directory', // Default value for development
+            REPORT_LINKING_ENABLED: true,
         };
     }
 
@@ -31,6 +33,7 @@ const getServerConfig = (): ServerConfig => {
         SERVER_MODE: window?.TTNN_VISUALIZER_CONFIG?.SERVER_MODE || false,
         TT_METAL_HOME: window?.TTNN_VISUALIZER_CONFIG?.TT_METAL_HOME,
         REPORT_DATA_DIRECTORY: window?.TTNN_VISUALIZER_CONFIG?.REPORT_DATA_DIRECTORY,
+        REPORT_LINKING_ENABLED: window?.TTNN_VISUALIZER_CONFIG?.REPORT_LINKING_ENABLED || false,
     };
 };
 

--- a/src/functions/reportLinks.ts
+++ b/src/functions/reportLinks.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { ReportLocation } from '../definitions/Reports';
+
+/**
+ * A memory (profiler) report and a performance report that were observed to link
+ * successfully — i.e. their device operation sequences matched while both were active.
+ *
+ * The match is a heuristic on the operation sequence, so this is intentionally
+ * many-to-many: one report can link with several counterparts (including reports from
+ * different runs that happen to share an operation sequence). Each distinct pair is
+ * stored separately and never collapsed to a single partner.
+ */
+export interface ReportLink {
+    profilerPath: string;
+    profilerLocation: ReportLocation;
+    performancePath: string;
+    performanceLocation: ReportLocation;
+}
+
+const isSamePair = (a: ReportLink, b: ReportLink): boolean =>
+    a.profilerPath === b.profilerPath &&
+    a.profilerLocation === b.profilerLocation &&
+    a.performancePath === b.performancePath &&
+    a.performanceLocation === b.performanceLocation;
+
+/**
+ * Returns the list with `next` appended, deduping on the full pair so a report can
+ * accumulate multiple distinct counterparts without duplicate entries.
+ */
+export const addReportLink = (links: ReportLink[], next: ReportLink): ReportLink[] =>
+    links.some((link) => isSamePair(link, next)) ? links : [...links, next];
+
+/**
+ * Performance report paths recorded as linked with the given (active) memory report.
+ */
+export const linkedPerformancePaths = (
+    links: ReportLink[],
+    profilerPath: string | null | undefined,
+    profilerLocation: ReportLocation | null | undefined,
+): Set<string> => {
+    if (!profilerPath || !profilerLocation) {
+        return new Set();
+    }
+
+    return new Set(
+        links
+            .filter((link) => link.profilerPath === profilerPath && link.profilerLocation === profilerLocation)
+            .map((link) => link.performancePath),
+    );
+};
+
+/**
+ * Memory report paths recorded as linked with the given (active) performance report.
+ */
+export const linkedProfilerPaths = (
+    links: ReportLink[],
+    performancePath: string | null | undefined,
+    performanceLocation: ReportLocation | null | undefined,
+): Set<string> => {
+    if (!performancePath || !performanceLocation) {
+        return new Set();
+    }
+
+    return new Set(
+        links
+            .filter(
+                (link) => link.performancePath === performancePath && link.performanceLocation === performanceLocation,
+            )
+            .map((link) => link.profilerPath),
+    );
+};

--- a/src/functions/reportLinks.ts
+++ b/src/functions/reportLinks.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { ReportLocation } from '../definitions/Reports';
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -12,6 +12,7 @@ import { ListStates } from '../definitions/VirtualLists';
 import { Signpost } from '../functions/perfFunctions';
 import { PerfTabIds } from '../definitions/Performance';
 import { ReportFolder, ReportLocation } from '../definitions/Reports';
+import { ReportLink } from '../functions/reportLinks';
 import { ColumnKeys, TypedPerfTableRow } from '../definitions/PerfTable';
 import { BufferType } from '../model/BufferType';
 import { StackedGroupBy } from '../definitions/StackedPerfTable';
@@ -49,6 +50,9 @@ export const operationRangeAtom = atom<NumberRange | null>(null);
 export const selectedOperationRangeAtom = atom<NumberRange | null>(null);
 export const performanceReportLocationAtom = atom<ReportLocation | null>(null);
 export const activePerformanceReportAtom = atom<ReportFolder | null>(null);
+// Persisted memory<->performance report pairs observed to link successfully. Many-to-many
+// by design; surfaced as badges against the active report in the report selection lists.
+export const successfulReportLinksAtom = atomWithStorage<ReportLink[]>('successfulReportLinks', []);
 export const performanceRangeAtom = atom<NumberRange | null>(null);
 export const selectedPerformanceRangeAtom = atom<NumberRange | null>(null);
 export const activeNpeOpTraceAtom = atom<string | null>(null);

--- a/tests/reportLinks.spec.ts
+++ b/tests/reportLinks.spec.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { ReportLocation } from '../src/definitions/Reports';
+import { ReportLink, addReportLink, linkedPerformancePaths, linkedProfilerPaths } from '../src/functions/reportLinks';
+
+const link = (profilerPath: string, performancePath: string): ReportLink => ({
+    profilerPath,
+    profilerLocation: ReportLocation.LOCAL,
+    performancePath,
+    performanceLocation: ReportLocation.LOCAL,
+});
+
+describe('reportLinks', () => {
+    describe('addReportLink', () => {
+        it('appends a new pair', () => {
+            const result = addReportLink([], link('mem-a', 'perf-a'));
+            expect(result).toHaveLength(1);
+        });
+
+        it('dedupes an identical pair', () => {
+            const links = [link('mem-a', 'perf-a')];
+            const result = addReportLink(links, link('mem-a', 'perf-a'));
+            expect(result).toBe(links);
+            expect(result).toHaveLength(1);
+        });
+
+        it('keeps distinct pairs that share one side (many-to-many)', () => {
+            let links = addReportLink([], link('mem-a', 'perf-a'));
+            links = addReportLink(links, link('mem-a', 'perf-b'));
+            links = addReportLink(links, link('mem-b', 'perf-a'));
+            expect(links).toHaveLength(3);
+        });
+
+        it('treats a differing location as a distinct pair', () => {
+            const links = [link('mem-a', 'perf-a')];
+            const result = addReportLink(links, {
+                ...link('mem-a', 'perf-a'),
+                performanceLocation: ReportLocation.REMOTE,
+            });
+            expect(result).toHaveLength(2);
+        });
+    });
+
+    describe('linkedPerformancePaths', () => {
+        const links = [link('mem-a', 'perf-a'), link('mem-a', 'perf-b'), link('mem-b', 'perf-c')];
+
+        it('returns every performance counterpart of the given memory report', () => {
+            const result = linkedPerformancePaths(links, 'mem-a', ReportLocation.LOCAL);
+            expect(result).toEqual(new Set(['perf-a', 'perf-b']));
+        });
+
+        it('returns an empty set when no memory report is active', () => {
+            expect(linkedPerformancePaths(links, null, null).size).toBe(0);
+        });
+
+        it('does not match when the location differs', () => {
+            expect(linkedPerformancePaths(links, 'mem-a', ReportLocation.REMOTE).size).toBe(0);
+        });
+    });
+
+    describe('linkedProfilerPaths', () => {
+        const links = [link('mem-a', 'perf-a'), link('mem-b', 'perf-a'), link('mem-c', 'perf-b')];
+
+        it('returns every memory counterpart of the given performance report', () => {
+            const result = linkedProfilerPaths(links, 'perf-a', ReportLocation.LOCAL);
+            expect(result).toEqual(new Set(['mem-a', 'mem-b']));
+        });
+
+        it('returns an empty set when no performance report is active', () => {
+            expect(linkedProfilerPaths(links, undefined, undefined).size).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
Tracks when reports can be successfully linked and adds a badge in the report select if true.

Initial feature hidden behind dev flag.

<img width="797" height="765" alt="Screenshot 2026-06-24 at 12 34 15" src="https://github.com/user-attachments/assets/d80f1f6c-5dce-479e-bff5-71c75ffe6363" />

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1668.