### PR TITLE
Extend CI smoke tests: upload demo report and exercise main tabs

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -4,51 +4,176 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 """
-Simple smoke test using Playwright to verify the ttnn-visualizer web app loads correctly.
+Playwright smoke tests for the ttnn-visualizer web app.
+
+Verifies the app loads, uploads demo memory reports, and exercises the core
+memory-profiler tabs without API or UI errors.
 """
+
+from __future__ import annotations
 
 import asyncio
 import sys
+import tempfile
+from pathlib import Path
 
-from playwright.async_api import async_playwright
+from playwright.async_api import Browser, Page, TimeoutError, async_playwright, expect
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from smoke_test_helpers import (
+    BASE_URL,
+    DEMO_REPORT_ZIPS,
+    DEMO_REPORTS_DIR,
+    MAIN_TAB_NAMES,
+    ApiErrorTracker,
+    assert_no_error_ui,
+    extract_profiler_report_dir,
+    verify_server_serving_spa,
+)
+
+UPLOAD_TIMEOUT_MS = 180_000
+TAB_TIMEOUT_MS = 120_000
 
 
-async def smoke_test():
-    """Run basic smoke test to verify the web app loads."""
-    async with async_playwright() as p:
-        browser = await p.chromium.launch()
+async def smoke_test_app_loads(page: Page) -> None:
+    """Verify the web app loads and contains expected content."""
+    await page.goto(BASE_URL, timeout=10_000)
+    await page.wait_for_load_state("networkidle", timeout=10_000)
+
+    title = await page.title()
+    print(f"✅ Page loaded successfully. Title: {title}")
+
+    body_text = (await page.text_content("body")) or ""
+    if (
+        "visualizer" in body_text.lower()
+        or "ttnn" in body_text.lower()
+        or "tt-nn" in body_text.lower()
+    ):
+        print("✅ Page contains expected content")
+        return
+
+    raise RuntimeError(
+        "Page did not contain expected TT-NN Visualizer content.\n"
+        f"Body text preview: {body_text[:200]}..."
+    )
+
+
+async def upload_profiler_report(page: Page, report_dir: Path) -> None:
+    """Upload a local memory report directory via the Reports page."""
+    await page.get_by_role("button", name="Reports").click()
+    await page.wait_for_url(f"{BASE_URL}/**")
+
+    upload_input = page.get_by_test_id("local-profiler-upload")
+    await upload_input.set_input_files(str(report_dir))
+
+    operations_button = page.get_by_role("button", name="Operations")
+    try:
+        await expect(operations_button).to_be_enabled(timeout=UPLOAD_TIMEOUT_MS)
+    except AssertionError as exc:
+        status = page.get_by_test_id("local-profiler-status")
+        status_text = (
+            await status.text_content() if await status.count() > 0 else "unknown"
+        )
+        raise TimeoutError(
+            f"Operations tab did not become enabled after upload ({status_text})"
+        ) from exc
+
+    await assert_no_error_ui(page)
+    print(f"✅ Uploaded report from {report_dir.name}")
+
+
+async def exercise_main_tabs(page: Page) -> None:
+    """Click Operations, Tensors, and Buffers and wait for each view to settle."""
+    tab_urls = {
+        "Operations": "**/operations**",
+        "Tensors": "**/tensors**",
+        "Buffers": "**/buffer-summary**",
+    }
+
+    for tab_name in MAIN_TAB_NAMES:
+        tab_button = page.get_by_role("button", name=tab_name)
+        if not await tab_button.is_enabled():
+            raise AssertionError(f"{tab_name} tab is disabled after upload")
+
+        await tab_button.click()
+        await page.wait_for_url(tab_urls[tab_name], timeout=TAB_TIMEOUT_MS)
+
+        spinner = page.locator(".loading-spinner").first
+        try:
+            if await spinner.is_visible():
+                await spinner.wait_for(state="hidden", timeout=TAB_TIMEOUT_MS)
+        except TimeoutError:
+            # Some views render without a spinner when data is already cached.
+            pass
+
+        await page.wait_for_load_state("networkidle", timeout=TAB_TIMEOUT_MS)
+        await assert_no_error_ui(page)
+        print(f"✅ {tab_name} tab loaded without errors")
+
+
+async def smoke_test_report_tabs(browser: Browser) -> None:
+    """Upload each demo report and walk the main memory-profiler tabs."""
+    for zip_name in DEMO_REPORT_ZIPS:
+        zip_path = DEMO_REPORTS_DIR / zip_name
+        if not zip_path.is_file():
+            raise FileNotFoundError(f"Demo report not found: {zip_path}")
+
         page = await browser.new_page()
