### PR TITLE
Add inline kernel-duration bars to operation list rows

### DIFF
--- a/src/components/OperationList.tsx
+++ b/src/components/OperationList.tsx
@@ -35,8 +35,10 @@ import SourceFileButton from './operation-details/SourceFileButton';
 import { extractOperationSourceData } from '../functions/stackTraceSource';
 import OperationArguments from './OperationArguments';
 import OperationListPerfData from './OperationListPerfData';
+import OperationPerfRowBar from './OperationPerfRowBar';
 import SearchField from './SearchField';
 import SimpleMultiselect from './SimpleMultiselect';
+import { useOpPerfRowScores } from '../hooks/useOpPerfRowScores';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 39; // Height in px of each list item
@@ -58,6 +60,7 @@ const OperationList = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const { data: fetchedOperations, error, isLoading } = useOperationsList();
+    const { scoreByOpId, isAvailable: hasPerfRowBars } = useOpPerfRowScores();
     const { hasScrolledFromTop, hasScrolledToBottom, updateScrollShade, resetScrollShade, shadeClasses } =
         useScrollShade();
     const { getListState, updateListState } = useRestoreScrollPosition(ScrollLocations.OPERATION_LIST);
@@ -462,7 +465,13 @@ const OperationList = () => {
                                                         filterQuery={filterQuery}
                                                         icon={operation?.error ? IconNames.ERROR : IconNames.CUBE}
                                                         iconColour={operation?.error ? 'error' : 'operation'}
-                                                    />
+                                                    >
+                                                        {hasPerfRowBars && (
+                                                            <OperationPerfRowBar
+                                                                score={scoreByOpId.get(operation.id)}
+                                                            />
+                                                        )}
+                                                    </ListItem>
                                                 </Tooltip>
                                             }
                                             additionalElements={

--- a/src/components/OperationPerfRowBar.tsx
+++ b/src/components/OperationPerfRowBar.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { PopoverPosition, Tooltip } from '@blueprintjs/core';
+import 'styles/components/OperationPerfRowBar.scss';
+import { perfColorScale } from '../functions/perfOverlay';
+import { formatSize } from '../functions/math';
+import { OpPerfRowScore } from '../hooks/useOpPerfRowScores';
+
+interface OperationPerfRowBarProps {
+    score: OpPerfRowScore | undefined;
+}
+
+const NS_TO_US = 1 / 1_000;
+// Floor so a near-zero `t` still leaves a visible marker instead of vanishing.
+const MIN_BAR_PERCENT = 2;
+
+const OperationPerfRowBar = ({ score }: OperationPerfRowBarProps) => {
+    if (!score) {
+        return null;
+    }
+    const { deviceTimeNs, t } = score;
+    const widthPercent = Math.max(MIN_BAR_PERCENT, Math.round(t * 100));
+    const colour = perfColorScale(t);
+    const deviceTimeUs = deviceTimeNs * NS_TO_US;
+    const tooltip = `Device kernel duration: ${formatSize(deviceTimeUs, 2)} µs`;
+
+    return (
+        <Tooltip
+            content={tooltip}
+            placement={PopoverPosition.TOP}
+            hoverOpenDelay={150}
+        >
+            <div
+                className='operation-perf-row-bar'
+                role='img'
+                aria-label={tooltip}
+            >
+                <div
+                    className='operation-perf-row-bar-fill'
+                    style={{ width: `${widthPercent}%`, backgroundColor: colour }}
+                />
+            </div>
+        </Tooltip>
+    );
+};
+
+export default OperationPerfRowBar;

--- a/src/components/OperationPerfRowBar.tsx
+++ b/src/components/OperationPerfRowBar.tsx
@@ -5,14 +5,13 @@
 import { PopoverPosition, Tooltip } from '@blueprintjs/core';
 import 'styles/components/OperationPerfRowBar.scss';
 import { perfColorScale } from '../functions/perfOverlay';
-import { formatSize } from '../functions/math';
+import { formatDuration } from '../functions/formatting';
 import { OpPerfRowScore } from '../hooks/useOpPerfRowScores';
 
 interface OperationPerfRowBarProps {
     score: OpPerfRowScore | undefined;
 }
 
-const NS_TO_US = 1 / 1_000;
 // Floor so a near-zero `t` still leaves a visible marker instead of vanishing.
 const MIN_BAR_PERCENT = 2;
 
@@ -23,8 +22,7 @@ const OperationPerfRowBar = ({ score }: OperationPerfRowBarProps) => {
     const { deviceTimeNs, t } = score;
     const widthPercent = Math.max(MIN_BAR_PERCENT, Math.round(t * 100));
     const colour = perfColorScale(t);
-    const deviceTimeUs = deviceTimeNs * NS_TO_US;
-    const tooltip = `Device kernel duration: ${formatSize(deviceTimeUs, 2)} µs`;
+    const tooltip = `Device kernel duration: ${formatDuration(deviceTimeNs)}`;
 
     return (
         <Tooltip

--- a/src/hooks/useOpPerfRowScores.ts
+++ b/src/hooks/useOpPerfRowScores.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useMemo } from 'react';
+import { PerfOverlaySource, aggregatePerfByOp, scoreOps } from '../functions/perfOverlay';
+import { DeviceOperationMapping, useGetDeviceOperationListPerf } from './useAPI';
+
+export interface OpPerfRowScore {
+    /** Worst-case device-kernel duration across this op's perf rows (ns). */
+    deviceTimeNs: number;
+    /** Log-normalised [0, 1] position driving bar width and colour. */
+    t: number;
+}
+
+export interface OpPerfRowScores {
+    scoreByOpId: Map<number, OpPerfRowScore>;
+    isAvailable: boolean;
+    maxNs: number;
+    minNs: number;
+}
+
+const EMPTY_RESULT: OpPerfRowScores = {
+    scoreByOpId: new Map(),
+    isAvailable: false,
+    maxNs: 0,
+    minNs: 0,
+};
+
+// Reuses the perfOverlay scoring (#1517) so the row-bar colour ramp matches
+// the graph view. #1516
+export const useOpPerfRowScores = (): OpPerfRowScores => {
+    const deviceOperations = useGetDeviceOperationListPerf();
+
+    return useMemo(() => {
+        if (deviceOperations.length === 0) {
+            return EMPTY_RESULT;
+        }
+        const sources: PerfOverlaySource[] = [];
+        for (const op of deviceOperations as DeviceOperationMapping[]) {
+            const { perfData } = op;
+            if (perfData) {
+                const deviceTimeUs = parseFloat(perfData.device_time);
+                if (Number.isFinite(deviceTimeUs)) {
+                    sources.push({ id: op.id, device_time: deviceTimeUs });
+                }
+            }
+        }
+        if (sources.length === 0) {
+            return EMPTY_RESULT;
+        }
+        const aggregates = aggregatePerfByOp(sources);
+        if (aggregates.size === 0) {
+            return EMPTY_RESULT;
+        }
+        const { scoreByOpId: rawScores, minNs, maxNs } = scoreOps(aggregates);
+        const scoreByOpId = new Map<number, OpPerfRowScore>();
+        for (const [opId, score] of rawScores) {
+            const aggregate = aggregates.get(opId);
+            if (aggregate) {
+                scoreByOpId.set(opId, { deviceTimeNs: aggregate.deviceTimeNs, t: score.t });
+            }
+        }
+        return {
+            scoreByOpId,
+            isAvailable: scoreByOpId.size > 0,
+            maxNs,
+            minNs,
+        };
+    }, [deviceOperations]);
+};

--- a/src/hooks/useOpPerfRowScores.ts
+++ b/src/hooks/useOpPerfRowScores.ts
@@ -16,15 +16,11 @@ export interface OpPerfRowScore {
 export interface OpPerfRowScores {
     scoreByOpId: Map<number, OpPerfRowScore>;
     isAvailable: boolean;
-    maxNs: number;
-    minNs: number;
 }
 
 const EMPTY_RESULT: OpPerfRowScores = {
     scoreByOpId: new Map(),
     isAvailable: false,
-    maxNs: 0,
-    minNs: 0,
 };
 
 // Reuses the perfOverlay scoring (#1517) so the row-bar colour ramp matches
@@ -53,19 +49,17 @@ export const useOpPerfRowScores = (): OpPerfRowScores => {
         if (aggregates.size === 0) {
             return EMPTY_RESULT;
         }
-        const { scoreByOpId: rawScores, minNs, maxNs } = scoreOps(aggregates);
+        const { scoreByOpId: rawScores } = scoreOps(aggregates);
         const scoreByOpId = new Map<number, OpPerfRowScore>();
-        for (const [opId, score] of rawScores) {
-            const aggregate = aggregates.get(opId);
-            if (aggregate) {
+        for (const [opId, aggregate] of aggregates) {
+            const score = rawScores.get(opId);
+            if (score) {
                 scoreByOpId.set(opId, { deviceTimeNs: aggregate.deviceTimeNs, t: score.t });
             }
         }
         return {
             scoreByOpId,
             isAvailable: scoreByOpId.size > 0,
-            maxNs,
-            minNs,
         };
     }, [deviceOperations]);
 };

--- a/src/scss/components/OperationPerfRowBar.scss
+++ b/src/scss/components/OperationPerfRowBar.scss
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Width / colour are driven inline from the log-normalised `t` score (#1516).
+.operation-perf-row-bar {
+    flex: 0 0 80px;
+    width: 80px;
+    height: 6px;
+    margin-left: 8px;
+    border-radius: 3px;
+    background-color: rgb(255 255 255 / 6%);
+    overflow: hidden;
+    align-self: center;
+}
+
+.operation-perf-row-bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition:
+        width 0.12s ease,
+        background-color 0.12s ease;
+}

--- a/tests/OperationPerfRowBar.spec.tsx
+++ b/tests/OperationPerfRowBar.spec.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import OperationPerfRowBar from '../src/components/OperationPerfRowBar';
+import { TestProviders } from './helpers/TestProviders';
+
+afterEach(cleanup);
+
+describe('OperationPerfRowBar', () => {
+    it('renders nothing when no score is provided', () => {
+        const { container } = render(
+            <TestProviders>
+                <OperationPerfRowBar score={undefined} />
+            </TestProviders>,
+        );
+
+        expect(container.querySelector('.operation-perf-row-bar')).toBeNull();
+    });
+
+    it('floors the fill at MIN_BAR_PERCENT (2%) for a near-zero score so it stays visible', () => {
+        const { container } = render(
+            <TestProviders>
+                <OperationPerfRowBar score={{ deviceTimeNs: 10_000, t: 0 }} />
+            </TestProviders>,
+        );
+
+        const fill = container.querySelector('.operation-perf-row-bar-fill') as HTMLElement | null;
+        expect(fill).not.toBeNull();
+        expect(fill?.style.width).toBe('2%');
+    });
+
+    it('paints the fill to 100% at t=1 and surfaces the formatted duration in the aria-label', () => {
+        const { container } = render(
+            <TestProviders>
+                <OperationPerfRowBar score={{ deviceTimeNs: 5_000_000, t: 1 }} />
+            </TestProviders>,
+        );
+
+        const fill = container.querySelector('.operation-perf-row-bar-fill') as HTMLElement | null;
+        expect(fill).not.toBeNull();
+        expect(fill?.style.width).toBe('100%');
+
+        const bar = screen.getByRole('img');
+        expect(bar.getAttribute('aria-label')).toMatch(/Device kernel duration:\s+5(?:\.\d+)?\s*ms/);
+    });
+});

--- a/tests/useOpPerfRowScores.spec.ts
+++ b/tests/useOpPerfRowScores.spec.ts
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { renderHook } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useOpPerfRowScores } from '../src/hooks/useOpPerfRowScores';
-import { DeviceOperationMapping } from '../src/hooks/useAPI';
+import { DeviceOperationMapping, useGetDeviceOperationListPerf } from '../src/hooks/useAPI';
 import { PerfTableRow } from '../src/definitions/PerfTable';
 
 vi.mock('../src/hooks/useAPI', () => ({
@@ -23,28 +23,20 @@ const mapping = (id: number, deviceTimeUs: number | null): DeviceOperationMappin
 });
 
 beforeEach(() => {
-    vi.resetAllMocks();
-});
-
-afterEach(() => {
-    vi.restoreAllMocks();
+    vi.mocked(useGetDeviceOperationListPerf).mockReset();
 });
 
 describe('useOpPerfRowScores', () => {
-    it('returns isAvailable=false and an empty map when no perf rows are present', async () => {
-        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+    it('returns isAvailable=false and an empty map when no perf rows are present', () => {
         vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([]);
 
         const { result } = renderHook(() => useOpPerfRowScores());
 
         expect(result.current.isAvailable).toBe(false);
         expect(result.current.scoreByOpId.size).toBe(0);
-        expect(result.current.minNs).toBe(0);
-        expect(result.current.maxNs).toBe(0);
     });
 
-    it('returns isAvailable=false when every mapping is missing perfData', async () => {
-        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+    it('returns isAvailable=false when every mapping is missing perfData', () => {
         vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([mapping(1, null), mapping(2, null)]);
 
         const { result } = renderHook(() => useOpPerfRowScores());
@@ -53,8 +45,7 @@ describe('useOpPerfRowScores', () => {
         expect(result.current.scoreByOpId.size).toBe(0);
     });
 
-    it('aggregates and scores mapped ops, converting µs → ns and placing min at t=0 / max at t=1', async () => {
-        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+    it('aggregates and scores mapped ops, converting µs → ns and placing min at t=0 / max at t=1', () => {
         vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([
             mapping(1, 10),
             mapping(2, 1_000),
@@ -65,16 +56,13 @@ describe('useOpPerfRowScores', () => {
 
         expect(result.current.isAvailable).toBe(true);
         expect(result.current.scoreByOpId.size).toBe(3);
-        expect(result.current.minNs).toBe(10_000);
-        expect(result.current.maxNs).toBe(100_000_000);
         expect(result.current.scoreByOpId.get(1)?.t).toBe(0);
         expect(result.current.scoreByOpId.get(3)?.t).toBe(1);
         expect(result.current.scoreByOpId.get(1)?.deviceTimeNs).toBe(10_000);
         expect(result.current.scoreByOpId.get(3)?.deviceTimeNs).toBe(100_000_000);
     });
 
-    it('skips mappings whose device_time fails to parse instead of dropping the whole report', async () => {
-        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+    it('skips mappings whose device_time fails to parse instead of dropping the whole report', () => {
         vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([
             { id: 1, name: 'a', operationName: 'a', perfData: { device_time: 'NaN' } as unknown as PerfTableRow },
             mapping(2, 50),

--- a/tests/useOpPerfRowScores.spec.tsx
+++ b/tests/useOpPerfRowScores.spec.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOpPerfRowScores } from '../src/hooks/useOpPerfRowScores';
+import { DeviceOperationMapping } from '../src/hooks/useAPI';
+import { PerfTableRow } from '../src/definitions/PerfTable';
+
+vi.mock('../src/hooks/useAPI', () => ({
+    useGetDeviceOperationListPerf: vi.fn(),
+}));
+
+const perfRow = (deviceTimeUs: number): PerfTableRow =>
+    ({ device_time: String(deviceTimeUs), raw_op_code: 'mock_op' }) as unknown as PerfTableRow;
+
+const mapping = (id: number, deviceTimeUs: number | null): DeviceOperationMapping => ({
+    id,
+    name: 'mock_op',
+    operationName: 'mock_op',
+    perfData: deviceTimeUs === null ? undefined : perfRow(deviceTimeUs),
+});
+
+beforeEach(() => {
+    vi.resetAllMocks();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('useOpPerfRowScores', () => {
+    it('returns isAvailable=false and an empty map when no perf rows are present', async () => {
+        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+        vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([]);
+
+        const { result } = renderHook(() => useOpPerfRowScores());
+
+        expect(result.current.isAvailable).toBe(false);
+        expect(result.current.scoreByOpId.size).toBe(0);
+        expect(result.current.minNs).toBe(0);
+        expect(result.current.maxNs).toBe(0);
+    });
+
+    it('returns isAvailable=false when every mapping is missing perfData', async () => {
+        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+        vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([mapping(1, null), mapping(2, null)]);
+
+        const { result } = renderHook(() => useOpPerfRowScores());
+
+        expect(result.current.isAvailable).toBe(false);
+        expect(result.current.scoreByOpId.size).toBe(0);
+    });
+
+    it('aggregates and scores mapped ops, converting µs → ns and placing min at t=0 / max at t=1', async () => {
+        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+        vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([
+            mapping(1, 10),
+            mapping(2, 1_000),
+            mapping(3, 100_000),
+        ]);
+
+        const { result } = renderHook(() => useOpPerfRowScores());
+
+        expect(result.current.isAvailable).toBe(true);
+        expect(result.current.scoreByOpId.size).toBe(3);
+        expect(result.current.minNs).toBe(10_000);
+        expect(result.current.maxNs).toBe(100_000_000);
+        expect(result.current.scoreByOpId.get(1)?.t).toBe(0);
+        expect(result.current.scoreByOpId.get(3)?.t).toBe(1);
+        expect(result.current.scoreByOpId.get(1)?.deviceTimeNs).toBe(10_000);
+        expect(result.current.scoreByOpId.get(3)?.deviceTimeNs).toBe(100_000_000);
+    });
+
+    it('skips mappings whose device_time fails to parse instead of dropping the whole report', async () => {
+        const { useGetDeviceOperationListPerf } = await import('../src/hooks/useAPI');
+        vi.mocked(useGetDeviceOperationListPerf).mockReturnValue([
+            { id: 1, name: 'a', operationName: 'a', perfData: { device_time: 'NaN' } as unknown as PerfTableRow },
+            mapping(2, 50),
+        ]);
+
+        const { result } = renderHook(() => useOpPerfRowScores());
+
+        expect(result.current.isAvailable).toBe(true);
+        expect(result.current.scoreByOpId.has(1)).toBe(false);
+        expect(result.current.scoreByOpId.has(2)).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #1516.

<img width="1320" height="904" alt="image" src="https://github.com/user-attachments/assets/bdaebf77-0604-4817-b41f-85bf3a08677f" />

When a perf report is loaded alongside the profiler report, each row in the operation list now renders a small inline bar showing that op's device kernel duration relative to the rest of the run. Hovering the bar surfaces the actual duration. The bar is omitted entirely when no perf report is loaded — the list visually degrades to its pre-#1516 layout.

## Summary

- **New hook `useOpPerfRowScores`** (`src/hooks/useOpPerfRowScores.ts`): wraps the existing `useGetDeviceOperationListPerf` and reuses `aggregatePerfByOp` + `scoreOps` from `perfOverlay.ts` (originally built for the graph perf overlay in #1517) so the row-bar colour ramp matches the graph view. Returns `scoreByOpId` and `isAvailable`; the latter gates rendering at the list level.
- **New component `OperationPerfRowBar`** (`src/components/OperationPerfRowBar.tsx`): fixed-width 80 px bar, fill width = `t * 100%` floored at `MIN_BAR_PERCENT = 2` so near-zero ops still leave a visible marker, fill colour = `perfColorScale(t)`, Blueprint tooltip on hover with the kernel duration formatted via `formatDuration` (auto-scales ns / µs / ms / s).
- **`OperationList` wiring**: the list pulls scores once at the top, then passes each row's `score` into the new bar as a `ListItem` child. When `isAvailable` is `false` the bar isn't rendered at all.
- **SCSS** (`src/scss/components/OperationPerfRowBar.scss`): bar geometry + track-background fade.

## Decisions on the issue's open questions

- **Visual**: thin coloured bar, not a sparkline (single value per op) and not row-background tint (too noisy at list density).
- **Default metric**: device kernel duration — most actionable for "find the slow op".
- **Scale**: log10, reusing the perf-overlay scoring so the colour ramp matches the graph view's legend semantics across the app.
- **No perf report loaded**: the bar column is omitted entirely. No empty column, no toggle.

## Tests

- `tests/useOpPerfRowScores.spec.ts` (new, 4 cases) — empty input, all-missing-perf, happy-path aggregation + scoring + µs→ns conversion, partial-parse-failure resilience.
- `tests/OperationPerfRowBar.spec.tsx` (new, 3 cases) — `score=undefined` renders nothing, `t=0` floors at `width: 2%`, `t=1` paints `width: 100%` and the formatted duration ends up in the aria-label.

`vitest run`, `tsc --noEmit`, and `eslint` on touched files are clean.

## Follow-ups

- Pre-existing mutation hazard in `useGetDeviceOperationListPerf` (`useAPI.tsx:801-810`): the hook mutates `deviceOperation.perfData` on React-Query-cached objects — same anti-pattern we removed for `BufferChunk` in #1633. This PR doesn't introduce or widen the mutation; it adds another reader of the mutated field. Worth a dedicated cleanup PR mirroring #1633's `Decorated…` projection.
- Cosmetic: the operation list already has an outer `Tooltip` on error rows that competes with the new bar tooltip on hover. Both render correctly (separate Blueprint roots) but it's worth eyeballing on a known-error op before merge.
