### PR TITLE
Align performance table cell colours with tt-perf-report

### DIFF
--- a/backend/ttnn_visualizer/tests/test_perf_report_contract.py
+++ b/backend/ttnn_visualizer/tests/test_perf_report_contract.py
@@ -11,7 +11,7 @@ itself changed its rules in a new release.
 
 This test closes that gap: it drives the *real* installed tt-perf-report functions over a
 matrix of scenarios and writes a golden file (``tests/data/perfReportColourContract.json``).
-The frontend test ``tests/perfReportColourContract.spec.ts`` then asserts that
+The frontend test ``tests/perfTableColouring.spec.ts`` then asserts that
 ``getCellColour`` / ``evaluateFidelity`` reproduce that same golden.
 
 Chain of trust: tt-perf-report  ->  this golden  ->  the frontend.

--- a/backend/ttnn_visualizer/tests/test_perf_report_contract.py
+++ b/backend/ttnn_visualizer/tests/test_perf_report_contract.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Contract test pinning the performance table's colouring to tt-perf-report.
+
+The frontend (``src/functions/perfFunctions.tsx``) re-implements tt-perf-report's
+``color_row`` / ``evaluate_fidelity`` rules in TypeScript. Plain frontend tests can only
+assert against hand-transcribed expectations, so they would keep passing if tt-perf-report
+itself changed its rules in a new release.
+
+This test closes that gap: it drives the *real* installed tt-perf-report functions over a
+matrix of scenarios and writes a golden file (``tests/data/perfReportColourContract.json``).
+The frontend test ``tests/perfReportColourContract.spec.ts`` then asserts that
+``getCellColour`` / ``evaluateFidelity`` reproduce that same golden.
+
+Chain of trust: tt-perf-report  ->  this golden  ->  the frontend.
+
+  * If a tt-perf-report upgrade changes the rules, the generated golden no longer matches the
+    committed one and THIS test fails — telling you to re-check the visualizer.
+  * If the frontend drifts from the rules, the TypeScript test fails.
+
+To refresh the golden after an intentional tt-perf-report change:
+
+    EXPECTED_TT_PERF_REPORT_VERSION  <- bump the constant below to the new version
+    pnpm run perf:golden             <- regenerates tests/data/perfReportColourContract.json
+
+then run the frontend suite and reconcile any TypeScript differences.
+"""
+
+import json
+import os
+from importlib.metadata import version
+from pathlib import Path
+
+from tt_perf_report.perf_report import (
+    Cell,
+    color_row,
+    default_cell_color,
+    evaluate_fidelity,
+)
+
+# Keep in lockstep with the tt-perf-report pin in pyproject.toml. Bumping the pin without
+# bumping this constant fails the version assertion below, forcing a deliberate parity review.
+EXPECTED_TT_PERF_REPORT_VERSION = "1.2.4"
+
+# tt-perf-report defaults (perf_report.py): --min-percentage and the Op-to-Op Gap threshold.
+MIN_PERCENTAGE = 0.5
+HIGH_DISPATCH_THRESHOLD_US = 6.5
+
+GOLDEN_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "data"
+    / "perfReportColourContract.json"
+)
+
+# Maps a frontend ColumnKeys value -> the op_data display key tt-perf-report's color_row() uses.
+COLUMN_TO_TT_KEY = {
+    "bound": "Bound",
+    "dram": "DRAM",
+    "dram_percent": "DRAM %",
+    "flops": "FLOPs",
+    "flops_percent": "FLOPs %",
+    "cores": "Cores",
+    "op_code": "OP Code",
+    "math_fidelity": "Math Fidelity",
+    "op_to_op_gap": "Op-to-Op Gap",
+}
+
+# Each colour scenario is described in *frontend* field names (the `row` that gets serialised for
+# the TypeScript side). Defaults below are chosen so an unrelated column never perturbs the result.
+ROW_DEFAULTS = {
+    "total_percent": 50.0,
+    "raw_op_code": "SomeDeviceOp",
+    "bound": None,
+    "cores": 32,
+    "dram_percent": None,
+    "flops_percent": None,
+    "op_to_op_gap": None,
+    "math_fidelity": "",
+    "input_0_datatype": "",
+    "input_1_datatype": "",
+    "output_datatype": "",
+}
+
+COLOUR_SCENARIOS = [
+    # Bound column
+    {"id": "bound-dram", "column": "bound", "row": {"bound": "DRAM"}},
+    {"id": "bound-flop", "column": "bound", "row": {"bound": "FLOP"}},
+    {"id": "bound-slow", "column": "bound", "row": {"bound": "SLOW"}},
+    {"id": "bound-host", "column": "bound", "row": {"bound": "HOST"}},
+    {"id": "bound-both", "column": "bound", "row": {"bound": "BOTH"}},
+    {"id": "bound-missing", "column": "bound", "row": {"bound": None}},
+    # DRAM / FLOPS columns
+    {"id": "dram-on-dram-bound", "column": "dram", "row": {"bound": "DRAM"}},
+    {
+        "id": "dram-pct-on-dram-bound",
+        "column": "dram_percent",
+        "row": {"bound": "DRAM"},
+    },
+    {"id": "flops-on-flop-bound", "column": "flops", "row": {"bound": "FLOP"}},
+    {
+        "id": "flops-pct-on-flop-bound",
+        "column": "flops_percent",
+        "row": {"bound": "FLOP"},
+    },
+    {
+        "id": "dram-on-slow-dram-heavy",
+        "column": "dram",
+        "row": {"bound": "SLOW", "dram_percent": 80.0, "flops_percent": 10.0},
+    },
+    {
+        "id": "flops-on-slow-dram-heavy",
+        "column": "flops",
+        "row": {"bound": "SLOW", "dram_percent": 80.0, "flops_percent": 10.0},
+    },
+    {
+        "id": "flops-on-slow-flop-heavy",
+        "column": "flops",
+        "row": {"bound": "SLOW", "dram_percent": 10.0, "flops_percent": 80.0},
+    },
+    {"id": "dram-on-host-bound", "column": "dram", "row": {"bound": "HOST"}},
+    {"id": "flops-on-host-bound", "column": "flops", "row": {"bound": "HOST"}},
+    # Cores column
+    {"id": "cores-low", "column": "cores", "row": {"cores": 4}},
+    {"id": "cores-full", "column": "cores", "row": {"cores": 64}},
+    {"id": "cores-mid", "column": "cores", "row": {"cores": 32}},
+    {"id": "cores-missing", "column": "cores", "row": {"cores": None}},
+    # OP Code column
+    {
+        "id": "op-torch",
+        "column": "op_code",
+        "row": {"raw_op_code": "(torch) aten::add"},
+    },
+    {"id": "op-matmul", "column": "op_code", "row": {"raw_op_code": "Matmul"}},
+    {"id": "op-conv2d", "column": "op_code", "row": {"raw_op_code": "Conv2d"}},
+    {
+        "id": "op-optimizedconv",
+        "column": "op_code",
+        "row": {"raw_op_code": "OptimizedConvNew"},
+    },
+    {"id": "op-layernorm", "column": "op_code", "row": {"raw_op_code": "LayerNorm"}},
+    {"id": "op-allgather", "column": "op_code", "row": {"raw_op_code": "AllGather"}},
+    {
+        "id": "op-sdpa",
+        "column": "op_code",
+        "row": {"raw_op_code": "ScaledDotProductAttentionDecode"},
+    },
+    {
+        "id": "op-updatecache",
+        "column": "op_code",
+        "row": {"raw_op_code": "UpdateCache"},
+    },
+    {"id": "op-unmapped", "column": "op_code", "row": {"raw_op_code": "Softmax"}},
+    # Op-to-Op Gap column
+    {"id": "gap-high", "column": "op_to_op_gap", "row": {"op_to_op_gap": 7.0}},
+    {"id": "gap-low", "column": "op_to_op_gap", "row": {"op_to_op_gap": 3.0}},
+    {"id": "gap-missing", "column": "op_to_op_gap", "row": {"op_to_op_gap": None}},
+    # Math Fidelity column
+    {
+        "id": "fidelity-sufficient",
+        "column": "math_fidelity",
+        "row": {
+            "raw_op_code": "Matmul",
+            "math_fidelity": "HiFi4",
+            "input_0_datatype": "BFLOAT16",
+            "input_1_datatype": "BFLOAT16",
+            "output_datatype": "BFLOAT16",
+        },
+    },
+    {
+        "id": "fidelity-too-high",
+        "column": "math_fidelity",
+        "row": {
+            "raw_op_code": "Matmul",
+            "math_fidelity": "HiFi4",
+            "input_0_datatype": "BFLOAT16",
+            "input_1_datatype": "BFLOAT16",
+            "output_datatype": "BFLOAT4_B",
+        },
+    },
+    {
+        "id": "fidelity-too-low",
+        "column": "math_fidelity",
+        "row": {
+            "raw_op_code": "Matmul",
+            "math_fidelity": "HiFi2",
+            "input_0_datatype": "BFLOAT16",
+            "input_1_datatype": "BFLOAT16",
+            "output_datatype": "BFLOAT16",
+        },
+    },
+    {
+        "id": "fidelity-non-matmul-not-coloured",
+        "column": "math_fidelity",
+        "row": {
+            "raw_op_code": "Softmax",
+            "math_fidelity": "HiFi4",
+            "input_0_datatype": "BFLOAT16",
+            "input_1_datatype": "BFLOAT16",
+            "output_datatype": "BFLOAT16",
+        },
+    },
+    # Sub-threshold (< 0.5%) muting — keyed off the op code, not the op type.
+    {
+        "id": "muted-device-op",
+        "column": "bound",
+        "row": {"total_percent": 0.3, "bound": "DRAM", "raw_op_code": "SomeDeviceOp"},
+    },
+    {
+        "id": "muted-non-torch-op",
+        "column": "bound",
+        "row": {"total_percent": 0.3, "bound": "DRAM", "raw_op_code": "SomeCpuOp"},
+    },
+    {
+        "id": "unmuted-torch-op",
+        "column": "op_code",
+        "row": {"total_percent": 0.3, "raw_op_code": "(torch) aten::add"},
+    },
+]
+
+FIDELITY_SCENARIOS = [
+    {
+        "id": "f-bf16-hifi4",
+        "input_0": "BFLOAT16",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi4",
+    },
+    {
+        "id": "f-bf16-hifi2",
+        "input_0": "BFLOAT16",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi2",
+    },
+    {
+        "id": "f-bf16-lofi",
+        "input_0": "BFLOAT16",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT16",
+        "math_fidelity": "LoFi",
+    },
+    {
+        "id": "f-bfp4out-hifi4",
+        "input_0": "BFLOAT16",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT4_B",
+        "math_fidelity": "HiFi4",
+    },
+    {
+        "id": "f-bfp4out-hifi2",
+        "input_0": "BFLOAT16",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT4_B",
+        "math_fidelity": "HiFi2",
+    },
+    {
+        "id": "f-bfp4out-lofi",
+        "input_0": "BFLOAT16",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT4_B",
+        "math_fidelity": "LoFi",
+    },
+    {
+        "id": "f-bfp8-hifi4",
+        "input_0": "BFLOAT8_B",
+        "input_1": "BFLOAT8_B",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi4",
+    },
+    {
+        "id": "f-bfp8-hifi2",
+        "input_0": "BFLOAT8_B",
+        "input_1": "BFLOAT8_B",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi2",
+    },
+    {
+        "id": "f-bfp8-lofi",
+        "input_0": "BFLOAT8_B",
+        "input_1": "BFLOAT8_B",
+        "output": "BFLOAT16",
+        "math_fidelity": "LoFi",
+    },
+    {
+        "id": "f-bfp4w-lofi",
+        "input_0": "BFLOAT8_B",
+        "input_1": "BFLOAT4_B",
+        "output": "BFLOAT16",
+        "math_fidelity": "LoFi",
+    },
+    {
+        "id": "f-bfp4w-hifi4",
+        "input_0": "BFLOAT8_B",
+        "input_1": "BFLOAT4_B",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi4",
+    },
+    {
+        "id": "f-integer",
+        "input_0": "UINT8",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi4",
+    },
+    {
+        "id": "f-unsupported",
+        "input_0": "MADE_UP",
+        "input_1": "BFLOAT16",
+        "output": "BFLOAT16",
+        "math_fidelity": "HiFi4",
+    },
+]
+
+
+def _build_op_data(row):
+    """Construct the op_data dict (display key -> Cell) that color_row() mutates."""
+    values = {**ROW_DEFAULTS, **row}
+
+    return {
+        "OP Code": Cell(values["raw_op_code"]),
+        "Cores": Cell(values["cores"]),
+        "Bound": Cell(values["bound"]),
+        "DRAM": Cell(0.0),
+        "DRAM %": Cell(values["dram_percent"]),
+        "FLOPs": Cell(0.0),
+        "FLOPs %": Cell(values["flops_percent"]),
+        "Op-to-Op Gap": Cell(values["op_to_op_gap"]),
+        "Math Fidelity": Cell(values["math_fidelity"]),
+        "Input 0 Datatype": Cell(values["input_0_datatype"]),
+        "Input 1 Datatype": Cell(values["input_1_datatype"]),
+        "Output Datatype": Cell(values["output_datatype"]),
+    }
+
+
+def _colour_of(scenario):
+    """Run the real color_row() and read the colour tt-perf-report assigned to the target cell."""
+    values = {**ROW_DEFAULTS, **scenario["row"]}
+    op_data = _build_op_data(scenario["row"])
+
+    color_row(op_data, values["total_percent"], MIN_PERCENTAGE)
+
+    colour = op_data[COLUMN_TO_TT_KEY[scenario["column"]]].color
+    # An un-coloured cell (color is None) renders as the neutral default.
+    return colour if colour is not None else default_cell_color
+
+
+def _generate_golden():
+    return {
+        "_comment": (
+            "GENERATED from tt-perf-report by "
+            "backend/ttnn_visualizer/tests/test_perf_report_contract.py. "
+            "Do not edit by hand; run UPDATE_PERF_GOLDEN=1 pytest to refresh."
+        ),
+        "ttPerfReportVersion": EXPECTED_TT_PERF_REPORT_VERSION,
+        "minPercentage": MIN_PERCENTAGE,
+        "highDispatchThresholdUs": HIGH_DISPATCH_THRESHOLD_US,
+        "colours": [
+            {
+                "id": scenario["id"],
+                "column": scenario["column"],
+                "row": {**ROW_DEFAULTS, **scenario["row"]},
+                "expected": _colour_of(scenario),
+            }
+            for scenario in COLOUR_SCENARIOS
+        ],
+        "fidelity": [
+            {
+                "id": scenario["id"],
+                "input_0": scenario["input_0"],
+                "input_1": scenario["input_1"],
+                "output": scenario["output"],
+                "math_fidelity": scenario["math_fidelity"],
+                "expected": evaluate_fidelity(
+                    scenario["input_0"],
+                    scenario["input_1"],
+                    scenario["output"],
+                    scenario["math_fidelity"],
+                )[0],
+            }
+            for scenario in FIDELITY_SCENARIOS
+        ],
+    }
+
+
+def test_installed_version_matches_pin():
+    assert version("tt-perf-report") == EXPECTED_TT_PERF_REPORT_VERSION, (
+        "Installed tt-perf-report differs from the version this contract was generated against. "
+        "Bump EXPECTED_TT_PERF_REPORT_VERSION (and the pyproject.toml pin), then regenerate the "
+        "golden with UPDATE_PERF_GOLDEN=1 and reconcile the frontend parity tests."
+    )
+
+
+def test_colour_contract_matches_golden():
+    generated = _generate_golden()
+
+    if os.environ.get("UPDATE_PERF_GOLDEN"):
+        GOLDEN_PATH.write_text(json.dumps(generated, indent=4) + "\n")
+
+    assert GOLDEN_PATH.exists(), (
+        f"Golden file missing: {GOLDEN_PATH}. Generate it with "
+        "UPDATE_PERF_GOLDEN=1 .venv/bin/python -m pytest "
+        "backend/ttnn_visualizer/tests/test_perf_report_contract.py"
+    )
+
+    committed = json.loads(GOLDEN_PATH.read_text())
+
+    assert generated == committed, (
+        "tt-perf-report's colouring no longer matches the committed golden. If this is an "
+        "intentional tt-perf-report change, regenerate with UPDATE_PERF_GOLDEN=1 and update the "
+        "frontend (src/functions/perfFunctions.tsx) to match."
+    )

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:spdx": "node scripts/check-spdx.mjs",
     "lint:ts": "pnpm exec tsc --noEmit",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "perf:golden": "UPDATE_PERF_GOLDEN=1 uv run pytest backend/ttnn_visualizer/tests/test_perf_report_contract.py",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
     "preview": "vite preview",

--- a/src/definitions/Performance.ts
+++ b/src/definitions/Performance.ts
@@ -18,4 +18,4 @@ export enum OpType {
 
 export const PATTERN_COUNT = 3; // Number of row patterns defined in PerfReport.scss
 
-export const HIGH_DISPATCH_THRESHOLD_MS = 6.5; // Threshold for flagging high dispatch latency ops
+export const HIGH_DISPATCH_THRESHOLD_US = 6.5; // Threshold for flagging high dispatch latency ops

--- a/src/functions/enrichPerfRowData.ts
+++ b/src/functions/enrichPerfRowData.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { PerfTableRow, TypedPerfTableRow } from '../definitions/PerfTable';
-import { HIGH_DISPATCH_THRESHOLD_MS } from '../definitions/Performance';
+import { HIGH_DISPATCH_THRESHOLD_US } from '../definitions/Performance';
 import { BufferType } from '../model/BufferType';
 import { DeviceOperationLayoutTypes } from '../model/APIData';
 import { L1PressureMetrics } from './l1Pressure';
@@ -48,14 +48,17 @@ export const enrichRowData = (
         // parseInt would truncate (e.g. "6.6" -> 6), wrongly clearing the > 6.5µs flag.
         const parsedGap = parseFloat(row.op_to_op_gap);
         const opToOpGap = Number.isNaN(parsedGap) ? null : parsedGap;
+        // parseInt yields NaN (not nullish) for missing values, so collapse it to null explicitly
+        // rather than leaking NaN into a `number | null` field.
+        const parsedDevice = parseInt(row.device, 10);
 
         return {
             ...row,
             op,
-            high_dispatch: opToOpGap !== null && opToOpGap > HIGH_DISPATCH_THRESHOLD_MS,
+            high_dispatch: opToOpGap !== null && opToOpGap > HIGH_DISPATCH_THRESHOLD_US,
             id: parseInt(row.id, 10),
             total_percent: parseFloat(row.total_percent),
-            device: parseInt(row.device, 10) ?? null,
+            device: Number.isNaN(parsedDevice) ? null : parsedDevice,
             device_time: parseFloat(row.device_time),
             op_to_op_gap: opToOpGap,
             cores: parseInt(row.cores, 10),

--- a/src/functions/enrichPerfRowData.ts
+++ b/src/functions/enrichPerfRowData.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { PerfTableRow, TypedPerfTableRow } from '../definitions/PerfTable';
+import { HIGH_DISPATCH_THRESHOLD_MS } from '../definitions/Performance';
+import { BufferType } from '../model/BufferType';
+import { DeviceOperationLayoutTypes } from '../model/APIData';
+import { L1PressureMetrics } from './l1Pressure';
+import { parsePerfRowTensorAttributes } from './parsePerfRowTensorAttributes';
+
+interface RowAttributes {
+    buffer_type: BufferType | null;
+    layout: DeviceOperationLayoutTypes | null;
+}
+
+export const getRowAttributes = (row: PerfTableRow): RowAttributes => {
+    const { buffer_type: bufferType, layout } = parsePerfRowTensorAttributes(row);
+
+    return {
+        buffer_type: bufferType,
+        layout,
+    };
+};
+
+// Converts the raw string-based rows produced by tt-perf-report (via the backend CSV parse) into
+// the typed numeric rows the performance table renders. Keep the parsing here aligned with the
+// columns tt-perf-report emits so the table reflects the same data.
+export const enrichRowData = (
+    rows: PerfTableRow[],
+    opIdsMap: { perfId?: string; opId: number }[],
+    l1PressureMap: Map<number, L1PressureMetrics> | null,
+): TypedPerfTableRow[] => {
+    // Build the perf-id -> op-id lookup once so enrichment stays O(N) instead of O(N·M) — the
+    // previous `.find()` per row scaled with both row count and the active report's op count.
+    const opIdByPerfId = new Map<string, number>();
+    for (const { perfId, opId } of opIdsMap) {
+        if (perfId !== undefined) {
+            opIdByPerfId.set(perfId, opId);
+        }
+    }
+
+    const typedRows = rows.map((row) => {
+        const val = parseInt(row.op_to_op_gap, 10);
+        const op = opIdByPerfId.get(row.id);
+        // TTNN-op snapshot is shared by all device ops that map to the same row.op.
+        const l1Pressure = op !== undefined ? l1PressureMap?.get(op) : undefined;
+
+        return {
+            ...row,
+            op,
+            high_dispatch: !!val && val > HIGH_DISPATCH_THRESHOLD_MS,
+            id: parseInt(row.id, 10),
+            total_percent: parseFloat(row.total_percent),
+            device: parseInt(row.device, 10) ?? null,
+            device_time: parseFloat(row.device_time),
+            op_to_op_gap: row.op_to_op_gap ? parseFloat(row.op_to_op_gap) : null,
+            cores: parseInt(row.cores, 10),
+            dram: row.dram ? parseFloat(row.dram) : null,
+            dram_percent: row.dram_percent ? parseFloat(row.dram_percent) : null,
+            flops: row.flops ? parseFloat(row.flops) : null,
+            flops_percent: row.flops_percent ? parseFloat(row.flops_percent) : null,
+            pm_ideal_ns: row.pm_ideal_ns ? parseFloat(row.pm_ideal_ns) : null,
+            l1_fullness_percent: l1Pressure?.fullnessPercent ?? null,
+            l1_free_segments: l1Pressure?.freeSegments ?? null,
+            l1_largest_free: l1Pressure?.largestFreeBytes ?? null,
+            l1_largest_free_percent: l1Pressure?.largestFreePercent ?? null,
+            ...getRowAttributes(row),
+            isFirstHashOccurrence: true, // Default to true, will be updated if needed in next step
+        };
+    });
+
+    // Mark which rows are the first occurrence of each hash
+    const hashFirstOccurrence = new Map<string | null, boolean>();
+    for (const row of typedRows) {
+        if (row.hash && !hashFirstOccurrence.has(row.hash)) {
+            hashFirstOccurrence.set(row.hash, true);
+            row.isFirstHashOccurrence = true;
+        } else if (row.hash) {
+            row.isFirstHashOccurrence = false;
+        }
+    }
+
+    return typedRows;
+};

--- a/src/functions/enrichPerfRowData.ts
+++ b/src/functions/enrichPerfRowData.ts
@@ -41,20 +41,23 @@ export const enrichRowData = (
     }
 
     const typedRows = rows.map((row) => {
-        const val = parseInt(row.op_to_op_gap, 10);
         const op = opIdByPerfId.get(row.id);
         // TTNN-op snapshot is shared by all device ops that map to the same row.op.
         const l1Pressure = op !== undefined ? l1PressureMap?.get(op) : undefined;
+        // Parse the gap as a float once and reuse it for both the value and the high-dispatch flag.
+        // parseInt would truncate (e.g. "6.6" -> 6), wrongly clearing the > 6.5µs flag.
+        const parsedGap = parseFloat(row.op_to_op_gap);
+        const opToOpGap = Number.isNaN(parsedGap) ? null : parsedGap;
 
         return {
             ...row,
             op,
-            high_dispatch: !!val && val > HIGH_DISPATCH_THRESHOLD_MS,
+            high_dispatch: opToOpGap !== null && opToOpGap > HIGH_DISPATCH_THRESHOLD_MS,
             id: parseInt(row.id, 10),
             total_percent: parseFloat(row.total_percent),
             device: parseInt(row.device, 10) ?? null,
             device_time: parseFloat(row.device_time),
-            op_to_op_gap: row.op_to_op_gap ? parseFloat(row.op_to_op_gap) : null,
+            op_to_op_gap: opToOpGap,
             cores: parseInt(row.cores, 10),
             dram: row.dram ? parseFloat(row.dram) : null,
             dram_percent: row.dram_percent ? parseFloat(row.dram_percent) : null,

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -272,7 +272,7 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
 
     if (key === ColumnKeys.Bound) {
         if (keyValue === BoundType.HOST) {
-            return CellColour.Green;
+            return CellColour.Red;
         }
 
         if (keyValue === BoundType.FLOP) {
@@ -285,6 +285,10 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
 
         if (keyValue === BoundType.DRAM) {
             return CellColour.Green;
+        }
+
+        if (keyValue === BoundType.BOTH) {
+            return DEFAULT_COLOUR;
         }
     }
 
@@ -304,10 +308,6 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
             if (key === ColumnKeys.Flops || key === ColumnKeys.FlopsPercent) {
                 return CellColour.Green;
             }
-        }
-
-        if (row.bound === BoundType.HOST) {
-            return CellColour.Red;
         }
 
         const dramP = row.dram_percent;
@@ -346,6 +346,14 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
     }
 
     if (key === ColumnKeys.MathFidelity && typeof keyValue === 'string') {
+        // tt-perf-report only evaluates fidelity for Matmul / OptimizedConvNew ops (perf_report.py:1055-1056).
+        const isFidelityEvaluatedOp =
+            row.raw_op_code.includes('Matmul') || row.raw_op_code.includes('OptimizedConvNew');
+
+        if (!isFidelityEvaluatedOp || keyValue === '') {
+            return DEFAULT_COLOUR;
+        }
+
         const parts = keyValue.split(' ');
         const mathFidelity = parts[0] as MathFidelity;
         const input0Datatype = row.input_0_datatype || '';
@@ -393,7 +401,7 @@ export const getCoreColour = (value: string | string[] | boolean | number): Cell
 };
 
 export const getOpToOpGapColour = (value: number): CellColour => {
-    return value > HIGH_DISPATCH_THRESHOLD_MS ? CellColour.Red : FALLBACK_COLOUR;
+    return value > HIGH_DISPATCH_THRESHOLD_MS ? CellColour.Red : DEFAULT_COLOUR;
 };
 
 export const calcHighDispatchOps = (rows: TypedPerfTableRow[]) => {
@@ -455,12 +463,30 @@ export function evaluateFidelity(
     outputDatatype: string,
     mathFidelity: MathFidelity | '',
 ): [string, string | null] {
+    // Mirrors tt-perf-report evaluate_fidelity() (perf_report.py:535-556).
+    const integerTypes = ['UINT8', 'UINT16', 'INT32', 'UINT32'];
+
+    if ([input0Datatype, input1Datatype, outputDatatype].some((datatype) => integerTypes.includes(datatype))) {
+        return [
+            'not_applicable',
+            'Fidelity evaluation is not applicable for integer datatypes (UINT8, UINT16, INT32, UINT32).',
+        ];
+    }
+
     const mantissaBits: Record<string, number> = {
         FLOAT32: 23,
         BFLOAT16: 8,
         BFLOAT8_B: 7,
         BFLOAT4_B: 3,
     };
+
+    const unsupportedDatatype = [input0Datatype, input1Datatype, outputDatatype].find(
+        (datatype) => mantissaBits[datatype] === undefined,
+    );
+
+    if (unsupportedDatatype !== undefined) {
+        return ['unknown', `Datatype ${unsupportedDatatype} is not supported for fidelity evaluation.`];
+    }
 
     const in0Bits = mantissaBits[input0Datatype];
     const in1Bits = mantissaBits[input1Datatype];

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -258,7 +258,9 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
     const keyValue = row[key];
     const percentage = row.total_percent;
 
-    if (row.op_type === OpType.DEVICE_OP && percentage != null && percentage < MIN_PERCENTAGE) {
+    // tt-perf-report mutes ops below the threshold, except host "(torch)" ops, which it always
+    // keeps coloured (perf_report.py color_row() + is_host_op()).
+    if (percentage != null && percentage < MIN_PERCENTAGE && !row.raw_op_code.includes('(torch)')) {
         return FALLBACK_COLOUR;
     }
 
@@ -287,9 +289,9 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
             return CellColour.Green;
         }
 
-        if (keyValue === BoundType.BOTH) {
-            return DEFAULT_COLOUR;
-        }
+        // tt-perf-report only colours the Bound cell for DRAM/FLOP/SLOW/HOST; anything else
+        // (BOTH, empty, unrecognised) stays neutral (perf_report.py color_row()).
+        return DEFAULT_COLOUR;
     }
 
     if (
@@ -377,7 +379,8 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
     }
 
     if (key === ColumnKeys.OpToOpGap) {
-        return typeof keyValue === 'number' ? getOpToOpGapColour(keyValue) : FALLBACK_COLOUR;
+        // tt-perf-report only ever colours this cell red (gap > 6.5µs); a missing gap stays neutral (perf_report.py:1052).
+        return typeof keyValue === 'number' ? getOpToOpGapColour(keyValue) : DEFAULT_COLOUR;
     }
 
     // Shouldn't get to this point but need to return something

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -12,7 +12,7 @@ import { OperationDescription } from '../model/APIData';
 import { formatMemorySize, formatPercentage, formatSize, toSecondsPretty } from './math';
 import ROUTES from '../definitions/Routes';
 import HighlightedText from '../components/HighlightedText';
-import { HIGH_DISPATCH_THRESHOLD_MS, OpType } from '../definitions/Performance';
+import { HIGH_DISPATCH_THRESHOLD_US, OpType } from '../definitions/Performance';
 import { TypedStackedPerfRow } from '../definitions/StackedPerfTable';
 import { NormalisedPerfData } from './normalisePerformanceData';
 import MemoryTag from '../components/MemoryTag';
@@ -88,9 +88,9 @@ export const formatCell = (
     }
 
     if (key === ColumnKeys.HighDispatch) {
-        const tooltipMessage = `Op with > ${HIGH_DISPATCH_THRESHOLD_MS} µs dispatch latency`;
+        const tooltipMessage = `Op with > ${HIGH_DISPATCH_THRESHOLD_US} µs dispatch latency`;
 
-        return row?.[ColumnKeys.DeviceTime] !== null && row?.[ColumnKeys.DeviceTime] > HIGH_DISPATCH_THRESHOLD_MS ? (
+        return row?.[ColumnKeys.DeviceTime] !== null && row?.[ColumnKeys.DeviceTime] > HIGH_DISPATCH_THRESHOLD_US ? (
             <Tooltip content={tooltipMessage}>
                 <Icon
                     className={WARNING_COLOUR}
@@ -259,8 +259,8 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
     const percentage = row.total_percent;
 
     // tt-perf-report mutes ops below the threshold, except host "(torch)" ops, which it always
-    // keeps coloured (perf_report.py color_row() + is_host_op()). Safe to read raw_op_code here:
-    // the only rows without it (signposts) have a null total_percent, so the guard above exits first.
+    // keeps coloured (perf_report.py color_row() + is_host_op()). raw_op_code is a required string
+    // on every row type (device ops, placeholders, signposts), so reading it here is always safe.
     if (percentage != null && percentage < MIN_PERCENTAGE && !row.raw_op_code.includes('(torch)')) {
         return FALLBACK_COLOUR;
     }
@@ -405,7 +405,7 @@ export const getCoreColour = (value: string | string[] | boolean | number): Cell
 };
 
 export const getOpToOpGapColour = (value: number): CellColour => {
-    return value > HIGH_DISPATCH_THRESHOLD_MS ? CellColour.Red : DEFAULT_COLOUR;
+    return value > HIGH_DISPATCH_THRESHOLD_US ? CellColour.Red : DEFAULT_COLOUR;
 };
 
 export const calcHighDispatchOps = (rows: TypedPerfTableRow[]) => {
@@ -413,7 +413,7 @@ export const calcHighDispatchOps = (rows: TypedPerfTableRow[]) => {
         .map((opData: TypedPerfTableRow, index: number): [number, TypedPerfTableRow] => [index + 1, opData])
         .filter(([_, opData]) => {
             const val = opData.op_to_op_gap;
-            return val !== null && val !== undefined && typeof val === 'number' && val > HIGH_DISPATCH_THRESHOLD_MS;
+            return val !== null && val !== undefined && typeof val === 'number' && val > HIGH_DISPATCH_THRESHOLD_US;
         });
 
     if (highDispatchOps.length === 0) {
@@ -424,7 +424,7 @@ export const calcHighDispatchOps = (rows: TypedPerfTableRow[]) => {
     const maxDispatchOverhead = highDispatchOps.reduce((acc, [_, opData]) => {
         const val = opData.op_to_op_gap || 0;
 
-        return acc + (val - HIGH_DISPATCH_THRESHOLD_MS);
+        return acc + (val - HIGH_DISPATCH_THRESHOLD_US);
     }, 0);
 
     // Compute total_duration as sum of device times + Op-to-Op Gaps
@@ -446,7 +446,7 @@ export const calcHighDispatchOps = (rows: TypedPerfTableRow[]) => {
     return (
         <div className='high-dispatch-advice'>
             <p>
-                Marked ops have &gt; {HIGH_DISPATCH_THRESHOLD_MS} µs dispatch latency. Running with tracing could save{' '}
+                Marked ops have &gt; {HIGH_DISPATCH_THRESHOLD_US} µs dispatch latency. Running with tracing could save{' '}
                 {formatSize(maxDispatchOverhead, 0)} µs {toSecondsPretty(maxDispatchOverhead)} (
                 {formatPercentage(percentageSaved, 1)} of overall time).
             </p>

--- a/src/functions/perfFunctions.tsx
+++ b/src/functions/perfFunctions.tsx
@@ -259,7 +259,8 @@ export const getCellColour = (row: TypedPerfTableRow, key: ColumnKeys): CellColo
     const percentage = row.total_percent;
 
     // tt-perf-report mutes ops below the threshold, except host "(torch)" ops, which it always
-    // keeps coloured (perf_report.py color_row() + is_host_op()).
+    // keeps coloured (perf_report.py color_row() + is_host_op()). Safe to read raw_op_code here:
+    // the only rows without it (signposts) have a null total_percent, so the guard above exits first.
     if (percentage != null && percentage < MIN_PERCENTAGE && !row.raw_op_code.includes('(torch)')) {
         return FALLBACK_COLOUR;
     }
@@ -460,40 +461,39 @@ export enum MathFidelity {
     LoFi = 'LoFi',
 }
 
+// Mirrors tt-perf-report evaluate_fidelity() (perf_report.py:535-556).
+const INTEGER_DATATYPES = ['UINT8', 'UINT16', 'INT32', 'UINT32'];
+const MANTISSA_BITS: Record<string, number> = {
+    FLOAT32: 23,
+    BFLOAT16: 8,
+    BFLOAT8_B: 7,
+    BFLOAT4_B: 3,
+};
+
 export function evaluateFidelity(
     input0Datatype: string,
     input1Datatype: string,
     outputDatatype: string,
     mathFidelity: MathFidelity | '',
 ): [string, string | null] {
-    // Mirrors tt-perf-report evaluate_fidelity() (perf_report.py:535-556).
-    const integerTypes = ['UINT8', 'UINT16', 'INT32', 'UINT32'];
-
-    if ([input0Datatype, input1Datatype, outputDatatype].some((datatype) => integerTypes.includes(datatype))) {
+    if ([input0Datatype, input1Datatype, outputDatatype].some((datatype) => INTEGER_DATATYPES.includes(datatype))) {
         return [
             'not_applicable',
             'Fidelity evaluation is not applicable for integer datatypes (UINT8, UINT16, INT32, UINT32).',
         ];
     }
 
-    const mantissaBits: Record<string, number> = {
-        FLOAT32: 23,
-        BFLOAT16: 8,
-        BFLOAT8_B: 7,
-        BFLOAT4_B: 3,
-    };
-
     const unsupportedDatatype = [input0Datatype, input1Datatype, outputDatatype].find(
-        (datatype) => mantissaBits[datatype] === undefined,
+        (datatype) => MANTISSA_BITS[datatype] === undefined,
     );
 
     if (unsupportedDatatype !== undefined) {
         return ['unknown', `Datatype ${unsupportedDatatype} is not supported for fidelity evaluation.`];
     }
 
-    const in0Bits = mantissaBits[input0Datatype];
-    const in1Bits = mantissaBits[input1Datatype];
-    const outBits = mantissaBits[outputDatatype];
+    const in0Bits = MANTISSA_BITS[input0Datatype];
+    const in1Bits = MANTISSA_BITS[input1Datatype];
+    const outBits = MANTISSA_BITS[outputDatatype];
 
     // I note that we're not using the second part of the returned array, only the first part.
     if (in0Bits === 8 && outBits >= 7) {

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -27,16 +27,14 @@ import {
     selectedPerformanceRangeAtom,
 } from '../store/app';
 import PerformanceChartsTab from '../components/performance/PerformanceChartsTab';
-import { Marker, MarkerColours, PerfTableRow, TypedPerfTableRow } from '../definitions/PerfTable';
-import { L1PressureMetrics, L1PressureStatus } from '../functions/l1Pressure';
+import { Marker, MarkerColours } from '../definitions/PerfTable';
+import { L1PressureStatus } from '../functions/l1Pressure';
 import ComparisonReportSelector from '../components/performance/ComparisonReportSelector';
 import 'styles/routes/Performance.scss';
 import getServerConfig from '../functions/getServerConfig';
-import { HIGH_DISPATCH_THRESHOLD_MS, OpType, PerfTabIds } from '../definitions/Performance';
-import { BufferType } from '../model/BufferType';
-import { DeviceOperationLayoutTypes } from '../model/APIData';
+import { OpType, PerfTabIds } from '../definitions/Performance';
 import { StackedColumnKeys, StackedPerfRow, TypedStackedPerfRow } from '../definitions/StackedPerfTable';
-import { parsePerfRowTensorAttributes } from '../functions/parsePerfRowTensorAttributes';
+import { enrichRowData } from '../functions/enrichPerfRowData';
 
 const INITIAL_TAB_ID = PerfTabIds.TABLE;
 
@@ -302,78 +300,6 @@ export default function Performance() {
         </div>
     );
 }
-
-interface RowAttributes {
-    buffer_type: BufferType | null;
-    layout: DeviceOperationLayoutTypes | null;
-}
-
-const getRowAttributes = (row: PerfTableRow): RowAttributes => {
-    const { buffer_type: bufferType, layout } = parsePerfRowTensorAttributes(row);
-
-    return {
-        buffer_type: bufferType,
-        layout,
-    };
-};
-
-const enrichRowData = (
-    rows: PerfTableRow[],
-    opIdsMap: { perfId?: string; opId: number }[],
-    l1PressureMap: Map<number, L1PressureMetrics> | null,
-): TypedPerfTableRow[] => {
-    // Build the perf-id -> op-id lookup once so enrichment stays O(N) instead of O(N·M) — the
-    // previous `.find()` per row scaled with both row count and the active report's op count.
-    const opIdByPerfId = new Map<string, number>();
-    for (const { perfId, opId } of opIdsMap) {
-        if (perfId !== undefined) {
-            opIdByPerfId.set(perfId, opId);
-        }
-    }
-
-    const typedRows = rows.map((row) => {
-        const val = parseInt(row.op_to_op_gap, 10);
-        const op = opIdByPerfId.get(row.id);
-        // TTNN-op snapshot is shared by all device ops that map to the same row.op.
-        const l1Pressure = op !== undefined ? l1PressureMap?.get(op) : undefined;
-
-        return {
-            ...row,
-            op,
-            high_dispatch: !!val && val > HIGH_DISPATCH_THRESHOLD_MS,
-            id: parseInt(row.id, 10),
-            total_percent: parseFloat(row.total_percent),
-            device: parseInt(row.device, 10) ?? null,
-            device_time: parseFloat(row.device_time),
-            op_to_op_gap: row.op_to_op_gap ? parseFloat(row.op_to_op_gap) : null,
-            cores: parseInt(row.cores, 10),
-            dram: row.dram ? parseFloat(row.dram) : null,
-            dram_percent: row.dram_percent ? parseFloat(row.dram_percent) : null,
-            flops: row.flops ? parseFloat(row.flops) : null,
-            flops_percent: row.flops_percent ? parseFloat(row.flops_percent) : null,
-            pm_ideal_ns: row.pm_ideal_ns ? parseFloat(row.pm_ideal_ns) : null,
-            l1_fullness_percent: l1Pressure?.fullnessPercent ?? null,
-            l1_free_segments: l1Pressure?.freeSegments ?? null,
-            l1_largest_free: l1Pressure?.largestFreeBytes ?? null,
-            l1_largest_free_percent: l1Pressure?.largestFreePercent ?? null,
-            ...getRowAttributes(row),
-            isFirstHashOccurrence: true, // Default to true, will be updated if needed in next step
-        };
-    });
-
-    // Mark which rows are the first occurrence of each hash
-    const hashFirstOccurrence = new Map<string | null, boolean>();
-    for (const row of typedRows) {
-        if (row.hash && !hashFirstOccurrence.has(row.hash)) {
-            hashFirstOccurrence.set(row.hash, true);
-            row.isFirstHashOccurrence = true;
-        } else if (row.hash) {
-            row.isFirstHashOccurrence = false;
-        }
-    }
-
-    return typedRows;
-};
 
 const enrichStackedRowData = (rows: StackedPerfRow[]): TypedStackedPerfRow[] =>
     rows.map((row) => ({

--- a/tests/data/perfReportColourContract.json
+++ b/tests/data/perfReportColourContract.json
@@ -1,0 +1,798 @@
+{
+    "_comment": "GENERATED from tt-perf-report by backend/ttnn_visualizer/tests/test_perf_report_contract.py. Do not edit by hand; run UPDATE_PERF_GOLDEN=1 pytest to refresh.",
+    "ttPerfReportVersion": "1.2.4",
+    "minPercentage": 0.5,
+    "highDispatchThresholdUs": 6.5,
+    "colours": [
+        {
+            "id": "bound-dram",
+            "column": "bound",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "DRAM",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "bound-flop",
+            "column": "bound",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "FLOP",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "bound-slow",
+            "column": "bound",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "SLOW",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "yellow"
+        },
+        {
+            "id": "bound-host",
+            "column": "bound",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "HOST",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "red"
+        },
+        {
+            "id": "bound-both",
+            "column": "bound",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "BOTH",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "bound-missing",
+            "column": "bound",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "dram-on-dram-bound",
+            "column": "dram",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "DRAM",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "dram-pct-on-dram-bound",
+            "column": "dram_percent",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "DRAM",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "flops-on-flop-bound",
+            "column": "flops",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "FLOP",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "flops-pct-on-flop-bound",
+            "column": "flops_percent",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "FLOP",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "dram-on-slow-dram-heavy",
+            "column": "dram",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "SLOW",
+                "cores": 32,
+                "dram_percent": 80.0,
+                "flops_percent": 10.0,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "yellow"
+        },
+        {
+            "id": "flops-on-slow-dram-heavy",
+            "column": "flops",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "SLOW",
+                "cores": 32,
+                "dram_percent": 80.0,
+                "flops_percent": 10.0,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "flops-on-slow-flop-heavy",
+            "column": "flops",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "SLOW",
+                "cores": 32,
+                "dram_percent": 10.0,
+                "flops_percent": 80.0,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "yellow"
+        },
+        {
+            "id": "dram-on-host-bound",
+            "column": "dram",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "HOST",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "flops-on-host-bound",
+            "column": "flops",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "HOST",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "cores-low",
+            "column": "cores",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 4,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "red"
+        },
+        {
+            "id": "cores-full",
+            "column": "cores",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 64,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "green"
+        },
+        {
+            "id": "cores-mid",
+            "column": "cores",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "cores-missing",
+            "column": "cores",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": null,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "grey"
+        },
+        {
+            "id": "op-torch",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "(torch) aten::add",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "red"
+        },
+        {
+            "id": "op-matmul",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Matmul",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "magenta"
+        },
+        {
+            "id": "op-conv2d",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Conv2d",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "orange"
+        },
+        {
+            "id": "op-optimizedconv",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "OptimizedConvNew",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "orange"
+        },
+        {
+            "id": "op-layernorm",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "LayerNorm",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "cyan"
+        },
+        {
+            "id": "op-allgather",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "AllGather",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "cyan"
+        },
+        {
+            "id": "op-sdpa",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "ScaledDotProductAttentionDecode",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "blue"
+        },
+        {
+            "id": "op-updatecache",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "UpdateCache",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "blue"
+        },
+        {
+            "id": "op-unmapped",
+            "column": "op_code",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Softmax",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "gap-high",
+            "column": "op_to_op_gap",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": 7.0,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "red"
+        },
+        {
+            "id": "gap-low",
+            "column": "op_to_op_gap",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": 3.0,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "gap-missing",
+            "column": "op_to_op_gap",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "white"
+        },
+        {
+            "id": "fidelity-sufficient",
+            "column": "math_fidelity",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Matmul",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "HiFi4",
+                "input_0_datatype": "BFLOAT16",
+                "input_1_datatype": "BFLOAT16",
+                "output_datatype": "BFLOAT16"
+            },
+            "expected": "green"
+        },
+        {
+            "id": "fidelity-too-high",
+            "column": "math_fidelity",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Matmul",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "HiFi4",
+                "input_0_datatype": "BFLOAT16",
+                "input_1_datatype": "BFLOAT16",
+                "output_datatype": "BFLOAT4_B"
+            },
+            "expected": "red"
+        },
+        {
+            "id": "fidelity-too-low",
+            "column": "math_fidelity",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Matmul",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "HiFi2",
+                "input_0_datatype": "BFLOAT16",
+                "input_1_datatype": "BFLOAT16",
+                "output_datatype": "BFLOAT16"
+            },
+            "expected": "cyan"
+        },
+        {
+            "id": "fidelity-non-matmul-not-coloured",
+            "column": "math_fidelity",
+            "row": {
+                "total_percent": 50.0,
+                "raw_op_code": "Softmax",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "HiFi4",
+                "input_0_datatype": "BFLOAT16",
+                "input_1_datatype": "BFLOAT16",
+                "output_datatype": "BFLOAT16"
+            },
+            "expected": "white"
+        },
+        {
+            "id": "muted-device-op",
+            "column": "bound",
+            "row": {
+                "total_percent": 0.3,
+                "raw_op_code": "SomeDeviceOp",
+                "bound": "DRAM",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "grey"
+        },
+        {
+            "id": "muted-non-torch-op",
+            "column": "bound",
+            "row": {
+                "total_percent": 0.3,
+                "raw_op_code": "SomeCpuOp",
+                "bound": "DRAM",
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "grey"
+        },
+        {
+            "id": "unmuted-torch-op",
+            "column": "op_code",
+            "row": {
+                "total_percent": 0.3,
+                "raw_op_code": "(torch) aten::add",
+                "bound": null,
+                "cores": 32,
+                "dram_percent": null,
+                "flops_percent": null,
+                "op_to_op_gap": null,
+                "math_fidelity": "",
+                "input_0_datatype": "",
+                "input_1_datatype": "",
+                "output_datatype": ""
+            },
+            "expected": "red"
+        }
+    ],
+    "fidelity": [
+        {
+            "id": "f-bf16-hifi4",
+            "input_0": "BFLOAT16",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi4",
+            "expected": "sufficient"
+        },
+        {
+            "id": "f-bf16-hifi2",
+            "input_0": "BFLOAT16",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi2",
+            "expected": "too_low"
+        },
+        {
+            "id": "f-bf16-lofi",
+            "input_0": "BFLOAT16",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT16",
+            "math_fidelity": "LoFi",
+            "expected": "too_low"
+        },
+        {
+            "id": "f-bfp4out-hifi4",
+            "input_0": "BFLOAT16",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT4_B",
+            "math_fidelity": "HiFi4",
+            "expected": "too_high"
+        },
+        {
+            "id": "f-bfp4out-hifi2",
+            "input_0": "BFLOAT16",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT4_B",
+            "math_fidelity": "HiFi2",
+            "expected": "sufficient"
+        },
+        {
+            "id": "f-bfp4out-lofi",
+            "input_0": "BFLOAT16",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT4_B",
+            "math_fidelity": "LoFi",
+            "expected": "too_low"
+        },
+        {
+            "id": "f-bfp8-hifi4",
+            "input_0": "BFLOAT8_B",
+            "input_1": "BFLOAT8_B",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi4",
+            "expected": "too_high"
+        },
+        {
+            "id": "f-bfp8-hifi2",
+            "input_0": "BFLOAT8_B",
+            "input_1": "BFLOAT8_B",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi2",
+            "expected": "sufficient"
+        },
+        {
+            "id": "f-bfp8-lofi",
+            "input_0": "BFLOAT8_B",
+            "input_1": "BFLOAT8_B",
+            "output": "BFLOAT16",
+            "math_fidelity": "LoFi",
+            "expected": "too_low"
+        },
+        {
+            "id": "f-bfp4w-lofi",
+            "input_0": "BFLOAT8_B",
+            "input_1": "BFLOAT4_B",
+            "output": "BFLOAT16",
+            "math_fidelity": "LoFi",
+            "expected": "sufficient"
+        },
+        {
+            "id": "f-bfp4w-hifi4",
+            "input_0": "BFLOAT8_B",
+            "input_1": "BFLOAT4_B",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi4",
+            "expected": "too_high"
+        },
+        {
+            "id": "f-integer",
+            "input_0": "UINT8",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi4",
+            "expected": "not_applicable"
+        },
+        {
+            "id": "f-unsupported",
+            "input_0": "MADE_UP",
+            "input_1": "BFLOAT16",
+            "output": "BFLOAT16",
+            "math_fidelity": "HiFi4",
+            "expected": "unknown"
+        }
+    ]
+}

--- a/tests/enrichPerfRowData.spec.ts
+++ b/tests/enrichPerfRowData.spec.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { enrichRowData } from '../src/functions/enrichPerfRowData';
+import { PerfTableRow } from '../src/definitions/PerfTable';
+import { BufferType } from '../src/model/BufferType';
+import { DeviceOperationLayoutTypes } from '../src/model/APIData';
+import { OpType } from '../src/definitions/Performance';
+
+// tt-perf-report emits a CSV whose columns (id, total_percent, bound, op_code, device, device_time,
+// op_to_op_gap, cores, dram, dram_percent, flops, flops_percent, ...) reach the frontend as strings.
+// enrichRowData converts those strings into the typed values the table renders. These tests verify
+// that conversion faithfully reflects the values tt-perf-report produced — including the >6.5µs
+// high-dispatch flag, which mirrors tt-perf-report's Op-to-Op Gap threshold (perf_report.py:1052).
+
+// A raw row as delivered to the frontend (every field a string, matching the CSV-derived JSON).
+const makeRawRow = (overrides: Partial<PerfTableRow> = {}): PerfTableRow =>
+    ({
+        id: '1',
+        global_call_count: 0,
+        advice: [],
+        total_percent: '12.5',
+        bound: 'DRAM',
+        op_code: 'Matmul',
+        raw_op_code: 'Matmul',
+        device: '0',
+        device_time: '123.4',
+        op_to_op_gap: '2.5',
+        cores: '64',
+        dram: '15.5',
+        dram_percent: '42.1',
+        flops: '88.8',
+        flops_percent: '73.2',
+        math_fidelity: 'HiFi4',
+        output_datatype: 'BFLOAT16',
+        output_0_memory: '',
+        input_0_datatype: 'BFLOAT16',
+        input_1_datatype: 'BFLOAT16',
+        dram_sharded: '',
+        input_0_memory: 'DEV_0_DRAM_INTERLEAVED',
+        input_1_memory: '',
+        inner_dim_block_size: '',
+        output_subblock_h: '',
+        output_subblock_w: '',
+        pm_ideal_ns: '1000',
+        op_type: OpType.DEVICE_OP,
+        hash: null,
+        cache_hit: null,
+        ...overrides,
+    }) as PerfTableRow;
+
+describe('enrichRowData — typed conversion of tt-perf-report values', () => {
+    it('parses numeric columns into numbers', () => {
+        const [row] = enrichRowData([makeRawRow()], [], null);
+
+        expect(row.id).toBe(1);
+        expect(row.total_percent).toBe(12.5);
+        expect(row.device).toBe(0);
+        expect(row.device_time).toBe(123.4);
+        expect(row.op_to_op_gap).toBe(2.5);
+        expect(row.cores).toBe(64);
+        expect(row.dram).toBe(15.5);
+        expect(row.dram_percent).toBe(42.1);
+        expect(row.flops).toBe(88.8);
+        expect(row.flops_percent).toBe(73.2);
+        expect(row.pm_ideal_ns).toBe(1000);
+    });
+
+    it('maps empty optional numeric columns to null', () => {
+        const [row] = enrichRowData(
+            [
+                makeRawRow({
+                    op_to_op_gap: '',
+                    dram: '',
+                    dram_percent: '',
+                    flops: '',
+                    flops_percent: '',
+                    pm_ideal_ns: '',
+                }),
+            ],
+            [],
+            null,
+        );
+
+        expect(row.op_to_op_gap).toBeNull();
+        expect(row.dram).toBeNull();
+        expect(row.dram_percent).toBeNull();
+        expect(row.flops).toBeNull();
+        expect(row.flops_percent).toBeNull();
+        expect(row.pm_ideal_ns).toBeNull();
+    });
+
+    it('extracts buffer type and layout from input_0_memory', () => {
+        const [row] = enrichRowData([makeRawRow({ input_0_memory: 'DEV_0_L1_TILE' })], [], null);
+
+        expect(row.buffer_type).toBe(BufferType.L1);
+        expect(row.layout).toBe(DeviceOperationLayoutTypes.TILE);
+    });
+
+    describe('high_dispatch flag (tt-perf-report Op-to-Op Gap > 6.5µs)', () => {
+        it('flags an op whose gap exceeds 6.5µs', () => {
+            const [row] = enrichRowData([makeRawRow({ op_to_op_gap: '7.0' })], [], null);
+
+            expect(row.high_dispatch).toBe(true);
+        });
+
+        it('does not flag an op at or below 6.5µs', () => {
+            const [row] = enrichRowData([makeRawRow({ op_to_op_gap: '3.0' })], [], null);
+
+            expect(row.high_dispatch).toBe(false);
+        });
+
+        it('does not flag an op with no gap', () => {
+            const [row] = enrichRowData([makeRawRow({ op_to_op_gap: '' })], [], null);
+
+            expect(row.high_dispatch).toBe(false);
+        });
+    });
+
+    describe('first-occurrence marking by hash', () => {
+        it('marks only the first row of each hash as the first occurrence', () => {
+            const rows = enrichRowData(
+                [
+                    makeRawRow({ id: '1', hash: 'abc' }),
+                    makeRawRow({ id: '2', hash: 'abc' }),
+                    makeRawRow({ id: '3', hash: 'def' }),
+                ],
+                [],
+                null,
+            );
+
+            expect(rows.map((row) => row.isFirstHashOccurrence)).toEqual([true, false, true]);
+        });
+    });
+
+    it('attaches the op id from the perf-id lookup', () => {
+        const [row] = enrichRowData([makeRawRow({ id: '7' })], [{ perfId: '7', opId: 42 }], null);
+
+        expect(row.op).toBe(42);
+    });
+});

--- a/tests/enrichPerfRowData.spec.ts
+++ b/tests/enrichPerfRowData.spec.ts
@@ -117,6 +117,20 @@ describe('enrichRowData — typed conversion of tt-perf-report values', () => {
 
             expect(row.high_dispatch).toBe(false);
         });
+
+        // Pins the decimal boundary: parsing with parseInt would truncate "6.6" to 6 and miss it.
+        it('flags a fractional gap just over 6.5µs', () => {
+            const [row] = enrichRowData([makeRawRow({ op_to_op_gap: '6.6' })], [], null);
+
+            expect(row.high_dispatch).toBe(true);
+            expect(row.op_to_op_gap).toBe(6.6);
+        });
+
+        it('does not flag a gap exactly at 6.5µs', () => {
+            const [row] = enrichRowData([makeRawRow({ op_to_op_gap: '6.5' })], [], null);
+
+            expect(row.high_dispatch).toBe(false);
+        });
     });
 
     describe('first-occurrence marking by hash', () => {

--- a/tests/enrichPerfRowData.spec.ts
+++ b/tests/enrichPerfRowData.spec.ts
@@ -15,7 +15,8 @@ import { OpType } from '../src/definitions/Performance';
 // that conversion faithfully reflects the values tt-perf-report produced — including the >6.5µs
 // high-dispatch flag, which mirrors tt-perf-report's Op-to-Op Gap threshold (perf_report.py:1052).
 
-// A raw row as delivered to the frontend (every field a string, matching the CSV-derived JSON).
+// A raw row as delivered to the frontend: the numeric columns arrive as strings (matching the
+// CSV-derived JSON), alongside non-string fields like global_call_count, advice, and hash.
 const makeRawRow = (overrides: Partial<PerfTableRow> = {}): PerfTableRow =>
     ({
         id: '1',

--- a/tests/perfTableColouring.spec.ts
+++ b/tests/perfTableColouring.spec.ts
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { MathFidelity, evaluateFidelity, getCellColour } from '../src/functions/perfFunctions';
+import { BoundType, ColumnKeys, TypedPerfTableRow } from '../src/definitions/PerfTable';
+import { CellColour } from '../src/definitions/CellColour';
+import { OpType } from '../src/definitions/Performance';
+
+// These tests pin the performance table's cell colouring to the rules tt-perf-report applies in
+// its `color_row` / `evaluate_fidelity` functions (tt_perf_report/perf_report.py). tt-perf-report
+// is treated as the source of truth: the visualizer adds columns and features, but for the columns
+// it shares with tt-perf-report the colours must match.
+//
+// Reference (perf_report.py):
+//   - op_colors map ...................... lines 32-45
+//   - default_cell_color = "white" ....... line 46  (an un-coloured cell renders neutral/white)
+//   - muted_cell_color  = "grey" ......... line 47
+//   - color_row() ........................ lines 1014-1075
+//   - is_host_op() = "(torch)" in op_code  line 2092
+//   - default --min-percentage = 0.5 ..... line 1834  (matches the visualizer's MIN_PERCENTAGE)
+//   - evaluate_fidelity() ................ lines 532-623
+
+// A device op comfortably above the 0.5% colouring threshold, with neutral defaults. Individual
+// tests override the bound / value / op-code fields that drive each colouring rule.
+const makeRow = (overrides: Partial<TypedPerfTableRow> = {}): TypedPerfTableRow =>
+    ({
+        op_type: OpType.DEVICE_OP,
+        total_percent: 50,
+        bound: null,
+        raw_op_code: 'SomeDeviceOp',
+        op_code: 'SomeDeviceOp',
+        cores: 32,
+        dram: null,
+        dram_percent: null,
+        flops: null,
+        flops_percent: null,
+        math_fidelity: '',
+        input_0_datatype: '',
+        input_1_datatype: '',
+        output_datatype: '',
+        cache_hit: null,
+        op_to_op_gap: null,
+        ...overrides,
+    }) as unknown as TypedPerfTableRow;
+
+describe('getCellColour — parity with tt-perf-report color_row()', () => {
+    describe('Bound column', () => {
+        // perf_report.py:1030-1037 — DRAM/FLOP bound ops are well-optimised → green.
+        it('colours a DRAM-bound op green', () => {
+            expect(getCellColour(makeRow({ bound: BoundType.DRAM }), ColumnKeys.Bound)).toBe(CellColour.Green);
+        });
+
+        it('colours a FLOP-bound op green', () => {
+            expect(getCellColour(makeRow({ bound: BoundType.FLOP }), ColumnKeys.Bound)).toBe(CellColour.Green);
+        });
+
+        // perf_report.py:1038-1039 — SLOW bound → yellow warning.
+        it('colours a SLOW-bound op yellow', () => {
+            expect(getCellColour(makeRow({ bound: BoundType.SLOW }), ColumnKeys.Bound)).toBe(CellColour.Yellow);
+        });
+
+        // perf_report.py:1049-1050 — HOST bound → red.
+        // DIVERGENCE: the visualizer returns CellColour.Green here (perfFunctions.tsx:274-276).
+        it('colours a HOST-bound op red', () => {
+            expect(getCellColour(makeRow({ bound: BoundType.HOST }), ColumnKeys.Bound)).toBe(CellColour.Red);
+        });
+
+        // perf_report.py — "BOTH" is never assigned a colour in color_row(), so it stays neutral.
+        // DIVERGENCE: the visualizer falls through to FALLBACK_COLOUR (grey) for BOTH.
+        it('leaves a BOTH-bound op neutral (white)', () => {
+            expect(getCellColour(makeRow({ bound: BoundType.BOTH }), ColumnKeys.Bound)).toBe(CellColour.White);
+        });
+    });
+
+    describe('DRAM / FLOPS columns', () => {
+        // perf_report.py:1031-1033 — DRAM bound highlights the DRAM throughput columns green.
+        it('colours DRAM and DRAM % green for a DRAM-bound op', () => {
+            const row = makeRow({ bound: BoundType.DRAM });
+
+            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.Green);
+            expect(getCellColour(row, ColumnKeys.DramPercent)).toBe(CellColour.Green);
+        });
+
+        // perf_report.py:1035-1037 — FLOP bound highlights the FLOPS columns green.
+        it('colours FLOPS and FLOPS % green for a FLOP-bound op', () => {
+            const row = makeRow({ bound: BoundType.FLOP });
+
+            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.Green);
+            expect(getCellColour(row, ColumnKeys.FlopsPercent)).toBe(CellColour.Green);
+        });
+
+        // perf_report.py:1040-1045 — SLOW bound: the larger of DRAM% / FLOPS% gets the yellow flag.
+        it('flags the DRAM columns yellow when SLOW and DRAM% > FLOPS%', () => {
+            const row = makeRow({ bound: BoundType.SLOW, dram_percent: 80, flops_percent: 10 });
+
+            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.Yellow);
+            expect(getCellColour(row, ColumnKeys.DramPercent)).toBe(CellColour.Yellow);
+            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.White);
+        });
+
+        // perf_report.py:1046-1048 — otherwise the FLOPS columns get the yellow flag.
+        it('flags the FLOPS columns yellow when SLOW and FLOPS% >= DRAM%', () => {
+            const row = makeRow({ bound: BoundType.SLOW, dram_percent: 10, flops_percent: 80 });
+
+            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.Yellow);
+            expect(getCellColour(row, ColumnKeys.FlopsPercent)).toBe(CellColour.Yellow);
+            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.White);
+        });
+
+        // perf_report.py — HOST bound only colours the Bound cell; the DRAM/FLOPS cells stay neutral.
+        // DIVERGENCE: the visualizer colours all four DRAM/FLOPS cells red for HOST (perfFunctions.tsx:309-311).
+        it('leaves the DRAM/FLOPS columns neutral for a HOST-bound op', () => {
+            const row = makeRow({ bound: BoundType.HOST });
+
+            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.White);
+            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.White);
+        });
+    });
+
+    describe('Cores column', () => {
+        // perf_report.py:1021-1028 — <10 red, ==64 green, otherwise neutral, missing → grey.
+        it('colours fewer than 10 cores red', () => {
+            expect(getCellColour(makeRow({ cores: 4 }), ColumnKeys.Cores)).toBe(CellColour.Red);
+        });
+
+        it('colours exactly 64 cores green', () => {
+            expect(getCellColour(makeRow({ cores: 64 }), ColumnKeys.Cores)).toBe(CellColour.Green);
+        });
+
+        it('leaves an intermediate core count (10-63) neutral (white)', () => {
+            expect(getCellColour(makeRow({ cores: 32 }), ColumnKeys.Cores)).toBe(CellColour.White);
+        });
+
+        it('mutes a missing core count to grey', () => {
+            expect(getCellColour(makeRow({ cores: null }), ColumnKeys.Cores)).toBe(CellColour.Grey);
+        });
+    });
+
+    describe('OP Code column', () => {
+        // perf_report.py:32-45 + get_op_color() — substring match against the op_colors map.
+        it.each([
+            ['(torch)', CellColour.Red],
+            ['Matmul', CellColour.Magenta],
+            ['OptimizedConvNew', CellColour.Orange],
+            ['Conv2d', CellColour.Orange],
+            ['LayerNorm', CellColour.Cyan],
+            ['AllGather', CellColour.Cyan],
+            ['AllReduce', CellColour.Cyan],
+            ['ScaledDotProductAttentionDecode', CellColour.Blue],
+            ['ScaledDotProductAttentionGQADecode', CellColour.Blue],
+            ['NlpCreateHeadsDeviceOperation', CellColour.Blue],
+            ['NLPConcatHeadsDecodeDeviceOperation', CellColour.Blue],
+            ['UpdateCache', CellColour.Blue],
+        ])('colours op code containing %s as %s', (rawOpCode, expected) => {
+            expect(getCellColour(makeRow({ raw_op_code: rawOpCode }), ColumnKeys.OpCode)).toBe(expected);
+        });
+
+        it('matches op codes by substring', () => {
+            expect(getCellColour(makeRow({ raw_op_code: 'ttnn.Matmul' }), ColumnKeys.OpCode)).toBe(CellColour.Magenta);
+        });
+
+        it('leaves an unmapped op code neutral (white)', () => {
+            expect(getCellColour(makeRow({ raw_op_code: 'Softmax' }), ColumnKeys.OpCode)).toBe(CellColour.White);
+        });
+    });
+
+    describe('Op-to-Op Gap column', () => {
+        // perf_report.py:1052-1053 — gap > 6.5µs → red.
+        it('colours a gap over 6.5µs red', () => {
+            expect(getCellColour(makeRow({ op_to_op_gap: 7 }), ColumnKeys.OpToOpGap)).toBe(CellColour.Red);
+        });
+
+        // perf_report.py — gaps at or below the threshold are never coloured, so they stay neutral.
+        // DIVERGENCE: the visualizer returns FALLBACK_COLOUR (grey) (perfFunctions.tsx:395-397).
+        it('leaves a gap at or below 6.5µs neutral (white)', () => {
+            expect(getCellColour(makeRow({ op_to_op_gap: 3 }), ColumnKeys.OpToOpGap)).toBe(CellColour.White);
+        });
+    });
+
+    describe('Math Fidelity column', () => {
+        const matmulFidelityRow = (overrides: Partial<TypedPerfTableRow> = {}) =>
+            makeRow({
+                raw_op_code: 'Matmul',
+                op_code: 'Matmul',
+                input_0_datatype: 'BFLOAT16',
+                input_1_datatype: 'BFLOAT16',
+                output_datatype: 'BFLOAT16',
+                ...overrides,
+            });
+
+        // perf_report.py:1066-1073 — fidelity verdict drives the colour for Matmul/Conv ops.
+        it('colours a sufficient fidelity green', () => {
+            expect(getCellColour(matmulFidelityRow({ math_fidelity: 'HiFi4' }), ColumnKeys.MathFidelity)).toBe(
+                CellColour.Green,
+            );
+        });
+
+        it('colours a too-high fidelity red', () => {
+            const row = matmulFidelityRow({ math_fidelity: 'HiFi4', output_datatype: 'BFLOAT4_B' });
+
+            expect(getCellColour(row, ColumnKeys.MathFidelity)).toBe(CellColour.Red);
+        });
+
+        it('colours a too-low fidelity cyan', () => {
+            expect(getCellColour(matmulFidelityRow({ math_fidelity: 'HiFi2' }), ColumnKeys.MathFidelity)).toBe(
+                CellColour.Cyan,
+            );
+        });
+
+        // perf_report.py:1055-1056 — fidelity is only coloured for Matmul / OptimizedConvNew ops.
+        // DIVERGENCE: the visualizer colours the fidelity cell for any op (perfFunctions.tsx:348-369).
+        it('leaves fidelity neutral for a non-Matmul/Conv op', () => {
+            const row = makeRow({
+                raw_op_code: 'Softmax',
+                op_code: 'Softmax',
+                math_fidelity: 'HiFi4',
+                input_0_datatype: 'BFLOAT16',
+                input_1_datatype: 'BFLOAT16',
+                output_datatype: 'BFLOAT16',
+            });
+
+            expect(getCellColour(row, ColumnKeys.MathFidelity)).toBe(CellColour.White);
+        });
+    });
+
+    describe('Low-impact rows (< 0.5% of total)', () => {
+        // perf_report.py:1015-1017 — ops below the threshold are muted grey, EXCEPT host "(torch)" ops.
+        it('mutes a sub-threshold device op to grey', () => {
+            const row = makeRow({ total_percent: 0.3, bound: BoundType.DRAM });
+
+            expect(getCellColour(row, ColumnKeys.Bound)).toBe(CellColour.Grey);
+        });
+
+        // perf_report.py:1015 + 2092 — "(torch)" host ops are exempt from muting; their op code stays red.
+        it('does not mute a sub-threshold host (torch) op', () => {
+            const row = makeRow({
+                op_type: OpType.PYTHON_OP,
+                total_percent: 0.3,
+                raw_op_code: '(torch) aten::add',
+                op_code: '(torch) aten::add',
+            });
+
+            expect(getCellColour(row, ColumnKeys.OpCode)).toBe(CellColour.Red);
+        });
+    });
+
+    describe('Always-neutral columns', () => {
+        // perf_report.py — ID / Total % / Device Time carry no conditional colour.
+        it.each([ColumnKeys.Id, ColumnKeys.TotalPercent, ColumnKeys.DeviceTime])('leaves %s neutral (white)', (key) => {
+            expect(getCellColour(makeRow({ bound: BoundType.HOST }), key)).toBe(CellColour.White);
+        });
+    });
+});
+
+describe('evaluateFidelity — parity with tt-perf-report evaluate_fidelity()', () => {
+    // perf_report.py:558-616 — only the verdict (first element) drives colour; we assert that.
+    it.each<[string, string, string, MathFidelity, string]>([
+        // in0 = 8 bits, out >= 7 (perf_report.py:558-567)
+        ['BFLOAT16', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi4, 'sufficient'],
+        ['BFLOAT16', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi2, 'too_low'],
+        ['BFLOAT16', 'BFLOAT16', 'BFLOAT16', MathFidelity.LoFi, 'too_low'],
+        // in0 = 8 bits, out = 3 bits (perf_report.py:570-585)
+        ['BFLOAT16', 'BFLOAT16', 'BFLOAT4_B', MathFidelity.HiFi4, 'too_high'],
+        ['BFLOAT16', 'BFLOAT16', 'BFLOAT4_B', MathFidelity.HiFi2, 'sufficient'],
+        ['BFLOAT16', 'BFLOAT16', 'BFLOAT4_B', MathFidelity.LoFi, 'too_low'],
+        // in1 >= 7 bits, out >= 7 (perf_report.py:588-596)
+        ['BFLOAT8_B', 'BFLOAT8_B', 'BFLOAT16', MathFidelity.HiFi4, 'too_high'],
+        ['BFLOAT8_B', 'BFLOAT8_B', 'BFLOAT16', MathFidelity.HiFi2, 'sufficient'],
+        ['BFLOAT8_B', 'BFLOAT8_B', 'BFLOAT16', MathFidelity.LoFi, 'too_low'],
+        // in1 = 3 bits (perf_report.py:612-616)
+        ['BFLOAT8_B', 'BFLOAT4_B', 'BFLOAT16', MathFidelity.LoFi, 'sufficient'],
+        ['BFLOAT8_B', 'BFLOAT4_B', 'BFLOAT16', MathFidelity.HiFi4, 'too_high'],
+    ])('evaluates %s/%s -> %s at %s as %s', (in0, in1, out, fidelity, expected) => {
+        const [verdict] = evaluateFidelity(in0, in1, out, fidelity);
+
+        expect(verdict).toBe(expected);
+    });
+
+    // perf_report.py:535-545 — integer datatypes short-circuit to "not_applicable".
+    // DIVERGENCE: the visualizer has no integer guard and returns "unknown" (perfFunctions.tsx:458-525).
+    it('reports integer datatypes as not_applicable', () => {
+        const [verdict] = evaluateFidelity('UINT8', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi4);
+
+        expect(verdict).toBe('not_applicable');
+    });
+
+    // perf_report.py:552-556 — unsupported datatypes report "unknown".
+    it('reports unsupported datatypes as unknown', () => {
+        const [verdict] = evaluateFidelity('MADE_UP', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi4);
+
+        expect(verdict).toBe('unknown');
+    });
+});

--- a/tests/perfTableColouring.spec.ts
+++ b/tests/perfTableColouring.spec.ts
@@ -4,309 +4,44 @@
 
 import { describe, expect, it } from 'vitest';
 import { MathFidelity, evaluateFidelity, getCellColour } from '../src/functions/perfFunctions';
-import { BoundType, ColumnKeys, TypedPerfTableRow } from '../src/definitions/PerfTable';
-import { CellColour } from '../src/definitions/CellColour';
+import { ColumnKeys, TypedPerfTableRow } from '../src/definitions/PerfTable';
 import { OpType } from '../src/definitions/Performance';
+import golden from './data/perfReportColourContract.json';
 
-// These tests pin the performance table's cell colouring to the rules tt-perf-report applies in
-// its `color_row` / `evaluate_fidelity` functions (tt_perf_report/perf_report.py). tt-perf-report
-// is treated as the source of truth: the visualizer adds columns and features, but for the columns
-// it shares with tt-perf-report the colours must match.
+// These tests pin the performance table's cell colouring to tt-perf-report by consuming a golden
+// file GENERATED from the real installed package by the Python contract test
+// (backend/ttnn_visualizer/tests/test_perf_report_contract.py).
 //
-// Reference (perf_report.py):
-//   - op_colors map ...................... lines 32-45
-//   - default_cell_color = "white" ....... line 46  (an un-coloured cell renders neutral/white)
-//   - muted_cell_color  = "grey" ......... line 47
-//   - color_row() ........................ lines 1014-1075
-//   - is_host_op() = "(torch)" in op_code  line 2092
-//   - default --min-percentage = 0.5 ..... line 1834  (matches the visualizer's MIN_PERCENTAGE)
-//   - evaluate_fidelity() ................ lines 532-623
+// Chain of trust: tt-perf-report -> golden -> these tests.
+//   * If tt-perf-report changes its rules, the Python test regenerates a different golden and fails
+//     until reconciled — so the expectations here are never a stale hand-transcription.
+//   * If getCellColour / evaluateFidelity drift from those rules, the assertions below fail.
+//
+// The golden's `row` entries use frontend field names, so each one is spread straight onto a row.
 
-// A device op comfortably above the 0.5% colouring threshold, with neutral defaults. Individual
-// tests override the bound / value / op-code fields that drive each colouring rule.
-const makeRow = (overrides: Partial<TypedPerfTableRow> = {}): TypedPerfTableRow =>
+const makeRow = (overrides: Record<string, unknown>): TypedPerfTableRow =>
     ({
         op_type: OpType.DEVICE_OP,
-        total_percent: 50,
-        bound: null,
-        raw_op_code: 'SomeDeviceOp',
-        op_code: 'SomeDeviceOp',
-        cores: 32,
-        dram: null,
-        dram_percent: null,
-        flops: null,
-        flops_percent: null,
-        math_fidelity: '',
-        input_0_datatype: '',
-        input_1_datatype: '',
-        output_datatype: '',
+        op_code: overrides.raw_op_code,
         cache_hit: null,
-        op_to_op_gap: null,
+        isFirstHashOccurrence: true,
+        advice: [],
         ...overrides,
     }) as unknown as TypedPerfTableRow;
 
-describe('getCellColour — parity with tt-perf-report color_row()', () => {
-    describe('Bound column', () => {
-        // perf_report.py:1030-1037 — DRAM/FLOP bound ops are well-optimised → green.
-        it('colours a DRAM-bound op green', () => {
-            expect(getCellColour(makeRow({ bound: BoundType.DRAM }), ColumnKeys.Bound)).toBe(CellColour.Green);
-        });
-
-        it('colours a FLOP-bound op green', () => {
-            expect(getCellColour(makeRow({ bound: BoundType.FLOP }), ColumnKeys.Bound)).toBe(CellColour.Green);
-        });
-
-        // perf_report.py:1038-1039 — SLOW bound → yellow warning.
-        it('colours a SLOW-bound op yellow', () => {
-            expect(getCellColour(makeRow({ bound: BoundType.SLOW }), ColumnKeys.Bound)).toBe(CellColour.Yellow);
-        });
-
-        // perf_report.py:1049-1050 — HOST bound → red.
-        // DIVERGENCE: the visualizer returns CellColour.Green here (perfFunctions.tsx:274-276).
-        it('colours a HOST-bound op red', () => {
-            expect(getCellColour(makeRow({ bound: BoundType.HOST }), ColumnKeys.Bound)).toBe(CellColour.Red);
-        });
-
-        // perf_report.py — "BOTH" is never assigned a colour in color_row(), so it stays neutral.
-        it('leaves a BOTH-bound op neutral (white)', () => {
-            expect(getCellColour(makeRow({ bound: BoundType.BOTH }), ColumnKeys.Bound)).toBe(CellColour.White);
-        });
-
-        // perf_report.py — the Bound cell is only coloured for DRAM/FLOP/SLOW/HOST; a missing or
-        // unrecognised bound stays neutral.
-        it('leaves a missing bound neutral (white)', () => {
-            expect(getCellColour(makeRow({ bound: null }), ColumnKeys.Bound)).toBe(CellColour.White);
-        });
-    });
-
-    describe('DRAM / FLOPS columns', () => {
-        // perf_report.py:1031-1033 — DRAM bound highlights the DRAM throughput columns green.
-        it('colours DRAM and DRAM % green for a DRAM-bound op', () => {
-            const row = makeRow({ bound: BoundType.DRAM });
-
-            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.Green);
-            expect(getCellColour(row, ColumnKeys.DramPercent)).toBe(CellColour.Green);
-        });
-
-        // perf_report.py:1035-1037 — FLOP bound highlights the FLOPS columns green.
-        it('colours FLOPS and FLOPS % green for a FLOP-bound op', () => {
-            const row = makeRow({ bound: BoundType.FLOP });
-
-            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.Green);
-            expect(getCellColour(row, ColumnKeys.FlopsPercent)).toBe(CellColour.Green);
-        });
-
-        // perf_report.py:1040-1045 — SLOW bound: the larger of DRAM% / FLOPS% gets the yellow flag.
-        it('flags the DRAM columns yellow when SLOW and DRAM% > FLOPS%', () => {
-            const row = makeRow({ bound: BoundType.SLOW, dram_percent: 80, flops_percent: 10 });
-
-            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.Yellow);
-            expect(getCellColour(row, ColumnKeys.DramPercent)).toBe(CellColour.Yellow);
-            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.White);
-        });
-
-        // perf_report.py:1046-1048 — otherwise the FLOPS columns get the yellow flag.
-        it('flags the FLOPS columns yellow when SLOW and FLOPS% >= DRAM%', () => {
-            const row = makeRow({ bound: BoundType.SLOW, dram_percent: 10, flops_percent: 80 });
-
-            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.Yellow);
-            expect(getCellColour(row, ColumnKeys.FlopsPercent)).toBe(CellColour.Yellow);
-            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.White);
-        });
-
-        // perf_report.py — HOST bound only colours the Bound cell; the DRAM/FLOPS cells stay neutral.
-        // DIVERGENCE: the visualizer colours all four DRAM/FLOPS cells red for HOST (perfFunctions.tsx:309-311).
-        it('leaves the DRAM/FLOPS columns neutral for a HOST-bound op', () => {
-            const row = makeRow({ bound: BoundType.HOST });
-
-            expect(getCellColour(row, ColumnKeys.Dram)).toBe(CellColour.White);
-            expect(getCellColour(row, ColumnKeys.Flops)).toBe(CellColour.White);
-        });
-    });
-
-    describe('Cores column', () => {
-        // perf_report.py:1021-1028 — <10 red, ==64 green, otherwise neutral, missing → grey.
-        it('colours fewer than 10 cores red', () => {
-            expect(getCellColour(makeRow({ cores: 4 }), ColumnKeys.Cores)).toBe(CellColour.Red);
-        });
-
-        it('colours exactly 64 cores green', () => {
-            expect(getCellColour(makeRow({ cores: 64 }), ColumnKeys.Cores)).toBe(CellColour.Green);
-        });
-
-        it('leaves an intermediate core count (10-63) neutral (white)', () => {
-            expect(getCellColour(makeRow({ cores: 32 }), ColumnKeys.Cores)).toBe(CellColour.White);
-        });
-
-        it('mutes a missing core count to grey', () => {
-            expect(getCellColour(makeRow({ cores: null }), ColumnKeys.Cores)).toBe(CellColour.Grey);
-        });
-    });
-
-    describe('OP Code column', () => {
-        // perf_report.py:32-45 + get_op_color() — substring match against the op_colors map.
-        it.each([
-            ['(torch)', CellColour.Red],
-            ['Matmul', CellColour.Magenta],
-            ['OptimizedConvNew', CellColour.Orange],
-            ['Conv2d', CellColour.Orange],
-            ['LayerNorm', CellColour.Cyan],
-            ['AllGather', CellColour.Cyan],
-            ['AllReduce', CellColour.Cyan],
-            ['ScaledDotProductAttentionDecode', CellColour.Blue],
-            ['ScaledDotProductAttentionGQADecode', CellColour.Blue],
-            ['NlpCreateHeadsDeviceOperation', CellColour.Blue],
-            ['NLPConcatHeadsDecodeDeviceOperation', CellColour.Blue],
-            ['UpdateCache', CellColour.Blue],
-        ])('colours op code containing %s as %s', (rawOpCode, expected) => {
-            expect(getCellColour(makeRow({ raw_op_code: rawOpCode }), ColumnKeys.OpCode)).toBe(expected);
-        });
-
-        it('matches op codes by substring', () => {
-            expect(getCellColour(makeRow({ raw_op_code: 'ttnn.Matmul' }), ColumnKeys.OpCode)).toBe(CellColour.Magenta);
-        });
-
-        it('leaves an unmapped op code neutral (white)', () => {
-            expect(getCellColour(makeRow({ raw_op_code: 'Softmax' }), ColumnKeys.OpCode)).toBe(CellColour.White);
-        });
-    });
-
-    describe('Op-to-Op Gap column', () => {
-        // perf_report.py:1052-1053 — gap > 6.5µs → red.
-        it('colours a gap over 6.5µs red', () => {
-            expect(getCellColour(makeRow({ op_to_op_gap: 7 }), ColumnKeys.OpToOpGap)).toBe(CellColour.Red);
-        });
-
-        // perf_report.py — gaps at or below the threshold are never coloured, so they stay neutral.
-        it('leaves a gap at or below 6.5µs neutral (white)', () => {
-            expect(getCellColour(makeRow({ op_to_op_gap: 3 }), ColumnKeys.OpToOpGap)).toBe(CellColour.White);
-        });
-
-        // perf_report.py:1052 — a missing gap (e.g. the first op) is never coloured, so it stays neutral.
-        it('leaves a missing gap neutral (white)', () => {
-            expect(getCellColour(makeRow({ op_to_op_gap: null }), ColumnKeys.OpToOpGap)).toBe(CellColour.White);
-        });
-    });
-
-    describe('Math Fidelity column', () => {
-        const matmulFidelityRow = (overrides: Partial<TypedPerfTableRow> = {}) =>
-            makeRow({
-                raw_op_code: 'Matmul',
-                op_code: 'Matmul',
-                input_0_datatype: 'BFLOAT16',
-                input_1_datatype: 'BFLOAT16',
-                output_datatype: 'BFLOAT16',
-                ...overrides,
-            });
-
-        // perf_report.py:1066-1073 — fidelity verdict drives the colour for Matmul/Conv ops.
-        it('colours a sufficient fidelity green', () => {
-            expect(getCellColour(matmulFidelityRow({ math_fidelity: 'HiFi4' }), ColumnKeys.MathFidelity)).toBe(
-                CellColour.Green,
-            );
-        });
-
-        it('colours a too-high fidelity red', () => {
-            const row = matmulFidelityRow({ math_fidelity: 'HiFi4', output_datatype: 'BFLOAT4_B' });
-
-            expect(getCellColour(row, ColumnKeys.MathFidelity)).toBe(CellColour.Red);
-        });
-
-        it('colours a too-low fidelity cyan', () => {
-            expect(getCellColour(matmulFidelityRow({ math_fidelity: 'HiFi2' }), ColumnKeys.MathFidelity)).toBe(
-                CellColour.Cyan,
-            );
-        });
-
-        // perf_report.py:1055-1056 — fidelity is only coloured for Matmul / OptimizedConvNew ops.
-        // DIVERGENCE: the visualizer colours the fidelity cell for any op (perfFunctions.tsx:348-369).
-        it('leaves fidelity neutral for a non-Matmul/Conv op', () => {
-            const row = makeRow({
-                raw_op_code: 'Softmax',
-                op_code: 'Softmax',
-                math_fidelity: 'HiFi4',
-                input_0_datatype: 'BFLOAT16',
-                input_1_datatype: 'BFLOAT16',
-                output_datatype: 'BFLOAT16',
-            });
-
-            expect(getCellColour(row, ColumnKeys.MathFidelity)).toBe(CellColour.White);
-        });
-    });
-
-    describe('Low-impact rows (< 0.5% of total)', () => {
-        // perf_report.py:1015-1017 — ops below the threshold are muted grey, EXCEPT host "(torch)" ops.
-        it('mutes a sub-threshold device op to grey', () => {
-            const row = makeRow({ total_percent: 0.3, bound: BoundType.DRAM });
-
-            expect(getCellColour(row, ColumnKeys.Bound)).toBe(CellColour.Grey);
-        });
-
-        // perf_report.py:1015 — muting keys off the op code, not the op type, so a non-device,
-        // non-torch op (e.g. a tt_dnn_cpu op) is muted too when below the threshold.
-        it('mutes a sub-threshold non-device, non-torch op to grey', () => {
-            const row = makeRow({ op_type: OpType.CPU_OP, total_percent: 0.3, bound: BoundType.DRAM });
-
-            expect(getCellColour(row, ColumnKeys.Bound)).toBe(CellColour.Grey);
-        });
-
-        // perf_report.py:1015 + 2092 — "(torch)" host ops are exempt from muting; their op code stays red.
-        it('does not mute a sub-threshold host (torch) op', () => {
-            const row = makeRow({
-                op_type: OpType.PYTHON_OP,
-                total_percent: 0.3,
-                raw_op_code: '(torch) aten::add',
-                op_code: '(torch) aten::add',
-            });
-
-            expect(getCellColour(row, ColumnKeys.OpCode)).toBe(CellColour.Red);
-        });
-    });
-
-    describe('Always-neutral columns', () => {
-        // perf_report.py — ID / Total % / Device Time carry no conditional colour.
-        it.each([ColumnKeys.Id, ColumnKeys.TotalPercent, ColumnKeys.DeviceTime])('leaves %s neutral (white)', (key) => {
-            expect(getCellColour(makeRow({ bound: BoundType.HOST }), key)).toBe(CellColour.White);
-        });
+describe('getCellColour — golden parity with tt-perf-report color_row()', () => {
+    it.each(golden.colours)('$id ($column) -> $expected', ({ column, row, expected }) => {
+        expect(getCellColour(makeRow(row), column as ColumnKeys)).toBe(expected);
     });
 });
 
-describe('evaluateFidelity — parity with tt-perf-report evaluate_fidelity()', () => {
-    // perf_report.py:558-616 — only the verdict (first element) drives colour; we assert that.
-    it.each<[string, string, string, MathFidelity, string]>([
-        // in0 = 8 bits, out >= 7 (perf_report.py:558-567)
-        ['BFLOAT16', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi4, 'sufficient'],
-        ['BFLOAT16', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi2, 'too_low'],
-        ['BFLOAT16', 'BFLOAT16', 'BFLOAT16', MathFidelity.LoFi, 'too_low'],
-        // in0 = 8 bits, out = 3 bits (perf_report.py:570-585)
-        ['BFLOAT16', 'BFLOAT16', 'BFLOAT4_B', MathFidelity.HiFi4, 'too_high'],
-        ['BFLOAT16', 'BFLOAT16', 'BFLOAT4_B', MathFidelity.HiFi2, 'sufficient'],
-        ['BFLOAT16', 'BFLOAT16', 'BFLOAT4_B', MathFidelity.LoFi, 'too_low'],
-        // in1 >= 7 bits, out >= 7 (perf_report.py:588-596)
-        ['BFLOAT8_B', 'BFLOAT8_B', 'BFLOAT16', MathFidelity.HiFi4, 'too_high'],
-        ['BFLOAT8_B', 'BFLOAT8_B', 'BFLOAT16', MathFidelity.HiFi2, 'sufficient'],
-        ['BFLOAT8_B', 'BFLOAT8_B', 'BFLOAT16', MathFidelity.LoFi, 'too_low'],
-        // in1 = 3 bits (perf_report.py:612-616)
-        ['BFLOAT8_B', 'BFLOAT4_B', 'BFLOAT16', MathFidelity.LoFi, 'sufficient'],
-        ['BFLOAT8_B', 'BFLOAT4_B', 'BFLOAT16', MathFidelity.HiFi4, 'too_high'],
-    ])('evaluates %s/%s -> %s at %s as %s', (in0, in1, out, fidelity, expected) => {
-        const [verdict] = evaluateFidelity(in0, in1, out, fidelity);
+describe('evaluateFidelity — golden parity with tt-perf-report evaluate_fidelity()', () => {
+    it.each(golden.fidelity)(
+        '$id -> $expected',
+        ({ input_0: input0, input_1: input1, output, math_fidelity: mathFidelity, expected }) => {
+            const [verdict] = evaluateFidelity(input0, input1, output, mathFidelity as MathFidelity | '');
 
-        expect(verdict).toBe(expected);
-    });
-
-    // perf_report.py:535-545 — integer datatypes short-circuit to "not_applicable".
-    // DIVERGENCE: the visualizer has no integer guard and returns "unknown" (perfFunctions.tsx:458-525).
-    it('reports integer datatypes as not_applicable', () => {
-        const [verdict] = evaluateFidelity('UINT8', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi4);
-
-        expect(verdict).toBe('not_applicable');
-    });
-
-    // perf_report.py:552-556 — unsupported datatypes report "unknown".
-    it('reports unsupported datatypes as unknown', () => {
-        const [verdict] = evaluateFidelity('MADE_UP', 'BFLOAT16', 'BFLOAT16', MathFidelity.HiFi4);
-
-        expect(verdict).toBe('unknown');
-    });
+            expect(verdict).toBe(expected);
+        },
+    );
 });

--- a/tests/perfTableColouring.spec.ts
+++ b/tests/perfTableColouring.spec.ts
@@ -68,9 +68,14 @@ describe('getCellColour — parity with tt-perf-report color_row()', () => {
         });
 
         // perf_report.py — "BOTH" is never assigned a colour in color_row(), so it stays neutral.
-        // DIVERGENCE: the visualizer falls through to FALLBACK_COLOUR (grey) for BOTH.
         it('leaves a BOTH-bound op neutral (white)', () => {
             expect(getCellColour(makeRow({ bound: BoundType.BOTH }), ColumnKeys.Bound)).toBe(CellColour.White);
+        });
+
+        // perf_report.py — the Bound cell is only coloured for DRAM/FLOP/SLOW/HOST; a missing or
+        // unrecognised bound stays neutral.
+        it('leaves a missing bound neutral (white)', () => {
+            expect(getCellColour(makeRow({ bound: null }), ColumnKeys.Bound)).toBe(CellColour.White);
         });
     });
 
@@ -173,9 +178,13 @@ describe('getCellColour — parity with tt-perf-report color_row()', () => {
         });
 
         // perf_report.py — gaps at or below the threshold are never coloured, so they stay neutral.
-        // DIVERGENCE: the visualizer returns FALLBACK_COLOUR (grey) (perfFunctions.tsx:395-397).
         it('leaves a gap at or below 6.5µs neutral (white)', () => {
             expect(getCellColour(makeRow({ op_to_op_gap: 3 }), ColumnKeys.OpToOpGap)).toBe(CellColour.White);
+        });
+
+        // perf_report.py:1052 — a missing gap (e.g. the first op) is never coloured, so it stays neutral.
+        it('leaves a missing gap neutral (white)', () => {
+            expect(getCellColour(makeRow({ op_to_op_gap: null }), ColumnKeys.OpToOpGap)).toBe(CellColour.White);
         });
     });
 
@@ -229,6 +238,14 @@ describe('getCellColour — parity with tt-perf-report color_row()', () => {
         // perf_report.py:1015-1017 — ops below the threshold are muted grey, EXCEPT host "(torch)" ops.
         it('mutes a sub-threshold device op to grey', () => {
             const row = makeRow({ total_percent: 0.3, bound: BoundType.DRAM });
+
+            expect(getCellColour(row, ColumnKeys.Bound)).toBe(CellColour.Grey);
+        });
+
+        // perf_report.py:1015 — muting keys off the op code, not the op type, so a non-device,
+        // non-torch op (e.g. a tt_dnn_cpu op) is muted too when below the threshold.
+        it('mutes a sub-threshold non-device, non-torch op to grey', () => {
+            const row = makeRow({ op_type: OpType.CPU_OP, total_percent: 0.3, bound: BoundType.DRAM });
 
             expect(getCellColour(row, ColumnKeys.Bound)).toBe(CellColour.Grey);
         });

--- a/tests/perfTableColouring.spec.ts
+++ b/tests/perfTableColouring.spec.ts
@@ -29,6 +29,13 @@ const makeRow = (overrides: Record<string, unknown>): TypedPerfTableRow =>
         ...overrides,
     }) as unknown as TypedPerfTableRow;
 
+// Guards against a silent vacuous pass: it.each([]) registers no tests, so an empty/missing golden
+// would otherwise leave the frontend uncovered while only the Python contract test fails.
+it('the golden covers colour and fidelity scenarios', () => {
+    expect(golden.colours.length).toBeGreaterThan(0);
+    expect(golden.fidelity.length).toBeGreaterThan(0);
+});
+
 describe('getCellColour — golden parity with tt-perf-report color_row()', () => {
     it.each(golden.colours)('$id ($column) -> $expected', ({ column, row, expected }) => {
         expect(getCellColour(makeRow(row), column as ColumnKeys)).toBe(expected);


### PR DESCRIPTION
Aligns styles and expands tests to try to avoid diverging styles.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1685.

---

This pull request refactors and improves the performance table data parsing and color logic to closely match the behavior of `tt-perf-report`, enhances datatype fidelity evaluation, and cleans up code duplication. The main changes include extracting and improving row enrichment logic, updating color assignment rules for table cells, and making fidelity evaluation more robust and aligned with the backend. Additionally, the high-dispatch threshold constant is clarified, and a new script is added for updating performance test goldens.

**Performance Table Data Enrichment and Refactoring:**

* Extracted and improved the row enrichment logic into a new `enrichPerfRowData.ts` module, ensuring consistent and accurate parsing of performance data and reducing code duplication in `Performance.tsx` (`src/functions/enrichPerfRowData.ts`, `src/routes/Performance.tsx`) [[1]](diffhunk://#diff-3bd520441fdbdc637e0e308c432bccf31e2601a2ef1bc5b20a2f2bfd90e9339bR1-R91) [[2]](diffhunk://#diff-5564bfad9f3e67aac3872de616c1d9ced57740f8c6906e4f6b88bd875e573aa8L30-R37) [[3]](diffhunk://#diff-5564bfad9f3e67aac3872de616c1d9ced57740f8c6906e4f6b88bd875e573aa8L306-L377).
* Improved parsing of numeric fields and high-dispatch flag assignment to avoid leaking `NaN` values and to correctly handle missing or malformed data (`src/functions/enrichPerfRowData.ts`).

**Color Assignment Logic Updates:**

* Updated cell color logic in `getCellColour` to match `tt-perf-report`, including:
    - Host-bound ops now show as red, and only DRAM/FLOP/SLOW/HOST bounds are colored, with others remaining neutral (`src/functions/perfFunctions.tsx`) [[1]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL275-R278) [[2]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aR292-R295).
    - Ops below the percentage threshold are muted except for host "(torch)" ops, which remain colored (`src/functions/perfFunctions.tsx`).
    - Math fidelity coloring is now only applied to relevant ops and datatypes (`src/functions/perfFunctions.tsx`).
    - Op-to-op gap cells only color red for values above the threshold, otherwise stay neutral (`src/functions/perfFunctions.tsx`) [[1]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL372-R384) [[2]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL396-R416).

**Fidelity Evaluation Improvements:**

* Refactored `evaluateFidelity` to skip evaluation for integer datatypes and unsupported types, matching backend logic and improving error messaging (`src/functions/perfFunctions.tsx`).

**Constants and Naming Consistency:**

* Renamed the high-dispatch threshold constant from `HIGH_DISPATCH_THRESHOLD_MS` to `HIGH_DISPATCH_THRESHOLD_US` for clarity and updated all usages accordingly (`src/definitions/Performance.ts`, `src/functions/perfFunctions.tsx`) [[1]](diffhunk://#diff-4ccc74840cd4869dad3c3c0f63a8f9223039b9a013b2ba34f705850bb79c93d8L21-R21) [[2]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL15-R15) [[3]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL91-R93) [[4]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL396-R416) [[5]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL415-R427) [[6]](diffhunk://#diff-06811d0e2ee912b54c0d90b02cd8926d71cbf822029522c63197b919c69c0c9aL437-R449).

**Tooling:**

* Added a new script `perf:golden` to `package.json` for updating performance test goldens (`package.json`).