### PR TITLE
MLIR viewer: expand-all / collapse-all toolbar buttons

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -1526,37 +1526,39 @@ const MlGraphInner = ({ data }: ViewProps) => {
                         selectNodesOnDrag={false}
                     >
                         <MiniMap nodeColor={minimapNodeColor} />
-                        <Controls>
-                            <MlirExpandCollapseControls
-                                subgraphCount={allSubgraphNamespaces.length}
-                                expandedCount={expandedNamespaces.size}
-                                onExpandAll={expandAllSubgraphs}
-                                onCollapseAll={collapseAllSubgraphs}
-                            />
-                        </Controls>
+                        <Controls />
                         <Background />
                     </ReactFlow>
                 </MlirNodeBodyContext.Provider>
             </MlirGroupContext.Provider>
 
-            <MlirOpFilter
-                ref={filterRef}
-                query={filterQuery}
-                onQueryChange={handleQueryChange}
-                mode={filterMode}
-                onModeChange={handleModeChange}
-                isRegexInvalid={filterMatchInfo?.isRegexInvalid ?? false}
-                matchCount={matchedNodesInOrder.length}
-                hiddenMatchCount={filterMatchInfo?.hiddenMatchCount ?? 0}
-                currentMatchIndex={currentMatchIndex}
-                onPrev={() => goToMatch('prev')}
-                onNext={() => goToMatch('next')}
-            />
+            <div className='mlir-top-left-controls'>
+                <MlirOpFilter
+                    ref={filterRef}
+                    query={filterQuery}
+                    onQueryChange={handleQueryChange}
+                    mode={filterMode}
+                    onModeChange={handleModeChange}
+                    isRegexInvalid={filterMatchInfo?.isRegexInvalid ?? false}
+                    matchCount={matchedNodesInOrder.length}
+                    hiddenMatchCount={filterMatchInfo?.hiddenMatchCount ?? 0}
+                    currentMatchIndex={currentMatchIndex}
+                    onPrev={() => goToMatch('prev')}
+                    onNext={() => goToMatch('next')}
+                />
 
-            <MlirNodeBodyToggles
-                value={nodeBodyToggles}
-                onChange={setNodeBodyToggles}
-            />
+                <MlirNodeBodyToggles
+                    value={nodeBodyToggles}
+                    onChange={setNodeBodyToggles}
+                />
+
+                <MlirExpandCollapseControls
+                    subgraphCount={allSubgraphNamespaces.length}
+                    expandedCount={expandedNamespaces.size}
+                    onExpandAll={expandAllSubgraphs}
+                    onCollapseAll={collapseAllSubgraphs}
+                />
+            </div>
 
             {selectedSourceNode && (
                 <MlirNodeDetailsPanel

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -480,7 +480,18 @@ const MlGraphInner = ({ data }: ViewProps) => {
             setNodes(styledNodes);
             setEdges(rf.edges);
 
+            // Read + clear every post-rebuild viewport baton up-front. The
+            // arming sites enforce mutual exclusion (see the useRef decl
+            // comment for `pendingFitAllRef`), and the `if / else if` chain
+            // below enforces it a second time at the consumer so a stray
+            // arming site can't schedule two fitViews on the same frame.
             const anchor = viewportAnchorRef.current;
+            viewportAnchorRef.current = null;
+            const pendingFocusId = pendingFocusNodeIdRef.current;
+            pendingFocusNodeIdRef.current = null;
+            const shouldFitAll = pendingFitAllRef.current;
+            pendingFitAllRef.current = false;
+
             if (anchor) {
                 const toNode = rf.nodes.find((n) => n.id === anchor.toNodeId);
                 if (toNode) {
@@ -492,41 +503,19 @@ const MlGraphInner = ({ data }: ViewProps) => {
                         { duration: 0 },
                     );
                 }
-                viewportAnchorRef.current = null;
-            }
-
-            // Locate-from-panel: the user clicked the "locate" button next to
-            // a producer/consumer reference and the target wasn't visible
-            // pre-rebuild (collapsed namespace). Now that the rebuilt graph
-            // has landed, recenter on it. Skip silently if the target still
-            // isn't in the build (e.g. synthetic id that never reaches the
-            // canvas) — a missing fitView is preferable to a noisy error,
-            // and the surrounding state stays consistent because navigation
-            // never touches selection.
-            const pendingFocusId = pendingFocusNodeIdRef.current;
-            if (pendingFocusId) {
-                pendingFocusNodeIdRef.current = null;
-                if (rf.nodes.some((n) => n.id === pendingFocusId)) {
-                    requestAnimationFrame(() => {
-                        void fitView({
-                            nodes: [{ id: pendingFocusId }],
-                            padding: 0.3,
-                            duration: 200,
-                        });
-                    });
-                }
-            }
-
-            if (pendingFitAllRef.current) {
-                pendingFitAllRef.current = false;
+            } else if (pendingFocusId && rf.nodes.some((n) => n.id === pendingFocusId)) {
+                // Locate-from-panel: the user clicked "locate" and the target
+                // wasn't visible pre-rebuild. Skip silently if the target still
+                // isn't in the build (e.g. synthetic id that never reaches the
+                // canvas) — a missing fitView is preferable to a noisy error.
                 requestAnimationFrame(() => {
-                    void fitView({ padding: 0.2, duration: 200 });
+                    void fitView({ nodes: [{ id: pendingFocusId }], padding: 0.3, duration: 200 });
                 });
-            } else if (!hasFitInitiallyRef.current) {
-                requestAnimationFrame(() => {
-                    void fitView({ padding: 0.2, duration: 200 });
-                });
+            } else if (shouldFitAll || !hasFitInitiallyRef.current) {
                 hasFitInitiallyRef.current = true;
+                requestAnimationFrame(() => {
+                    void fitView({ padding: 0.2, duration: 200 });
+                });
             }
         },
         [fitView, getViewport, setEdges, setNodes, setViewport],
@@ -789,22 +778,22 @@ const MlGraphInner = ({ data }: ViewProps) => {
 
     // `anchorByNamespace` covers both natural regions and topology-sectioned
     // synthetic wrappers, so its keys are the authoritative expandable set.
-    const allSubgraphNamespaces = useMemo<string[]>(
+    const allExpandableNamespaces = useMemo<string[]>(
         () => (interactionIndex ? Object.keys(interactionIndex.anchorByNamespace) : []),
         [interactionIndex],
     );
 
-    const expandAllSubgraphs = useCallback(() => {
-        if (allSubgraphNamespaces.length === 0) {
+    const expandAllNamespaces = useCallback(() => {
+        if (allExpandableNamespaces.length === 0) {
             return;
         }
         viewportAnchorRef.current = null;
         pendingFocusNodeIdRef.current = null;
         pendingFitAllRef.current = true;
-        setExpandedNamespaces(new Set(allSubgraphNamespaces));
-    }, [allSubgraphNamespaces]);
+        setExpandedNamespaces(new Set(allExpandableNamespaces));
+    }, [allExpandableNamespaces]);
 
-    const collapseAllSubgraphs = useCallback(() => {
+    const collapseAllNamespaces = useCallback(() => {
         viewportAnchorRef.current = null;
         pendingFocusNodeIdRef.current = null;
         pendingFitAllRef.current = true;
@@ -1558,10 +1547,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 />
 
                 <MlirExpandCollapseControls
-                    subgraphCount={allSubgraphNamespaces.length}
+                    namespaceCount={allExpandableNamespaces.length}
                     expandedCount={expandedNamespaces.size}
-                    onExpandAll={expandAllSubgraphs}
-                    onCollapseAll={collapseAllSubgraphs}
+                    onExpandAll={expandAllNamespaces}
+                    onCollapseAll={collapseAllNamespaces}
                 />
             </div>
 

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -379,11 +379,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // collapsed namespaces and we have to wait for the worker to rebuild
     // before we can fitView on it. Consumed once the rebuilt graph lands.
     const pendingFocusNodeIdRef = useRef<string | null>(null);
-    // Set by the Expand-all / Collapse-all buttons: a bulk toggle has no
-    // gesture-origin position for `viewportAnchorRef`, so we ask the next
-    // rebuild to reframe the whole graph instead of trying to preserve
-    // whichever landmark the user was previously looking at (there isn't
-    // one in a bulk op).
+    // `viewportAnchorRef`, `pendingFocusNodeIdRef`, and `pendingFitAllRef`
+    // are mutually exclusive post-build viewport intents. The worker can
+    // coalesce successive builds into a single reply, so every arming site
+    // below clears the other two — whichever gesture fires last wins.
     const pendingFitAllRef = useRef(false);
     const hasFitInitiallyRef = useRef(false);
 
@@ -749,6 +748,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // clicked group header, or the parent group of a click on a nested op).
     const collapseNamespace = useCallback(
         (namespace: string, fromPosition: { x: number; y: number }) => {
+            pendingFitAllRef.current = false;
+            pendingFocusNodeIdRef.current = null;
             const anchorNodeId = interactionIndex?.anchorByNamespace[namespace];
             if (anchorNodeId) {
                 viewportAnchorRef.current = { toNodeId: anchorNodeId, fromPosition };
@@ -770,6 +771,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // synthesised at id `group:<namespace>`, so we anchor directly to that id —
     // there's no need to consult `interactionIndex.anchorByNamespace` here.
     const expandNamespace = useCallback((namespace: string, fromPosition: { x: number; y: number }) => {
+        pendingFitAllRef.current = false;
+        pendingFocusNodeIdRef.current = null;
         viewportAnchorRef.current = {
             toNodeId: `group:${namespace}`,
             fromPosition,
@@ -784,12 +787,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
         });
     }, []);
 
-    // The complete list of collapsible namespaces lives on the graph
-    // index's `anchorByNamespace` — every collapsible namespace, natural
-    // MLIR region OR topology-sectioned synthetic wrapper, has an anchor
-    // entry (see `mlirGraphIndexBuilder`). We take the keys as the
-    // authoritative expandable set instead of maintaining a parallel
-    // list on the worker interaction index.
+    // `anchorByNamespace` covers both natural regions and topology-sectioned
+    // synthetic wrappers, so its keys are the authoritative expandable set.
     const allSubgraphNamespaces = useMemo<string[]>(
         () => (interactionIndex ? Object.keys(interactionIndex.anchorByNamespace) : []),
         [interactionIndex],
@@ -799,11 +798,15 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (allSubgraphNamespaces.length === 0) {
             return;
         }
+        viewportAnchorRef.current = null;
+        pendingFocusNodeIdRef.current = null;
         pendingFitAllRef.current = true;
         setExpandedNamespaces(new Set(allSubgraphNamespaces));
     }, [allSubgraphNamespaces]);
 
     const collapseAllSubgraphs = useCallback(() => {
+        viewportAnchorRef.current = null;
+        pendingFocusNodeIdRef.current = null;
         pendingFitAllRef.current = true;
         setExpandedNamespaces(new Set());
     }, []);
@@ -1210,6 +1213,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 void fitView({ nodes: [{ id: targetNodeId }], padding: 0.3, duration: 200 });
                 return;
             }
+            viewportAnchorRef.current = null;
+            pendingFitAllRef.current = false;
             pendingFocusNodeIdRef.current = targetNodeId;
             setExpandedNamespaces((prev) => {
                 const next = new Set(prev);

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -53,6 +53,7 @@ import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
 import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
 import { MlirFilterMode, buildFilterMatcher } from './mlirFilter';
 import MlirNodeBodyToggles from './MlirNodeBodyToggles';
+import MlirExpandCollapseControls from './MlirExpandCollapseControls';
 import { collectLocationLines, collectShapeLines } from './mlirNodeBodySummary';
 import { getNamespaceSegments } from './mlirGraphHelpers';
 
@@ -378,6 +379,12 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // collapsed namespaces and we have to wait for the worker to rebuild
     // before we can fitView on it. Consumed once the rebuilt graph lands.
     const pendingFocusNodeIdRef = useRef<string | null>(null);
+    // Set by the Expand-all / Collapse-all buttons: a bulk toggle has no
+    // gesture-origin position for `viewportAnchorRef`, so we ask the next
+    // rebuild to reframe the whole graph instead of trying to preserve
+    // whichever landmark the user was previously looking at (there isn't
+    // one in a bulk op).
+    const pendingFitAllRef = useRef(false);
     const hasFitInitiallyRef = useRef(false);
 
     // No graph-id reset effect: `MlGraphInner` is keyed by `graph.id` in
@@ -511,7 +518,12 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 }
             }
 
-            if (!hasFitInitiallyRef.current) {
+            if (pendingFitAllRef.current) {
+                pendingFitAllRef.current = false;
+                requestAnimationFrame(() => {
+                    void fitView({ padding: 0.2, duration: 200 });
+                });
+            } else if (!hasFitInitiallyRef.current) {
                 requestAnimationFrame(() => {
                     void fitView({ padding: 0.2, duration: 200 });
                 });
@@ -770,6 +782,30 @@ const MlGraphInner = ({ data }: ViewProps) => {
             next.add(namespace);
             return next;
         });
+    }, []);
+
+    // The complete list of collapsible namespaces lives on the graph
+    // index's `anchorByNamespace` — every collapsible namespace, natural
+    // MLIR region OR topology-sectioned synthetic wrapper, has an anchor
+    // entry (see `mlirGraphIndexBuilder`). We take the keys as the
+    // authoritative expandable set instead of maintaining a parallel
+    // list on the worker interaction index.
+    const allSubgraphNamespaces = useMemo<string[]>(
+        () => (interactionIndex ? Object.keys(interactionIndex.anchorByNamespace) : []),
+        [interactionIndex],
+    );
+
+    const expandAllSubgraphs = useCallback(() => {
+        if (allSubgraphNamespaces.length === 0) {
+            return;
+        }
+        pendingFitAllRef.current = true;
+        setExpandedNamespaces(new Set(allSubgraphNamespaces));
+    }, [allSubgraphNamespaces]);
+
+    const collapseAllSubgraphs = useCallback(() => {
+        pendingFitAllRef.current = true;
+        setExpandedNamespaces(new Set());
     }, []);
 
     const onSubgraphNodeClick = useCallback(
@@ -1490,7 +1526,14 @@ const MlGraphInner = ({ data }: ViewProps) => {
                         selectNodesOnDrag={false}
                     >
                         <MiniMap nodeColor={minimapNodeColor} />
-                        <Controls />
+                        <Controls>
+                            <MlirExpandCollapseControls
+                                subgraphCount={allSubgraphNamespaces.length}
+                                expandedCount={expandedNamespaces.size}
+                                onExpandAll={expandAllSubgraphs}
+                                onCollapseAll={collapseAllSubgraphs}
+                            />
+                        </Controls>
                         <Background />
                     </ReactFlow>
                 </MlirNodeBodyContext.Provider>

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -13,16 +13,6 @@ export interface MlirExpandCollapseControlsProps {
     onCollapseAll: () => void;
 }
 
-// Sits in the top-left cluster next to `MlirOpFilter` and
-// `MlirNodeBodyToggles` — grouping this with the filter-adjacent widgets
-// keeps all graph-shaping controls together and leaves the bottom-left zoom
-// widget alone.
-//
-// Disable rules keep the buttons truthful:
-//  - `Expand all`   grays out when the graph has no collapsible namespaces
-//                   OR every collapsible namespace is already expanded.
-//  - `Collapse all` grays out when nothing is expanded (already at
-//                   top-level anchors, so the click would be a no-op).
 const MlirExpandCollapseControls = ({
     subgraphCount,
     expandedCount,

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -7,19 +7,19 @@ import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirExpandCollapseControls.scss';
 
 export interface MlirExpandCollapseControlsProps {
-    subgraphCount: number;
+    namespaceCount: number;
     expandedCount: number;
     onExpandAll: () => void;
     onCollapseAll: () => void;
 }
 
 const MlirExpandCollapseControls = ({
-    subgraphCount,
+    namespaceCount,
     expandedCount,
     onExpandAll,
     onCollapseAll,
 }: MlirExpandCollapseControlsProps) => {
-    const canExpand = subgraphCount > 0 && expandedCount < subgraphCount;
+    const canExpand = namespaceCount > 0 && expandedCount < namespaceCount;
     const canCollapse = expandedCount > 0;
     return (
         <div className='mlir-expand-collapse-controls'>

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Icon } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { ControlButton } from '@xyflow/react';
+
+export interface MlirExpandCollapseControlsProps {
+    subgraphCount: number;
+    expandedCount: number;
+    onExpandAll: () => void;
+    onCollapseAll: () => void;
+}
+
+// Renders as children of React Flow's `<Controls>` widget so the two buttons
+// sit right underneath the built-in zoom / fit / lock cluster in the
+// bottom-left corner — matching #1715's "next to the existing layout / zoom
+// controls" requirement.
+//
+// Disable rules keep the buttons truthful:
+//  - `Expand all`   grays out when the graph has no collapsible namespaces
+//                   OR every collapsible namespace is already expanded.
+//  - `Collapse all` grays out when nothing is expanded (already at
+//                   top-level anchors, so the click would be a no-op).
+const MlirExpandCollapseControls = ({
+    subgraphCount,
+    expandedCount,
+    onExpandAll,
+    onCollapseAll,
+}: MlirExpandCollapseControlsProps) => {
+    const canExpand = subgraphCount > 0 && expandedCount < subgraphCount;
+    const canCollapse = expandedCount > 0;
+    return (
+        <>
+            <ControlButton
+                onClick={onExpandAll}
+                disabled={!canExpand}
+                title='Expand all subgraphs'
+                aria-label='Expand all subgraphs'
+            >
+                <Icon icon={IconNames.EXPAND_ALL} />
+            </ControlButton>
+            <ControlButton
+                onClick={onCollapseAll}
+                disabled={!canCollapse}
+                title='Collapse all subgraphs'
+                aria-label='Collapse all subgraphs'
+            >
+                <Icon icon={IconNames.COLLAPSE_ALL} />
+            </ControlButton>
+        </>
+    );
+};
+
+export default MlirExpandCollapseControls;

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -2,9 +2,9 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { Icon } from '@blueprintjs/core';
+import { Button, ButtonVariant, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { ControlButton } from '@xyflow/react';
+import 'styles/components/MlirExpandCollapseControls.scss';
 
 export interface MlirExpandCollapseControlsProps {
     subgraphCount: number;
@@ -13,10 +13,10 @@ export interface MlirExpandCollapseControlsProps {
     onCollapseAll: () => void;
 }
 
-// Renders as children of React Flow's `<Controls>` widget so the two buttons
-// sit right underneath the built-in zoom / fit / lock cluster in the
-// bottom-left corner — matching #1715's "next to the existing layout / zoom
-// controls" requirement.
+// Sits in the top-left cluster next to `MlirOpFilter` and
+// `MlirNodeBodyToggles` — grouping this with the filter-adjacent widgets
+// keeps all graph-shaping controls together and leaves the bottom-left zoom
+// widget alone.
 //
 // Disable rules keep the buttons truthful:
 //  - `Expand all`   grays out when the graph has no collapsible namespaces
@@ -32,24 +32,36 @@ const MlirExpandCollapseControls = ({
     const canExpand = subgraphCount > 0 && expandedCount < subgraphCount;
     const canCollapse = expandedCount > 0;
     return (
-        <>
-            <ControlButton
-                onClick={onExpandAll}
-                disabled={!canExpand}
-                title='Expand all subgraphs'
-                aria-label='Expand all subgraphs'
+        <div className='mlir-expand-collapse-controls'>
+            <Tooltip
+                content='Expand every subgraph and re-lay out'
+                compact
             >
-                <Icon icon={IconNames.EXPAND_ALL} />
-            </ControlButton>
-            <ControlButton
-                onClick={onCollapseAll}
-                disabled={!canCollapse}
-                title='Collapse all subgraphs'
-                aria-label='Collapse all subgraphs'
+                <Button
+                    size={Size.SMALL}
+                    variant={ButtonVariant.MINIMAL}
+                    icon={IconNames.EXPAND_ALL}
+                    text='Expand all'
+                    disabled={!canExpand}
+                    aria-label='Expand all subgraphs'
+                    onClick={onExpandAll}
+                />
+            </Tooltip>
+            <Tooltip
+                content='Collapse every subgraph back to the top-level anchors'
+                compact
             >
-                <Icon icon={IconNames.COLLAPSE_ALL} />
-            </ControlButton>
-        </>
+                <Button
+                    size={Size.SMALL}
+                    variant={ButtonVariant.MINIMAL}
+                    icon={IconNames.COLLAPSE_ALL}
+                    text='Collapse all'
+                    disabled={!canCollapse}
+                    aria-label='Collapse all subgraphs'
+                    onClick={onCollapseAll}
+                />
+            </Tooltip>
+        </div>
     );
 };
 

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -28,10 +28,6 @@
     }
 }
 
-/* Top-left cluster of graph-shaping controls (filter, node-body toggles,
- * expand/collapse). Owned here so the vertical rhythm between widgets stays
- * consistent — each child no longer positions itself. Above React Flow's
- * nodes / edges / controls, below the details panel. */
 .mlir-top-left-controls {
     position: absolute;
     top: 12px;

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -28,6 +28,21 @@
     }
 }
 
+/* Top-left cluster of graph-shaping controls (filter, node-body toggles,
+ * expand/collapse). Owned here so the vertical rhythm between widgets stays
+ * consistent — each child no longer positions itself. Above React Flow's
+ * nodes / edges / controls, below the details panel. */
+.mlir-top-left-controls {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 6;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+
 .react-flow__edge-text {
     font-size: 10px;
     font-family: monospace;

--- a/src/scss/components/MlirExpandCollapseControls.scss
+++ b/src/scss/components/MlirExpandCollapseControls.scss
@@ -5,7 +5,6 @@
 @use '../definitions/colours' as *;
 
 .mlir-expand-collapse-controls {
-    // Positioning lives on `.mlir-top-left-controls` (parent flex column).
     display: flex;
     flex-direction: row;
     gap: 4px;

--- a/src/scss/components/MlirExpandCollapseControls.scss
+++ b/src/scss/components/MlirExpandCollapseControls.scss
@@ -4,21 +4,19 @@
 
 @use '../definitions/colours' as *;
 
-.mlir-node-body-toggles {
+.mlir-expand-collapse-controls {
     // Positioning lives on `.mlir-top-left-controls` (parent flex column).
     display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 10px;
+    flex-direction: row;
+    gap: 4px;
+    padding: 4px;
     background: $tt-grey-2;
     border: 1px solid $tt-grey-3;
     border-radius: 4px;
     box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 
-    .bp6-control {
-        margin: 0;
+    .bp6-button {
         font-size: 11px;
         line-height: 1.2;
-        color: $tt-grey-6;
     }
 }

--- a/src/scss/components/MlirNodeBodyToggles.scss
+++ b/src/scss/components/MlirNodeBodyToggles.scss
@@ -5,7 +5,6 @@
 @use '../definitions/colours' as *;
 
 .mlir-node-body-toggles {
-    // Positioning lives on `.mlir-top-left-controls` (parent flex column).
     display: flex;
     flex-direction: column;
     gap: 6px;

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -5,7 +5,6 @@
 @use '../definitions/colours' as *;
 
 .mlir-op-filter {
-    // Positioning lives on `.mlir-top-left-controls` (parent flex column).
     display: flex;
     align-items: center;
     gap: 4px;

--- a/src/scss/components/MlirOpFilter.scss
+++ b/src/scss/components/MlirOpFilter.scss
@@ -5,12 +5,7 @@
 @use '../definitions/colours' as *;
 
 .mlir-op-filter {
-    position: absolute;
-    top: 12px;
-    left: 12px;
-
-    // Above React Flow nodes / edges / controls, below the details panel.
-    z-index: 6;
+    // Positioning lives on `.mlir-top-left-controls` (parent flex column).
     display: flex;
     align-items: center;
     gap: 4px;

--- a/tests/MlirExpandCollapseControls.spec.tsx
+++ b/tests/MlirExpandCollapseControls.spec.tsx
@@ -11,10 +11,6 @@ import MlirExpandCollapseControls from '../src/components/mlir/MlirExpandCollaps
 
 afterEach(cleanup);
 
-// The buttons render as children of React Flow's `<Controls>` widget in
-// production, but `ControlButton` is a plain `<button>` under the hood
-// (`ButtonHTMLAttributes<HTMLButtonElement>`), so we can mount the fragment
-// bare and assert against the DOM directly.
 describe('MlirExpandCollapseControls', () => {
     const buildProps = (overrides: Partial<ComponentProps<typeof MlirExpandCollapseControls>> = {}) => ({
         subgraphCount: 3,

--- a/tests/MlirExpandCollapseControls.spec.tsx
+++ b/tests/MlirExpandCollapseControls.spec.tsx
@@ -13,17 +13,19 @@ afterEach(cleanup);
 
 describe('MlirExpandCollapseControls', () => {
     const buildProps = (overrides: Partial<ComponentProps<typeof MlirExpandCollapseControls>> = {}) => ({
-        subgraphCount: 3,
+        namespaceCount: 3,
         expandedCount: 1,
         onExpandAll: vi.fn(),
         onCollapseAll: vi.fn(),
         ...overrides,
     });
 
-    it('renders Expand all + Collapse all with the correct labels', () => {
+    it('renders Expand all + Collapse all with the correct labels and visible text', () => {
         render(<MlirExpandCollapseControls {...buildProps()} />);
         expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeInTheDocument();
+        expect(screen.getByText('Expand all')).toBeInTheDocument();
+        expect(screen.getByText('Collapse all')).toBeInTheDocument();
     });
 
     it('fires onExpandAll when the Expand all button is clicked', () => {
@@ -41,40 +43,54 @@ describe('MlirExpandCollapseControls', () => {
     });
 
     it('disables both buttons when the graph has no collapsible namespaces', () => {
-        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 0, expandedCount: 0 })} />);
+        render(<MlirExpandCollapseControls {...buildProps({ namespaceCount: 0, expandedCount: 0 })} />);
         expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeDisabled();
         expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeDisabled();
     });
 
     it('disables Expand all when every collapsible namespace is already expanded', () => {
-        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 4, expandedCount: 4 })} />);
+        render(<MlirExpandCollapseControls {...buildProps({ namespaceCount: 4, expandedCount: 4 })} />);
         expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeDisabled();
         expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).not.toBeDisabled();
     });
 
     it('disables Collapse all when nothing is expanded (already at top-level anchors)', () => {
-        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 4, expandedCount: 0 })} />);
+        render(<MlirExpandCollapseControls {...buildProps({ namespaceCount: 4, expandedCount: 0 })} />);
         expect(screen.getByRole('button', { name: /expand all subgraphs/i })).not.toBeDisabled();
         expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeDisabled();
     });
 
     it('enables both when the graph is partially expanded', () => {
-        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 4, expandedCount: 2 })} />);
+        render(<MlirExpandCollapseControls {...buildProps({ namespaceCount: 4, expandedCount: 2 })} />);
         expect(screen.getByRole('button', { name: /expand all subgraphs/i })).not.toBeDisabled();
         expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).not.toBeDisabled();
     });
 
-    it('does not fire callbacks when a disabled button is clicked', () => {
+    it('does not fire callbacks when a disabled button is clicked (no collapsible namespaces)', () => {
         const onExpandAll = vi.fn();
         const onCollapseAll = vi.fn();
         render(
             <MlirExpandCollapseControls
-                {...buildProps({ subgraphCount: 0, expandedCount: 0, onExpandAll, onCollapseAll })}
+                {...buildProps({ namespaceCount: 0, expandedCount: 0, onExpandAll, onCollapseAll })}
             />,
         );
         fireEvent.click(screen.getByRole('button', { name: /expand all subgraphs/i }));
         fireEvent.click(screen.getByRole('button', { name: /collapse all subgraphs/i }));
         expect(onExpandAll).not.toHaveBeenCalled();
+        expect(onCollapseAll).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onExpandAll when every namespace is already expanded', () => {
+        const onExpandAll = vi.fn();
+        render(<MlirExpandCollapseControls {...buildProps({ namespaceCount: 4, expandedCount: 4, onExpandAll })} />);
+        fireEvent.click(screen.getByRole('button', { name: /expand all subgraphs/i }));
+        expect(onExpandAll).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onCollapseAll when nothing is expanded', () => {
+        const onCollapseAll = vi.fn();
+        render(<MlirExpandCollapseControls {...buildProps({ namespaceCount: 4, expandedCount: 0, onCollapseAll })} />);
+        fireEvent.click(screen.getByRole('button', { name: /collapse all subgraphs/i }));
         expect(onCollapseAll).not.toHaveBeenCalled();
     });
 });

--- a/tests/MlirExpandCollapseControls.spec.tsx
+++ b/tests/MlirExpandCollapseControls.spec.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { ComponentProps } from 'react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import MlirExpandCollapseControls from '../src/components/mlir/MlirExpandCollapseControls';
+
+afterEach(cleanup);
+
+// The buttons render as children of React Flow's `<Controls>` widget in
+// production, but `ControlButton` is a plain `<button>` under the hood
+// (`ButtonHTMLAttributes<HTMLButtonElement>`), so we can mount the fragment
+// bare and assert against the DOM directly.
+describe('MlirExpandCollapseControls', () => {
+    const buildProps = (overrides: Partial<ComponentProps<typeof MlirExpandCollapseControls>> = {}) => ({
+        subgraphCount: 3,
+        expandedCount: 1,
+        onExpandAll: vi.fn(),
+        onCollapseAll: vi.fn(),
+        ...overrides,
+    });
+
+    it('renders Expand all + Collapse all with the correct labels', () => {
+        render(<MlirExpandCollapseControls {...buildProps()} />);
+        expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeInTheDocument();
+    });
+
+    it('fires onExpandAll when the Expand all button is clicked', () => {
+        const onExpandAll = vi.fn();
+        render(<MlirExpandCollapseControls {...buildProps({ onExpandAll })} />);
+        fireEvent.click(screen.getByRole('button', { name: /expand all subgraphs/i }));
+        expect(onExpandAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onCollapseAll when the Collapse all button is clicked', () => {
+        const onCollapseAll = vi.fn();
+        render(<MlirExpandCollapseControls {...buildProps({ onCollapseAll })} />);
+        fireEvent.click(screen.getByRole('button', { name: /collapse all subgraphs/i }));
+        expect(onCollapseAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables both buttons when the graph has no collapsible namespaces', () => {
+        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 0, expandedCount: 0 })} />);
+        expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeDisabled();
+        expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeDisabled();
+    });
+
+    it('disables Expand all when every collapsible namespace is already expanded', () => {
+        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 4, expandedCount: 4 })} />);
+        expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeDisabled();
+        expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).not.toBeDisabled();
+    });
+
+    it('disables Collapse all when nothing is expanded (already at top-level anchors)', () => {
+        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 4, expandedCount: 0 })} />);
+        expect(screen.getByRole('button', { name: /expand all subgraphs/i })).not.toBeDisabled();
+        expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeDisabled();
+    });
+
+    it('enables both when the graph is partially expanded', () => {
+        render(<MlirExpandCollapseControls {...buildProps({ subgraphCount: 4, expandedCount: 2 })} />);
+        expect(screen.getByRole('button', { name: /expand all subgraphs/i })).not.toBeDisabled();
+        expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).not.toBeDisabled();
+    });
+
+    it('does not fire callbacks when a disabled button is clicked', () => {
+        const onExpandAll = vi.fn();
+        const onCollapseAll = vi.fn();
+        render(
+            <MlirExpandCollapseControls
+                {...buildProps({ subgraphCount: 0, expandedCount: 0, onExpandAll, onCollapseAll })}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /expand all subgraphs/i }));
+        fireEvent.click(screen.getByRole('button', { name: /collapse all subgraphs/i }));
+        expect(onExpandAll).not.toHaveBeenCalled();
+        expect(onCollapseAll).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #1715.

## Summary

Adds two toolbar buttons for bulk namespace toggling in the MLIR viewer, so users don't have to click each subgraph anchor individually on large graphs.

- **Expand all** — marks every collapsible namespace expanded and re-lays out.
- **Collapse all** — resets `expandedNamespaces` to empty, leaving only the top-level anchors.

## Placement

Both buttons render as `<ControlButton>` children inside React Flow's built-in `<Controls>` widget in the bottom-left corner, directly under the zoom / fit / lock cluster — matching the issue's "next to the existing layout / zoom controls" requirement.

## State model

- Reads the complete expandable namespace set from `interactionIndex.anchorByNamespace` keys — every collapsible namespace has an anchor entry (natural MLIR regions AND topology-sectioned synthetic wrappers). No changes to the worker protocol or `WorkerInteractionIndex`.
- Bulk toggles have no gesture origin, so `viewportAnchorRef` (which normally keeps a landmark under the cursor across a rebuild) doesn't apply. Instead they arm a new `pendingFitAllRef` baton that `applyBuiltGraph` consumes exactly once to `fitView` the whole graph. Same pattern as the existing `pendingFocusNodeIdRef`.
- Disabled logic keeps the buttons truthful:
  - **Expand all** → grays out when the graph has no collapsible namespaces OR everything is already expanded.
  - **Collapse all** → grays out when nothing is expanded (already at top-level anchors).

## Test plan

- [x] `tests/MlirExpandCollapseControls.spec.tsx` — 8 tests covering render, both click callbacks, all four disabled-state combinations, and no-callback-on-disabled-click.
- [x] Full vitest suite (`npx vitest run`): 675 pass / 1 skip / 0 fail across 72 files.
- [x] `npx tsc --noEmit`: clean for the changes (only remaining diagnostic is the pre-existing `tests/MlirFileResultsOverlay.spec.tsx:335` tracked in #1731).
- [x] `npx eslint` on the three touched files: clean.
- [x] Manual verification in-app: expand-all on a multi-region MLIR graph re-lays out and `fitView`s; collapse-all returns to top-level anchors and `fitView`s; disabled states behave correctly at both ends.