### PR TITLE
Add MLIR op-name filter with dim / navigation / buried-match surfacing

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -461,10 +461,15 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // `source.namespace` because topology sectioning wraps top-level ops in
     // synthetic `section_N_of_M` namespaces that aren't reflected in the raw
     // namespace field.
+    // Collapsibility is derived from `visibleNodeIds.has(anchorId)` rather
+    // than `expandedNamespaces`: `nodes` is the authoritative post-worker
+    // snapshot, so reading collapsibility from it avoids the transient
+    // window where `expandedNamespaces` has updated but the worker rebuild
+    // is still in flight.
     const filterMatchInfo = useMemo<{
         visibleRepIds: Set<string>;
         buriedCountByRepId: Map<string, number>;
-        totalSourceMatches: number;
+        hiddenMatchCount: number;
     } | null>(() => {
         if (filterQuery.length === 0) {
             return null;
@@ -478,31 +483,26 @@ const MlGraphInner = ({ data }: ViewProps) => {
         }
         const visibleRepIds = new Set<string>();
         const buriedCountByRepId = new Map<string, number>();
-        let totalSourceMatches = 0;
+        let hiddenMatchCount = 0;
         for (const source of sourceNodes) {
             if (!source.label.toLowerCase().includes(needle)) {
                 continue;
             }
-            totalSourceMatches += 1;
             const containing = containingNamespacesByNodeId[source.id];
             let repId: string | null = null;
-            if (!containing || containing.length === 0) {
-                repId = visibleNodeIds.has(source.id) ? source.id : null;
-            } else {
-                // `containing` is ordered outer→inner; the shortest collapsed
-                // one is where visibility stops.
-                let hitCollapsed = false;
+            if (containing && containing.length > 0) {
+                // Outer→inner; first namespace whose anchor is on canvas is
+                // the outermost collapsed ancestor.
                 for (const ns of containing) {
-                    if (!expandedNamespaces.has(ns)) {
-                        const anchorId = anchorByNamespace[ns];
-                        repId = anchorId && visibleNodeIds.has(anchorId) ? anchorId : null;
-                        hitCollapsed = true;
+                    const anchorId = anchorByNamespace[ns];
+                    if (anchorId && visibleNodeIds.has(anchorId)) {
+                        repId = anchorId;
                         break;
                     }
                 }
-                if (!hitCollapsed) {
-                    repId = visibleNodeIds.has(source.id) ? source.id : null;
-                }
+            }
+            if (repId === null) {
+                repId = visibleNodeIds.has(source.id) ? source.id : null;
             }
             if (repId === null) {
                 continue;
@@ -510,10 +510,11 @@ const MlGraphInner = ({ data }: ViewProps) => {
             visibleRepIds.add(repId);
             if (repId !== source.id) {
                 buriedCountByRepId.set(repId, (buriedCountByRepId.get(repId) ?? 0) + 1);
+                hiddenMatchCount += 1;
             }
         }
-        return { visibleRepIds, buriedCountByRepId, totalSourceMatches };
-    }, [filterQuery, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
+        return { visibleRepIds, buriedCountByRepId, hiddenMatchCount };
+    }, [filterQuery, sourceNodes, interactionIndex, nodes]);
 
     // Visible reps in canvas order so prev/next walks top-to-bottom.
     const matchedNodesInOrder = useMemo<string[]>(() => {
@@ -528,19 +529,6 @@ const MlGraphInner = ({ data }: ViewProps) => {
         }
         return result;
     }, [nodes, filterMatchInfo]);
-
-    // Sum of buried counts across all anchors — drives the "+K inside"
-    // suffix on the counter.
-    const hiddenMatchCount = useMemo<number>(() => {
-        if (!filterMatchInfo) {
-            return 0;
-        }
-        let total = 0;
-        for (const count of filterMatchInfo.buriedCountByRepId.values()) {
-            total += count;
-        }
-        return total;
-    }, [filterMatchInfo]);
 
     const goToMatch = useCallback(
         (direction: 'next' | 'prev') => {
@@ -1197,12 +1185,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const styledNodes = useMemo<MLNode[]>(() => {
         const { inputNodeIds, outputNodeIds } = focusedConnections;
         const hasSelectionHighlight = !!selectedNodeId && (inputNodeIds.size > 0 || outputNodeIds.size > 0);
-        const hasFilter = !!filterMatchInfo;
-        if (!hasSelectionHighlight && !hasFilter) {
+        if (!hasSelectionHighlight && !filterMatchInfo) {
             return nodes;
         }
-        const visibleRepIds = filterMatchInfo?.visibleRepIds;
-        const buriedByRep = filterMatchInfo?.buriedCountByRepId;
         return nodes.map((n) => {
             let next = n;
             if (hasSelectionHighlight) {
@@ -1220,12 +1205,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     }
                 }
             }
-            if (hasFilter) {
-                const buriedCount = buriedByRep?.get(n.id) ?? 0;
+            if (filterMatchInfo) {
+                const { visibleRepIds, buriedCountByRepId } = filterMatchInfo;
+                const buriedCount = buriedCountByRepId.get(n.id) ?? 0;
                 if (buriedCount > 0) {
                     next = { ...next, data: { ...next.data, buriedMatchCount: buriedCount } };
                 }
-                const isMatch = visibleRepIds!.has(n.id);
+                const isMatch = visibleRepIds.has(n.id);
                 if (n.type !== 'mlirGroup' && n.id !== selectedNodeId && !isMatch) {
                     next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
                 }
@@ -1257,11 +1243,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const styledEdges = useMemo<Edge[]>(() => {
         const { inputEdgeIds, outputEdgeIds } = focusedConnections;
         const hasSelectionHighlight = !!selectedNodeId && (inputEdgeIds.size > 0 || outputEdgeIds.size > 0);
-        const hasFilter = !!filterMatchInfo;
-        if (!hasSelectionHighlight && !hasFilter) {
+        if (!hasSelectionHighlight && !filterMatchInfo) {
             return displayedEdges;
         }
-        const visibleRepIds = filterMatchInfo?.visibleRepIds;
         return displayedEdges.map((e) => {
             let next = e;
             if (hasSelectionHighlight) {
@@ -1285,8 +1269,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     };
                 }
             }
-            if (hasFilter) {
-                const bothMatch = visibleRepIds!.has(e.source) && visibleRepIds!.has(e.target);
+            if (filterMatchInfo) {
+                const { visibleRepIds } = filterMatchInfo;
+                const bothMatch = visibleRepIds.has(e.source) && visibleRepIds.has(e.target);
                 const isSelectionEdge = inputEdgeIds.has(e.id) || outputEdgeIds.has(e.id);
                 if (!bothMatch && !isSelectionEdge) {
                     next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
@@ -1324,7 +1309,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 query={filterQuery}
                 onQueryChange={handleQueryChange}
                 matchCount={matchedNodesInOrder.length}
-                hiddenMatchCount={hiddenMatchCount}
+                hiddenMatchCount={filterMatchInfo?.hiddenMatchCount ?? 0}
                 currentMatchIndex={currentMatchIndex}
                 onPrev={() => goToMatch('prev')}
                 onNext={() => goToMatch('next')}

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -54,16 +54,13 @@ import { getNamespaceSegments } from './mlirGraphHelpers';
 
 const FILTER_DIM_OPACITY = 0.18;
 
-// Re-uses `WorkerNode['data']` (the canonical shape produced by the layout
-// worker) and tacks on view-layer-only flags:
-//  - `highlight`: producer/consumer role vs. the selected node. Op nodes get
-//    a coloured fill via `style.background`; groups route it through
-//    `data.highlight` so the dashed body border is colourised instead
-//    (painting the wrapper background bleeds behind the body and hides
-//    children).
-//  - `buriedMatchCount`: how many buried source nodes match the current
-//    filter query. Set on collapsed anchors that owe their filter-match
-//    entirely or partially to descendants; drives the "+N" badge.
+// View-layer additions to the worker's canonical node data:
+//  - `highlight`: producer/consumer role vs. the selected node. Ops take a
+//    fill via `style.background`; groups route through `data.highlight` so
+//    the border is colourised instead — painting the wrapper background
+//    bleeds behind the dashed body and hides children.
+//  - `buriedMatchCount`: hidden filter matches under a collapsed anchor;
+//    drives the "+N" badge.
 type MLNodeData = WorkerNode['data'] & {
     highlight?: 'input' | 'output';
     buriedMatchCount?: number;
@@ -303,9 +300,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(() => new Set());
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-    // Live op-name filter. Empty query means "no filter" (canvas is the
-    // default state); a non-empty query dims non-matching op nodes and the
-    // edges between them. `currentMatchIndex` is the prev/next pan cursor.
+    // Live op-name filter. `currentMatchIndex` is the prev/next pan cursor.
     const [filterQuery, setFilterQuery] = useState('');
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const filterRef = useRef<MlirOpFilterHandle>(null);
@@ -343,17 +338,15 @@ const MlGraphInner = ({ data }: ViewProps) => {
         pendingFocusNodeIdRef.current = null;
     }, [selectedNodeId]);
 
-    // Reset the prev/next cursor whenever the query changes so the next
-    // arrow click starts at the first match. Done here (not in an effect)
-    // to keep set-state-in-effect lint clean.
+    // Reset the prev/next cursor with the query; kept out of an effect to
+    // avoid tripping set-state-in-effect.
     const handleQueryChange = useCallback((next: string) => {
         setFilterQuery(next);
         setCurrentMatchIndex(null);
     }, []);
 
-    // Cmd+F / Ctrl+F focuses the filter input. Hijacks the browser's
-    // find-in-page only while the MLIR view is mounted; the rest of the app
-    // gets the native shortcut back as soon as the user navigates away.
+    // Cmd/Ctrl+F focuses the filter input while the MLIR view is mounted;
+    // the native find-in-page returns as soon as the user navigates away.
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
             if (!(event.metaKey || event.ctrlKey) || event.key !== 'f' || event.shiftKey || event.altKey) {
@@ -462,24 +455,12 @@ const MlGraphInner = ({ data }: ViewProps) => {
         runBuild(expandedNamespaces);
     }, [expandedNamespaces, runBuild]);
 
-    // Filter index. Walks `sourceNodes` (the raw graph, regardless of
-    // collapse state) and maps each label-matching source to its "visible
-    // representative": itself if it's on the canvas, otherwise the collapsed
-    // anchor of its shallowest enclosing namespace. Buried matches roll up
-    // to the anchor so the user never gets a silent "no matches" on a
-    // collapsed graph.
-    //
-    // Walks `containingNamespacesByNodeId` (outer→inner) instead of
+    // Maps each label-matching source to its visible representative: itself
+    // if on canvas, otherwise the collapsed anchor of its shallowest
+    // enclosing namespace. Uses `containingNamespacesByNodeId` rather than
     // `source.namespace` because topology sectioning wraps top-level ops in
     // synthetic `section_N_of_M` namespaces that aren't reflected in the raw
-    // `namespace` field. Consulting the index makes sections indistinguishable
-    // from real MLIR namespaces for filter purposes.
-    //
-    // - `visibleRepIds`: what the canvas keeps bright, what prev/next walks.
-    // - `buriedCountByRepId`: per-anchor count of buried descendants that
-    //   contributed. Drives the "+N" badge on collapsed anchors.
-    // - `totalSourceMatches`: sum across visible + buried. What the counter
-    //   reports so the user knows the true match count.
+    // namespace field.
     const filterMatchInfo = useMemo<{
         visibleRepIds: Set<string>;
         buriedCountByRepId: Map<string, number>;
@@ -506,11 +487,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
             const containing = containingNamespacesByNodeId[source.id];
             let repId: string | null = null;
             if (!containing || containing.length === 0) {
-                // Truly top-level — no containing subgraph or section.
                 repId = visibleNodeIds.has(source.id) ? source.id : null;
             } else {
-                // `containing` is ordered outer→inner. The shortest namespace
-                // that isn't currently expanded is where visibility stops.
+                // `containing` is ordered outer→inner; the shortest collapsed
+                // one is where visibility stops.
                 let hitCollapsed = false;
                 for (const ns of containing) {
                     if (!expandedNamespaces.has(ns)) {
@@ -521,8 +501,6 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     }
                 }
                 if (!hitCollapsed) {
-                    // Every containing namespace is expanded — the source
-                    // itself is on canvas.
                     repId = visibleNodeIds.has(source.id) ? source.id : null;
                 }
             }
@@ -537,8 +515,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return { visibleRepIds, buriedCountByRepId, totalSourceMatches };
     }, [filterQuery, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
 
-    // Matched visible reps in canvas order so prev/next steps through them
-    // top-to-bottom as the user sees them.
+    // Visible reps in canvas order so prev/next walks top-to-bottom.
     const matchedNodesInOrder = useMemo<string[]>(() => {
         if (!filterMatchInfo || filterMatchInfo.visibleRepIds.size === 0) {
             return [];
@@ -552,8 +529,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return result;
     }, [nodes, filterMatchInfo]);
 
-    // Sum of buried counts across every anchor — the number the counter
-    // suffixes as "+K inside".
+    // Sum of buried counts across all anchors — drives the "+K inside"
+    // suffix on the counter.
     const hiddenMatchCount = useMemo<number>(() => {
         if (!filterMatchInfo) {
             return 0;
@@ -1213,16 +1190,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return { inputNodeIds, outputNodeIds, inputEdgeIds, outputEdgeIds };
     }, [displayedEdges, selectedNodeId]);
 
-    // Combines three orthogonal passes:
-    //  - Selection highlight: green/yellow fill (op) or border colour (group)
-    //    for the producers/consumers of the selected node.
-    //  - Filter dim: fade non-matching leaf op nodes to `FILTER_DIM_OPACITY`.
-    //    Groups stay neutral (dimming the wrapper bleeds through to children),
-    //    the selected node itself never dims (so the user doesn't lose track),
-    //    and an empty query is a no-op.
-    //  - Buried-match badge: attach `data.buriedMatchCount` to any anchor
-    //    whose match is (fully or partially) owed to hidden descendants, so
-    //    `MlirOpNode` can render a "+N" indicator.
+    // Composes selection highlight + filter dim + buried-match badge in one
+    // map pass. Groups stay neutral (opacity on the wrapper bleeds into
+    // children); the selected node stays bright regardless of match state
+    // so the user doesn't lose their anchor.
     const styledNodes = useMemo<MLNode[]>(() => {
         const { inputNodeIds, outputNodeIds } = focusedConnections;
         const hasSelectionHighlight = !!selectedNodeId && (inputNodeIds.size > 0 || outputNodeIds.size > 0);
@@ -1280,10 +1251,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return '#f5f5f5';
     }, []);
 
-    // Colourise selection's incoming edges green / outgoing yellow, then
-    // dim everything else when a filter is active. Edges between two
-    // matches stay bright so the matched subset remains traceable; edges
-    // touching the selection always stay bright (selection trumps filter).
+    // Selection incoming green / outgoing yellow, then dim when a filter is
+    // active. Edges between two matches stay bright so the matched subset
+    // remains traceable; selection edges trump filter dim.
     const styledEdges = useMemo<Edge[]>(() => {
         const { inputEdgeIds, outputEdgeIds } = focusedConnections;
         const hasSelectionHighlight = !!selectedNodeId && (inputEdgeIds.size > 0 || outputEdgeIds.size > 0);

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -55,12 +55,19 @@ import { getNamespaceSegments } from './mlirGraphHelpers';
 const FILTER_DIM_OPACITY = 0.18;
 
 // Re-uses `WorkerNode['data']` (the canonical shape produced by the layout
-// worker) and tacks on `highlight` — a view-layer-only flag. Set when this
-// node is a producer/consumer of the currently selected node. Op nodes get a
-// coloured fill via `style.background`; groups route the highlight through
-// `data.highlight` so the dashed body border is colourised instead, because
-// painting the wrapper background bleeds behind the body and hides children.
-type MLNodeData = WorkerNode['data'] & { highlight?: 'input' | 'output' };
+// worker) and tacks on view-layer-only flags:
+//  - `highlight`: producer/consumer role vs. the selected node. Op nodes get
+//    a coloured fill via `style.background`; groups route it through
+//    `data.highlight` so the dashed body border is colourised instead
+//    (painting the wrapper background bleeds behind the body and hides
+//    children).
+//  - `buriedMatchCount`: how many buried source nodes match the current
+//    filter query. Set on collapsed anchors that owe their filter-match
+//    entirely or partially to descendants; drives the "+N" badge.
+type MLNodeData = WorkerNode['data'] & {
+    highlight?: 'input' | 'output';
+    buriedMatchCount?: number;
+};
 
 interface ViewProps {
     data: GraphBundle;
@@ -86,6 +93,16 @@ const MlirOpNode = memo<NodeProps<MLNode>>(({ id, data }) => (
                 }
             >
                 {data.subgraphToggleState === 'expanded' ? '▾' : '▸'}
+            </span>
+        ) : null}
+        {data.buriedMatchCount ? (
+            <span
+                className='mlir-op-node-buried-badge'
+                title={`${data.buriedMatchCount} filter ${
+                    data.buriedMatchCount === 1 ? 'match' : 'matches'
+                } inside this collapsed subgraph`}
+            >
+                {`+${data.buriedMatchCount}`}
             </span>
         ) : null}
         <div className='mlir-op-node-label'>{data.label}</div>
@@ -326,45 +343,6 @@ const MlGraphInner = ({ data }: ViewProps) => {
         pendingFocusNodeIdRef.current = null;
     }, [selectedNodeId]);
 
-    // Visible op nodes whose label matches the current filter query.
-    // Matched against `nodes` (the post-build, collapse-aware list) so the
-    // user only sees hits among what's actually on the canvas. Collapsed-
-    // anchor and group nodes are excluded — group dimming would hide their
-    // children, and matching descendants buried in a collapsed namespace
-    // would dim everything visible. Surfacing buried matches is a follow-up.
-    const filterMatchedNodeIds = useMemo<Set<string> | null>(() => {
-        if (filterQuery.length === 0) {
-            return null;
-        }
-        const needle = filterQuery.toLowerCase();
-        const out = new Set<string>();
-        for (const node of nodes) {
-            if (node.type === 'mlirGroup') {
-                continue;
-            }
-            const label = (node.data?.label ?? '').toLowerCase();
-            if (label.includes(needle)) {
-                out.add(node.id);
-            }
-        }
-        return out;
-    }, [filterQuery, nodes]);
-
-    // Matched ids in canvas order so prev/next pans through them
-    // predictably as the user sees them stacked top-to-bottom.
-    const matchedNodesInOrder = useMemo<string[]>(() => {
-        if (!filterMatchedNodeIds || filterMatchedNodeIds.size === 0) {
-            return [];
-        }
-        const result: string[] = [];
-        for (const node of nodes) {
-            if (filterMatchedNodeIds.has(node.id)) {
-                result.push(node.id);
-            }
-        }
-        return result;
-    }, [nodes, filterMatchedNodeIds]);
-
     // Reset the prev/next cursor whenever the query changes so the next
     // arrow click starts at the first match. Done here (not in an effect)
     // to keep set-state-in-effect lint clean.
@@ -372,29 +350,6 @@ const MlGraphInner = ({ data }: ViewProps) => {
         setFilterQuery(next);
         setCurrentMatchIndex(null);
     }, []);
-
-    const goToMatch = useCallback(
-        (direction: 'next' | 'prev') => {
-            if (matchedNodesInOrder.length === 0) {
-                return;
-            }
-            const total = matchedNodesInOrder.length;
-            setCurrentMatchIndex((prev) => {
-                let nextIdx: number;
-                if (prev === null) {
-                    nextIdx = direction === 'next' ? 0 : total - 1;
-                } else {
-                    nextIdx = direction === 'next' ? (prev + 1) % total : (prev - 1 + total) % total;
-                }
-                const targetId = matchedNodesInOrder[nextIdx];
-                if (targetId) {
-                    void fitView({ nodes: [{ id: targetId }], padding: 0.3, duration: 200 });
-                }
-                return nextIdx;
-            });
-        },
-        [matchedNodesInOrder, fitView],
-    );
 
     // Cmd+F / Ctrl+F focuses the filter input. Hijacks the browser's
     // find-in-page only while the MLIR view is mounted; the rest of the app
@@ -506,6 +461,132 @@ const MlGraphInner = ({ data }: ViewProps) => {
     useEffect(() => {
         runBuild(expandedNamespaces);
     }, [expandedNamespaces, runBuild]);
+
+    // Filter index. Walks `sourceNodes` (the raw graph, regardless of
+    // collapse state) and maps each label-matching source to its "visible
+    // representative": itself if it's on the canvas, otherwise the collapsed
+    // anchor of its shallowest enclosing namespace. Buried matches roll up
+    // to the anchor so the user never gets a silent "no matches" on a
+    // collapsed graph.
+    //
+    // Walks `containingNamespacesByNodeId` (outer→inner) instead of
+    // `source.namespace` because topology sectioning wraps top-level ops in
+    // synthetic `section_N_of_M` namespaces that aren't reflected in the raw
+    // `namespace` field. Consulting the index makes sections indistinguishable
+    // from real MLIR namespaces for filter purposes.
+    //
+    // - `visibleRepIds`: what the canvas keeps bright, what prev/next walks.
+    // - `buriedCountByRepId`: per-anchor count of buried descendants that
+    //   contributed. Drives the "+N" badge on collapsed anchors.
+    // - `totalSourceMatches`: sum across visible + buried. What the counter
+    //   reports so the user knows the true match count.
+    const filterMatchInfo = useMemo<{
+        visibleRepIds: Set<string>;
+        buriedCountByRepId: Map<string, number>;
+        totalSourceMatches: number;
+    } | null>(() => {
+        if (filterQuery.length === 0) {
+            return null;
+        }
+        const needle = filterQuery.toLowerCase();
+        const anchorByNamespace = interactionIndex?.anchorByNamespace ?? {};
+        const containingNamespacesByNodeId = interactionIndex?.containingNamespacesByNodeId ?? {};
+        const visibleNodeIds = new Set<string>();
+        for (const node of nodes) {
+            visibleNodeIds.add(node.id);
+        }
+        const visibleRepIds = new Set<string>();
+        const buriedCountByRepId = new Map<string, number>();
+        let totalSourceMatches = 0;
+        for (const source of sourceNodes) {
+            if (!source.label.toLowerCase().includes(needle)) {
+                continue;
+            }
+            totalSourceMatches += 1;
+            const containing = containingNamespacesByNodeId[source.id];
+            let repId: string | null = null;
+            if (!containing || containing.length === 0) {
+                // Truly top-level — no containing subgraph or section.
+                repId = visibleNodeIds.has(source.id) ? source.id : null;
+            } else {
+                // `containing` is ordered outer→inner. The shortest namespace
+                // that isn't currently expanded is where visibility stops.
+                let hitCollapsed = false;
+                for (const ns of containing) {
+                    if (!expandedNamespaces.has(ns)) {
+                        const anchorId = anchorByNamespace[ns];
+                        repId = anchorId && visibleNodeIds.has(anchorId) ? anchorId : null;
+                        hitCollapsed = true;
+                        break;
+                    }
+                }
+                if (!hitCollapsed) {
+                    // Every containing namespace is expanded — the source
+                    // itself is on canvas.
+                    repId = visibleNodeIds.has(source.id) ? source.id : null;
+                }
+            }
+            if (repId === null) {
+                continue;
+            }
+            visibleRepIds.add(repId);
+            if (repId !== source.id) {
+                buriedCountByRepId.set(repId, (buriedCountByRepId.get(repId) ?? 0) + 1);
+            }
+        }
+        return { visibleRepIds, buriedCountByRepId, totalSourceMatches };
+    }, [filterQuery, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
+
+    // Matched visible reps in canvas order so prev/next steps through them
+    // top-to-bottom as the user sees them.
+    const matchedNodesInOrder = useMemo<string[]>(() => {
+        if (!filterMatchInfo || filterMatchInfo.visibleRepIds.size === 0) {
+            return [];
+        }
+        const result: string[] = [];
+        for (const node of nodes) {
+            if (filterMatchInfo.visibleRepIds.has(node.id)) {
+                result.push(node.id);
+            }
+        }
+        return result;
+    }, [nodes, filterMatchInfo]);
+
+    // Sum of buried counts across every anchor — the number the counter
+    // suffixes as "+K inside".
+    const hiddenMatchCount = useMemo<number>(() => {
+        if (!filterMatchInfo) {
+            return 0;
+        }
+        let total = 0;
+        for (const count of filterMatchInfo.buriedCountByRepId.values()) {
+            total += count;
+        }
+        return total;
+    }, [filterMatchInfo]);
+
+    const goToMatch = useCallback(
+        (direction: 'next' | 'prev') => {
+            if (matchedNodesInOrder.length === 0) {
+                return;
+            }
+            const total = matchedNodesInOrder.length;
+            setCurrentMatchIndex((prev) => {
+                let nextIdx: number;
+                if (prev === null) {
+                    nextIdx = direction === 'next' ? 0 : total - 1;
+                } else {
+                    nextIdx = direction === 'next' ? (prev + 1) % total : (prev - 1 + total) % total;
+                }
+                const targetId = matchedNodesInOrder[nextIdx];
+                if (targetId) {
+                    void fitView({ nodes: [{ id: targetId }], padding: 0.3, duration: 200 });
+                }
+                return nextIdx;
+            });
+        },
+        [matchedNodesInOrder, fitView],
+    );
 
     // Anchor the viewport so the namespace's representative op (post-collapse)
     // visually stays put, then drop the namespace from `expandedNamespaces`.
@@ -1132,20 +1213,25 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return { inputNodeIds, outputNodeIds, inputEdgeIds, outputEdgeIds };
     }, [displayedEdges, selectedNodeId]);
 
-    // Combines two orthogonal passes:
+    // Combines three orthogonal passes:
     //  - Selection highlight: green/yellow fill (op) or border colour (group)
     //    for the producers/consumers of the selected node.
     //  - Filter dim: fade non-matching leaf op nodes to `FILTER_DIM_OPACITY`.
     //    Groups stay neutral (dimming the wrapper bleeds through to children),
     //    the selected node itself never dims (so the user doesn't lose track),
     //    and an empty query is a no-op.
+    //  - Buried-match badge: attach `data.buriedMatchCount` to any anchor
+    //    whose match is (fully or partially) owed to hidden descendants, so
+    //    `MlirOpNode` can render a "+N" indicator.
     const styledNodes = useMemo<MLNode[]>(() => {
         const { inputNodeIds, outputNodeIds } = focusedConnections;
         const hasSelectionHighlight = !!selectedNodeId && (inputNodeIds.size > 0 || outputNodeIds.size > 0);
-        const hasFilter = !!filterMatchedNodeIds;
+        const hasFilter = !!filterMatchInfo;
         if (!hasSelectionHighlight && !hasFilter) {
             return nodes;
         }
+        const visibleRepIds = filterMatchInfo?.visibleRepIds;
+        const buriedByRep = filterMatchInfo?.buriedCountByRepId;
         return nodes.map((n) => {
             let next = n;
             if (hasSelectionHighlight) {
@@ -1163,12 +1249,19 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     }
                 }
             }
-            if (hasFilter && n.type !== 'mlirGroup' && n.id !== selectedNodeId && !filterMatchedNodeIds.has(n.id)) {
-                next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
+            if (hasFilter) {
+                const buriedCount = buriedByRep?.get(n.id) ?? 0;
+                if (buriedCount > 0) {
+                    next = { ...next, data: { ...next.data, buriedMatchCount: buriedCount } };
+                }
+                const isMatch = visibleRepIds!.has(n.id);
+                if (n.type !== 'mlirGroup' && n.id !== selectedNodeId && !isMatch) {
+                    next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
+                }
             }
             return next;
         });
-    }, [nodes, focusedConnections, selectedNodeId, filterMatchedNodeIds]);
+    }, [nodes, focusedConnections, selectedNodeId, filterMatchInfo]);
 
     // MiniMap reads `node.style.background` to colour each mini-node. The
     // unhighlighted op-node fill now lives in SCSS (`.react-flow__node-mlirOp`),
@@ -1194,10 +1287,11 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const styledEdges = useMemo<Edge[]>(() => {
         const { inputEdgeIds, outputEdgeIds } = focusedConnections;
         const hasSelectionHighlight = !!selectedNodeId && (inputEdgeIds.size > 0 || outputEdgeIds.size > 0);
-        const hasFilter = !!filterMatchedNodeIds;
+        const hasFilter = !!filterMatchInfo;
         if (!hasSelectionHighlight && !hasFilter) {
             return displayedEdges;
         }
+        const visibleRepIds = filterMatchInfo?.visibleRepIds;
         return displayedEdges.map((e) => {
             let next = e;
             if (hasSelectionHighlight) {
@@ -1222,7 +1316,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 }
             }
             if (hasFilter) {
-                const bothMatch = filterMatchedNodeIds.has(e.source) && filterMatchedNodeIds.has(e.target);
+                const bothMatch = visibleRepIds!.has(e.source) && visibleRepIds!.has(e.target);
                 const isSelectionEdge = inputEdgeIds.has(e.id) || outputEdgeIds.has(e.id);
                 if (!bothMatch && !isSelectionEdge) {
                     next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
@@ -1230,7 +1324,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             }
             return next;
         });
-    }, [displayedEdges, focusedConnections, selectedNodeId, filterMatchedNodeIds]);
+    }, [displayedEdges, focusedConnections, selectedNodeId, filterMatchInfo]);
 
     return (
         <div className='mlir-view-pane'>
@@ -1260,6 +1354,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 query={filterQuery}
                 onQueryChange={handleQueryChange}
                 matchCount={matchedNodesInOrder.length}
+                hiddenMatchCount={hiddenMatchCount}
                 currentMatchIndex={currentMatchIndex}
                 onPrev={() => goToMatch('prev')}
                 onNext={() => goToMatch('next')}

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -49,7 +49,10 @@ import type {
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
+import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
 import { getNamespaceSegments } from './mlirGraphHelpers';
+
+const FILTER_DIM_OPACITY = 0.18;
 
 // Re-uses `WorkerNode['data']` (the canonical shape produced by the layout
 // worker) and tacks on `highlight` — a view-layer-only flag. Set when this
@@ -283,6 +286,12 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(() => new Set());
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+    // Live op-name filter. Empty query means "no filter" (canvas is the
+    // default state); a non-empty query dims non-matching op nodes and the
+    // edges between them. `currentMatchIndex` is the prev/next pan cursor.
+    const [filterQuery, setFilterQuery] = useState('');
+    const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
+    const filterRef = useRef<MlirOpFilterHandle>(null);
     const selectedNodeIdRef = useRef<string | null>(null);
     const viewportAnchorRef = useRef<{
         toNodeId: string;
@@ -316,6 +325,93 @@ const MlGraphInner = ({ data }: ViewProps) => {
     useEffect(() => {
         pendingFocusNodeIdRef.current = null;
     }, [selectedNodeId]);
+
+    // Visible op nodes whose label matches the current filter query.
+    // Matched against `nodes` (the post-build, collapse-aware list) so the
+    // user only sees hits among what's actually on the canvas. Collapsed-
+    // anchor and group nodes are excluded — group dimming would hide their
+    // children, and matching descendants buried in a collapsed namespace
+    // would dim everything visible. Surfacing buried matches is a follow-up.
+    const filterMatchedNodeIds = useMemo<Set<string> | null>(() => {
+        if (filterQuery.length === 0) {
+            return null;
+        }
+        const needle = filterQuery.toLowerCase();
+        const out = new Set<string>();
+        for (const node of nodes) {
+            if (node.type === 'mlirGroup') {
+                continue;
+            }
+            const label = (node.data?.label ?? '').toLowerCase();
+            if (label.includes(needle)) {
+                out.add(node.id);
+            }
+        }
+        return out;
+    }, [filterQuery, nodes]);
+
+    // Matched ids in canvas order so prev/next pans through them
+    // predictably as the user sees them stacked top-to-bottom.
+    const matchedNodesInOrder = useMemo<string[]>(() => {
+        if (!filterMatchedNodeIds || filterMatchedNodeIds.size === 0) {
+            return [];
+        }
+        const result: string[] = [];
+        for (const node of nodes) {
+            if (filterMatchedNodeIds.has(node.id)) {
+                result.push(node.id);
+            }
+        }
+        return result;
+    }, [nodes, filterMatchedNodeIds]);
+
+    // Reset the prev/next cursor whenever the query changes so the next
+    // arrow click starts at the first match. Done here (not in an effect)
+    // to keep set-state-in-effect lint clean.
+    const handleQueryChange = useCallback((next: string) => {
+        setFilterQuery(next);
+        setCurrentMatchIndex(null);
+    }, []);
+
+    const goToMatch = useCallback(
+        (direction: 'next' | 'prev') => {
+            if (matchedNodesInOrder.length === 0) {
+                return;
+            }
+            const total = matchedNodesInOrder.length;
+            setCurrentMatchIndex((prev) => {
+                let nextIdx: number;
+                if (prev === null) {
+                    nextIdx = direction === 'next' ? 0 : total - 1;
+                } else {
+                    nextIdx = direction === 'next' ? (prev + 1) % total : (prev - 1 + total) % total;
+                }
+                const targetId = matchedNodesInOrder[nextIdx];
+                if (targetId) {
+                    void fitView({ nodes: [{ id: targetId }], padding: 0.3, duration: 200 });
+                }
+                return nextIdx;
+            });
+        },
+        [matchedNodesInOrder, fitView],
+    );
+
+    // Cmd+F / Ctrl+F focuses the filter input. Hijacks the browser's
+    // find-in-page only while the MLIR view is mounted; the rest of the app
+    // gets the native shortcut back as soon as the user navigates away.
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (!(event.metaKey || event.ctrlKey) || event.key !== 'f' || event.shiftKey || event.altKey) {
+                return;
+            }
+            event.preventDefault();
+            filterRef.current?.focus();
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+        };
+    }, []);
 
     // Reflect selectedNodeId onto each node's `selected` flag so React Flow
     // applies its built-in selected styling.
@@ -1036,36 +1132,43 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return { inputNodeIds, outputNodeIds, inputEdgeIds, outputEdgeIds };
     }, [displayedEdges, selectedNodeId]);
 
-    // Highlight input neighbours green and output neighbours yellow. Op nodes
-    // get a colored fill via `style.background`; group nodes route the
-    // highlight through `data.highlight` so their body border is colorized
-    // instead — painting the wrapper background on a group bleeds behind the
-    // dashed body and hides the children inside. The selected node itself
-    // still gets its blue ring from CSS (`.selected`).
+    // Combines two orthogonal passes:
+    //  - Selection highlight: green/yellow fill (op) or border colour (group)
+    //    for the producers/consumers of the selected node.
+    //  - Filter dim: fade non-matching leaf op nodes to `FILTER_DIM_OPACITY`.
+    //    Groups stay neutral (dimming the wrapper bleeds through to children),
+    //    the selected node itself never dims (so the user doesn't lose track),
+    //    and an empty query is a no-op.
     const styledNodes = useMemo<MLNode[]>(() => {
-        if (!selectedNodeId) {
-            return nodes;
-        }
         const { inputNodeIds, outputNodeIds } = focusedConnections;
-        if (inputNodeIds.size === 0 && outputNodeIds.size === 0) {
+        const hasSelectionHighlight = !!selectedNodeId && (inputNodeIds.size > 0 || outputNodeIds.size > 0);
+        const hasFilter = !!filterMatchedNodeIds;
+        if (!hasSelectionHighlight && !hasFilter) {
             return nodes;
         }
         return nodes.map((n) => {
-            const role: 'input' | 'output' | undefined = inputNodeIds.has(n.id)
-                ? 'input'
-                : outputNodeIds.has(n.id)
-                  ? 'output'
-                  : undefined;
-            if (!role) {
-                return n;
+            let next = n;
+            if (hasSelectionHighlight) {
+                const role: 'input' | 'output' | undefined = inputNodeIds.has(n.id)
+                    ? 'input'
+                    : outputNodeIds.has(n.id)
+                      ? 'output'
+                      : undefined;
+                if (role) {
+                    const color = role === 'input' ? GRAPH_COLORS.inputNode : GRAPH_COLORS.outputNode;
+                    if (n.type === 'mlirGroup') {
+                        next = { ...next, data: { ...next.data, highlight: role } };
+                    } else {
+                        next = { ...next, style: { ...(next.style ?? {}), background: color } };
+                    }
+                }
             }
-            const color = role === 'input' ? GRAPH_COLORS.inputNode : GRAPH_COLORS.outputNode;
-            if (n.type === 'mlirGroup') {
-                return { ...n, data: { ...n.data, highlight: role } };
+            if (hasFilter && n.type !== 'mlirGroup' && n.id !== selectedNodeId && !filterMatchedNodeIds.has(n.id)) {
+                next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
             }
-            return { ...n, style: { ...(n.style ?? {}), background: color } };
+            return next;
         });
-    }, [nodes, focusedConnections, selectedNodeId]);
+    }, [nodes, focusedConnections, selectedNodeId, filterMatchedNodeIds]);
 
     // MiniMap reads `node.style.background` to colour each mini-node. The
     // unhighlighted op-node fill now lives in SCSS (`.react-flow__node-mlirOp`),
@@ -1084,39 +1187,50 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return '#f5f5f5';
     }, []);
 
-    // Colorize incoming edges green, outgoing edges yellow.
+    // Colourise selection's incoming edges green / outgoing yellow, then
+    // dim everything else when a filter is active. Edges between two
+    // matches stay bright so the matched subset remains traceable; edges
+    // touching the selection always stay bright (selection trumps filter).
     const styledEdges = useMemo<Edge[]>(() => {
-        if (!selectedNodeId) {
-            return displayedEdges;
-        }
         const { inputEdgeIds, outputEdgeIds } = focusedConnections;
-        if (inputEdgeIds.size === 0 && outputEdgeIds.size === 0) {
+        const hasSelectionHighlight = !!selectedNodeId && (inputEdgeIds.size > 0 || outputEdgeIds.size > 0);
+        const hasFilter = !!filterMatchedNodeIds;
+        if (!hasSelectionHighlight && !hasFilter) {
             return displayedEdges;
         }
         return displayedEdges.map((e) => {
-            if (inputEdgeIds.has(e.id)) {
-                return {
-                    ...e,
-                    style: { ...(e.style ?? {}), stroke: GRAPH_COLORS.inputEdge, strokeWidth: 2 },
-                    markerEnd:
-                        typeof e.markerEnd === 'object' && e.markerEnd
-                            ? { ...e.markerEnd, color: GRAPH_COLORS.inputEdge }
-                            : e.markerEnd,
-                };
+            let next = e;
+            if (hasSelectionHighlight) {
+                if (inputEdgeIds.has(e.id)) {
+                    next = {
+                        ...next,
+                        style: { ...(next.style ?? {}), stroke: GRAPH_COLORS.inputEdge, strokeWidth: 2 },
+                        markerEnd:
+                            typeof next.markerEnd === 'object' && next.markerEnd
+                                ? { ...next.markerEnd, color: GRAPH_COLORS.inputEdge }
+                                : next.markerEnd,
+                    };
+                } else if (outputEdgeIds.has(e.id)) {
+                    next = {
+                        ...next,
+                        style: { ...(next.style ?? {}), stroke: GRAPH_COLORS.outputEdge, strokeWidth: 2 },
+                        markerEnd:
+                            typeof next.markerEnd === 'object' && next.markerEnd
+                                ? { ...next.markerEnd, color: GRAPH_COLORS.outputEdge }
+                                : next.markerEnd,
+                    };
+                }
             }
-            if (outputEdgeIds.has(e.id)) {
-                return {
-                    ...e,
-                    style: { ...(e.style ?? {}), stroke: GRAPH_COLORS.outputEdge, strokeWidth: 2 },
-                    markerEnd:
-                        typeof e.markerEnd === 'object' && e.markerEnd
-                            ? { ...e.markerEnd, color: GRAPH_COLORS.outputEdge }
-                            : e.markerEnd,
-                };
+            if (hasFilter) {
+                const bothMatch = filterMatchedNodeIds.has(e.source) && filterMatchedNodeIds.has(e.target);
+                const isSelectionEdge = inputEdgeIds.has(e.id) || outputEdgeIds.has(e.id);
+                if (!bothMatch && !isSelectionEdge) {
+                    next = { ...next, style: { ...(next.style ?? {}), opacity: FILTER_DIM_OPACITY } };
+                }
             }
-            return e;
+            return next;
         });
-    }, [displayedEdges, focusedConnections, selectedNodeId]);
+    }, [displayedEdges, focusedConnections, selectedNodeId, filterMatchedNodeIds]);
 
     return (
         <div className='mlir-view-pane'>
@@ -1140,6 +1254,16 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     <Background />
                 </ReactFlow>
             </MlirGroupContext.Provider>
+
+            <MlirOpFilter
+                ref={filterRef}
+                query={filterQuery}
+                onQueryChange={handleQueryChange}
+                matchCount={matchedNodesInOrder.length}
+                currentMatchIndex={currentMatchIndex}
+                onPrev={() => goToMatch('prev')}
+                onNext={() => goToMatch('next')}
+            />
 
             <Button
                 className='mlir-relayout-button'

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -479,16 +479,15 @@ const MlGraphInner = ({ data }: ViewProps) => {
     }, [expandedNamespaces, runBuild]);
 
     // Maps each label-matching source to its visible representative: itself
-    // if on canvas, otherwise the collapsed anchor of its shallowest
-    // enclosing namespace. Uses `containingNamespacesByNodeId` rather than
-    // `source.namespace` because topology sectioning wraps top-level ops in
-    // synthetic `section_N_of_M` namespaces that aren't reflected in the raw
-    // namespace field.
-    // Collapsibility is derived from `visibleNodeIds.has(anchorId)` rather
-    // than `expandedNamespaces`: `nodes` is the authoritative post-worker
-    // snapshot, so reading collapsibility from it avoids the transient
-    // window where `expandedNamespaces` has updated but the worker rebuild
-    // is still in flight.
+    // if on canvas, otherwise the anchor of its outermost collapsed
+    // ancestor. Reads `containingNamespacesByNodeId` (not `source.namespace`)
+    // so topology sections and MLIR namespaces are walked uniformly.
+    //
+    // Collapsibility MUST come from `expandedNamespaces` — anchors are always
+    // visible under their own id (they render either as themselves in an
+    // expanded parent or as the collapsed anchor of their own namespace), so
+    // `visibleNodeIds.has(anchorId)` can't distinguish collapsed from
+    // expanded. Mirrors the graph builder's `resolveRenderedNodeId`.
     const filterMatchInfo = useMemo<{
         visibleRepIds: Set<string>;
         buriedCountByRepId: Map<string, number>;
@@ -514,12 +513,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
             const containing = containingNamespacesByNodeId[source.id];
             let repId: string | null = null;
             if (containing && containing.length > 0) {
-                // Outer→inner; first namespace whose anchor is on canvas is
-                // the outermost collapsed ancestor.
+                // Outer→inner: the shortest collapsed namespace is where the
+                // source folds up to. Missing anchors fall back to `source.id`
+                // (mirrors `resolveRenderedNodeId`'s `?? nodeId`).
                 for (const ns of containing) {
-                    const anchorId = anchorByNamespace[ns];
-                    if (anchorId && visibleNodeIds.has(anchorId)) {
-                        repId = anchorId;
+                    if (!expandedNamespaces.has(ns)) {
+                        const anchorId = anchorByNamespace[ns] ?? source.id;
+                        repId = visibleNodeIds.has(anchorId) ? anchorId : null;
                         break;
                     }
                 }
@@ -537,7 +537,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             }
         }
         return { visibleRepIds, buriedCountByRepId, hiddenMatchCount };
-    }, [appliedFilterQuery, sourceNodes, interactionIndex, nodes]);
+    }, [appliedFilterQuery, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
 
     // Visible reps in canvas order so prev/next walks top-to-bottom.
     const matchedNodesInOrder = useMemo<string[]>(() => {

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -53,6 +53,10 @@ import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
 import { getNamespaceSegments } from './mlirGraphHelpers';
 
 const FILTER_DIM_OPACITY = 0.18;
+// Debounce the applied filter query so the memo chain (filterMatchInfo →
+// styledNodes/styledEdges → React Flow diff) only runs after typing settles.
+// Cleared queries bypass the debounce so Escape / clear feels instant.
+const FILTER_DEBOUNCE_MS = 120;
 
 // View-layer additions to the worker's canonical node data:
 //  - `highlight`: producer/consumer role vs. the selected node. Ops take a
@@ -300,8 +304,11 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(() => new Set());
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-    // Live op-name filter. `currentMatchIndex` is the prev/next pan cursor.
+    // Live op-name filter. `filterQuery` drives the input for instant visual
+    // feedback; `appliedFilterQuery` is what the memo chain reads and lags
+    // by `FILTER_DEBOUNCE_MS` on non-empty queries.
     const [filterQuery, setFilterQuery] = useState('');
+    const [appliedFilterQuery, setAppliedFilterQuery] = useState('');
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const filterRef = useRef<MlirOpFilterHandle>(null);
     const selectedNodeIdRef = useRef<string | null>(null);
@@ -338,12 +345,28 @@ const MlGraphInner = ({ data }: ViewProps) => {
         pendingFocusNodeIdRef.current = null;
     }, [selectedNodeId]);
 
-    // Reset the prev/next cursor with the query; kept out of an effect to
-    // avoid tripping set-state-in-effect.
+    // Reset the prev/next cursor with the query; clearing also applies
+    // instantly so Escape / clear feels responsive. Non-empty updates flow
+    // through the debounce effect below.
     const handleQueryChange = useCallback((next: string) => {
         setFilterQuery(next);
         setCurrentMatchIndex(null);
+        if (next === '') {
+            setAppliedFilterQuery('');
+        }
     }, []);
+
+    // Debounce non-empty query updates. `filterQuery` drives the input for
+    // instant feedback; `appliedFilterQuery` lands one debounce interval
+    // past the last keystroke so the memo → styledNodes → React Flow diff
+    // chain doesn't run per keystroke.
+    useEffect(() => {
+        if (filterQuery === '') {
+            return undefined;
+        }
+        const id = window.setTimeout(() => setAppliedFilterQuery(filterQuery), FILTER_DEBOUNCE_MS);
+        return () => window.clearTimeout(id);
+    }, [filterQuery]);
 
     // Cmd/Ctrl+F focuses the filter input while the MLIR view is mounted;
     // the native find-in-page returns as soon as the user navigates away.
@@ -471,10 +494,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
         buriedCountByRepId: Map<string, number>;
         hiddenMatchCount: number;
     } | null>(() => {
-        if (filterQuery.length === 0) {
+        if (appliedFilterQuery.length === 0) {
             return null;
         }
-        const needle = filterQuery.toLowerCase();
+        const needle = appliedFilterQuery.toLowerCase();
         const anchorByNamespace = interactionIndex?.anchorByNamespace ?? {};
         const containingNamespacesByNodeId = interactionIndex?.containingNamespacesByNodeId ?? {};
         const visibleNodeIds = new Set<string>();
@@ -514,7 +537,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             }
         }
         return { visibleRepIds, buriedCountByRepId, hiddenMatchCount };
-    }, [filterQuery, sourceNodes, interactionIndex, nodes]);
+    }, [appliedFilterQuery, sourceNodes, interactionIndex, nodes]);
 
     // Visible reps in canvas order so prev/next walks top-to-bottom.
     const matchedNodesInOrder = useMemo<string[]>(() => {

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'react';
+import { Button, ButtonVariant, InputGroup } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import 'styles/components/MlirOpFilter.scss';
+
+export interface MlirOpFilterHandle {
+    focus: () => void;
+}
+
+interface MlirOpFilterProps {
+    query: string;
+    onQueryChange: (next: string) => void;
+    matchCount: number;
+    // 0-based index of the currently focused match within `matchCount`, or
+    // null when nothing is focused (e.g. before any prev/next click).
+    currentMatchIndex: number | null;
+    onPrev: () => void;
+    onNext: () => void;
+}
+
+// Floating filter control mounted over the React Flow canvas. The visible
+// dim/highlight behaviour lives in the view component; this is purely the
+// input + match-count + prev/next surface.
+const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
+    ({ query, onQueryChange, matchCount, currentMatchIndex, onPrev, onNext }, ref) => {
+        const inputRef = useRef<HTMLInputElement>(null);
+
+        useImperativeHandle(ref, () => ({
+            focus: () => {
+                inputRef.current?.focus();
+                inputRef.current?.select();
+            },
+        }));
+
+        const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onQueryChange('');
+                return;
+            }
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                if (event.shiftKey) {
+                    onPrev();
+                } else {
+                    onNext();
+                }
+            }
+        };
+
+        const hasQuery = query.length > 0;
+        let counterText: string | null = null;
+        if (hasQuery) {
+            if (matchCount === 0) {
+                counterText = 'no matches';
+            } else if (currentMatchIndex !== null) {
+                counterText = `${currentMatchIndex + 1} / ${matchCount}`;
+            } else {
+                counterText = `${matchCount} matches`;
+            }
+        }
+
+        return (
+            <div className='mlir-op-filter'>
+                <InputGroup
+                    inputRef={inputRef}
+                    leftIcon={IconNames.SEARCH}
+                    placeholder='Filter ops (substring)'
+                    value={query}
+                    onChange={(event) => onQueryChange(event.target.value)}
+                    onKeyDown={handleKeyDown}
+                    rightElement={
+                        counterText ? <span className='mlir-op-filter-counter'>{counterText}</span> : undefined
+                    }
+                    spellCheck={false}
+                    autoComplete='off'
+                />
+                <Button
+                    className='mlir-op-filter-step'
+                    variant={ButtonVariant.MINIMAL}
+                    icon={IconNames.CHEVRON_UP}
+                    aria-label='Previous match'
+                    disabled={matchCount === 0}
+                    onClick={onPrev}
+                />
+                <Button
+                    className='mlir-op-filter-step'
+                    variant={ButtonVariant.MINIMAL}
+                    icon={IconNames.CHEVRON_DOWN}
+                    aria-label='Next match'
+                    disabled={matchCount === 0}
+                    onClick={onNext}
+                />
+            </div>
+        );
+    },
+);
+
+MlirOpFilter.displayName = 'MlirOpFilter';
+
+export default MlirOpFilter;

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -74,11 +74,20 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
                     onChange={(event) => onQueryChange(event.target.value)}
                     onKeyDown={handleKeyDown}
                     rightElement={
-                        counterText ? <span className='mlir-op-filter-counter'>{counterText}</span> : undefined
+                        hasQuery ? (
+                            <Button
+                                className='mlir-op-filter-clear'
+                                variant={ButtonVariant.MINIMAL}
+                                icon={IconNames.CROSS}
+                                aria-label='Clear filter'
+                                onClick={() => onQueryChange('')}
+                            />
+                        ) : undefined
                     }
                     spellCheck={false}
                     autoComplete='off'
                 />
+                {counterText ? <span className='mlir-op-filter-counter'>{counterText}</span> : null}
                 <Button
                     className='mlir-op-filter-step'
                     variant={ButtonVariant.MINIMAL}

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -14,22 +14,19 @@ export interface MlirOpFilterHandle {
 interface MlirOpFilterProps {
     query: string;
     onQueryChange: (next: string) => void;
-    // Number of visible reps prev/next steps through. Visible reps include
-    // collapsed anchors that stand in for one or more buried descendants.
+    // Number of visible reps prev/next steps through; collapsed anchors
+    // standing in for buried descendants are counted here.
     matchCount: number;
-    // Total buried descendants across all anchors — reported as "+K inside"
-    // so the user can tell that some matches are hidden.
+    // Buried descendants across all anchors; drives the "+K inside" suffix.
     hiddenMatchCount: number;
-    // 0-based index of the currently focused match within `matchCount`, or
-    // null when nothing is focused (e.g. before any prev/next click).
+    // 0-based cursor within `matchCount`, or null when no match is focused.
     currentMatchIndex: number | null;
     onPrev: () => void;
     onNext: () => void;
 }
 
-// Floating filter control mounted over the React Flow canvas. The visible
-// dim/highlight behaviour lives in the view component; this is purely the
-// input + match-count + prev/next surface.
+// Floating filter control over the React Flow canvas. Dim/highlight lives
+// in the view component; this is just the input + counter + prev/next.
 const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
     ({ query, onQueryChange, matchCount, hiddenMatchCount, currentMatchIndex, onPrev, onNext }, ref) => {
         const inputRef = useRef<HTMLInputElement>(null);

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -14,7 +14,12 @@ export interface MlirOpFilterHandle {
 interface MlirOpFilterProps {
     query: string;
     onQueryChange: (next: string) => void;
+    // Number of visible reps prev/next steps through. Visible reps include
+    // collapsed anchors that stand in for one or more buried descendants.
     matchCount: number;
+    // Total buried descendants across all anchors — reported as "+K inside"
+    // so the user can tell that some matches are hidden.
+    hiddenMatchCount: number;
     // 0-based index of the currently focused match within `matchCount`, or
     // null when nothing is focused (e.g. before any prev/next click).
     currentMatchIndex: number | null;
@@ -26,7 +31,7 @@ interface MlirOpFilterProps {
 // dim/highlight behaviour lives in the view component; this is purely the
 // input + match-count + prev/next surface.
 const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
-    ({ query, onQueryChange, matchCount, currentMatchIndex, onPrev, onNext }, ref) => {
+    ({ query, onQueryChange, matchCount, hiddenMatchCount, currentMatchIndex, onPrev, onNext }, ref) => {
         const inputRef = useRef<HTMLInputElement>(null);
 
         useImperativeHandle(ref, () => ({
@@ -53,14 +58,15 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
         };
 
         const hasQuery = query.length > 0;
+        const hiddenSuffix = hiddenMatchCount > 0 ? ` (+${hiddenMatchCount} inside)` : '';
         let counterText: string | null = null;
         if (hasQuery) {
-            if (matchCount === 0) {
+            if (matchCount === 0 && hiddenMatchCount === 0) {
                 counterText = 'no matches';
             } else if (currentMatchIndex !== null) {
-                counterText = `${currentMatchIndex + 1} / ${matchCount}`;
+                counterText = `${currentMatchIndex + 1} / ${matchCount}${hiddenSuffix}`;
             } else {
-                counterText = `${matchCount} matches`;
+                counterText = `${matchCount} matches${hiddenSuffix}`;
             }
         }
 

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -177,10 +177,9 @@ export type WorkerInteractionIndex = {
      */
     namespaceInputByNamespace: Record<string, string[]>;
     /**
-     * Ordered outer→inner list of every subgraph / synthetic-section
-     * namespace containing a given source node. Populated over
-     * post-sectioning namespaces, so filter code doesn't have to reason
-     * separately about topology-sectioned wrappers.
+     * Outer→inner list of every subgraph / synthetic-section namespace
+     * containing a given source node. Covers topology-sectioned wrappers so
+     * callers don't have to reason about them separately.
      */
     containingNamespacesByNodeId: Record<string, string[]>;
 };

--- a/src/components/mlir/mlirGraphTypes.ts
+++ b/src/components/mlir/mlirGraphTypes.ts
@@ -176,6 +176,13 @@ export type WorkerInteractionIndex = {
      * to attribute those edges back to the outer op's input port.
      */
     namespaceInputByNamespace: Record<string, string[]>;
+    /**
+     * Ordered outer→inner list of every subgraph / synthetic-section
+     * namespace containing a given source node. Populated over
+     * post-sectioning namespaces, so filter code doesn't have to reason
+     * separately about topology-sectioned wrappers.
+     */
+    containingNamespacesByNodeId: Record<string, string[]>;
 };
 
 export type WorkerIndexedMessage = {

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -121,6 +121,7 @@ self.addEventListener('message', (event: MessageEvent<WorkerInboundMessage>) => 
                     outerNamespaceByNodeId: index.outerNamespaceByNodeId,
                     namespaceReturnNodeByNamespace: index.namespaceReturnNodeByNamespace,
                     namespaceInputByNamespace: index.namespaceInputByNamespace,
+                    containingNamespacesByNodeId: index.containingNamespacesByNodeId,
                 },
             });
         } catch (error) {

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -217,6 +217,24 @@
     user-select: none;
 }
 
+// "+N" badge on collapsed anchors that own buried filter matches. Uses the
+// yellow accent so it reads as an informational hint distinct from the
+// input/output highlight greens/yellows on selected neighbours.
+.mlir-op-node-buried-badge {
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    padding: 1px 5px;
+    background: $tt-yellow;
+    color: $tt-black;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.1;
+    pointer-events: none;
+    user-select: none;
+}
+
 .mlir-op-node-label {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -217,9 +217,8 @@
     user-select: none;
 }
 
-// "+N" badge on collapsed anchors that own buried filter matches. Uses the
-// yellow accent so it reads as an informational hint distinct from the
-// input/output highlight greens/yellows on selected neighbours.
+// "+N" badge on collapsed anchors with buried filter matches. Yellow reads
+// as informational, distinct from the input/output highlight fills.
 .mlir-op-node-buried-badge {
     position: absolute;
     right: 4px;

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -9,8 +9,7 @@
     top: 12px;
     left: 12px;
 
-    // Sit above React Flow nodes (1) and edges (0) but below the details
-    // panel (which uses 10). Controls panel uses 5.
+    // Above React Flow nodes / edges / controls, below the details panel.
     z-index: 6;
     display: flex;
     align-items: center;

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+@use '../definitions/colours' as *;
+
+.mlir-op-filter {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+
+    // Sit above React Flow nodes (1) and edges (0) but below the details
+    // panel (which uses 10). Controls panel uses 5.
+    z-index: 6;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    background: $tt-grey-2;
+    border: 1px solid $tt-grey-3;
+    border-radius: 4px;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
+
+    .bp6-input-group {
+        width: 240px;
+    }
+
+    .mlir-op-filter-counter {
+        align-self: center;
+        padding: 0 8px;
+        color: $tt-grey-6;
+        font-size: 11px;
+        white-space: nowrap;
+    }
+
+    .mlir-op-filter-step {
+        flex-shrink: 0;
+    }
+}

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -22,18 +22,26 @@
     box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 
     .bp6-input-group {
+        display: flex;
+        align-items: center;
         width: 240px;
     }
 
     .mlir-op-filter-counter {
-        align-self: center;
-        padding: 0 8px;
+        display: inline-flex;
+        align-items: center;
+        padding: 0 4px;
         color: $tt-grey-6;
         font-size: 11px;
+        line-height: 1;
         white-space: nowrap;
     }
 
+    .mlir-op-filter-clear,
     .mlir-op-filter-step {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         flex-shrink: 0;
     }
 }


### PR DESCRIPTION
Closes #1545.

<img width="1479" height="869" alt="image" src="https://github.com/user-attachments/assets/189eb216-729a-4cc1-bb97-c181f69ccf56" />

<img width="1485" height="908" alt="image" src="https://github.com/user-attachments/assets/301cb86a-ed46-4eb0-9094-4d168ef33045" />


## Summary

Inline op-name filter over the MLIR React Flow canvas. Substring match, live dim of non-matches, match counter with prev/next navigation, and "+K inside" surfacing for matches buried under collapsed subgraphs.

## Behaviour

- **Floating panel** (top-left of the canvas) with a search input, match counter, prev/next buttons, and a clear (X) button.
- **Substring, case-insensitive** matching over `source.label`. Non-matching leaf ops dim to `opacity: 0.18`; matching nodes stay bright. Edges between two matched nodes stay bright too.
- **Selection highlight is preserved.** The selected node and its input/output edges are never dimmed by the filter — selection trumps filter.
- **Buried matches surface as "+N" badges** on collapsed anchors that own filter matches. The counter reports `M / N (+K inside)` so a collapsed graph never gives a silent "no matches".
- **Prev/next** (`Enter` / `Shift-Enter`, or the up/down chevrons) walks the visible reps in canvas order and `fitView`s onto each.
- **`Cmd/Ctrl+F`** focuses the input while the MLIR view is mounted. **`Escape`** clears the query.

## Non-obvious implementation notes

- **`containingNamespacesByNodeId`** was added to the worker's `WorkerInteractionIndex`. It's the outer→inner list of every subgraph / synthetic `section_N_of_M` namespace enclosing a source node. The filter walks it (rather than `source.namespace`) so topology-sectioned wrappers don't hide matches from the resolver.
- **Collapsibility is derived from `visibleNodeIds.has(anchorByNamespace[ns])`** rather than from `expandedNamespaces`. The two states can disagree during the worker rebuild window; consulting the post-worker `nodes` snapshot avoids the transient staleness (and halves the recompute cost on collapse/expand).
- **Non-empty queries debounce (120 ms)** so the memo chain (`filterMatchInfo` → `styledNodes` / `styledEdges` → React Flow diff) doesn't run per keystroke on large graphs. Empty queries land immediately so Escape / clear feels instant.
- **`styledNodes` and `styledEdges`** were refactored from selection-only into a single map pass that composes selection highlight + filter dim + `+N` badge. The zero-cost `if (!hasSelectionHighlight && !filterMatchInfo) return nodes;` fast path is preserved.

## Follow-ups

- #1707 — extract `computeFilterMatches` as a pure function + unit tests. Non-blocking refactor; the inline memo is small and correct.
- #1546 — sidebar list of matches (kept as a separate deliverable; this PR only handles in-canvas dim/navigation).
- Auto-expand collapsed subgraphs when prev/next steps into a `+N` anchor (deferred; slot for 0.97.0).