### PR TITLE
Add regex mode to MLIR op-name filter

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -315,7 +315,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const [appliedFilterQuery, setAppliedFilterQuery] = useState('');
     const [filterMode, setFilterMode] = useState<MlirFilterMode>(() => {
         const stored = sessionStorage.getItem(FILTER_MODE_STORAGE_KEY);
-        return stored === 'regex' ? 'regex' : 'substring';
+        return stored === MlirFilterMode.Regex ? MlirFilterMode.Regex : MlirFilterMode.Substring;
     });
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const filterRef = useRef<MlirOpFilterHandle>(null);

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -49,7 +49,7 @@ import type {
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
-import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
+import MlirOpFilter, { MlirFilterMode, MlirOpFilterHandle } from './MlirOpFilter';
 import { getNamespaceSegments } from './mlirGraphHelpers';
 
 const FILTER_DIM_OPACITY = 0.18;
@@ -57,6 +57,9 @@ const FILTER_DIM_OPACITY = 0.18;
 // styledNodes/styledEdges → React Flow diff) only runs after typing settles.
 // Cleared queries bypass the debounce so Escape / clear feels instant.
 const FILTER_DEBOUNCE_MS = 120;
+// Session-scoped so a page reload preserves the user's mode choice without
+// leaking across browser sessions or profiles.
+const FILTER_MODE_STORAGE_KEY = 'mlirFilterMode';
 
 // View-layer additions to the worker's canonical node data:
 //  - `highlight`: producer/consumer role vs. the selected node. Ops take a
@@ -309,6 +312,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // by `FILTER_DEBOUNCE_MS` on non-empty queries.
     const [filterQuery, setFilterQuery] = useState('');
     const [appliedFilterQuery, setAppliedFilterQuery] = useState('');
+    const [filterMode, setFilterMode] = useState<MlirFilterMode>(() => {
+        const stored = sessionStorage.getItem(FILTER_MODE_STORAGE_KEY);
+        return stored === 'regex' ? 'regex' : 'substring';
+    });
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const filterRef = useRef<MlirOpFilterHandle>(null);
     const selectedNodeIdRef = useRef<string | null>(null);
@@ -354,6 +361,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (next === '') {
             setAppliedFilterQuery('');
         }
+    }, []);
+
+    // Match set differs across modes, so reset the cursor on toggle.
+    const handleModeChange = useCallback((next: MlirFilterMode) => {
+        setFilterMode(next);
+        setCurrentMatchIndex(null);
+        sessionStorage.setItem(FILTER_MODE_STORAGE_KEY, next);
     }, []);
 
     // Debounce non-empty query updates. `filterQuery` drives the input for
