### PR TITLE
Render globally-allocated CBs as outlined overlays in the L1 stack

### DIFF
--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -113,6 +113,7 @@ function L1Plots({
                             ...cb,
                             markerType: MarkerType.CB,
                             colorVariance: op.id,
+                            globallyAllocated: cb.globallyAllocated,
                         }) as FragmentationEntry,
                 ),
             )
@@ -316,6 +317,7 @@ function L1Plots({
                             onLegendClick={onLegendClick}
                             colorVariance={chunk.colorVariance}
                             userL1ZoomRange={userL1ZoomRange}
+                            isGloballyAllocated={chunk.globallyAllocated === true}
                         />
                     ))}
 

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -172,18 +172,25 @@ export const MemoryLegendElement = ({
                         {isGloballyAllocated && (
                             <Tooltip
                                 content={
-                                    <span>
-                                        Aliased to tensor @ {prettyPrintAddress(chunk.address, memSize, showHex)}{' '}
-                                        &mdash; no new allocation
-                                    </span>
+                                    derivedTensor ? (
+                                        <span>
+                                            Aliased to Tensor {derivedTensor.id} {toReadableShape(derivedTensor.shape)}{' '}
+                                            {toReadableType(derivedTensor.dtype)}
+                                        </span>
+                                    ) : (
+                                        <span>
+                                            Aliased to tensor @ {prettyPrintAddress(chunk.address, memSize, showHex)}
+                                        </span>
+                                    )
                                 }
                             >
                                 <span
                                     className='globally-allocated-marker'
-                                    // aria-label keeps the row a single tab-stop
-                                    // while still surfacing the "aliased" semantic
-                                    // to assistive tech users.
-                                    aria-label='Globally allocated — aliased to tensor at this address'
+                                    aria-label={
+                                        derivedTensor
+                                            ? `Globally allocated — aliased to Tensor ${derivedTensor.id} ${toReadableShape(derivedTensor.shape)} ${toReadableType(derivedTensor.dtype)}`
+                                            : 'Globally allocated — aliased to tensor at this address'
+                                    }
                                 >
                                     <Icon
                                         icon={IconNames.LINK}

--- a/src/definitions/PlotConfigurations.ts
+++ b/src/definitions/PlotConfigurations.ts
@@ -149,6 +149,8 @@ export interface PlotDataOverrides {
     color?: string;
     hovertemplate?: string;
     colorVariance?: number;
+    /** Render trace as a tinted-fill bordered overlay for aliased CBs. #1652 */
+    outline?: boolean;
 }
 
 export const PerfChartConfig: Partial<Config> = {

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -6,7 +6,7 @@ import { getBufferColor, getTensorColor } from './colorGenerator';
 import { formatMemorySize, getMemoryAddress } from './math';
 import { toReadableShape, toReadableType } from './formatting';
 import { Chunk, ColoredChunk, DecoratedBufferChunk, Tensor } from '../model/APIData';
-import { PlotDataCustom } from '../definitions/PlotConfigurations';
+import { PlotDataCustom, PlotDataOverrides } from '../definitions/PlotConfigurations';
 import { TensorMemoryLayout } from './parseMemoryConfig';
 
 // Half-opacity tint + solid border; fill keeps the bar readable when the stroke clips at plot edges. #1652
@@ -39,7 +39,7 @@ const withAlpha = (color: string | undefined, alpha: number): string | undefined
 export default function getChartData(
     memory: Chunk[],
     getTensorForAddress: (id: number) => Tensor | null,
-    overrides?: { color?: string; colorVariance?: number; hovertemplate?: string; outline?: boolean },
+    overrides?: PlotDataOverrides,
     options?: { renderPattern?: boolean; lateDeallocation?: boolean; showHex?: boolean },
 ): Partial<PlotDataCustom>[] {
     return memory.map((chunk) => {

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -9,10 +9,37 @@ import { Chunk, ColoredChunk, DecoratedBufferChunk, Tensor } from '../model/APID
 import { PlotDataCustom } from '../definitions/PlotConfigurations';
 import { TensorMemoryLayout } from './parseMemoryConfig';
 
+// Half-opacity tint + solid border; fill keeps the bar readable when the stroke clips at plot edges. #1652
+const OUTLINE_FILL_ALPHA = 0.5;
+const OUTLINE_BORDER_WIDTH = 2;
+
+const RGB_TUPLE_RE = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i;
+
+const withAlpha = (color: string | undefined, alpha: number): string | undefined => {
+    if (!color) {
+        return color;
+    }
+    const match = color.match(RGB_TUPLE_RE);
+    if (match) {
+        return `rgba(${match[1]},${match[2]},${match[3]},${alpha})`;
+    }
+    if (color.startsWith('#') && (color.length === 7 || color.length === 4)) {
+        const hex =
+            color.length === 4 ? `${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}` : color.slice(1);
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
+            return `rgba(${r},${g},${b},${alpha})`;
+        }
+    }
+    return color;
+};
+
 export default function getChartData(
     memory: Chunk[],
     getTensorForAddress: (id: number) => Tensor | null,
-    overrides?: { color?: string; colorVariance?: number; hovertemplate?: string },
+    overrides?: { color?: string; colorVariance?: number; hovertemplate?: string; outline?: boolean },
     options?: { renderPattern?: boolean; lateDeallocation?: boolean; showHex?: boolean },
 ): Partial<PlotDataCustom>[] {
     return memory.map((chunk) => {
@@ -81,20 +108,35 @@ export default function getChartData(
             };
         }
 
+        const outline = overrides?.outline === true;
+        const borderColor = outline ? color : undefined;
+        const fillColor = outline ? withAlpha(color, OUTLINE_FILL_ALPHA) : color;
+        const marker = outline
+            ? {
+                  color: fillColor,
+                  line: {
+                      width: OUTLINE_BORDER_WIDTH,
+                      color: borderColor,
+                      simplify: false,
+                  },
+                  pattern,
+              }
+            : {
+                  color: fillColor,
+                  line: {
+                      width: 0,
+                      opacity: 0,
+                      simplify: false,
+                  },
+                  pattern,
+              };
+
         return {
             x: [address + size / 2],
             y: [1],
             type: 'bar',
             width: [size],
-            marker: {
-                color,
-                line: {
-                    width: 0,
-                    opacity: 0,
-                    simplify: false,
-                },
-                pattern,
-            },
+            marker,
             memoryData: {
                 address,
                 size,
@@ -104,7 +146,16 @@ export default function getChartData(
             hovertemplate:
                 overrides?.hovertemplate !== undefined
                     ? overrides?.hovertemplate
-                    : createHoverTemplate(address, size, chunk, tensor, tensorMemoryLayout, color, options),
+                    : createHoverTemplate(
+                          address,
+                          size,
+                          chunk,
+                          tensor,
+                          tensorMemoryLayout,
+                          outline ? borderColor : color,
+                          options,
+                          { aliased: outline },
+                      ),
             hoverlabel: {
                 align: 'right',
                 bgcolor: 'white',
@@ -142,6 +193,7 @@ const createHoverTemplate = (
     tensorMemoryLayout: TensorMemoryLayout | undefined,
     color?: string,
     options?: { lateDeallocation?: boolean; showHex?: boolean },
+    extras?: { aliased?: boolean },
 ): string => {
     const square = `<span style="color:${color};font-size:22px">&#9632;</span>`;
     const formattedAddress = getMemoryAddress(address, options?.showHex || false);
@@ -151,6 +203,13 @@ const createHoverTemplate = (
     const tensorDetails = tensor
         ? `${toReadableShape(tensor.shape)} ${toReadableType(tensor.dtype)}<br />${tensorMemoryLayout || ''}<br />Tensor ${tensor.id}${canDeallocateText}`
         : '';
+    // Plotly hover doesn't decode named HTML entities — use ASCII dash. #1652
+    let aliasedHeader = '';
+    if (extras?.aliased) {
+        aliasedHeader = tensor
+            ? `<b>Globally allocated CB</b> - aliased to Tensor ${tensor.id} below<br />`
+            : `<b>Globally allocated CB</b><br />`;
+    }
 
-    return `${square} ${formattedAddress} (${formattedSize})<br />${tensorDetails}<extra></extra>`;
+    return `${aliasedHeader}${square} ${formattedAddress} (${formattedSize})<br />${tensorDetails}<extra></extra>`;
 };

--- a/src/functions/getChartData.ts
+++ b/src/functions/getChartData.ts
@@ -146,16 +146,10 @@ export default function getChartData(
             hovertemplate:
                 overrides?.hovertemplate !== undefined
                     ? overrides?.hovertemplate
-                    : createHoverTemplate(
-                          address,
-                          size,
-                          chunk,
-                          tensor,
-                          tensorMemoryLayout,
-                          outline ? borderColor : color,
-                          options,
-                          { aliased: outline },
-                      ),
+                    : createHoverTemplate(address, size, chunk, tensor, tensorMemoryLayout, fillColor, {
+                          ...options,
+                          aliased: outline,
+                      }),
             hoverlabel: {
                 align: 'right',
                 bgcolor: 'white',
@@ -192,8 +186,7 @@ const createHoverTemplate = (
     tensor: Tensor | null,
     tensorMemoryLayout: TensorMemoryLayout | undefined,
     color?: string,
-    options?: { lateDeallocation?: boolean; showHex?: boolean },
-    extras?: { aliased?: boolean },
+    options?: { lateDeallocation?: boolean; showHex?: boolean; aliased?: boolean },
 ): string => {
     const square = `<span style="color:${color};font-size:22px">&#9632;</span>`;
     const formattedAddress = getMemoryAddress(address, options?.showHex || false);
@@ -205,7 +198,7 @@ const createHoverTemplate = (
         : '';
     // Plotly hover doesn't decode named HTML entities — use ASCII dash. #1652
     let aliasedHeader = '';
-    if (extras?.aliased) {
+    if (options?.aliased) {
         aliasedHeader = tensor
             ? `<b>Globally allocated CB</b> - aliased to Tensor ${tensor.id} below<br />`
             : `<b>Globally allocated CB</b><br />`;

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -204,6 +204,8 @@ export interface FragmentationEntry extends Chunk {
     colorVariance?: number | undefined;
     empty?: boolean;
     largestEmpty?: boolean;
+    // Mirrors `CircularBuffer.globallyAllocated` for the legend renderer. #1652
+    globallyAllocated?: boolean;
 }
 
 // export interface ReportMetaData {
@@ -377,6 +379,8 @@ export interface CircularBuffer extends Chunk {
     num_cores: number;
     core_range_set: string;
     colorVariance?: number | undefined;
+    // Aliased views into an existing L1 buffer — not new allocations. #1651 / #1652
+    globallyAllocated?: boolean;
 }
 
 export interface TensorBuffer extends Chunk {

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -251,12 +251,16 @@ export class OperationDetails implements Partial<OperationDetailsData> {
                             .find((op) => op.name === deviceOpNode.params.name);
 
                         if (deviceOp) {
+                            // Accept string/number for forward-compat — keep in sync with processMemoryAllocations. #1651 / #1652
+                            const rawGlobalFlag = node.params.globally_allocated as unknown;
+                            const globallyAllocated = rawGlobalFlag === '1' || rawGlobalFlag === 1;
                             deviceOp.cbList.push({
                                 address: parseInt(node.params.address, 10),
                                 size: parseInt(node.params.size, 10),
                                 core_range_set: node.params.core_range_set,
                                 num_cores: getCoresInRange(node.params.core_range_set),
                                 colorVariance: deviceOp.id,
+                                globallyAllocated,
                             });
                         }
                     }
@@ -401,6 +405,8 @@ export class OperationDetails implements Partial<OperationDetailsData> {
                 .sort((a, b) => a.address - b.address) || [];
 
         const cbMemory = bufferType === BufferType.L1 ? this.deviceOperations.flatMap((op) => op.cbList) : [];
+        // Aliased CBs share bytes with a tensor already in `memory` — exclude them to avoid double-counting. #1652
+        const anonymousCBMemory = cbMemory.filter((cb) => !cb.globallyAllocated);
         const bufferMemory =
             bufferType === BufferType.L1
                 ? this.deviceOperations.flatMap((op) => op.bufferList).filter((op) => op.type === 'L1')
@@ -480,7 +486,7 @@ export class OperationDetails implements Partial<OperationDetailsData> {
         });
 
         const condensed: Chunk = calculateCondensed(memory);
-        const cbCondensed: Chunk = calculateCondensed(cbMemory);
+        const cbCondensed: Chunk = calculateCondensed(anonymousCBMemory);
         const bufferCondensed: Chunk = calculateCondensed(bufferMemory);
 
         const chartData = this.getChartData(memory);
@@ -495,12 +501,18 @@ ${getMemoryAddress(cbCondensed.address, this.options.showHex)} <br />${formatMem
         const cbChartDataByOperation: Map<{ name: string; index: number }, Partial<PlotData>[]> = new Map();
         this.deviceOperations.forEach((op) => {
             if (op.cbList.length !== 0) {
+                // Aliased CBs are emitted as a separate outlined trace so they don't obscure the tensor below. #1652
+                const anonymousCBs = op.cbList.filter((cb) => !cb.globallyAllocated);
+                const aliasedCBs = op.cbList.filter((cb) => cb.globallyAllocated);
+                const filled = this.getChartData(anonymousCBs, { colorVariance: op.id });
+                const outlined =
+                    aliasedCBs.length > 0 ? this.getChartData(aliasedCBs, { colorVariance: op.id, outline: true }) : [];
                 cbChartDataByOperation.set(
                     {
                         name: op.name,
                         index: op.id,
                     },
-                    this.getChartData(op.cbList, { colorVariance: op.id }),
+                    [...filled, ...outlined],
                 );
             }
         });

--- a/tests/MemoryLegendElement.spec.tsx
+++ b/tests/MemoryLegendElement.spec.tsx
@@ -147,4 +147,35 @@ describe('MemoryLegendElement globally_allocated marker (#1651)', () => {
         const row = container.querySelector('.legend-item');
         expect(row).toHaveClass('globally-allocated');
     });
+
+    it('surfaces the aliased tensor id/shape/dtype in the marker tooltip when a tensor is resolved', () => {
+        const aliasedTensor = {
+            id: 188,
+            shape: 'Shape([1, 32, 64, 64])',
+            dtype: 'DataType.BFLOAT16',
+        };
+        const opDetails = {
+            getTensorForAddress: () => aliasedTensor,
+        } as unknown as OperationDetails;
+
+        render(
+            <TestProviders>
+                <MemoryLegendElement
+                    chunk={chunk}
+                    memSize={1024}
+                    selectedTensorAddress={null}
+                    operationDetails={opDetails}
+                    onLegendClick={onLegendClick}
+                    isGloballyAllocated
+                />
+            </TestProviders>,
+        );
+
+        // aria-label is the most reliable assertion — Blueprint renders the tooltip lazily on hover.
+        const marker = document.querySelector('.globally-allocated-marker');
+        expect(marker).toHaveAttribute(
+            'aria-label',
+            expect.stringMatching(/Globally allocated.*Tensor 188.*\[1, 32, 64, 64\].*bf16/),
+        );
+    });
 });

--- a/tests/OperationDetails.globallyAllocatedCB.spec.ts
+++ b/tests/OperationDetails.globallyAllocatedCB.spec.ts
@@ -32,14 +32,25 @@ const functionEnd = (name: string) =>
         params: { name },
     } as unknown as Partial<Node>);
 
-const cbAllocate = (address: number, size: number, options: { globallyAllocated?: boolean } = {}) =>
+const resolveGloballyAllocatedFlag = (options: { globallyAllocated?: boolean; rawFlag?: string | number }) => {
+    if (options.rawFlag !== undefined) {
+        return options.rawFlag;
+    }
+    return options.globallyAllocated ? '1' : '0';
+};
+
+const cbAllocate = (
+    address: number,
+    size: number,
+    options: { globallyAllocated?: boolean; rawFlag?: string | number } = {},
+) =>
     mkNode({
         node_type: NodeType.circular_buffer_allocate,
         params: {
             core_range_set: '{[(x=0,y=0) - (x=0,y=0)]}',
             size: String(size),
             address: String(address),
-            globally_allocated: options.globallyAllocated ? '1' : '0',
+            globally_allocated: resolveGloballyAllocatedFlag(options),
         },
     } as unknown as Partial<Node>);
 
@@ -92,6 +103,16 @@ describe('OperationDetails circular_buffer_allocate flag plumbing (#1652)', () =
 
         expect(op.deviceOperations[0].cbList[0].globallyAllocated).toBe(false);
     });
+
+    it('accepts numeric 1 for globally_allocated (forward-compat with future tt-metal emits)', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            cbAllocate(0x2000, 2048, { rawFlag: 1 }),
+            functionEnd('matmul'),
+        ]);
+
+        expect(op.deviceOperations[0].cbList[0].globallyAllocated).toBe(true);
+    });
 });
 
 describe('OperationDetails.memoryData() CB trace split (#1652)', () => {
@@ -134,5 +155,62 @@ describe('OperationDetails.memoryData() CB trace split (#1652)', () => {
         const traces = [...data.cbChartDataByOperation.values()][0];
         expect(traces).toHaveLength(2);
         expect(traces.every((trace) => !/^rgba\(/.test(trace.marker?.color as string))).toBe(true);
+    });
+
+    it('emits only outlined traces when all CBs on a DeviceOp are aliased (Halo case)', () => {
+        const op = buildOperationDetails([
+            functionStart('halo'),
+            cbAllocate(0x1000, 1024, { globallyAllocated: true }),
+            cbAllocate(0x2000, 2048, { globallyAllocated: true }),
+            functionEnd('halo'),
+        ]);
+
+        const data = op.memoryData();
+        const traces = [...data.cbChartDataByOperation.values()][0];
+        expect(traces).toHaveLength(2);
+        expect(traces.every((trace) => /^rgba\(\d+,\d+,\d+,0\.5\)$/.test(trace.marker?.color as string))).toBe(true);
+        expect(traces.every((trace) => Number(trace.marker?.line?.width ?? 0) > 0)).toBe(true);
+
+        // Top condensed CB stripe collapses to zero size when the op contributes no fresh CB bytes.
+        const condensedRange = (data.cbChartData[0] as Partial<PlotDataCustom>)?.memoryData;
+        expect(condensedRange?.size).toBe(0);
+    });
+
+    it('handles multi-DeviceOp graphs with mixed aliasing per op (Conv2d case)', () => {
+        const op = buildOperationDetails([
+            functionStart('halo'),
+            cbAllocate(0x1000, 1024, { globallyAllocated: true }),
+            functionEnd('halo'),
+            functionStart('conv2d'),
+            cbAllocate(0x4000, 2048),
+            cbAllocate(0x8000, 1024, { globallyAllocated: true }),
+            functionEnd('conv2d'),
+        ]);
+
+        const entries = [...op.memoryData().cbChartDataByOperation.entries()];
+        expect(entries).toHaveLength(2);
+
+        const haloTraces = entries[0][1];
+        expect(haloTraces).toHaveLength(1);
+        expect(haloTraces[0].marker?.color).toMatch(/^rgba\(\d+,\d+,\d+,0\.5\)$/);
+
+        const convTraces = entries[1][1];
+        expect(convTraces).toHaveLength(2);
+        expect(convTraces[0].marker?.color).not.toMatch(/^rgba\(/);
+        expect(convTraces[1].marker?.color).toMatch(/^rgba\(\d+,\d+,\d+,0\.5\)$/);
+    });
+
+    it('cbCondensed range excludes aliased CB addresses above the anonymous envelope', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            cbAllocate(0x1000, 1024),
+            cbAllocate(0xff000, 2048, { globallyAllocated: true }),
+            functionEnd('matmul'),
+        ]);
+
+        const data = op.memoryData();
+        const top = (data.cbChartData[0] as Partial<PlotDataCustom>).memoryData!;
+        expect(top.address).toBe(0x1000);
+        expect(top.address + top.size).toBeLessThan(0xff000);
     });
 });

--- a/tests/OperationDetails.globallyAllocatedCB.spec.ts
+++ b/tests/OperationDetails.globallyAllocatedCB.spec.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { OperationDetails } from '../src/model/OperationDetails';
+import { Node, NodeType, OperationDetailsData } from '../src/model/APIData';
+import { PlotDataCustom } from '../src/definitions/PlotConfigurations';
+
+let nextId = 0;
+function mkNode<T extends Partial<Node>>(node: T): Node {
+    nextId += 1;
+    return {
+        id: nextId,
+        connections: [],
+        inputs: [],
+        outputs: [],
+        stacking_level: 0,
+        ...node,
+    } as Node;
+}
+
+const functionStart = (name: string) =>
+    mkNode({
+        node_type: NodeType.function_start,
+        params: { name, device_id: 0 },
+    } as unknown as Partial<Node>);
+
+const functionEnd = (name: string) =>
+    mkNode({
+        node_type: NodeType.function_end,
+        params: { name },
+    } as unknown as Partial<Node>);
+
+const cbAllocate = (address: number, size: number, options: { globallyAllocated?: boolean } = {}) =>
+    mkNode({
+        node_type: NodeType.circular_buffer_allocate,
+        params: {
+            core_range_set: '{[(x=0,y=0) - (x=0,y=0)]}',
+            size: String(size),
+            address: String(address),
+            globally_allocated: options.globallyAllocated ? '1' : '0',
+        },
+    } as unknown as Partial<Node>);
+
+const buildOperationDetails = (deviceOperations: Node[]): OperationDetails => {
+    nextId = 0;
+    const data = {
+        id: 1,
+        name: 'op',
+        inputs: [],
+        outputs: [],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+        operationFileIdentifier: 'op',
+        error: null,
+        buffers: [],
+        buffersSummary: [],
+        l1_sizes: [1_000_000],
+        device_operations: deviceOperations,
+    } as unknown as OperationDetailsData;
+
+    return new OperationDetails(data, [], [], { l1start: 0, l1end: 1_000_000 });
+};
+
+describe('OperationDetails circular_buffer_allocate flag plumbing (#1652)', () => {
+    it('stamps globallyAllocated onto cbList entries for aliased CBs', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            cbAllocate(0x1000, 1024),
+            cbAllocate(0x2000, 2048, { globallyAllocated: true }),
+            functionEnd('matmul'),
+        ]);
+
+        expect(op.deviceOperations).toHaveLength(1);
+        const [matmul] = op.deviceOperations;
+        expect(matmul.cbList).toHaveLength(2);
+        expect(matmul.cbList[0].globallyAllocated).toBe(false);
+        expect(matmul.cbList[1].globallyAllocated).toBe(true);
+    });
+
+    it('treats a missing globally_allocated param as anonymous for back-compat', () => {
+        const cbNodeWithoutFlag = mkNode({
+            node_type: NodeType.circular_buffer_allocate,
+            params: {
+                core_range_set: '{[(x=0,y=0) - (x=0,y=0)]}',
+                size: '1024',
+                address: '4096',
+            },
+        } as unknown as Partial<Node>);
+        const op = buildOperationDetails([functionStart('matmul'), cbNodeWithoutFlag, functionEnd('matmul')]);
+
+        expect(op.deviceOperations[0].cbList[0].globallyAllocated).toBe(false);
+    });
+});
+
+describe('OperationDetails.memoryData() CB trace split (#1652)', () => {
+    it('emits a separate outlined trace for aliased CBs and excludes them from the condensed CB stripe', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            cbAllocate(0x1000, 1024),
+            cbAllocate(0x4000, 2048, { globallyAllocated: true }),
+            functionEnd('matmul'),
+        ]);
+
+        const data = op.memoryData();
+
+        const condensedRange = (data.cbChartData[0] as Partial<PlotDataCustom>)?.memoryData;
+        expect(condensedRange?.address).toBe(0x1000);
+        expect(condensedRange?.size).toBe(1024);
+
+        const entries = [...data.cbChartDataByOperation.entries()];
+        expect(entries).toHaveLength(1);
+        const traces = entries[0][1];
+        expect(traces).toHaveLength(2);
+
+        const filled = traces[0];
+        const outlined = traces[1];
+        expect(filled.marker?.color).not.toMatch(/^rgba\(/);
+        expect(outlined.marker?.color).toMatch(/^rgba\(\d+,\d+,\d+,0\.5\)$/);
+        expect(outlined.marker?.line?.width).toBeGreaterThan(0);
+        expect(outlined.hovertemplate).toMatch(/Globally allocated/);
+    });
+
+    it('skips the outlined trace entirely when no aliased CBs are present', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            cbAllocate(0x1000, 1024),
+            cbAllocate(0x2000, 2048),
+            functionEnd('matmul'),
+        ]);
+
+        const data = op.memoryData();
+        const traces = [...data.cbChartDataByOperation.values()][0];
+        expect(traces).toHaveLength(2);
+        expect(traces.every((trace) => !/^rgba\(/.test(trace.marker?.color as string))).toBe(true);
+    });
+});

--- a/tests/getChartData.spec.ts
+++ b/tests/getChartData.spec.ts
@@ -31,7 +31,6 @@ describe('getChartData outline mode (#1652)', () => {
         const [bar] = getChartData([chunk], noTensor);
 
         expect(bar.marker?.color).toBeDefined();
-        expect(bar.marker?.color).not.toMatch(/rgba/);
         expect(bar.marker?.line?.width).toBe(0);
     });
 

--- a/tests/getChartData.spec.ts
+++ b/tests/getChartData.spec.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import getChartData from '../src/functions/getChartData';
+import { Chunk, Tensor } from '../src/model/APIData';
+
+const noTensor = (): Tensor | null => null;
+
+const makeTensor = (id: number, address: number): Tensor =>
+    ({
+        id,
+        address,
+        buffer_type: null,
+        producers: [],
+        consumers: [],
+        producerNames: [],
+        consumerNames: [],
+        shape: '[1, 1, 32, 32]',
+        dtype: 'BFLOAT16',
+        layout: 'TILE',
+        memory_config: null,
+        device_id: 0,
+    }) as unknown as Tensor;
+
+describe('getChartData outline mode (#1652)', () => {
+    const chunk: Chunk = { address: 0x4000, size: 1024 };
+
+    it('emits a filled bar by default', () => {
+        const [bar] = getChartData([chunk], noTensor);
+
+        expect(bar.marker?.color).toBeDefined();
+        expect(bar.marker?.color).not.toMatch(/rgba/);
+        expect(bar.marker?.line?.width).toBe(0);
+    });
+
+    it('emits a half-opacity tinted fill with a solid-colour border when outline is set', () => {
+        const tensorLookup = (address: number) => (address === chunk.address ? makeTensor(7, address) : null);
+        const [bar] = getChartData([chunk], tensorLookup, { outline: true });
+
+        expect(bar.marker?.line?.width).toBeGreaterThan(0);
+        expect(bar.marker?.line?.color).toBeDefined();
+        expect(bar.marker?.line?.color).not.toMatch(/rgba\(/);
+        expect(bar.marker?.color).toMatch(/^rgba\(\d+,\d+,\d+,0\.5\)$/);
+    });
+
+    it('prepends the "Globally allocated CB" header to the hover when outline is set', () => {
+        const tensorLookup = (address: number) => (address === chunk.address ? makeTensor(7, address) : null);
+
+        const [aliased] = getChartData([chunk], tensorLookup, { outline: true });
+        const [anonymous] = getChartData([chunk], tensorLookup);
+
+        expect(aliased.hovertemplate).toMatch(/Globally allocated CB/);
+        expect(aliased.hovertemplate).toMatch(/aliased to Tensor 7/);
+        expect(anonymous.hovertemplate).not.toMatch(/Globally allocated/);
+    });
+
+    it('emits a minimal aliased header when no tensor sits at the address', () => {
+        const [aliased] = getChartData([chunk], noTensor, { outline: true });
+
+        expect(aliased.hovertemplate).toMatch(/Globally allocated CB/);
+        expect(aliased.hovertemplate).not.toMatch(/aliased to/);
+    });
+});


### PR DESCRIPTION
Closes #1652.

<img width="1466" height="865" alt="image" src="https://github.com/user-attachments/assets/a354e2ab-efa1-4187-8a6d-4e14cad93fcd" />


Follow-up to #1651 (which fixed the data-layer accounting and per-DeviceOp / modal treatment). The L1 Address Space stack at the top of the operation details page uses a separate render path that still drew `globally_allocated` CBs as solid filled stripes on top of the tensor row they alias — exaggerating apparent L1 pressure and occluding the underlying tensor stripe (e.g. `resnet50_main_jun10_2110/`, op 8 `ttnn.conv2d`: CBs 108/113 over buffer 97 @ 1,147,232).

Implements **Option B** from the issue: keep the CB stripe but render aliased CBs as a half-opacity tinted overlay with a solid border on top of the tensor row, with a hover that names the aliased tensor.

## Summary

- **Data plumbing**: `CircularBuffer` (and `FragmentationEntry`) carry a `globallyAllocated` flag. `OperationDetails` stamps it onto each `op.cbList[]` entry by reading `node.params.globally_allocated` (accepts both `'1'` and `1`, matching `processMemoryAllocations`).
- **Plot rendering**: `getChartData` gains an `outline` override. When set, the bar renders with the tensor colour at 50% opacity plus a solid 2 px border in the same colour at full opacity — the fill keeps the bar readable when Plotly clips the stroke at plot edges, the alpha keeps the underlying tensor row legible underneath.
- **Per-DeviceOp plot**: each op's CB list splits into anonymous CBs (filled trace, as before) and aliased CBs (outlined trace), emitted as two traces in `cbChartDataByOperation` so they don't compete for the same colour. Both traces use the same `colorVariance` (op.id), so aliased and anonymous CBs within one DeviceOp share a hue and are distinguished by fill vs outline; the legend marker disambiguates them.
- **Top "Current Summarized L1 Report" stripe**: `cbCondensed` now uses anonymous CBs only, so the condensed CB band doesn't double-count bytes already shown in the tensor row beneath. **Behaviour shift worth flagging**: when *all* CBs on a DeviceOp are aliased (the Halo case on the repro report), the condensed stripe collapses to width 0 for that op — semantically correct since the op contributes zero new bytes to the CB pool, but users scanning only the condensed stripes will need to drop into the per-op strips to see aliased CB activity. Acceptable trade-off; can be tightened later if signal warrants.
- **Hover**: aliased traces get a `<b>Globally allocated CB</b> - aliased to Tensor N below` header; the row below already shows shape/dtype/layout/tensor id so the header stays short. The hover swatch uses the same half-opacity fill the bar uses, so the tooltip square matches the chart.
- **Legend**: `L1Plots` forwards the flag to `MemoryLegendElement`, whose `isGloballyAllocated` path (added in #1651) renders the outline swatch and the `Globally allocated` tag. The marker tooltip / aria-label now surface the aliased tensor's id, shape and dtype instead of just the address.

## Tests

- `tests/getChartData.spec.ts` (new) — covers default vs outline mode (half-opacity fill, solid border) and both header forms (resolved tensor / no-tensor fallback).
- `tests/OperationDetails.globallyAllocatedCB.spec.ts` (new) — end-to-end through `OperationDetails`: flag propagation, back-compat for missing `globally_allocated` param, numeric `1` forward-compat, `cbCondensed` exclusion (including a high-address aliased CB outside the anonymous envelope), per-DeviceOp filled + outlined trace split, all-aliased DeviceOp (Halo case, zero-width condensed stripe), and multi-DeviceOp with mixed aliasing (Conv2d case).
- `tests/MemoryLegendElement.spec.tsx` — extended with a case asserting the aria-label carries the aliased tensor identity.

`vitest run`, `tsc --noEmit`, and `eslint` on touched files are all clean.

## Manual verification

Load `resnet50_main_jun10_2110/` and open op 8 (`ttnn.conv2d`):

- `HaloDeviceOperation` and `Conv2dDeviceOperation` rows now show the aliased CBs as half-opacity tinted overlays with a colored border — the underlying tensor stripe stays visible.
- The legend row for the aliased CB shows the outline swatch and the `Globally allocated` tag; hovering it surfaces `Aliased to Tensor N [shape] dtype`.
- The top "Current Summarized L1 Report" stripe no longer adds the aliased CB byte range a second time on top of the tensor row.
- Anonymous CBs are unchanged.

## Follow-ups

- Shared `parseGloballyAllocatedFlag(raw)` helper to retire the inline parse currently duplicated in `processMemoryAllocations.ts` and `OperationDetails.ts` — tracked separately.