### PR TITLE
docs: add html_theme_options, CDN CSS, search context to conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,13 +84,22 @@ exclude_patterns = []
 #
 
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
 html_logo = "shared/images/tt_logo.svg"
 html_favicon = "shared/images/favicon.png"
 html_static_path = ["shared/_static"]
 templates_path = ["shared/_templates"]
 html_last_updated_fmt = "%b %d, %Y"
+html_css_files = ["https://docs.tenstorrent.com/_static/tt_theme.css"]
 html_baseurl = f"https://docs.tenstorrent.com/{project}"
-html_context = {"logo_link_url": "https://docs.tenstorrent.com/"}
+html_context = {
+    "logo_link_url": "https://docs.tenstorrent.com/",
+    "search_site_base_url": f"https://docs.tenstorrent.com/{project}/",
+}
 
 
 def setup(app):


### PR DESCRIPTION
## Summary

- `docs/conf.py`:
  - Added `html_theme_options` (collapse_navigation, titles_only, navigation_depth)
  - Added `html_css_files` pointing to `docs.tenstorrent.com/_static/tt_theme.css`
  - Added `logo_link_url` and `search_site_base_url: https://docs.tenstorrent.com/ttnn-visualizer/` to `html_context`

## Merge order

Merge before `docs/theme-nav-search-modal` in this repo.

## Test plan

- [ ] Sphinx build completes without warnings
- [ ] Theme CSS loads from CDN