+        tracker = ApiErrorTracker()
+        tracker.attach(page)
 
         try:
-            # Navigate to the app
-            await page.goto("http://localhost:8000", timeout=10000)
+            await page.goto(BASE_URL, timeout=10_000)
+            await page.wait_for_load_state("networkidle", timeout=10_000)
 
-            # Wait for the page to load and check title
-            await page.wait_for_load_state("networkidle", timeout=10000)
-            title = await page.title()
-            print(f"✅ Page loaded successfully. Title: {title}")
+            with tempfile.TemporaryDirectory(prefix="smoke-report-") as temp_dir:
+                report_dir = extract_profiler_report_dir(zip_path, Path(temp_dir))
+                print(f"▶️  Smoke testing {zip_name} ({report_dir.name})")
+                await upload_profiler_report(page, report_dir)
+                await exercise_main_tabs(page)
 
-            # Check if the page contains expected content
-            body_text = await page.text_content("body")
-            if (
-                "visualizer" in body_text.lower()
-                or "ttnn" in body_text.lower()
-                or "tt-nn" in body_text.lower()
-            ):
-                print("✅ Page contains expected content")
-            else:
-                print(
-                    "⚠️  Page may not have loaded correctly - no expected content found"
+            if tracker.errors:
+                raise AssertionError(
+                    "API errors during report tab smoke test:\n"
+                    + "\n".join(tracker.errors)
                 )
-                print(f"Body text preview: {body_text[:200]}...")
+            print(f"✅ Report tab smoke test passed for {zip_name}")
+        finally:
+            await page.close()
 
-        except Exception as e:
-            print(f"❌ Smoke test failed: {e}")
+
+async def run_smoke_tests() -> None:
+    """Run all smoke tests in a single browser session where possible."""
+    verify_server_serving_spa()
+
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch()
+
+        page = await browser.new_page()
+        try:
+            await smoke_test_app_loads(page)
+        except Exception as exc:
+            print(f"❌ App load smoke test failed: {exc}")
+            await browser.close()
+            raise
+        finally:
+            await page.close()
+
+        try:
+            await smoke_test_report_tabs(browser)
+        except Exception as exc:
+            print(f"❌ Report tab smoke test failed: {exc}")
             raise
         finally:
             await browser.close()
 
 
 if __name__ == "__main__":
-    # Run the test
-    asyncio.run(smoke_test())
+    try:
+        asyncio.run(run_smoke_tests())
+    except Exception as exc:
+        print(f"❌ Smoke test failed: {exc}")
+        sys.exit(1)

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -37,6 +37,8 @@ from smoke_test_helpers import (
 
 UPLOAD_TIMEOUT_MS = 180_000
 TAB_TIMEOUT_MS = 120_000
+TAB_ENABLED_TIMEOUT_MS = 5_000
+SPINNER_VISIBLE_TIMEOUT_MS = 2_000
 
 
 async def smoke_test_app_loads(page: Page) -> None:
@@ -96,16 +98,15 @@ async def exercise_main_tabs(page: Page) -> None:
 
     for tab_name in MAIN_TAB_NAMES:
         tab_button = page.get_by_role("button", name=tab_name)
-        if not await tab_button.is_enabled():
-            raise AssertionError(f"{tab_name} tab is disabled after upload")
+        await expect(tab_button).to_be_enabled(timeout=TAB_ENABLED_TIMEOUT_MS)
 
         await tab_button.click()
         await page.wait_for_url(tab_urls[tab_name], timeout=TAB_TIMEOUT_MS)
 
         spinner = page.locator(".loading-spinner").first
         try:
-            if await spinner.is_visible():
-                await spinner.wait_for(state="hidden", timeout=TAB_TIMEOUT_MS)
+            await spinner.wait_for(state="visible", timeout=SPINNER_VISIBLE_TIMEOUT_MS)
+            await spinner.wait_for(state="hidden", timeout=TAB_TIMEOUT_MS)
         except TimeoutError:
             # Some views render without a spinner when data is already cached.
             pass

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -27,6 +27,7 @@ from smoke_test_helpers import (
     BASE_URL,
     DEMO_REPORT_ZIPS,
     DEMO_REPORTS_DIR,
+    HOME_URL,
     MAIN_TAB_NAMES,
     ApiErrorTracker,
     assert_no_error_ui,
@@ -64,7 +65,7 @@ async def smoke_test_app_loads(page: Page) -> None:
 async def upload_profiler_report(page: Page, report_dir: Path) -> None:
     """Upload a local memory report directory via the Reports page."""
     await page.get_by_role("button", name="Reports").click()
-    await page.wait_for_url(f"{BASE_URL}/**")
+    await page.wait_for_url(HOME_URL)
 
     upload_input = page.get_by_test_id("local-profiler-upload")
     await upload_input.set_input_files(str(report_dir))
@@ -152,21 +153,21 @@ async def run_smoke_tests() -> None:
     async with async_playwright() as playwright:
         browser = await playwright.chromium.launch()
 
-        page = await browser.new_page()
         try:
-            await smoke_test_app_loads(page)
-        except Exception as exc:
-            print(f"❌ App load smoke test failed: {exc}")
-            await browser.close()
-            raise
-        finally:
-            await page.close()
+            page = await browser.new_page()
+            try:
+                await smoke_test_app_loads(page)
+            except Exception as exc:
+                print(f"❌ App load smoke test failed: {exc}")
+                raise
+            finally:
+                await page.close()
 
-        try:
-            await smoke_test_report_tabs(browser)
-        except Exception as exc:
-            print(f"❌ Report tab smoke test failed: {exc}")
-            raise
+            try:
+                await smoke_test_report_tabs(browser)
+            except Exception as exc:
+                print(f"❌ Report tab smoke test failed: {exc}")
+                raise
         finally:
             await browser.close()
 

--- a/scripts/smoke_test_helpers.py
+++ b/scripts/smoke_test_helpers.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Shared helpers for Playwright smoke tests."""
+
+from __future__ import annotations
+
+import os
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from playwright.async_api import Page, Response
+
+BASE_URL = os.getenv("SMOKE_TEST_BASE_URL", "http://localhost:8000").rstrip("/")
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEMO_REPORTS_DIR = REPO_ROOT / "demo-reports"
+
+DEMO_REPORT_ZIPS = (
+    "n300-llama.zip",
+    "segformer_decoder_3119846618735255520.zip",
+    "segformer_encoder_11911356357027855134.zip",
+)
+
+MAIN_TAB_NAMES = ("Operations", "Tensors", "Buffers")
+
+SERVER_SETUP_HINT = """\
+Smoke tests require the production server with a built frontend at {base_url}.
+
+Development mode (pnpm dev + flask:start-debug) only serves the API on port 8000.
+The React app runs on Vite at http://localhost:5173 instead.
+
+In a separate terminal:
+  pnpm build
+  FLASK_ENV=production uv run ttnn-visualizer
+
+Or:
+  pnpm serve
+"""
+
+
+def verify_server_serving_spa(base_url: str = BASE_URL) -> None:
+    """Fail fast when the server is not serving the built SPA."""
+    request = urllib.request.Request(base_url, headers={"Accept": "text/html"})
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            content_type = response.headers.get("Content-Type", "")
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        content_type = exc.headers.get("Content-Type", "")
+        body = exc.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Could not reach {base_url}.\n\n{SERVER_SETUP_HINT.format(base_url=base_url)}"
+        ) from exc
+
+    if "application/json" in content_type or body.lstrip().startswith("{"):
+        raise RuntimeError(
+            f"{base_url} returned JSON instead of the SPA.\n\n"
+            f"{SERVER_SETUP_HINT.format(base_url=base_url)}"
+        )
+
+    if 'id="root"' not in body and "TT-NN Visualizer" not in body:
+        raise RuntimeError(
+            f"{base_url} did not return the TT-NN Visualizer app.\n\n"
+            f"Response preview: {body[:200]!r}\n\n"
+            f"{SERVER_SETUP_HINT.format(base_url=base_url)}"
+        )
+
+
+@dataclass
+class ApiErrorTracker:
+    """Collects /api/ responses with HTTP status >= 500."""
+
+    errors: list[str] = field(default_factory=list)
+
+    def attach(self, page: Page) -> None:
+        page.on("response", self._on_response)
+
+    def _on_response(self, response: Response) -> None:
+        if "/api/" not in response.url or response.status < 500:
+            return
+        self.errors.append(
+            f"{response.status} {response.request.method} {response.url}"
+        )
+
+
+def extract_profiler_report_dir(zip_path: Path, work_dir: Path) -> Path:
+    """Extract the memory-profiler report folder from a demo zip archive."""
+    with zipfile.ZipFile(zip_path) as archive:
+        db_paths = [name for name in archive.namelist() if name.endswith("/db.sqlite")]
+        if not db_paths:
+            raise ValueError(f"No db.sqlite found in {zip_path}")
+
+        report_prefix = f"{db_paths[0].rsplit('/', 1)[0]}/"
+        report_name = report_prefix.rstrip("/").split("/")[-1]
+        report_dir = work_dir / report_name
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        for name in archive.namelist():
+            if not name.startswith(report_prefix) or name.endswith("/"):
+                continue
+            relative_path = name[len(report_prefix) :]
+            target = report_dir / relative_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(archive.read(name))
+
+        return report_dir
+
+
+async def assert_no_error_ui(page: Page) -> None:
+    """Fail when the React router error page is visible."""
+    error_page = page.locator("#error-page")
+    if await error_page.count() > 0 and await error_page.is_visible():
+        message = await error_page.text_content()
+        raise AssertionError(f"Error page visible: {message}")

--- a/scripts/smoke_test_helpers.py
+++ b/scripts/smoke_test_helpers.py
@@ -92,16 +92,33 @@ class ApiErrorTracker:
 
 def extract_profiler_report_dir(zip_path: Path, work_dir: Path) -> Path:
     """Extract the memory-profiler report folder from a demo zip archive."""
+    work_dir_resolved = work_dir.resolve()
+
     with zipfile.ZipFile(zip_path) as archive:
         db_paths = [name for name in archive.namelist() if name.endswith("/db.sqlite")]
         if not db_paths:
             raise ValueError(f"No db.sqlite found in {zip_path}")
+        if len(db_paths) > 1:
+            raise ValueError(
+                f"Expected exactly one db.sqlite in {zip_path}, found {len(db_paths)}: "
+                f"{db_paths}"
+            )
 
         report_prefix = f"{db_paths[0].rsplit('/', 1)[0]}/"
         report_name = report_prefix.rstrip("/").split("/")[-1]
+        if not report_name or report_name in (".", ".."):
+            raise ValueError(
+                f"Invalid report directory name derived from zip entry: {db_paths[0]!r}"
+            )
+
         report_dir = work_dir / report_name
-        report_dir.mkdir(parents=True, exist_ok=True)
         report_dir_resolved = report_dir.resolve()
+        if not report_dir_resolved.is_relative_to(work_dir_resolved):
+            raise ValueError(
+                f"Report directory escapes work directory: {report_dir} in {zip_path}"
+            )
+
+        report_dir.mkdir(parents=True, exist_ok=True)
 
         for name in archive.namelist():
             if not name.startswith(report_prefix) or name.endswith("/"):

--- a/scripts/smoke_test_helpers.py
+++ b/scripts/smoke_test_helpers.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import re
 import urllib.error
 import urllib.request
 import zipfile
@@ -16,6 +17,7 @@ from pathlib import Path
 from playwright.async_api import Page, Response
 
 BASE_URL = os.getenv("SMOKE_TEST_BASE_URL", "http://localhost:8000").rstrip("/")
+HOME_URL = re.compile(f"^{re.escape(BASE_URL)}/?$")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEMO_REPORTS_DIR = REPO_ROOT / "demo-reports"
 
@@ -99,12 +101,17 @@ def extract_profiler_report_dir(zip_path: Path, work_dir: Path) -> Path:
         report_name = report_prefix.rstrip("/").split("/")[-1]
         report_dir = work_dir / report_name
         report_dir.mkdir(parents=True, exist_ok=True)
+        report_dir_resolved = report_dir.resolve()
 
         for name in archive.namelist():
             if not name.startswith(report_prefix) or name.endswith("/"):
                 continue
             relative_path = name[len(report_prefix) :]
-            target = report_dir / relative_path
+            target = (report_dir / relative_path).resolve()
+            if not target.is_relative_to(report_dir_resolved):
+                raise ValueError(
+                    f"Zip entry escapes extraction directory: {name} in {zip_path}"
+                )
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(archive.read(name))
 


### PR DESCRIPTION
## Summary
- Extend `scripts/smoke_test.py` to upload each `demo-reports/` zip and click through **Operations**, **Tensors**, and **Buffers**
- Add `scripts/smoke_test_helpers.py` for fixture extraction, API 5xx tracking, and a preflight check that the production SPA is being served
- Fail fast locally when Flask is running in development mode (API-only on port 8000)

Closes #1644

## Test plan
- [x] `pnpm build && FLASK_ENV=production uv run ttnn-visualizer` then `uv run python scripts/smoke_test.py`
- [x] CI smoke workflow passes on this PR


Made with [Cursor](https://cursor.com)