@@ -492,11 +506,27 @@ const MlGraphInner = ({ data }: ViewProps) => {
         visibleRepIds: Set<string>;
         buriedCountByRepId: Map<string, number>;
         hiddenMatchCount: number;
+        isRegexInvalid: boolean;
     } | null>(() => {
         if (appliedFilterQuery.length === 0) {
             return null;
         }
-        const needle = appliedFilterQuery.toLowerCase();
+        // Precompute the matcher so an invalid regex short-circuits to
+        // "zero matches" instead of throwing inside the walk.
+        let testLabel: (label: string) => boolean;
+        let isRegexInvalid = false;
+        if (filterMode === 'regex') {
+            try {
+                const re = new RegExp(appliedFilterQuery, 'i');
+                testLabel = (label) => re.test(label);
+            } catch {
+                testLabel = () => false;
+                isRegexInvalid = true;
+            }
+        } else {
+            const needle = appliedFilterQuery.toLowerCase();
+            testLabel = (label) => label.toLowerCase().includes(needle);
+        }
         const anchorByNamespace = interactionIndex?.anchorByNamespace ?? {};
         const containingNamespacesByNodeId = interactionIndex?.containingNamespacesByNodeId ?? {};
         const visibleNodeIds = new Set<string>();
@@ -507,7 +537,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
         const buriedCountByRepId = new Map<string, number>();
         let hiddenMatchCount = 0;
         for (const source of sourceNodes) {
-            if (!source.label.toLowerCase().includes(needle)) {
+            if (!testLabel(source.label)) {
                 continue;
             }
             const containing = containingNamespacesByNodeId[source.id];
@@ -536,8 +566,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 hiddenMatchCount += 1;
             }
         }
-        return { visibleRepIds, buriedCountByRepId, hiddenMatchCount };
-    }, [appliedFilterQuery, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
+        return { visibleRepIds, buriedCountByRepId, hiddenMatchCount, isRegexInvalid };
+    }, [appliedFilterQuery, filterMode, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
 
     // Visible reps in canvas order so prev/next walks top-to-bottom.
     const matchedNodesInOrder = useMemo<string[]>(() => {
@@ -1336,6 +1366,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 ref={filterRef}
                 query={filterQuery}
                 onQueryChange={handleQueryChange}
+                mode={filterMode}
+                onModeChange={handleModeChange}
+                isRegexInvalid={filterMatchInfo?.isRegexInvalid ?? false}
                 matchCount={matchedNodesInOrder.length}
                 hiddenMatchCount={filterMatchInfo?.hiddenMatchCount ?? 0}
                 currentMatchIndex={currentMatchIndex}

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -49,7 +49,8 @@ import type {
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
-import MlirOpFilter, { MlirFilterMode, MlirOpFilterHandle } from './MlirOpFilter';
+import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
+import { MlirFilterMode, buildFilterMatcher } from './mlirFilter';
 import { getNamespaceSegments } from './mlirGraphHelpers';
 
 const FILTER_DIM_OPACITY = 0.18;
@@ -511,22 +512,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (appliedFilterQuery.length === 0) {
             return null;
         }
-        // Precompute the matcher so an invalid regex short-circuits to
-        // "zero matches" instead of throwing inside the walk.
-        let testLabel: (label: string) => boolean;
-        let isRegexInvalid = false;
-        if (filterMode === 'regex') {
-            try {
-                const re = new RegExp(appliedFilterQuery, 'i');
-                testLabel = (label) => re.test(label);
-            } catch {
-                testLabel = () => false;
-                isRegexInvalid = true;
-            }
-        } else {
-            const needle = appliedFilterQuery.toLowerCase();
-            testLabel = (label) => label.toLowerCase().includes(needle);
-        }
+        const { testLabel, isRegexInvalid } = buildFilterMatcher(filterMode, appliedFilterQuery);
         const anchorByNamespace = interactionIndex?.anchorByNamespace ?? {};
         const containingNamespacesByNodeId = interactionIndex?.containingNamespacesByNodeId ?? {};
         const visibleNodeIds = new Set<string>();

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'react';
+import { type KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'react';
 import { Button, ButtonVariant, InputGroup, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirOpFilter.scss';
@@ -79,14 +79,19 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
         const hasQuery = query.length > 0;
         const isRegexMode = mode === 'regex';
         const hiddenSuffix = hiddenMatchCount > 0 ? ` (+${hiddenMatchCount} inside)` : '';
+        // Ignore a stale cursor whose index no longer lives inside the current
+        // match set (e.g. after an expand/collapse changed the visible reps)
+        // so the counter can't render impossible ratios like "5 / 2".
+        const activeMatchIndex =
+            currentMatchIndex !== null && currentMatchIndex < matchCount ? currentMatchIndex : null;
         let counterText: string | null = null;
         if (hasQuery) {
             if (isRegexInvalid) {
                 counterText = 'invalid regex';
             } else if (matchCount === 0 && hiddenMatchCount === 0) {
                 counterText = 'no matches';
-            } else if (currentMatchIndex !== null) {
-                counterText = `${currentMatchIndex + 1} / ${matchCount}${hiddenSuffix}`;
+            } else if (activeMatchIndex !== null) {
+                counterText = `${activeMatchIndex + 1} / ${matchCount}${hiddenSuffix}`;
             } else {
                 counterText = `${matchCount} matches${hiddenSuffix}`;
             }

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -6,8 +6,9 @@ import { KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'react';
 import { Button, ButtonVariant, InputGroup, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirOpFilter.scss';
+import type { MlirFilterMode } from './mlirFilter';
 
-export type MlirFilterMode = 'substring' | 'regex';
+export type { MlirFilterMode };
 
 export interface MlirOpFilterHandle {
     focus: () => void;

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -3,9 +3,11 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'react';
-import { Button, ButtonVariant, InputGroup } from '@blueprintjs/core';
+import { Button, ButtonVariant, InputGroup, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirOpFilter.scss';
+
+export type MlirFilterMode = 'substring' | 'regex';
 
 export interface MlirOpFilterHandle {
     focus: () => void;
@@ -14,6 +16,11 @@ export interface MlirOpFilterHandle {
 interface MlirOpFilterProps {
     query: string;
     onQueryChange: (next: string) => void;
+    mode: MlirFilterMode;
+    onModeChange: (next: MlirFilterMode) => void;
+    // True only when in regex mode and the current query fails to compile —
+    // drives the danger-intent input styling and the counter text.
+    isRegexInvalid: boolean;
     // Number of visible reps prev/next steps through; collapsed anchors
     // standing in for buried descendants are counted here.
     matchCount: number;
@@ -28,7 +35,21 @@ interface MlirOpFilterProps {
 // Floating filter control over the React Flow canvas. Dim/highlight lives
 // in the view component; this is just the input + counter + prev/next.
 const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
-    ({ query, onQueryChange, matchCount, hiddenMatchCount, currentMatchIndex, onPrev, onNext }, ref) => {
+    (
+        {
+            query,
+            onQueryChange,
+            mode,
+            onModeChange,
+            isRegexInvalid,
+            matchCount,
+            hiddenMatchCount,
+            currentMatchIndex,
+            onPrev,
+            onNext,
+        },
+        ref,
+    ) => {
         const inputRef = useRef<HTMLInputElement>(null);
 
         useImperativeHandle(ref, () => ({
@@ -55,10 +76,13 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
         };
 
         const hasQuery = query.length > 0;
+        const isRegexMode = mode === 'regex';
         const hiddenSuffix = hiddenMatchCount > 0 ? ` (+${hiddenMatchCount} inside)` : '';
         let counterText: string | null = null;
         if (hasQuery) {
-            if (matchCount === 0 && hiddenMatchCount === 0) {
+            if (isRegexInvalid) {
+                counterText = 'invalid regex';
+            } else if (matchCount === 0 && hiddenMatchCount === 0) {
                 counterText = 'no matches';
             } else if (currentMatchIndex !== null) {
                 counterText = `${currentMatchIndex + 1} / ${matchCount}${hiddenSuffix}`;
@@ -67,25 +91,43 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
             }
         }
 
+        const toggleMode = () => onModeChange(isRegexMode ? 'substring' : 'regex');
+
         return (
             <div className='mlir-op-filter'>
                 <InputGroup
                     inputRef={inputRef}
                     leftIcon={IconNames.SEARCH}
-                    placeholder='Filter ops (substring)'
+                    placeholder={isRegexMode ? 'Filter ops (regex)' : 'Filter ops (substring)'}
                     value={query}
                     onChange={(event) => onQueryChange(event.target.value)}
                     onKeyDown={handleKeyDown}
+                    intent={isRegexInvalid ? Intent.DANGER : Intent.NONE}
                     rightElement={
-                        hasQuery ? (
+                        <div className='mlir-op-filter-right-slot'>
                             <Button
-                                className='mlir-op-filter-clear'
+                                className='mlir-op-filter-mode'
                                 variant={ButtonVariant.MINIMAL}
-                                icon={IconNames.CROSS}
-                                aria-label='Clear filter'
-                                onClick={() => onQueryChange('')}
+                                active={isRegexMode}
+                                text='.*'
+                                aria-label={isRegexMode ? 'Switch to substring mode' : 'Switch to regex mode'}
+                                title={
+                                    isRegexMode
+                                        ? 'Regex mode (click for substring)'
+                                        : 'Substring mode (click for regex)'
+                                }
+                                onClick={toggleMode}
                             />
-                        ) : undefined
+                            {hasQuery ? (
+                                <Button
+                                    className='mlir-op-filter-clear'
+                                    variant={ButtonVariant.MINIMAL}
+                                    icon={IconNames.CROSS}
+                                    aria-label='Clear filter'
+                                    onClick={() => onQueryChange('')}
+                                />
+                            ) : null}
+                        </div>
                     }
                     spellCheck={false}
                     autoComplete='off'

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -6,9 +6,9 @@ import { type KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'rea
 import { Button, ButtonVariant, InputGroup, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirOpFilter.scss';
-import type { MlirFilterMode } from './mlirFilter';
+import { MlirFilterMode } from './mlirFilter';
 
-export type { MlirFilterMode };
+export { MlirFilterMode };
 
 export interface MlirOpFilterHandle {
     focus: () => void;
@@ -77,7 +77,7 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
         };
 
         const hasQuery = query.length > 0;
-        const isRegexMode = mode === 'regex';
+        const isRegexMode = mode === MlirFilterMode.Regex;
         const hiddenSuffix = hiddenMatchCount > 0 ? ` (+${hiddenMatchCount} inside)` : '';
         // Ignore a stale cursor whose index no longer lives inside the current
         // match set (e.g. after an expand/collapse changed the visible reps)
@@ -97,7 +97,7 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
             }
         }
 
-        const toggleMode = () => onModeChange(isRegexMode ? 'substring' : 'regex');
+        const toggleMode = () => onModeChange(isRegexMode ? MlirFilterMode.Substring : MlirFilterMode.Regex);
 
         return (
             <div className='mlir-op-filter'>

--- a/src/components/mlir/mlirFilter.ts
+++ b/src/components/mlir/mlirFilter.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+export type MlirFilterMode = 'substring' | 'regex';
+
+export interface MlirFilterMatcher {
+    /** True if a source label should be treated as a filter match. */
+    testLabel: (label: string) => boolean;
+    /** True only in regex mode when the query fails to compile. */
+    isRegexInvalid: boolean;
+}
+
+// Empty queries and invalid regexes both surface a matcher that rejects
+// everything so the caller doesn't need branch-per-case handling; the
+// `isRegexInvalid` flag lets the UI distinguish "no query" from "bad regex".
+export function buildFilterMatcher(mode: MlirFilterMode, query: string): MlirFilterMatcher {
+    if (query.length === 0) {
+        return { testLabel: () => false, isRegexInvalid: false };
+    }
+    if (mode === 'regex') {
+        try {
+            const re = new RegExp(query, 'i');
+            return { testLabel: (label) => re.test(label), isRegexInvalid: false };
+        } catch {
+            return { testLabel: () => false, isRegexInvalid: true };
+        }
+    }
+    const needle = query.toLowerCase();
+    return {
+        testLabel: (label) => label.toLowerCase().includes(needle),
+        isRegexInvalid: false,
+    };
+}

--- a/src/components/mlir/mlirFilter.ts
+++ b/src/components/mlir/mlirFilter.ts
@@ -2,7 +2,12 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-export type MlirFilterMode = 'substring' | 'regex';
+// String-backed so the enum member values match the historical `sessionStorage`
+// payload ('substring' / 'regex'); persisted state migrates without a version bump.
+export enum MlirFilterMode {
+    Substring = 'substring',
+    Regex = 'regex',
+}
 
 export interface MlirFilterMatcher {
     /** True if a source label should be treated as a filter match. */
@@ -18,7 +23,7 @@ export function buildFilterMatcher(mode: MlirFilterMode, query: string): MlirFil
     if (query.length === 0) {
         return { testLabel: () => false, isRegexInvalid: false };
     }
-    if (mode === 'regex') {
+    if (mode === MlirFilterMode.Regex) {
         try {
             const re = new RegExp(query, 'i');
             return { testLabel: (label) => re.test(label), isRegexInvalid: false };

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -266,7 +266,7 @@
  * minimap/controls panels. */
 .mlir-relayout-button {
     position: absolute;
-    top: 80px;
+    top: 56px;
     left: 12px;
     z-index: 10;
     padding: 8px 10px;

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -47,6 +47,21 @@
         font-family: monospace;
         font-size: 12px;
         font-weight: 600;
+
+        &.bp6-button {
+            color: $tt-grey-5;
+            background: transparent;
+            border-radius: 3px;
+        }
+
+        &.bp6-button.bp6-active {
+            color: $tt-black;
+            background: $tt-yellow;
+        }
+
+        &.bp6-button.bp6-active:hover {
+            background: $tt-yellow-tint-1;
+        }
     }
 
     .mlir-op-filter-clear,

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -43,7 +43,6 @@
     }
 
     .mlir-op-filter-mode {
-        // Monospace so `.*` reads as a symbol, not a variable-width sentence.
         font-family: monospace;
         font-size: 12px;
         font-weight: 600;

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -36,8 +36,22 @@
         white-space: nowrap;
     }
 
+    .mlir-op-filter-right-slot {
+        display: inline-flex;
+        align-items: center;
+        gap: 2px;
+    }
+
+    .mlir-op-filter-mode {
+        // Monospace so `.*` reads as a symbol, not a variable-width sentence.
+        font-family: monospace;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
     .mlir-op-filter-clear,
-    .mlir-op-filter-step {
+    .mlir-op-filter-step,
+    .mlir-op-filter-mode {
         display: inline-flex;
         align-items: center;
         justify-content: center;

--- a/tests/MlirOpFilter.spec.tsx
+++ b/tests/MlirOpFilter.spec.tsx
@@ -6,7 +6,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { type Ref, createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import MlirOpFilter, { type MlirFilterMode, type MlirOpFilterHandle } from '../src/components/mlir/MlirOpFilter';
+import MlirOpFilter, { MlirFilterMode, type MlirOpFilterHandle } from '../src/components/mlir/MlirOpFilter';
 import { TestProviders } from './helpers/TestProviders';
 
 afterEach(cleanup);
@@ -37,7 +37,7 @@ const renderFilter = (overrides: Overrides = {}) => {
                 ref={overrides.ref}
                 query={overrides.query ?? ''}
                 onQueryChange={onQueryChange}
-                mode={overrides.mode ?? 'substring'}
+                mode={overrides.mode ?? MlirFilterMode.Substring}
                 onModeChange={onModeChange}
                 isRegexInvalid={overrides.isRegexInvalid ?? false}
                 matchCount={overrides.matchCount ?? 0}
@@ -58,14 +58,14 @@ const getModeToggle = () => screen.getByRole('button', { name: /Switch to (regex
 describe('MlirOpFilter', () => {
     describe('mode toggle', () => {
         it('reflects substring mode with a non-active toggle and matching placeholder', () => {
-            renderFilter({ mode: 'substring' });
+            renderFilter({ mode: MlirFilterMode.Substring });
 
             expect(getInput().placeholder).toBe('Filter ops (substring)');
             expect(getModeToggle()).not.toHaveClass('bp6-active');
         });
 
         it('reflects regex mode with an active toggle and matching placeholder', () => {
-            renderFilter({ mode: 'regex' });
+            renderFilter({ mode: MlirFilterMode.Regex });
 
             expect(getInput().placeholder).toBe('Filter ops (regex)');
             expect(getModeToggle()).toHaveClass('bp6-active');
@@ -73,20 +73,20 @@ describe('MlirOpFilter', () => {
 
         it('calls onModeChange with the opposite mode when clicked', () => {
             const onModeChange = vi.fn();
-            renderFilter({ mode: 'substring', onModeChange });
+            renderFilter({ mode: MlirFilterMode.Substring, onModeChange });
 
             fireEvent.click(getModeToggle());
 
-            expect(onModeChange).toHaveBeenCalledWith('regex');
+            expect(onModeChange).toHaveBeenCalledWith(MlirFilterMode.Regex);
         });
 
         it('flips regex → substring on click', () => {
             const onModeChange = vi.fn();
-            renderFilter({ mode: 'regex', onModeChange });
+            renderFilter({ mode: MlirFilterMode.Regex, onModeChange });
 
             fireEvent.click(getModeToggle());
 
-            expect(onModeChange).toHaveBeenCalledWith('substring');
+            expect(onModeChange).toHaveBeenCalledWith(MlirFilterMode.Substring);
         });
     });
 
@@ -104,7 +104,7 @@ describe('MlirOpFilter', () => {
         });
 
         it('reads "invalid regex" when the regex fails to compile, regardless of counts', () => {
-            renderFilter({ query: '(', mode: 'regex', isRegexInvalid: true });
+            renderFilter({ query: '(', mode: MlirFilterMode.Regex, isRegexInvalid: true });
 
             expect(screen.getByText('invalid regex')).toBeInTheDocument();
             expect(screen.queryByText('no matches')).toBeNull();
@@ -140,7 +140,7 @@ describe('MlirOpFilter', () => {
 
     describe('regex-invalid styling', () => {
         it('applies bp6-intent-danger to the input group when invalid', () => {
-            const { container } = renderFilter({ query: '(', mode: 'regex', isRegexInvalid: true });
+            const { container } = renderFilter({ query: '(', mode: MlirFilterMode.Regex, isRegexInvalid: true });
 
             const group = container.querySelector('.bp6-input-group');
             expect(group).not.toBeNull();
@@ -148,7 +148,7 @@ describe('MlirOpFilter', () => {
         });
 
         it('does not apply the danger class when the regex compiles cleanly', () => {
-            const { container } = renderFilter({ query: '^foo$', mode: 'regex', isRegexInvalid: false });
+            const { container } = renderFilter({ query: '^foo$', mode: MlirFilterMode.Regex, isRegexInvalid: false });
 
             const group = container.querySelector('.bp6-input-group');
             expect(group).not.toHaveClass('bp6-intent-danger');

--- a/tests/MlirOpFilter.spec.tsx
+++ b/tests/MlirOpFilter.spec.tsx
@@ -4,9 +4,9 @@
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-import { Ref, createRef } from 'react';
+import { type Ref, createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import MlirOpFilter, { MlirFilterMode, MlirOpFilterHandle } from '../src/components/mlir/MlirOpFilter';
+import MlirOpFilter, { type MlirFilterMode, type MlirOpFilterHandle } from '../src/components/mlir/MlirOpFilter';
 import { TestProviders } from './helpers/TestProviders';
 
 afterEach(cleanup);
@@ -126,6 +126,15 @@ describe('MlirOpFilter', () => {
             renderFilter({ query: 'foo', matchCount: 4, currentMatchIndex: null });
 
             expect(screen.getByText('4 matches')).toBeInTheDocument();
+        });
+
+        it('ignores a stale currentMatchIndex that no longer fits the match set', () => {
+            // Cursor was at match 5/5, then expand/collapse shrank the set to 2.
+            // Counter must not read "6 / 2" — it should fall back to "2 matches".
+            renderFilter({ query: 'foo', matchCount: 2, currentMatchIndex: 5 });
+
+            expect(screen.getByText('2 matches')).toBeInTheDocument();
+            expect(screen.queryByText(/6\s*\/\s*2/)).toBeNull();
         });
     });
 

--- a/tests/MlirOpFilter.spec.tsx
+++ b/tests/MlirOpFilter.spec.tsx
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { Ref, createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MlirOpFilter, { MlirFilterMode, MlirOpFilterHandle } from '../src/components/mlir/MlirOpFilter';
+import { TestProviders } from './helpers/TestProviders';
+
+afterEach(cleanup);
+
+interface Overrides {
+    query?: string;
+    mode?: MlirFilterMode;
+    isRegexInvalid?: boolean;
+    matchCount?: number;
+    hiddenMatchCount?: number;
+    currentMatchIndex?: number | null;
+    onQueryChange?: (next: string) => void;
+    onModeChange?: (next: MlirFilterMode) => void;
+    onPrev?: () => void;
+    onNext?: () => void;
+    ref?: Ref<MlirOpFilterHandle>;
+}
+
+const renderFilter = (overrides: Overrides = {}) => {
+    const onQueryChange = overrides.onQueryChange ?? vi.fn();
+    const onModeChange = overrides.onModeChange ?? vi.fn();
+    const onPrev = overrides.onPrev ?? vi.fn();
+    const onNext = overrides.onNext ?? vi.fn();
+
+    const utils = render(
+        <TestProviders>
+            <MlirOpFilter
+                ref={overrides.ref}
+                query={overrides.query ?? ''}
+                onQueryChange={onQueryChange}
+                mode={overrides.mode ?? 'substring'}
+                onModeChange={onModeChange}
+                isRegexInvalid={overrides.isRegexInvalid ?? false}
+                matchCount={overrides.matchCount ?? 0}
+                hiddenMatchCount={overrides.hiddenMatchCount ?? 0}
+                currentMatchIndex={overrides.currentMatchIndex ?? null}
+                onPrev={onPrev}
+                onNext={onNext}
+            />
+        </TestProviders>,
+    );
+
+    return { ...utils, onQueryChange, onModeChange, onPrev, onNext };
+};
+
+const getInput = () => screen.getByPlaceholderText(/^Filter ops/) as HTMLInputElement;
+const getModeToggle = () => screen.getByRole('button', { name: /Switch to (regex|substring) mode/ });
+
+describe('MlirOpFilter', () => {
+    describe('mode toggle', () => {
+        it('reflects substring mode with a non-active toggle and matching placeholder', () => {
+            renderFilter({ mode: 'substring' });
+
+            expect(getInput().placeholder).toBe('Filter ops (substring)');
+            expect(getModeToggle()).not.toHaveClass('bp6-active');
+        });
+
+        it('reflects regex mode with an active toggle and matching placeholder', () => {
+            renderFilter({ mode: 'regex' });
+
+            expect(getInput().placeholder).toBe('Filter ops (regex)');
+            expect(getModeToggle()).toHaveClass('bp6-active');
+        });
+
+        it('calls onModeChange with the opposite mode when clicked', () => {
+            const onModeChange = vi.fn();
+            renderFilter({ mode: 'substring', onModeChange });
+
+            fireEvent.click(getModeToggle());
+
+            expect(onModeChange).toHaveBeenCalledWith('regex');
+        });
+
+        it('flips regex → substring on click', () => {
+            const onModeChange = vi.fn();
+            renderFilter({ mode: 'regex', onModeChange });
+
+            fireEvent.click(getModeToggle());
+
+            expect(onModeChange).toHaveBeenCalledWith('substring');
+        });
+    });
+
+    describe('counter text', () => {
+        it('is hidden when the query is empty', () => {
+            renderFilter({ query: '' });
+
+            expect(screen.queryByText(/matches|invalid|no matches/)).toBeNull();
+        });
+
+        it('reads "no matches" when the query is non-empty but nothing hits', () => {
+            renderFilter({ query: 'foo', matchCount: 0, hiddenMatchCount: 0 });
+
+            expect(screen.getByText('no matches')).toBeInTheDocument();
+        });
+
+        it('reads "invalid regex" when the regex fails to compile, regardless of counts', () => {
+            renderFilter({ query: '(', mode: 'regex', isRegexInvalid: true });
+
+            expect(screen.getByText('invalid regex')).toBeInTheDocument();
+            expect(screen.queryByText('no matches')).toBeNull();
+        });
+
+        it('shows N-of-M when a match is focused', () => {
+            renderFilter({ query: 'foo', matchCount: 5, currentMatchIndex: 2 });
+
+            expect(screen.getByText('3 / 5')).toBeInTheDocument();
+        });
+
+        it('appends the "(+K inside)" suffix for buried matches', () => {
+            renderFilter({ query: 'foo', matchCount: 5, currentMatchIndex: 2, hiddenMatchCount: 3 });
+
+            expect(screen.getByText('3 / 5 (+3 inside)')).toBeInTheDocument();
+        });
+
+        it('shows "N matches" pre-focus when the cursor has not been placed yet', () => {
+            renderFilter({ query: 'foo', matchCount: 4, currentMatchIndex: null });
+
+            expect(screen.getByText('4 matches')).toBeInTheDocument();
+        });
+    });
+
+    describe('regex-invalid styling', () => {
+        it('applies bp6-intent-danger to the input group when invalid', () => {
+            const { container } = renderFilter({ query: '(', mode: 'regex', isRegexInvalid: true });
+
+            const group = container.querySelector('.bp6-input-group');
+            expect(group).not.toBeNull();
+            expect(group).toHaveClass('bp6-intent-danger');
+        });
+
+        it('does not apply the danger class when the regex compiles cleanly', () => {
+            const { container } = renderFilter({ query: '^foo$', mode: 'regex', isRegexInvalid: false });
+
+            const group = container.querySelector('.bp6-input-group');
+            expect(group).not.toHaveClass('bp6-intent-danger');
+        });
+    });
+
+    describe('keyboard shortcuts', () => {
+        it('Escape clears the query', () => {
+            const onQueryChange = vi.fn();
+            renderFilter({ query: 'foo', onQueryChange });
+
+            fireEvent.keyDown(getInput(), { key: 'Escape' });
+
+            expect(onQueryChange).toHaveBeenCalledWith('');
+        });
+
+        it('Enter advances to the next match', () => {
+            const onNext = vi.fn();
+            renderFilter({ query: 'foo', matchCount: 3, onNext });
+
+            fireEvent.keyDown(getInput(), { key: 'Enter' });
+
+            expect(onNext).toHaveBeenCalledTimes(1);
+        });
+
+        it('Shift+Enter walks back to the previous match', () => {
+            const onPrev = vi.fn();
+            renderFilter({ query: 'foo', matchCount: 3, onPrev });
+
+            fireEvent.keyDown(getInput(), { key: 'Enter', shiftKey: true });
+
+            expect(onPrev).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('clear button', () => {
+        it('is hidden when the query is empty', () => {
+            renderFilter({ query: '' });
+
+            expect(screen.queryByRole('button', { name: 'Clear filter' })).toBeNull();
+        });
+
+        it('clears the query when clicked', () => {
+            const onQueryChange = vi.fn();
+            renderFilter({ query: 'foo', onQueryChange });
+
+            fireEvent.click(screen.getByRole('button', { name: 'Clear filter' }));
+
+            expect(onQueryChange).toHaveBeenCalledWith('');
+        });
+    });
+
+    describe('prev/next buttons', () => {
+        it('disables prev/next when there are no matches', () => {
+            renderFilter({ query: 'foo', matchCount: 0 });
+
+            expect(screen.getByRole('button', { name: 'Previous match' })).toBeDisabled();
+            expect(screen.getByRole('button', { name: 'Next match' })).toBeDisabled();
+        });
+
+        it('enables prev/next when at least one match is present', () => {
+            renderFilter({ query: 'foo', matchCount: 1 });
+
+            expect(screen.getByRole('button', { name: 'Previous match' })).not.toBeDisabled();
+            expect(screen.getByRole('button', { name: 'Next match' })).not.toBeDisabled();
+        });
+    });
+
+    describe('imperative focus handle', () => {
+        it('focuses and selects the input when the parent calls handle.focus()', () => {
+            const ref = createRef<MlirOpFilterHandle>();
+            renderFilter({ query: 'foo', ref });
+
+            ref.current?.focus();
+
+            const input = getInput();
+            expect(document.activeElement).toBe(input);
+            expect(input.selectionStart).toBe(0);
+            expect(input.selectionEnd).toBe('foo'.length);
+        });
+    });
+});

--- a/tests/mlirFilter.spec.ts
+++ b/tests/mlirFilter.spec.ts
@@ -3,22 +3,25 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { buildFilterMatcher } from '../src/components/mlir/mlirFilter';
+import { MlirFilterMode, buildFilterMatcher } from '../src/components/mlir/mlirFilter';
 
 describe('buildFilterMatcher', () => {
     describe('empty query', () => {
-        it.each([['substring'], ['regex']] as const)('rejects every label in %s mode', (mode) => {
-            const { testLabel, isRegexInvalid } = buildFilterMatcher(mode, '');
+        it.each([[MlirFilterMode.Substring], [MlirFilterMode.Regex]] as const)(
+            'rejects every label in %s mode',
+            (mode) => {
+                const { testLabel, isRegexInvalid } = buildFilterMatcher(mode, '');
 
-            expect(testLabel('stablehlo.constant')).toBe(false);
-            expect(testLabel('')).toBe(false);
-            expect(isRegexInvalid).toBe(false);
-        });
+                expect(testLabel('stablehlo.constant')).toBe(false);
+                expect(testLabel('')).toBe(false);
+                expect(isRegexInvalid).toBe(false);
+            },
+        );
     });
 
     describe('substring mode', () => {
         it('matches case-insensitive substrings', () => {
-            const { testLabel } = buildFilterMatcher('substring', 'Add');
+            const { testLabel } = buildFilterMatcher(MlirFilterMode.Substring, 'Add');
 
             expect(testLabel('stablehlo.add')).toBe(true);
             expect(testLabel('stablehlo.ADD')).toBe(true);
@@ -26,7 +29,7 @@ describe('buildFilterMatcher', () => {
         });
 
         it('treats regex metacharacters as literals', () => {
-            const { testLabel } = buildFilterMatcher('substring', 'co*');
+            const { testLabel } = buildFilterMatcher(MlirFilterMode.Substring, 'co*');
 
             // Literal `co*` never appears in normal op names.
             expect(testLabel('stablehlo.constant')).toBe(false);
@@ -36,14 +39,14 @@ describe('buildFilterMatcher', () => {
         });
 
         it('never reports isRegexInvalid', () => {
-            expect(buildFilterMatcher('substring', '(').isRegexInvalid).toBe(false);
-            expect(buildFilterMatcher('substring', '[unclosed').isRegexInvalid).toBe(false);
+            expect(buildFilterMatcher(MlirFilterMode.Substring, '(').isRegexInvalid).toBe(false);
+            expect(buildFilterMatcher(MlirFilterMode.Substring, '[unclosed').isRegexInvalid).toBe(false);
         });
     });
 
     describe('regex mode', () => {
         it('matches case-insensitive patterns', () => {
-            const { testLabel } = buildFilterMatcher('regex', '^stablehlo\\.');
+            const { testLabel } = buildFilterMatcher(MlirFilterMode.Regex, '^stablehlo\\.');
 
             expect(testLabel('stablehlo.constant')).toBe(true);
             expect(testLabel('STABLEHLO.constant')).toBe(true);
@@ -53,7 +56,7 @@ describe('buildFilterMatcher', () => {
         it('honours zero-or-more semantics — `co*` matches a bare `c`', () => {
             // Regression for the "why is broadcast_in_dim matched by `co*`" question:
             // `co*` = `c` + zero-or-more `o`, so `c` alone in `broadcast` matches.
-            const { testLabel } = buildFilterMatcher('regex', 'co*');
+            const { testLabel } = buildFilterMatcher(MlirFilterMode.Regex, 'co*');
 
             expect(testLabel('stablehlo.constant')).toBe(true);
             expect(testLabel('stablehlo.broadcast_in_dim')).toBe(true);
@@ -61,7 +64,7 @@ describe('buildFilterMatcher', () => {
         });
 
         it('flags invalid patterns and rejects every label without throwing', () => {
-            const { testLabel, isRegexInvalid } = buildFilterMatcher('regex', '(');
+            const { testLabel, isRegexInvalid } = buildFilterMatcher(MlirFilterMode.Regex, '(');
 
             expect(isRegexInvalid).toBe(true);
             expect(testLabel('stablehlo.constant')).toBe(false);
@@ -69,7 +72,7 @@ describe('buildFilterMatcher', () => {
         });
 
         it('does not conflate "no matches" with "invalid regex"', () => {
-            const { testLabel, isRegexInvalid } = buildFilterMatcher('regex', '^zzz$');
+            const { testLabel, isRegexInvalid } = buildFilterMatcher(MlirFilterMode.Regex, '^zzz$');
 
             expect(isRegexInvalid).toBe(false);
             expect(testLabel('stablehlo.constant')).toBe(false);

--- a/tests/mlirFilter.spec.ts
+++ b/tests/mlirFilter.spec.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { buildFilterMatcher } from '../src/components/mlir/mlirFilter';
+
+describe('buildFilterMatcher', () => {
+    describe('empty query', () => {
+        it.each([['substring'], ['regex']] as const)('rejects every label in %s mode', (mode) => {
+            const { testLabel, isRegexInvalid } = buildFilterMatcher(mode, '');
+
+            expect(testLabel('stablehlo.constant')).toBe(false);
+            expect(testLabel('')).toBe(false);
+            expect(isRegexInvalid).toBe(false);
+        });
+    });
+
+    describe('substring mode', () => {
+        it('matches case-insensitive substrings', () => {
+            const { testLabel } = buildFilterMatcher('substring', 'Add');
+
+            expect(testLabel('stablehlo.add')).toBe(true);
+            expect(testLabel('stablehlo.ADD')).toBe(true);
+            expect(testLabel('stablehlo.subtract')).toBe(false);
+        });
+
+        it('treats regex metacharacters as literals', () => {
+            const { testLabel } = buildFilterMatcher('substring', 'co*');
+
+            // Literal `co*` never appears in normal op names.
+            expect(testLabel('stablehlo.constant')).toBe(false);
+            expect(testLabel('stablehlo.broadcast_in_dim')).toBe(false);
+            // But the literal three-char sequence does match if it's present.
+            expect(testLabel('stablehlo.co*_debug')).toBe(true);
+        });
+
+        it('never reports isRegexInvalid', () => {
+            expect(buildFilterMatcher('substring', '(').isRegexInvalid).toBe(false);
+            expect(buildFilterMatcher('substring', '[unclosed').isRegexInvalid).toBe(false);
+        });
+    });
+
+    describe('regex mode', () => {
+        it('matches case-insensitive patterns', () => {
+            const { testLabel } = buildFilterMatcher('regex', '^stablehlo\\.');
+
+            expect(testLabel('stablehlo.constant')).toBe(true);
+            expect(testLabel('STABLEHLO.constant')).toBe(true);
+            expect(testLabel('ttir.stablehlo.constant')).toBe(false);
+        });
+
+        it('honours zero-or-more semantics — `co*` matches a bare `c`', () => {
+            // Regression for the "why is broadcast_in_dim matched by `co*`" question:
+            // `co*` = `c` + zero-or-more `o`, so `c` alone in `broadcast` matches.
+            const { testLabel } = buildFilterMatcher('regex', 'co*');
+
+            expect(testLabel('stablehlo.constant')).toBe(true);
+            expect(testLabel('stablehlo.broadcast_in_dim')).toBe(true);
+            expect(testLabel('stablehlo.add')).toBe(false);
+        });
+
+        it('flags invalid patterns and rejects every label without throwing', () => {
+            const { testLabel, isRegexInvalid } = buildFilterMatcher('regex', '(');
+
+            expect(isRegexInvalid).toBe(true);
+            expect(testLabel('stablehlo.constant')).toBe(false);
+            expect(testLabel('anything')).toBe(false);
+        });
+
+        it('does not conflate "no matches" with "invalid regex"', () => {
+            const { testLabel, isRegexInvalid } = buildFilterMatcher('regex', '^zzz$');
+
+            expect(isRegexInvalid).toBe(false);
+            expect(testLabel('stablehlo.constant')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Extends the op-name filter shipped in #1545 with a regex mode toggle.

<img width="1484" height="806" alt="image" src="https://github.com/user-attachments/assets/e9340937-2205-4b99-bdb5-bbabe72f51de" />

## Behaviour
- Mode toggle sits in the filter input's right slot — `.*` glyph, high-contrast active/inactive states (transparent grey vs. solid yellow).
- Patterns compile with the `i` flag, mirroring the substring path's `toLowerCase()` semantics.
- Invalid regex short-circuits to a zero-match matcher, paints the input with `Intent.DANGER`, and reads `invalid regex` in the counter — so the user can distinguish a broken pattern from a query that just doesn't hit.
- Mode persists in `sessionStorage` under `mlirFilterMode` and is restored on mount.
- Flipping mode resets the prev/next cursor since the match set can change.

## Structure
- Pure `buildFilterMatcher(mode, query)` helper extracted to `src/components/mlir/mlirFilter.ts` — makes the substring / regex / invalid paths unit-testable without wiring up the whole graph view. Also lays groundwork for #1707 (extract `computeFilterMatches` as a pure function).
- `MlirOpFilter` gains `mode` / `onModeChange` / `isRegexInvalid` props; existing `MlirFilterMode` type re-exported so callers don't shift imports.

## Tests
29 tests, split across `tests/mlirFilter.spec.ts` (matcher unit coverage, including the `co*` regression that prompted the review) and `tests/MlirOpFilter.spec.tsx` (mode toggle, placeholder swap, danger-intent styling, counter text for all states, keyboard shortcuts, imperative focus handle).

Closes #1716.