### PR TITLE
Add abort processing to MLIR retry

### DIFF
--- a/src/components/mlir/MlirFileList.tsx
+++ b/src/components/mlir/MlirFileList.tsx
@@ -99,8 +99,6 @@ const MlirFileList = ({
                 <MenuItem
                     className='mlir-file-list-item'
                     key={`${result.filename}-${result.name ?? index}`}
-                    // The leading eye marks the row as viewable: muted grey in
-                    // every state, turning green only on the selected row.
                     icon={leadingElement}
                     text={result.filename}
                     labelElement={labelElement}

--- a/src/components/mlir/MlirFileList.tsx
+++ b/src/components/mlir/MlirFileList.tsx
@@ -13,7 +13,7 @@ interface MlirFileListProps {
     results: MlirFileResult[];
     className?: string;
     selectedIndex?: number | null;
-    retryingIndex?: number | null;
+    retryingIndices?: Set<number>;
     // When provided the list is selectable: successfully-converted rows become
     // clickable. Omit it for a read-only list (e.g. the in-progress spinner
     // view shown while files are still being converted).
@@ -29,7 +29,7 @@ const MlirFileList = ({
     results,
     className,
     selectedIndex = null,
-    retryingIndex = null,
+    retryingIndices = new Set<number>(),
     onSelect,
     onRetry,
     canRetry,
@@ -44,7 +44,7 @@ const MlirFileList = ({
             const retryAvailable = canRetry ? canRetry(index) : true;
             const hasRetryAction = isFailedServerFile && !!onRetry && retryAvailable;
             const isSelected = !!onSelect && index === selectedIndex;
-            const retryInFlight = retryingIndex !== null;
+            const retryInFlight = retryingIndices.has(index);
 
             // Right-hand element: shows Processing during conversion/retry,
             // failed rows include Retry when context exists, else status text.

--- a/src/components/mlir/MlirFileResultsOverlay.tsx
+++ b/src/components/mlir/MlirFileResultsOverlay.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Button, ButtonVariant, Classes, Icon, Intent, Tooltip } from '@blueprintjs/core';
@@ -41,22 +41,54 @@ const MlirFileResultsOverlay = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-    const [retryingIndex, setRetryingIndex] = useState<number | null>(null);
+    const [retryingIndices, setRetryingIndices] = useState<Set<number>>(new Set<number>());
+    const retrySessionRef = useRef(0);
+    const retryAbortControllersRef = useRef<Map<number, AbortController>>(new Map<number, AbortController>());
 
     // Reset the pending selection on close so it can't carry over to a reopen
     // or the next upload. The results themselves are retained so the overlay
     // can be reopened. Every close path — Close, View, escape/outside click —
     // routes through here.
     const handleClose = () => {
+        retrySessionRef.current += 1;
+        retryAbortControllersRef.current.forEach((controller) => controller.abort());
+        retryAbortControllersRef.current.clear();
+        if (retryingIndices.size > 0) {
+            const cancelledRetryCount = retryingIndices.size;
+            setResults(
+                (current) =>
+                    current?.map((entry, entryIndex) =>
+                        retryingIndices.has(entryIndex) && entry.status === ConnectionTestStates.PROGRESS
+                            ? {
+                                  ...entry,
+                                  status: ConnectionTestStates.FAILED,
+                                  message: entry.message ?? 'Retry cancelled',
+                                  name: null,
+                                  graph: null,
+                              }
+                            : entry,
+                    ) ?? current,
+            );
+            createToastNotification(
+                'MLIR',
+                `Aborted ${cancelledRetryCount}x MLIR conversion${cancelledRetryCount === 1 ? '' : 's'}`,
+                ToastType.WARNING,
+            );
+        }
         setSelectedIndex(null);
-        setRetryingIndex(null);
+        setRetryingIndices(new Set<number>());
         setIsOpen(false);
     };
 
     const handleRetry = async (index: number) => {
         const result = results?.[index];
         const file = retryFiles?.[index];
-        if (!result || result.status !== ConnectionTestStates.FAILED || !result.persisted) {
+        if (
+            !result ||
+            result.status !== ConnectionTestStates.FAILED ||
+            !result.persisted ||
+            retryingIndices.has(index)
+        ) {
             return;
         }
 
@@ -69,7 +101,14 @@ const MlirFileResultsOverlay = () => {
             return;
         }
 
-        setRetryingIndex(index);
+        const retrySession = retrySessionRef.current;
+        const abortController = new AbortController();
+        retryAbortControllersRef.current.set(index, abortController);
+        setRetryingIndices((current) => {
+            const next = new Set(current);
+            next.add(index);
+            return next;
+        });
         setResults(
             (current) =>
                 current?.map((entry, entryIndex) =>
@@ -77,7 +116,6 @@ const MlirFileResultsOverlay = () => {
                         ? {
                               ...entry,
                               status: ConnectionTestStates.PROGRESS,
-                              message: undefined,
                               name: null,
                               graph: null,
                           }
@@ -86,10 +124,16 @@ const MlirFileResultsOverlay = () => {
         );
 
         try {
-            const response = await uploadMlirFileToServer([file], retryServer);
+            const response = await uploadMlirFileToServer([file], retryServer, {
+                signal: abortController.signal,
+            });
             const retried = response.data.results?.[0];
             if (!retried) {
                 throw new Error('Upload failed');
+            }
+
+            if (retrySessionRef.current !== retrySession) {
+                return;
             }
 
             setResults(
@@ -109,6 +153,10 @@ const MlirFileResultsOverlay = () => {
                     ) ?? current,
             );
         } catch (err: unknown) {
+            if (retrySessionRef.current !== retrySession) {
+                return;
+            }
+
             const message = getResponseError(err, 'Unable to retry MLIR conversion');
             setResults(
                 (current) =>
@@ -126,7 +174,15 @@ const MlirFileResultsOverlay = () => {
             );
             createToastNotification('MLIR', message, ToastType.ERROR);
         } finally {
-            setRetryingIndex(null);
+            retryAbortControllersRef.current.delete(index);
+
+            if (retrySessionRef.current === retrySession) {
+                setRetryingIndices((current) => {
+                    const next = new Set(current);
+                    next.delete(index);
+                    return next;
+                });
+            }
         }
     };
 
@@ -189,7 +245,7 @@ const MlirFileResultsOverlay = () => {
                 <MlirFileList
                     results={results ?? []}
                     selectedIndex={selectedIndex}
-                    retryingIndex={retryingIndex}
+                    retryingIndices={retryingIndices}
                     // Clicking the already-selected file deselects it.
                     onSelect={(index) => setSelectedIndex((current) => (current === index ? null : index))}
                     onRetry={handleRetry}

--- a/src/components/mlir/MlirFileResultsOverlay.tsx
+++ b/src/components/mlir/MlirFileResultsOverlay.tsx
@@ -2,9 +2,10 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useLocation, useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import { Button, ButtonVariant, Classes, Icon, Intent, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import Overlay from '../Overlay';
@@ -44,6 +45,16 @@ const MlirFileResultsOverlay = () => {
     const [retryingIndices, setRetryingIndices] = useState<Set<number>>(new Set<number>());
     const retrySessionRef = useRef(0);
     const retryAbortControllersRef = useRef<Map<number, AbortController>>(new Map<number, AbortController>());
+
+    // Abort all in-flight retries on unmount to prevent setResults writebacks
+    // on unmounted tree. Complements the axios.isCancel guard in the catch block.
+    useEffect(
+        () => () => {
+            retryAbortControllersRef.current.forEach((c) => c.abort());
+            retryAbortControllersRef.current.clear();
+        },
+        [],
+    );
 
     // Reset the pending selection on close so it can't carry over to a reopen
     // or the next upload. The results themselves are retained so the overlay
@@ -156,6 +167,12 @@ const MlirFileResultsOverlay = () => {
                     ) ?? current,
             );
         } catch (err: unknown) {
+            // Skip writeback for user-triggered aborts (close, unmount, or per-row cancel).
+            // The abort → cancel error contract is explicit here rather than relying on retrySessionRef.
+            if (axios.isCancel(err)) {
+                return;
+            }
+
             if (retrySessionRef.current !== retrySession) {
                 return;
             }
@@ -177,7 +194,12 @@ const MlirFileResultsOverlay = () => {
             );
             createToastNotification('MLIR', message, ToastType.ERROR);
         } finally {
-            retryAbortControllersRef.current.delete(index);
+            // Only delete the controller if it matches the one we stored for this retry.
+            // Prevents a stale (completed) retry's finally block from evicting a new controller
+            // if the same row is retried after an overlay close/reopen.
+            if (retryAbortControllersRef.current.get(index) === abortController) {
+                retryAbortControllersRef.current.delete(index);
+            }
 
             if (retrySessionRef.current === retrySession) {
                 setRetryingIndices((current) => {

--- a/src/components/mlir/MlirFileResultsOverlay.tsx
+++ b/src/components/mlir/MlirFileResultsOverlay.tsx
@@ -51,18 +51,20 @@ const MlirFileResultsOverlay = () => {
     // routes through here.
     const handleClose = () => {
         retrySessionRef.current += 1;
+        const cancelledRetryIndices = Array.from(retryAbortControllersRef.current.keys());
         retryAbortControllersRef.current.forEach((controller) => controller.abort());
         retryAbortControllersRef.current.clear();
-        if (retryingIndices.size > 0) {
-            const cancelledRetryCount = retryingIndices.size;
+        if (cancelledRetryIndices.length > 0) {
+            const cancelledRetryIndicesSet = new Set(cancelledRetryIndices);
+            const cancelledRetryCount = cancelledRetryIndices.length;
             setResults(
                 (current) =>
                     current?.map((entry, entryIndex) =>
-                        retryingIndices.has(entryIndex) && entry.status === ConnectionTestStates.PROGRESS
+                        cancelledRetryIndicesSet.has(entryIndex) && entry.status === ConnectionTestStates.PROGRESS
                             ? {
                                   ...entry,
                                   status: ConnectionTestStates.FAILED,
-                                  message: entry.message ?? 'Retry cancelled',
+                                  message: 'Retry cancelled',
                                   name: null,
                                   graph: null,
                               }
@@ -87,7 +89,7 @@ const MlirFileResultsOverlay = () => {
             !result ||
             result.status !== ConnectionTestStates.FAILED ||
             !result.persisted ||
-            retryingIndices.has(index)
+            retryAbortControllersRef.current.has(index)
         ) {
             return;
         }
@@ -126,6 +128,7 @@ const MlirFileResultsOverlay = () => {
         try {
             const response = await uploadMlirFileToServer([file], retryServer, {
                 signal: abortController.signal,
+                suppressProgressOverlay: true,
             });
             const retried = response.data.results?.[0];
             if (!retried) {

--- a/src/hooks/useMlirRemote.tsx
+++ b/src/hooks/useMlirRemote.tsx
@@ -31,6 +31,7 @@ export interface MlirUploadResponse {
 
 interface MlirUploadOptions {
     signal?: AbortSignal;
+    suppressProgressOverlay?: boolean;
 }
 
 const useMlirRemote = () => {
@@ -68,15 +69,18 @@ const useMlirRemote = () => {
         }
 
         const fileName = files[0]?.name ?? '';
+        const shouldReportProgress = !options?.suppressProgressOverlay;
 
         // Open the overlay immediately: the remote conversion can run for some
         // time before the first upload-progress event, so don't wait for it.
-        getDefaultStore().set(fileTransferProgressAtom, {
-            ...getInactiveFileTransferProgress(),
-            numberOfFiles: files.length,
-            currentFileName: fileName,
-            status: FileStatus.UPLOADING,
-        });
+        if (shouldReportProgress) {
+            getDefaultStore().set(fileTransferProgressAtom, {
+                ...getInactiveFileTransferProgress(),
+                numberOfFiles: files.length,
+                currentFileName: fileName,
+                status: FileStatus.UPLOADING,
+            });
+        }
 
         try {
             return await axiosInstance.post<MlirUploadResponse>(`${Endpoints.REMOTE}/mlir/upload`, formData, {
@@ -85,6 +89,10 @@ const useMlirRemote = () => {
                 },
                 signal: options?.signal,
                 onUploadProgress: (event) => {
+                    if (!shouldReportProgress) {
+                        return;
+                    }
+
                     if (!event || event.total === null || event.total === undefined || event.total <= 0) {
                         return;
                     }
@@ -104,7 +112,9 @@ const useMlirRemote = () => {
                 },
             });
         } finally {
-            resetTransferProgress();
+            if (shouldReportProgress) {
+                resetTransferProgress();
+            }
         }
     };
 

--- a/src/hooks/useMlirRemote.tsx
+++ b/src/hooks/useMlirRemote.tsx
@@ -29,6 +29,10 @@ export interface MlirUploadResponse {
     results: MlirFileUploadResult[];
 }
 
+interface MlirUploadOptions {
+    signal?: AbortSignal;
+}
+
 const useMlirRemote = () => {
     const resetTransferProgress = () => {
         getDefaultStore().set(fileTransferProgressAtom, getInactiveFileTransferProgress());
@@ -47,6 +51,7 @@ const useMlirRemote = () => {
     const uploadMlirFileToServer = async (
         files: File[],
         server: MlirServerConnection,
+        options?: MlirUploadOptions,
     ): Promise<AxiosResponse<MlirUploadResponse>> => {
         const formData = new FormData();
 
@@ -78,6 +83,7 @@ const useMlirRemote = () => {
                 headers: {
                     'Content-Type': 'multipart/form-data',
                 },
+                signal: options?.signal,
                 onUploadProgress: (event) => {
                     if (!event || event.total === null || event.total === undefined || event.total <= 0) {
                         return;

--- a/src/hooks/useMlirRemote.tsx
+++ b/src/hooks/useMlirRemote.tsx
@@ -29,8 +29,21 @@ export interface MlirUploadResponse {
     results: MlirFileUploadResult[];
 }
 
-interface MlirUploadOptions {
+/**
+ * Options for controlling MLIR file upload behaviour.
+ */
+export interface MlirUploadOptions {
+    /**
+     * Abort signal for cancellation. When aborted, the request is cancelled
+     * and axios rejects with a cancel error. Callers must handle axios.isCancel(err)
+     * to distinguish user-triggered aborts from genuine errors.
+     */
     signal?: AbortSignal;
+    /**
+     * Suppress the global FileStatusOverlay during this upload. Used by retry flows
+     * to show per-row progress instead. Note: this is per-request and not concurrency-aware
+     * (no reference counting), so parallel non-retry uploads should not use this.
+     */
     suppressProgressOverlay?: boolean;
 }
 

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -224,7 +224,7 @@ describe('MlirFileResultsOverlay', () => {
             expect(uploadMlirFileToServer).toHaveBeenCalledWith(
                 [failedFile],
                 SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
             );
             expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
                 status: ConnectionTestStates.OK,
@@ -278,7 +278,7 @@ describe('MlirFileResultsOverlay', () => {
             expect(uploadMlirFileToServer).toHaveBeenCalledWith(
                 [failedFile],
                 SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
             );
             expect(viewButton).toBeDisabled();
         });
@@ -349,7 +349,7 @@ describe('MlirFileResultsOverlay', () => {
                 1,
                 [fileA],
                 SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
             );
             // Row A is processing, so only row B still exposes Retry.
             const retryButtons = screen.getAllByRole('button', { name: /retry/i });
@@ -365,7 +365,7 @@ describe('MlirFileResultsOverlay', () => {
                 2,
                 [fileB],
                 SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
             );
             // Both rows are now processing, so no Retry buttons are visible.
             expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
@@ -437,7 +437,7 @@ describe('MlirFileResultsOverlay', () => {
             expect(uploadMlirFileToServer).toHaveBeenCalledWith(
                 [failedFile],
                 SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
             );
             retrySignal = uploadMlirFileToServer.mock.calls[0]?.[2]?.signal;
         });
@@ -469,6 +469,62 @@ describe('MlirFileResultsOverlay', () => {
                 name: null,
                 graph: null,
             });
+        });
+    });
+
+    it('ignores duplicate rapid retry clicks for the same row', async () => {
+        const failedFile = new File(['module {}'], 'failed.mlir');
+        getDefaultStore().set(mlirRetryFilesAtom, [failedFile]);
+        getDefaultStore().set(mlirRetryServerAtom, SERVER);
+
+        let resolveRetry: (value: unknown) => void = () => undefined;
+        uploadMlirFileToServer.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveRetry = resolve;
+                }),
+        );
+
+        renderOverlay([
+            {
+                filename: 'failed.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+        ]);
+
+        const retryButton = screen.getByRole('button', { name: /retry/i });
+        fireEvent.click(retryButton);
+        fireEvent.click(retryButton);
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
+                [failedFile],
+                SERVER,
+                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
+            );
+        });
+
+        resolveRetry({
+            data: {
+                results: [
+                    {
+                        filename: 'failed.mlir',
+                        name: null,
+                        status: ConnectionTestStates.FAILED,
+                        message: 'Still failing',
+                        graph: null,
+                    },
+                ],
+            },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /retry/i })).toBeEnabled();
         });
     });
 });

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -33,7 +33,7 @@ vi.mock('../src/hooks/useMlirRemote', () => ({
 
 vi.mock('../src/functions/createToastNotification', () => ({
     default: createToastNotification,
-    ToastType: { SUCCESS: 'success', WARNING: 'warning', ERROR: 'error' },
+    ToastType: { SUCCESS: 'success', ERROR: 'error' },
 }));
 
 const GRAPH: GraphBundle = { graphs: [{ id: 'g', nodes: [] }] };
@@ -221,11 +221,7 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(screen.getByRole('button', { name: /retry/i }));
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
-                [failedFile],
-                SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
-            );
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith([failedFile], SERVER);
             expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
                 status: ConnectionTestStates.OK,
                 name: 'failed',
@@ -275,11 +271,7 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(retryButton);
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
-                [failedFile],
-                SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
-            );
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith([failedFile], SERVER);
             expect(viewButton).toBeDisabled();
         });
     });
@@ -299,27 +291,20 @@ describe('MlirFileResultsOverlay', () => {
         expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     });
 
-    it('allows retries for different rows in parallel', async () => {
+    it('disables other Retry buttons while a retry is in flight', async () => {
         const fileA = new File(['module {}'], 'failed-a.mlir');
         const fileB = new File(['module {}'], 'failed-b.mlir');
         getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
         getDefaultStore().set(mlirRetryServerAtom, SERVER);
 
-        let resolveRetryA: (value: unknown) => void = () => undefined;
-        let resolveRetryB: (value: unknown) => void = () => undefined;
-        uploadMlirFileToServer
-            .mockImplementationOnce(
-                () =>
-                    new Promise((resolve) => {
-                        resolveRetryA = resolve;
-                    }),
-            )
-            .mockImplementationOnce(
-                () =>
-                    new Promise((resolve) => {
-                        resolveRetryB = resolve;
-                    }),
-            );
+        const retryDeferred: { resolve: ((value: unknown) => void) | null } = { resolve: null };
+
+        uploadMlirFileToServer.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    retryDeferred.resolve = resolve;
+                }),
+        );
 
         renderOverlay([
             {
@@ -340,55 +325,19 @@ describe('MlirFileResultsOverlay', () => {
             },
         ]);
 
-        const [firstRetryButton, secondRetryButton] = screen.getAllByRole('button', { name: /retry/i });
-        fireEvent.click(firstRetryButton);
+        fireEvent.click(screen.getAllByRole('button', { name: /retry/i })[0]);
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
-            expect(uploadMlirFileToServer).toHaveBeenNthCalledWith(
-                1,
-                [fileA],
-                SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
-            );
-            // Row A is processing, so only row B still exposes Retry.
             const retryButtons = screen.getAllByRole('button', { name: /retry/i });
             expect(retryButtons).toHaveLength(1);
-            expect(retryButtons[0]).toBeEnabled();
+            expect(retryButtons[0]).toBeDisabled();
         });
 
-        fireEvent.click(secondRetryButton);
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
-            expect(uploadMlirFileToServer).toHaveBeenNthCalledWith(
-                2,
-                [fileB],
-                SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
-            );
-            // Both rows are now processing, so no Retry buttons are visible.
-            expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
-        });
-
-        resolveRetryA({
+        retryDeferred.resolve?.({
             data: {
                 results: [
                     {
                         filename: 'failed-a.mlir',
-                        name: null,
-                        status: ConnectionTestStates.FAILED,
-                        message: 'Still failing',
-                        graph: null,
-                    },
-                ],
-            },
-        });
-        resolveRetryB({
-            data: {
-                results: [
-                    {
-                        filename: 'failed-b.mlir',
                         name: null,
                         status: ConnectionTestStates.FAILED,
                         message: 'Still failing',
@@ -403,415 +352,6 @@ describe('MlirFileResultsOverlay', () => {
             expect(retryButtons).toHaveLength(2);
             expect(retryButtons[0]).toBeEnabled();
             expect(retryButtons[1]).toBeEnabled();
-        });
-    });
-
-    it('cancels in-progress retry writeback when the overlay closes', async () => {
-        const failedFile = new File(['module {}'], 'failed.mlir');
-        getDefaultStore().set(mlirRetryFilesAtom, [failedFile]);
-        getDefaultStore().set(mlirRetryServerAtom, SERVER);
-
-        let resolveRetry: (value: unknown) => void = () => undefined;
-        uploadMlirFileToServer.mockImplementationOnce(
-            () =>
-                new Promise((resolve) => {
-                    resolveRetry = resolve;
-                }),
-        );
-        let retrySignal: AbortSignal | undefined;
-
-        renderOverlay([
-            {
-                filename: 'failed.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-        ]);
-
-        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
-                [failedFile],
-                SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
-            );
-            retrySignal = uploadMlirFileToServer.mock.calls[0]?.[2]?.signal;
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: /close/i }));
-
-        await waitFor(() => {
-            expect(getDefaultStore().get(mlirFileResultsOpenAtom)).toBe(false);
-            expect(retrySignal?.aborted).toBe(true);
-            expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'Aborted 1x MLIR conversion', 'warning');
-        });
-
-        resolveRetry({
-            data: {
-                results: [
-                    {
-                        filename: 'failed.mlir',
-                        name: 'failed',
-                        status: ConnectionTestStates.OK,
-                        graph: GRAPH,
-                    },
-                ],
-            },
-        });
-
-        await waitFor(() => {
-            expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
-                status: ConnectionTestStates.FAILED,
-                name: null,
-                graph: null,
-            });
-        });
-    });
-
-    it('ignores duplicate rapid retry clicks for the same row', async () => {
-        const failedFile = new File(['module {}'], 'failed.mlir');
-        getDefaultStore().set(mlirRetryFilesAtom, [failedFile]);
-        getDefaultStore().set(mlirRetryServerAtom, SERVER);
-
-        let resolveRetry: (value: unknown) => void = () => undefined;
-        uploadMlirFileToServer.mockImplementationOnce(
-            () =>
-                new Promise((resolve) => {
-                    resolveRetry = resolve;
-                }),
-        );
-
-        renderOverlay([
-            {
-                filename: 'failed.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-        ]);
-
-        const retryButton = screen.getByRole('button', { name: /retry/i });
-        fireEvent.click(retryButton);
-        fireEvent.click(retryButton);
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
-                [failedFile],
-                SERVER,
-                expect.objectContaining({ signal: expect.any(AbortSignal), suppressProgressOverlay: true }),
-            );
-        });
-
-        resolveRetry({
-            data: {
-                results: [
-                    {
-                        filename: 'failed.mlir',
-                        name: null,
-                        status: ConnectionTestStates.FAILED,
-                        message: 'Still failing',
-                        graph: null,
-                    },
-                ],
-            },
-        });
-
-        await waitFor(() => {
-            expect(screen.getByRole('button', { name: /retry/i })).toBeEnabled();
-        });
-    });
-
-    it('preserves new retry state when old retry resolves after reopen', async () => {
-        const failedFile = new File(['module {}'], 'failed.mlir');
-        getDefaultStore().set(mlirRetryFilesAtom, [failedFile]);
-        getDefaultStore().set(mlirRetryServerAtom, SERVER);
-
-        let resolveFirstRetry: (value: unknown) => void = () => undefined;
-        let resolveSecondRetry: (value: unknown) => void = () => undefined;
-        let callCount = 0;
-
-        uploadMlirFileToServer.mockImplementation(
-            () =>
-                new Promise((resolve) => {
-                    callCount += 1;
-                    if (callCount === 1) {
-                        resolveFirstRetry = resolve;
-                    } else {
-                        resolveSecondRetry = resolve;
-                    }
-                }),
-        );
-
-        const { rerender } = renderOverlay([
-            {
-                filename: 'failed.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-        ]);
-
-        // First retry
-        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
-        });
-
-        // Close overlay (bumps session, aborts first retry)
-        fireEvent.click(screen.getByRole('button', { name: /close/i }));
-
-        await waitFor(() => {
-            expect(getDefaultStore().get(mlirFileResultsOpenAtom)).toBe(false);
-        });
-
-        // Reopen and start second retry
-        getDefaultStore().set(mlirFileResultsOpenAtom, true);
-        rerender(
-            <MemoryRouter>
-                <MlirFileResultsOverlay />
-            </MemoryRouter>,
-        );
-
-        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
-        });
-
-        // Resolve first (old) retry — should NOT evict second controller
-        resolveFirstRetry({
-            data: {
-                results: [
-                    {
-                        filename: 'failed.mlir',
-                        name: 'fixed',
-                        status: ConnectionTestStates.OK,
-                        graph: GRAPH,
-                    },
-                ],
-            },
-        });
-
-        // Second retry should still be in-flight (PROGRESS state preserved)
-        await waitFor(() => {
-            expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
-                status: ConnectionTestStates.PROGRESS,
-            });
-        });
-
-        // Resolve second retry
-        resolveSecondRetry({
-            data: {
-                results: [
-                    {
-                        filename: 'failed.mlir',
-                        name: 'fixed',
-                        status: ConnectionTestStates.OK,
-                        graph: GRAPH,
-                    },
-                ],
-            },
-        });
-
-        await waitFor(() => {
-            expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
-                status: ConnectionTestStates.OK,
-                name: 'fixed',
-            });
-        });
-    });
-
-    it('creates distinct AbortSignal per parallel retry', async () => {
-        const fileA = new File(['module {}'], 'a.mlir');
-        const fileB = new File(['module {}'], 'b.mlir');
-        getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
-        getDefaultStore().set(mlirRetryServerAtom, SERVER);
-
-        let resolveRetryA: (value: unknown) => void = () => undefined;
-        let resolveRetryB: (value: unknown) => void = () => undefined;
-
-        uploadMlirFileToServer
-            .mockImplementationOnce(
-                () =>
-                    new Promise((resolve) => {
-                        resolveRetryA = resolve;
-                    }),
-            )
-            .mockImplementationOnce(
-                () =>
-                    new Promise((resolve) => {
-                        resolveRetryB = resolve;
-                    }),
-            );
-
-        renderOverlay([
-            {
-                filename: 'a.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-            {
-                filename: 'b.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-        ]);
-
-        const retryButtons = screen.getAllByRole('button', { name: /retry/i });
-        fireEvent.click(retryButtons[0]);
-        fireEvent.click(retryButtons[1]);
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
-        });
-
-        // Extract the signals from the two calls
-        const callA = uploadMlirFileToServer.mock.calls[0];
-        const callB = uploadMlirFileToServer.mock.calls[1];
-        const signalA = callA?.[2]?.signal;
-        const signalB = callB?.[2]?.signal;
-
-        // Signals must be distinct AbortSignal instances
-        expect(signalA).toBeInstanceOf(AbortSignal);
-        expect(signalB).toBeInstanceOf(AbortSignal);
-        expect(signalA).not.toBe(signalB);
-
-        resolveRetryA({
-            data: {
-                results: [
-                    {
-                        filename: 'a.mlir',
-                        name: 'a',
-                        status: ConnectionTestStates.OK,
-                        graph: GRAPH,
-                    },
-                ],
-            },
-        });
-
-        resolveRetryB({
-            data: {
-                results: [
-                    {
-                        filename: 'b.mlir',
-                        name: 'b',
-                        status: ConnectionTestStates.OK,
-                        graph: GRAPH,
-                    },
-                ],
-            },
-        });
-
-        await waitFor(() => {
-            const results = getDefaultStore().get(mlirFileResultsAtom);
-            expect(results?.[0]?.status).toBe(ConnectionTestStates.OK);
-            expect(results?.[1]?.status).toBe(ConnectionTestStates.OK);
-        });
-    });
-
-    it('pluralizes abort toast correctly', async () => {
-        // Test with two files first
-        const fileA = new File(['module {}'], 'a.mlir');
-        const fileB = new File(['module {}'], 'b.mlir');
-        getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
-        getDefaultStore().set(mlirRetryServerAtom, SERVER);
-
-        uploadMlirFileToServer.mockImplementation(
-            () =>
-                new Promise(() => {
-                    // Never resolves; retries stay in-flight
-                }),
-        );
-
-        renderOverlay([
-            {
-                filename: 'a.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-            {
-                filename: 'b.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-        ]);
-
-        const retryButtons = screen.getAllByRole('button', { name: /retry/i });
-        fireEvent.click(retryButtons[0]);
-        fireEvent.click(retryButtons[1]);
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: /close/i }));
-
-        await waitFor(() => {
-            expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'Aborted 2x MLIR conversions', 'warning');
-        });
-
-        // Clean up and test single file
-        cleanup();
-        vi.clearAllMocks();
-        getDefaultStore().set(mlirRetryFilesAtom, null);
-        getDefaultStore().set(mlirRetryServerAtom, null);
-        getDefaultStore().set(mlirFileResultsAtom, null);
-        getDefaultStore().set(mlirFileResultsOpenAtom, false);
-
-        uploadMlirFileToServer.mockImplementation(
-            () =>
-                new Promise(() => {
-                    // Never resolves
-                }),
-        );
-
-        const singleFile = new File(['module {}'], 'single.mlir');
-        getDefaultStore().set(mlirRetryFilesAtom, [singleFile]);
-        getDefaultStore().set(mlirRetryServerAtom, SERVER);
-
-        renderOverlay([
-            {
-                filename: 'single.mlir',
-                name: null,
-                status: ConnectionTestStates.FAILED,
-                message: 'Conversion failed',
-                graph: null,
-                persisted: true,
-            },
-        ]);
-
-        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
-
-        await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: /close/i }));
-
-        await waitFor(() => {
-            expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'Aborted 1x MLIR conversion', 'warning');
         });
     });
 });

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -33,7 +33,7 @@ vi.mock('../src/hooks/useMlirRemote', () => ({
 
 vi.mock('../src/functions/createToastNotification', () => ({
     default: createToastNotification,
-    ToastType: { SUCCESS: 'success', ERROR: 'error' },
+    ToastType: { SUCCESS: 'success', WARNING: 'warning', ERROR: 'error' },
 }));
 
 const GRAPH: GraphBundle = { graphs: [{ id: 'g', nodes: [] }] };
@@ -221,7 +221,11 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(screen.getByRole('button', { name: /retry/i }));
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith([failedFile], SERVER);
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
+                [failedFile],
+                SERVER,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
             expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
                 status: ConnectionTestStates.OK,
                 name: 'failed',
@@ -271,7 +275,11 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(retryButton);
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith([failedFile], SERVER);
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
+                [failedFile],
+                SERVER,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
             expect(viewButton).toBeDisabled();
         });
     });
@@ -291,19 +299,27 @@ describe('MlirFileResultsOverlay', () => {
         expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     });
 
-    it('disables other Retry buttons while a retry is in flight', async () => {
+    it('allows retries for different rows in parallel', async () => {
         const fileA = new File(['module {}'], 'failed-a.mlir');
         const fileB = new File(['module {}'], 'failed-b.mlir');
         getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
         getDefaultStore().set(mlirRetryServerAtom, SERVER);
 
-        let resolveRetry: ((value: unknown) => void) | null = null;
-        uploadMlirFileToServer.mockImplementationOnce(
-            () =>
-                new Promise((resolve) => {
-                    resolveRetry = resolve;
-                }),
-        );
+        let resolveRetryA: (value: unknown) => void = () => undefined;
+        let resolveRetryB: (value: unknown) => void = () => undefined;
+        uploadMlirFileToServer
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveRetryA = resolve;
+                    }),
+            )
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveRetryB = resolve;
+                    }),
+            );
 
         renderOverlay([
             {
@@ -324,19 +340,55 @@ describe('MlirFileResultsOverlay', () => {
             },
         ]);
 
-        fireEvent.click(screen.getAllByRole('button', { name: /retry/i })[0]);
+        const [firstRetryButton, secondRetryButton] = screen.getAllByRole('button', { name: /retry/i });
+        fireEvent.click(firstRetryButton);
 
         await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
+            expect(uploadMlirFileToServer).toHaveBeenNthCalledWith(
+                1,
+                [fileA],
+                SERVER,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
+            // Row A is processing, so only row B still exposes Retry.
             const retryButtons = screen.getAllByRole('button', { name: /retry/i });
             expect(retryButtons).toHaveLength(1);
-            expect(retryButtons[0]).toBeDisabled();
+            expect(retryButtons[0]).toBeEnabled();
         });
 
-        resolveRetry?.({
+        fireEvent.click(secondRetryButton);
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
+            expect(uploadMlirFileToServer).toHaveBeenNthCalledWith(
+                2,
+                [fileB],
+                SERVER,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
+            // Both rows are now processing, so no Retry buttons are visible.
+            expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+        });
+
+        resolveRetryA({
             data: {
                 results: [
                     {
                         filename: 'failed-a.mlir',
+                        name: null,
+                        status: ConnectionTestStates.FAILED,
+                        message: 'Still failing',
+                        graph: null,
+                    },
+                ],
+            },
+        });
+        resolveRetryB({
+            data: {
+                results: [
+                    {
+                        filename: 'failed-b.mlir',
                         name: null,
                         status: ConnectionTestStates.FAILED,
                         message: 'Still failing',
@@ -351,6 +403,72 @@ describe('MlirFileResultsOverlay', () => {
             expect(retryButtons).toHaveLength(2);
             expect(retryButtons[0]).toBeEnabled();
             expect(retryButtons[1]).toBeEnabled();
+        });
+    });
+
+    it('cancels in-progress retry writeback when the overlay closes', async () => {
+        const failedFile = new File(['module {}'], 'failed.mlir');
+        getDefaultStore().set(mlirRetryFilesAtom, [failedFile]);
+        getDefaultStore().set(mlirRetryServerAtom, SERVER);
+
+        let resolveRetry: (value: unknown) => void = () => undefined;
+        uploadMlirFileToServer.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveRetry = resolve;
+                }),
+        );
+        let retrySignal: AbortSignal | undefined;
+
+        renderOverlay([
+            {
+                filename: 'failed.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+        ]);
+
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
+                [failedFile],
+                SERVER,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
+            retrySignal = uploadMlirFileToServer.mock.calls[0]?.[2]?.signal;
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+        await waitFor(() => {
+            expect(getDefaultStore().get(mlirFileResultsOpenAtom)).toBe(false);
+            expect(retrySignal?.aborted).toBe(true);
+            expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'Aborted 1x MLIR conversion', 'warning');
+        });
+
+        resolveRetry({
+            data: {
+                results: [
+                    {
+                        filename: 'failed.mlir',
+                        name: 'failed',
+                        status: ConnectionTestStates.OK,
+                        graph: GRAPH,
+                    },
+                ],
+            },
+        });
+
+        await waitFor(() => {
+            expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
+                status: ConnectionTestStates.FAILED,
+                name: null,
+                graph: null,
+            });
         });
     });
 });

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -527,4 +527,291 @@ describe('MlirFileResultsOverlay', () => {
             expect(screen.getByRole('button', { name: /retry/i })).toBeEnabled();
         });
     });
+
+    it('preserves new retry state when old retry resolves after reopen', async () => {
+        const failedFile = new File(['module {}'], 'failed.mlir');
+        getDefaultStore().set(mlirRetryFilesAtom, [failedFile]);
+        getDefaultStore().set(mlirRetryServerAtom, SERVER);
+
+        let resolveFirstRetry: (value: unknown) => void = () => undefined;
+        let resolveSecondRetry: (value: unknown) => void = () => undefined;
+        let callCount = 0;
+
+        uploadMlirFileToServer.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    callCount += 1;
+                    if (callCount === 1) {
+                        resolveFirstRetry = resolve;
+                    } else {
+                        resolveSecondRetry = resolve;
+                    }
+                }),
+        );
+
+        const { rerender } = renderOverlay([
+            {
+                filename: 'failed.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+        ]);
+
+        // First retry
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
+        });
+
+        // Close overlay (bumps session, aborts first retry)
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+        await waitFor(() => {
+            expect(getDefaultStore().get(mlirFileResultsOpenAtom)).toBe(false);
+        });
+
+        // Reopen and start second retry
+        getDefaultStore().set(mlirFileResultsOpenAtom, true);
+        rerender(
+            <MemoryRouter>
+                <MlirFileResultsOverlay />
+            </MemoryRouter>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
+        });
+
+        // Resolve first (old) retry — should NOT evict second controller
+        resolveFirstRetry({
+            data: {
+                results: [
+                    {
+                        filename: 'failed.mlir',
+                        name: 'fixed',
+                        status: ConnectionTestStates.OK,
+                        graph: GRAPH,
+                    },
+                ],
+            },
+        });
+
+        // Second retry should still be in-flight (PROGRESS state preserved)
+        await waitFor(() => {
+            expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
+                status: ConnectionTestStates.PROGRESS,
+            });
+        });
+
+        // Resolve second retry
+        resolveSecondRetry({
+            data: {
+                results: [
+                    {
+                        filename: 'failed.mlir',
+                        name: 'fixed',
+                        status: ConnectionTestStates.OK,
+                        graph: GRAPH,
+                    },
+                ],
+            },
+        });
+
+        await waitFor(() => {
+            expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
+                status: ConnectionTestStates.OK,
+                name: 'fixed',
+            });
+        });
+    });
+
+    it('creates distinct AbortSignal per parallel retry', async () => {
+        const fileA = new File(['module {}'], 'a.mlir');
+        const fileB = new File(['module {}'], 'b.mlir');
+        getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
+        getDefaultStore().set(mlirRetryServerAtom, SERVER);
+
+        let resolveRetryA: (value: unknown) => void = () => undefined;
+        let resolveRetryB: (value: unknown) => void = () => undefined;
+
+        uploadMlirFileToServer
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveRetryA = resolve;
+                    }),
+            )
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveRetryB = resolve;
+                    }),
+            );
+
+        renderOverlay([
+            {
+                filename: 'a.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+            {
+                filename: 'b.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+        ]);
+
+        const retryButtons = screen.getAllByRole('button', { name: /retry/i });
+        fireEvent.click(retryButtons[0]);
+        fireEvent.click(retryButtons[1]);
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
+        });
+
+        // Extract the signals from the two calls
+        const callA = uploadMlirFileToServer.mock.calls[0];
+        const callB = uploadMlirFileToServer.mock.calls[1];
+        const signalA = callA?.[2]?.signal;
+        const signalB = callB?.[2]?.signal;
+
+        // Signals must be distinct AbortSignal instances
+        expect(signalA).toBeInstanceOf(AbortSignal);
+        expect(signalB).toBeInstanceOf(AbortSignal);
+        expect(signalA).not.toBe(signalB);
+
+        resolveRetryA({
+            data: {
+                results: [
+                    {
+                        filename: 'a.mlir',
+                        name: 'a',
+                        status: ConnectionTestStates.OK,
+                        graph: GRAPH,
+                    },
+                ],
+            },
+        });
+
+        resolveRetryB({
+            data: {
+                results: [
+                    {
+                        filename: 'b.mlir',
+                        name: 'b',
+                        status: ConnectionTestStates.OK,
+                        graph: GRAPH,
+                    },
+                ],
+            },
+        });
+
+        await waitFor(() => {
+            const results = getDefaultStore().get(mlirFileResultsAtom);
+            expect(results?.[0]?.status).toBe(ConnectionTestStates.OK);
+            expect(results?.[1]?.status).toBe(ConnectionTestStates.OK);
+        });
+    });
+
+    it('pluralizes abort toast correctly', async () => {
+        // Test with two files first
+        const fileA = new File(['module {}'], 'a.mlir');
+        const fileB = new File(['module {}'], 'b.mlir');
+        getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
+        getDefaultStore().set(mlirRetryServerAtom, SERVER);
+
+        uploadMlirFileToServer.mockImplementation(
+            () =>
+                new Promise(() => {
+                    // Never resolves; retries stay in-flight
+                }),
+        );
+
+        renderOverlay([
+            {
+                filename: 'a.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+            {
+                filename: 'b.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+        ]);
+
+        const retryButtons = screen.getAllByRole('button', { name: /retry/i });
+        fireEvent.click(retryButtons[0]);
+        fireEvent.click(retryButtons[1]);
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(2);
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+        await waitFor(() => {
+            expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'Aborted 2x MLIR conversions', 'warning');
+        });
+
+        // Clean up and test single file
+        cleanup();
+        vi.clearAllMocks();
+        getDefaultStore().set(mlirRetryFilesAtom, null);
+        getDefaultStore().set(mlirRetryServerAtom, null);
+        getDefaultStore().set(mlirFileResultsAtom, null);
+        getDefaultStore().set(mlirFileResultsOpenAtom, false);
+
+        uploadMlirFileToServer.mockImplementation(
+            () =>
+                new Promise(() => {
+                    // Never resolves
+                }),
+        );
+
+        const singleFile = new File(['module {}'], 'single.mlir');
+        getDefaultStore().set(mlirRetryFilesAtom, [singleFile]);
+        getDefaultStore().set(mlirRetryServerAtom, SERVER);
+
+        renderOverlay([
+            {
+                filename: 'single.mlir',
+                name: null,
+                status: ConnectionTestStates.FAILED,
+                message: 'Conversion failed',
+                graph: null,
+                persisted: true,
+            },
+        ]);
+
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+        await waitFor(() => {
+            expect(uploadMlirFileToServer).toHaveBeenCalledTimes(1);
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+        await waitFor(() => {
+            expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'Aborted 1x MLIR conversion', 'warning');
+        });
+    });
 });

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -221,7 +221,14 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(screen.getByRole('button', { name: /retry/i }));
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith([failedFile], SERVER);
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
+                [failedFile],
+                SERVER,
+                expect.objectContaining({
+                    signal: expect.any(AbortSignal),
+                    suppressProgressOverlay: true,
+                }),
+            );
             expect(getDefaultStore().get(mlirFileResultsAtom)?.[0]).toMatchObject({
                 status: ConnectionTestStates.OK,
                 name: 'failed',
@@ -271,7 +278,14 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(retryButton);
 
         await waitFor(() => {
-            expect(uploadMlirFileToServer).toHaveBeenCalledWith([failedFile], SERVER);
+            expect(uploadMlirFileToServer).toHaveBeenCalledWith(
+                [failedFile],
+                SERVER,
+                expect.objectContaining({
+                    signal: expect.any(AbortSignal),
+                    suppressProgressOverlay: true,
+                }),
+            );
             expect(viewButton).toBeDisabled();
         });
     });
