### PR TITLE
fix: add missing SPDX license header to docs-toc.js

### DIFF
--- a/docs/shared/_static/docs-toc.js
+++ b/docs/shared/_static/docs-toc.js
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
 (function () {
   'use strict';
 


### PR DESCRIPTION
## Summary
- Added missing `SPDX-License-Identifier: Apache-2.0` header to `docs/shared/_static/docs-toc.js`
- Required by `pnpm lint:spdx` check

## Note
The YAML syntax fix and `index_remote_search.py` SPDX header are part of the `docs/sidebar-search-improvements` branch and will be submitted with that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)