### PR TITLE
fix: resolve YAML syntax error in build-docs workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -56,7 +56,8 @@ jobs:
 
     - name: Warn if search ingest key is missing
       if: ${{ env.DOCS_SEARCH_INGEST_API_KEY == '' }}
-      run: echo "::warning::Skipping OpenSearch indexing: DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT secret not set."
+      run: |
+        echo "::warning::Skipping OpenSearch indexing: DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT secret not set."
 
     - name: Index docs into OpenSearch
       if: ${{ env.DOCS_SEARCH_INGEST_API_KEY != '' }}

--- a/docs/shared/_static/docs-toc.js
+++ b/docs/shared/_static/docs-toc.js
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
 (function () {
   'use strict';
 

--- a/scripts/index_remote_search.py
+++ b/scripts/index_remote_search.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 """Crawl the built docs in output/ and push them to the OpenSearch-backed
 docs search service so the in-page search modal has something to query.
 


### PR DESCRIPTION
## Summary
- Fixed invalid YAML syntax in `.github/workflows/build-docs.yml`
- The `run:` step contained `: ` (colon-space) inside a plain YAML scalar (`indexing: DOCS_SEARCH_INGEST_API_KEY...`), which the YAML parser rejected as a mapping indicator
- Changed to block literal (`|`) — standard fix for `run:` steps with special characters

## Test plan
- [ ] Trigger the `Docs - Build & Deploy` workflow on the `dev` branch and confirm it passes YAML validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)