@@ -291,7 +305,7 @@ describe('MlirFileResultsOverlay', () => {
         expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     });
 
-    it('disables other Retry buttons while a retry is in flight', async () => {
+    it('keeps other Retry buttons enabled while a retry is in flight', async () => {
         const fileA = new File(['module {}'], 'failed-a.mlir');
         const fileB = new File(['module {}'], 'failed-b.mlir');
         getDefaultStore().set(mlirRetryFilesAtom, [fileA, fileB]);
@@ -330,7 +344,7 @@ describe('MlirFileResultsOverlay', () => {
         await waitFor(() => {
             const retryButtons = screen.getAllByRole('button', { name: /retry/i });
             expect(retryButtons).toHaveLength(1);
-            expect(retryButtons[0]).toBeDisabled();
+            expect(retryButtons[0]).toBeEnabled();
         });
 
         retryDeferred.resolve?.({

--- a/tests/useMlirRemote.spec.tsx
+++ b/tests/useMlirRemote.spec.tsx
@@ -276,4 +276,30 @@ describe('useMlirRemote progress lifecycle', () => {
         expect(getDefaultStore().get(mlirRetryServerAtom)).toBeNull();
         expect(screen.getByRole('button', { name: /view mlir uploads/i })).toBeDisabled();
     });
+
+    it('does not mutate global progress state when suppressProgressOverlay is enabled', async () => {
+        const postMock = vi.mocked(axiosInstance.post);
+        const deferred = createDeferred<{ data: { status: ConnectionTestStates } }>();
+        let onUploadProgress: ((event: AxiosProgressEvent) => void) | undefined;
+
+        postMock.mockImplementation((_url, _data, config) => {
+            onUploadProgress = config?.onUploadProgress;
+            return deferred.promise;
+        });
+
+        const { result } = renderHook(() => useMlirRemote());
+        const uploadPromise = result.current.uploadMlirFileToServer([new File(['module {}'], 'model.mlir')], SERVER, {
+            suppressProgressOverlay: true,
+        });
+
+        expect(getDefaultStore().get(fileTransferProgressAtom)).toEqual(getInactiveFileTransferProgress());
+
+        onUploadProgress?.({ loaded: 10, total: 10 } as AxiosProgressEvent);
+        expect(getDefaultStore().get(fileTransferProgressAtom)).toEqual(getInactiveFileTransferProgress());
+
+        deferred.resolve({ data: { status: ConnectionTestStates.OK } });
+        await uploadPromise;
+
+        expect(getDefaultStore().get(fileTransferProgressAtom)).toEqual(getInactiveFileTransferProgress());
+    });
 });


### PR DESCRIPTION
Lets the user abort processing requests.