### PR TITLE
Tracking issue: keyboard-accessible chart filtering interaction

### DIFF
--- a/src/components/performance/NonFilterablePerfCharts.tsx
+++ b/src/components/performance/NonFilterablePerfCharts.tsx
@@ -24,6 +24,7 @@ interface NonFilterablePerfChartsProps {
     convData: TypedPerfTableRow[][];
     hasMatmulData: boolean;
     hasConvData: boolean;
+    onOpCodeClick?: (opCode: string) => void;
 }
 
 const NonFilterablePerfCharts = ({
@@ -34,6 +35,7 @@ const NonFilterablePerfCharts = ({
     convData,
     hasMatmulData,
     hasConvData,
+    onOpCodeClick,
 }: NonFilterablePerfChartsProps) => {
     const performanceReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
@@ -117,6 +119,7 @@ const NonFilterablePerfCharts = ({
                         data={chartData}
                         opCodes={opCodeOptions}
                         id={getOperationTypesChartId('active')}
+                        onOpCodeClick={onOpCodeClick}
                     />
                 )}
 
@@ -128,6 +131,7 @@ const NonFilterablePerfCharts = ({
                         data={secondaryData[index]}
                         opCodes={opCodeOptions}
                         id={getOperationTypesChartId(`comparison-${index}`)}
+                        onOpCodeClick={onOpCodeClick}
                     />
                 ))}
             </div>

--- a/src/components/performance/PerfChart.tsx
+++ b/src/components/performance/PerfChart.tsx
@@ -2,10 +2,12 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Config, Layout, PlotData } from 'plotly.js';
+import { Config, Layout, PlotData, PlotMouseEvent } from 'plotly.js';
 import classNames from 'classnames';
 import Plot from '../../libs/PlotComponent';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
+import { PERF_CHART_TABLE_FILTER_HINT } from '../../definitions/PerformanceCharts';
+import { TEST_IDS } from '../../definitions/TestIds';
 import 'styles/components/PerfChart.scss';
 
 interface PerfChartProps {
@@ -13,13 +15,16 @@ interface PerfChartProps {
     configuration: PlotConfiguration;
     id?: string;
     title: string;
+    onPlotClick?: (event: Readonly<PlotMouseEvent>) => void;
 }
 
 const GRID_COLOUR = '#575757';
 const LINE_COLOUR = '#575757';
 const LEGEND_COLOUR = '#FFF';
 
-function PerfChart({ chartData, configuration, id, title }: PerfChartProps) {
+function PerfChart({ chartData, configuration, id, title, onPlotClick }: PerfChartProps) {
+    const isClickable = onPlotClick != null;
+
     const layout: Partial<Layout> = {
         autosize: true,
         paper_bgcolor: 'transparent',
@@ -109,15 +114,28 @@ function PerfChart({ chartData, configuration, id, title }: PerfChartProps) {
     return (
         <div
             id={id}
-            className={classNames('chart-container', { 'legend-instructions': configuration.showLegend })}
+            className={classNames('chart-container', {
+                'legend-instructions': configuration.showLegend,
+                'perf-chart-clickable': isClickable,
+            })}
         >
             <h3>{title}</h3>
+
+            {isClickable ? (
+                <p
+                    className='perf-chart-hint'
+                    data-testid={TEST_IDS.PERF_CHART_TABLE_FILTER_HINT}
+                >
+                    {PERF_CHART_TABLE_FILTER_HINT}
+                </p>
+            ) : null}
 
             <Plot
                 className='chart'
                 data={chartData}
                 layout={layout}
                 config={config}
+                onClick={onPlotClick}
                 useResizeHandler
             />
         </div>

--- a/src/components/performance/PerfCharts.tsx
+++ b/src/components/performance/PerfCharts.tsx
@@ -11,9 +11,10 @@ interface PerfChartsProps {
     filteredPerfData: TypedPerfTableRow[];
     comparisonData?: TypedPerfTableRow[][];
     selectedOpCodes: Marker[];
+    onOpCodeClick?: (opCode: string) => void;
 }
 
-const PerfCharts = ({ filteredPerfData, comparisonData, selectedOpCodes }: PerfChartsProps) => {
+const PerfCharts = ({ filteredPerfData, comparisonData, selectedOpCodes, onOpCodeClick }: PerfChartsProps) => {
     const data = [filteredPerfData, ...(comparisonData || [])].filter((set) => set.length > 0);
 
     return (
@@ -21,6 +22,7 @@ const PerfCharts = ({ filteredPerfData, comparisonData, selectedOpCodes }: PerfC
             <PerfOpCountVsRuntimeChart
                 datasets={data}
                 selectedOpCodes={selectedOpCodes}
+                onOpCodeClick={onOpCodeClick}
             />
 
             <PerfDeviceKernelRuntimeChart datasets={data} />

--- a/src/components/performance/PerfOpCountVsRuntimeChart.tsx
+++ b/src/components/performance/PerfOpCountVsRuntimeChart.tsx
@@ -2,22 +2,24 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useMemo } from 'react';
-import { PlotData } from 'plotly.js';
+import { useCallback, useMemo } from 'react';
+import { PlotData, PlotMouseEvent } from 'plotly.js';
 import { useAtomValue } from 'jotai';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
 import { PlotConfiguration } from '../../definitions/PlotConfigurations';
 import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
+import { getRawOpCodeFromPlotClick } from '../../functions/getRawOpCodeFromPlotClick';
+import getPlotLabel from '../../functions/getPlotLabel';
 import PerfChart from './PerfChart';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
-import getPlotLabel from '../../functions/getPlotLabel';
 
 interface PerfOpCountVsRuntimeChartProps {
     selectedOpCodes: Marker[];
     datasets?: TypedPerfTableRow[][];
+    onOpCodeClick?: (opCode: string) => void;
 }
 
-function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCountVsRuntimeChartProps) {
+function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [], onOpCodeClick }: PerfOpCountVsRuntimeChartProps) {
     const perfReport = useAtomValue(activePerformanceReportAtom);
     const comparisonReportList = useAtomValue(comparisonPerformanceReportListAtom);
     const flattenedData = datasets.flat();
@@ -36,6 +38,20 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
         [opCodes, selectedOpCodeSet],
     );
 
+    const handlePlotClick = useCallback(
+        (event: Readonly<PlotMouseEvent>) => {
+            if (!onOpCodeClick) {
+                return;
+            }
+
+            const opCode = getRawOpCodeFromPlotClick(event);
+            if (opCode) {
+                onOpCodeClick(opCode);
+            }
+        },
+        [onOpCodeClick],
+    );
+
     const opCountData = useMemo(
         () =>
             datasets.map((data, dataIndex) =>
@@ -47,6 +63,7 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
                             type: 'bar',
                             name: getPlotLabel(dataIndex, perfReport?.reportName, comparisonReportList),
                             hovertemplate: `${opCode}<br />%{y:.1%}`,
+                            customdata: [[opCode]],
                             marker: {
                                 color: selectedOpCodes.find((selected) => selected.opCode === opCode)?.colour,
                             },
@@ -70,6 +87,7 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
                             type: 'bar',
                             name: getPlotLabel(dataIndex, perfReport?.reportName, comparisonReportList),
                             hovertemplate: `${opCode}<br />%{y:.1%}`,
+                            customdata: [[opCode]],
                             marker: {
                                 color: selectedOpCodes.find((selected) => selected.opCode === opCode)?.colour,
                             },
@@ -99,6 +117,7 @@ function PerfOpCountVsRuntimeChart({ selectedOpCodes, datasets = [] }: PerfOpCou
             title={PERF_CHART_LABELS[PerfChartId.OpCountVsRuntime]}
             chartData={[...opCountData.flat(), ...opDeviceTimeData.flat()]}
             configuration={configuration}
+            onPlotClick={onOpCodeClick ? handlePlotClick : undefined}
         />
     );
 }

--- a/src/components/performance/PerfOperationTypesChart.tsx
+++ b/src/components/performance/PerfOperationTypesChart.tsx
@@ -3,13 +3,15 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import classNames from 'classnames';
-import { Layout, PlotData } from 'plotly.js';
-import { useMemo } from 'react';
+import { Layout, PlotData, PlotMouseEvent } from 'plotly.js';
+import { useCallback, useMemo } from 'react';
 import Plot from '../../libs/PlotComponent';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
-import { PERF_CHART_LABELS, PerfChartId } from '../../definitions/PerformanceCharts';
-import 'styles/components/PerformanceOperationTypesChart.scss';
+import { PERF_CHART_LABELS, PERF_CHART_TABLE_FILTER_HINT, PerfChartId } from '../../definitions/PerformanceCharts';
 import { PerfChartConfig } from '../../definitions/PlotConfigurations';
+import { TEST_IDS } from '../../definitions/TestIds';
+import { getRawOpCodeFromPlotClick } from '../../functions/getRawOpCodeFromPlotClick';
+import 'styles/components/PerformanceOperationTypesChart.scss';
 
 interface PerfOperationTypesChartProps {
     reportTitle: string;
@@ -17,6 +19,7 @@ interface PerfOperationTypesChartProps {
     data?: TypedPerfTableRow[];
     className?: string;
     id?: string;
+    onOpCodeClick?: (opCode: string) => void;
 }
 
 const LAYOUT: Partial<Layout> = {
@@ -37,10 +40,25 @@ function PerfOperationTypesChart({
     opCodes,
     className = '',
     id,
+    onOpCodeClick,
 }: PerfOperationTypesChartProps) {
     const filteredOpCodes = useMemo(
         () => [...new Set(data?.filter((row) => row.raw_op_code !== undefined).map((row) => row.raw_op_code))],
         [data],
+    );
+
+    const handlePlotClick = useCallback(
+        (event: Readonly<PlotMouseEvent>) => {
+            if (!onOpCodeClick) {
+                return;
+            }
+
+            const opCode = getRawOpCodeFromPlotClick(event);
+            if (opCode) {
+                onOpCodeClick(opCode);
+            }
+        },
+        [onOpCodeClick],
     );
 
     const chartData = useMemo(
@@ -48,6 +66,7 @@ function PerfOperationTypesChart({
             ({
                 values: filteredOpCodes.map((opCode) => data.filter((row) => row.raw_op_code === opCode).length),
                 labels: [...filteredOpCodes],
+                customdata: [...filteredOpCodes],
                 type: 'pie',
                 textinfo: 'percent',
                 hovertemplate: `%{label}<br />Count: %{value}<extra></extra>`,
@@ -63,19 +82,33 @@ function PerfOperationTypesChart({
         [data, opCodes, filteredOpCodes],
     );
 
+    const isClickable = onOpCodeClick != null;
+
     return (
         <div
             id={id}
-            className={classNames('operation-types-chart', className)}
+            className={classNames('operation-types-chart', className, {
+                'perf-chart-clickable': isClickable,
+            })}
         >
             <h3>{PERF_CHART_LABELS[PerfChartId.OperationTypes]}</h3>
             <p>{reportTitle}</p>
+
+            {isClickable ? (
+                <p
+                    className='perf-chart-hint'
+                    data-testid={TEST_IDS.PERF_CHART_TABLE_FILTER_HINT}
+                >
+                    {PERF_CHART_TABLE_FILTER_HINT}
+                </p>
+            ) : null}
 
             <Plot
                 className='chart'
                 data={[chartData]}
                 layout={LAYOUT}
                 config={PerfChartConfig}
+                onClick={isClickable ? handlePlotClick : undefined}
                 useResizeHandler
             />
         </div>

--- a/src/components/performance/PerformanceChartsTab.tsx
+++ b/src/components/performance/PerformanceChartsTab.tsx
@@ -11,6 +11,7 @@ import NonFilterablePerfCharts from './NonFilterablePerfCharts';
 import { Marker, TypedPerfTableRow } from '../../definitions/PerfTable';
 import { buildChartIndexEntries } from '../../definitions/PerformanceCharts';
 import { useActiveSection } from '../../hooks/useActiveSection';
+import { usePrefilterPerfTableByOpCode } from '../../hooks/usePrefilterPerfTableByOpCode';
 import { activePerformanceReportAtom, comparisonPerformanceReportListAtom } from '../../store/app';
 import 'styles/components/PerfCharts.scss';
 
@@ -69,6 +70,7 @@ const PerformanceChartsTab = ({
 
     const chartIndexIds = useMemo(() => chartIndexEntries.map((entry) => entry.id), [chartIndexEntries]);
     const activeId = useActiveSection(chartIndexIds, PERF_CHARTS_NAV_OFFSET_PX);
+    const prefilterPerfTableByOpCode = usePrefilterPerfTableByOpCode();
 
     return (
         <div className='charts-container'>
@@ -91,6 +93,7 @@ const PerformanceChartsTab = ({
                         filteredPerfData={filteredPerfData}
                         comparisonData={filteredComparisonData}
                         selectedOpCodes={selectedOpCodes}
+                        onOpCodeClick={prefilterPerfTableByOpCode}
                     />
 
                     <NonFilterablePerfCharts
@@ -101,6 +104,7 @@ const PerformanceChartsTab = ({
                         convData={convData}
                         hasMatmulData={hasMatmulData}
                         hasConvData={hasConvData}
+                        onOpCodeClick={prefilterPerfTableByOpCode}
                     />
                 </div>
             </div>

--- a/src/definitions/PerformanceCharts.ts
+++ b/src/definitions/PerformanceCharts.ts
@@ -17,6 +17,8 @@ export enum PerfChartId {
     OperationTypes = 'perf-chart-operation-types',
 }
 
+export const PERF_CHART_TABLE_FILTER_HINT = 'Click an operation to filter the performance table';
+
 export const PERF_CHART_LABELS: Record<PerfChartId, string> = {
     [PerfChartId.OpCountVsRuntime]: 'Operation Count vs Device Time',
     [PerfChartId.CoreCountKernelRuntime]: 'Core Count + Device Kernel Runtime',

--- a/src/definitions/TestIds.ts
+++ b/src/definitions/TestIds.ts
@@ -38,6 +38,7 @@ export const TEST_IDS = Object.freeze({
     PERF_COLUMN_PICKER_TRIGGER: 'perf-column-picker-trigger',
     PERF_COLUMN_PICKER_RESET: 'perf-column-picker-reset',
     PERF_COLUMN_PICKER_OPTION: 'perf-column-picker-option',
+    PERF_CHART_TABLE_FILTER_HINT: 'perf-chart-table-filter-hint',
 
     // General UI
     LOADING_SPINNER: 'loading-spinner',

--- a/src/functions/getRawOpCodeFromPlotClick.ts
+++ b/src/functions/getRawOpCodeFromPlotClick.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { PlotMouseEvent } from 'plotly.js';
+
+interface PlotClickDatum {
+    customdata?: unknown;
+    label?: unknown;
+}
+
+export function getRawOpCodeFromPlotClick(event: Readonly<PlotMouseEvent>): string | null {
+    const point = event.points[0] as PlotClickDatum | undefined;
+    if (!point) {
+        return null;
+    }
+
+    const raw = point.customdata ?? point.label;
+    const opCode = Array.isArray(raw) ? raw[0] : raw;
+
+    return typeof opCode === 'string' && opCode.length > 0 ? opCode : null;
+}

--- a/src/hooks/usePrefilterPerfTableByOpCode.ts
+++ b/src/hooks/usePrefilterPerfTableByOpCode.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback } from 'react';
+import { useSetAtom } from 'jotai';
+import { PerfTabIds } from '../definitions/Performance';
+import { perfSelectedTabAtom, rawOpCodeFilterListAtom } from '../store/app';
+
+export function usePrefilterPerfTableByOpCode() {
+    const setTab = useSetAtom(perfSelectedTabAtom);
+    const setFilters = useSetAtom(rawOpCodeFilterListAtom);
+
+    return useCallback(
+        (opCode: string) => {
+            if (!opCode) {
+                return;
+            }
+
+            setFilters([opCode]);
+            setTab(PerfTabIds.TABLE);
+            // Charts tab content (especially Operation Types) sits far down the page; preserve
+            // scroll position across tab swap would land the table view mid-page.
+            window.requestAnimationFrame(() => {
+                window.scrollTo({ top: 0, left: 0 });
+            });
+        },
+        [setFilters, setTab],
+    );
+}

--- a/src/routes/Performance.tsx
+++ b/src/routes/Performance.tsx
@@ -23,6 +23,7 @@ import {
     activePerformanceReportAtom,
     comparisonPerformanceReportListAtom,
     perfSelectedTabAtom,
+    rawOpCodeFilterListAtom,
     selectedPerfRowIdAtom,
     selectedPerformanceRangeAtom,
 } from '../store/app';
@@ -67,6 +68,7 @@ export default function Performance() {
     // hide it only once we know the data is genuinely unavailable.
     const hasL1PressureData = l1Pressure.status !== L1PressureStatus.Unavailable;
     const setSelectedPerfRowId = useSetAtom(selectedPerfRowIdAtom);
+    const setRawOpCodeFilterList = useSetAtom(rawOpCodeFilterListAtom);
 
     const shouldDisableComparison = getServerConfig()?.SERVER_MODE;
 
@@ -178,7 +180,8 @@ export default function Performance() {
 
     useEffect(() => {
         setSelectedPerfRowId(null);
-    }, [activePerformanceReport?.path, setSelectedPerfRowId]);
+        setRawOpCodeFilterList([]);
+    }, [activePerformanceReport?.path, setRawOpCodeFilterList, setSelectedPerfRowId]);
 
     // Clear comparison report if users switches active perf report to the comparison report
     useEffect(() => {

--- a/src/scss/components/PerfCharts.scss
+++ b/src/scss/components/PerfCharts.scss
@@ -45,3 +45,19 @@ $perf-charts-nav-offset: 60px;
         flex-grow: 1;
     }
 }
+
+@mixin perf-chart-table-filter-hint {
+    .perf-chart-hint {
+        margin: 0 0 8px;
+        font-style: italic;
+        font-size: 12px;
+    }
+}
+
+.perf-chart-clickable {
+    @include perf-chart-table-filter-hint;
+
+    .chart {
+        cursor: pointer;
+    }
+}

--- a/src/scss/components/PerformanceOperationTypesChart.scss
+++ b/src/scss/components/PerformanceOperationTypesChart.scss
@@ -2,6 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+@use './PerfCharts' as perf-charts;
+
 .operation-types-chart {
     margin-bottom: 20px;
     height: 500px; // TEMP: Stops charts from collapsing on occasion
@@ -9,5 +11,13 @@
     .chart {
         width: 100%;
         height: 450px;
+    }
+
+    &.perf-chart-clickable {
+        @include perf-charts.perf-chart-table-filter-hint;
+
+        .chart {
+            cursor: pointer;
+        }
     }
 }

--- a/tests/PerfChart.spec.tsx
+++ b/tests/PerfChart.spec.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { PlotData } from 'plotly.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import PerfChart from '../src/components/performance/PerfChart';
+import { PERF_CHART_TABLE_FILTER_HINT } from '../src/definitions/PerformanceCharts';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import { firePlotClick, resetPlotPropsCapture } from './mocks/plotComponent';
+
+afterEach(() => {
+    cleanup();
+    resetPlotPropsCapture();
+});
+
+describe('PerfChart', () => {
+    it('forwards onPlotClick to Plot and shows the table-filter hint when clickable', () => {
+        const onPlotClick = vi.fn();
+
+        render(
+            <PerfChart
+                title='Test chart'
+                chartData={[{ type: 'bar', x: ['a'], y: [1] } as Partial<PlotData>]}
+                configuration={{}}
+                onPlotClick={onPlotClick}
+            />,
+        );
+
+        expect(screen.getByTestId(TEST_IDS.PERF_CHART_TABLE_FILTER_HINT)).toHaveTextContent(
+            PERF_CHART_TABLE_FILTER_HINT,
+        );
+
+        firePlotClick({ points: [{ customdata: 'Matmul' }] } as never);
+        expect(onPlotClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show the hint when the chart is not clickable', () => {
+        render(
+            <PerfChart
+                title='Test chart'
+                chartData={[{ type: 'bar', x: ['a'], y: [1] } as Partial<PlotData>]}
+                configuration={{}}
+            />,
+        );
+
+        expect(screen.queryByTestId(TEST_IDS.PERF_CHART_TABLE_FILTER_HINT)).not.toBeInTheDocument();
+    });
+});

--- a/tests/PerfOpCountVsRuntimeChart.spec.tsx
+++ b/tests/PerfOpCountVsRuntimeChart.spec.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import PerfOpCountVsRuntimeChart from '../src/components/performance/PerfOpCountVsRuntimeChart';
+import { MarkerColours, TypedPerfTableRow } from '../src/definitions/PerfTable';
+import { OpType } from '../src/definitions/Performance';
+import { TestProviders } from './helpers/TestProviders';
+import { firePlotClick, resetPlotPropsCapture } from './mocks/plotComponent';
+
+const matmulMarker = { opCode: 'Matmul', colour: MarkerColours[0] };
+const convMarker = { opCode: 'Conv2d', colour: MarkerColours[1] };
+
+const row = (rawOpCode: string): TypedPerfTableRow =>
+    ({
+        op_type: OpType.DEVICE_OP,
+        op_code: rawOpCode,
+        raw_op_code: rawOpCode,
+        device_time: 10,
+        advice: [],
+        bound: null,
+        isFirstHashOccurrence: true,
+        id: 1,
+    }) as unknown as TypedPerfTableRow;
+
+afterEach(() => {
+    cleanup();
+    resetPlotPropsCapture();
+});
+
+describe('PerfOpCountVsRuntimeChart', () => {
+    it('calls onOpCodeClick with customdata from a bar segment click', () => {
+        const onOpCodeClick = vi.fn();
+
+        render(
+            <TestProviders>
+                <PerfOpCountVsRuntimeChart
+                    datasets={[[row('Matmul'), row('Conv2d')]]}
+                    selectedOpCodes={[matmulMarker, convMarker]}
+                    onOpCodeClick={onOpCodeClick}
+                />
+            </TestProviders>,
+        );
+
+        firePlotClick({ points: [{ customdata: ['Matmul'] }] } as never);
+
+        expect(onOpCodeClick).toHaveBeenCalledWith('Matmul');
+    });
+
+    it('does not call onOpCodeClick when customdata is missing', () => {
+        const onOpCodeClick = vi.fn();
+
+        render(
+            <TestProviders>
+                <PerfOpCountVsRuntimeChart
+                    datasets={[[row('Matmul')]]}
+                    selectedOpCodes={[matmulMarker]}
+                    onOpCodeClick={onOpCodeClick}
+                />
+            </TestProviders>,
+        );
+
+        firePlotClick({ points: [{}] } as never);
+
+        expect(onOpCodeClick).not.toHaveBeenCalled();
+    });
+});

--- a/tests/PerfOperationTypesChart.spec.tsx
+++ b/tests/PerfOperationTypesChart.spec.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import PerfOperationTypesChart from '../src/components/performance/PerfOperationTypesChart';
+import { MarkerColours, TypedPerfTableRow } from '../src/definitions/PerfTable';
+import { OpType } from '../src/definitions/Performance';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import { TestProviders } from './helpers/TestProviders';
+import { firePlotClick, getPlotInstances, resetPlotPropsCapture } from './mocks/plotComponent';
+
+const matmulMarker = { opCode: 'Matmul', colour: MarkerColours[0] };
+const convMarker = { opCode: 'Conv2d', colour: MarkerColours[1] };
+
+const row = (rawOpCode: string, id: number): TypedPerfTableRow =>
+    ({
+        op_type: OpType.DEVICE_OP,
+        op_code: rawOpCode,
+        raw_op_code: rawOpCode,
+        advice: [],
+        bound: null,
+        isFirstHashOccurrence: true,
+        id,
+    }) as unknown as TypedPerfTableRow;
+
+afterEach(() => {
+    cleanup();
+    resetPlotPropsCapture();
+});
+
+describe('PerfOperationTypesChart', () => {
+    it('calls onOpCodeClick when a pie slice is clicked', () => {
+        const onOpCodeClick = vi.fn();
+
+        render(
+            <TestProviders>
+                <PerfOperationTypesChart
+                    reportTitle='active-report'
+                    data={[row('Matmul', 1), row('Conv2d', 2)]}
+                    opCodes={[matmulMarker, convMarker]}
+                    onOpCodeClick={onOpCodeClick}
+                />
+            </TestProviders>,
+        );
+
+        firePlotClick({ points: [{ customdata: 'Conv2d', label: 'Conv2d' }] } as never);
+
+        expect(onOpCodeClick).toHaveBeenCalledWith('Conv2d');
+        expect(screen.getByTestId(TEST_IDS.PERF_CHART_TABLE_FILTER_HINT)).toBeInTheDocument();
+    });
+
+    it('wires separate chart instances for active and comparison data', () => {
+        const onOpCodeClick = vi.fn();
+
+        render(
+            <TestProviders>
+                <div>
+                    <PerfOperationTypesChart
+                        reportTitle='active-report'
+                        data={[row('Matmul', 1)]}
+                        opCodes={[matmulMarker, convMarker]}
+                        onOpCodeClick={onOpCodeClick}
+                    />
+                    <PerfOperationTypesChart
+                        reportTitle='comparison-report'
+                        data={[row('Conv2d', 2)]}
+                        opCodes={[matmulMarker, convMarker]}
+                        onOpCodeClick={onOpCodeClick}
+                    />
+                </div>
+            </TestProviders>,
+        );
+
+        expect(getPlotInstances()).toHaveLength(2);
+
+        const comparisonOnClick = getPlotInstances()[1]?.onClick as
+            | ((event: { points: { customdata: string }[] }) => void)
+            | undefined;
+        comparisonOnClick?.({ points: [{ customdata: 'Conv2d' }] });
+
+        expect(onOpCodeClick).toHaveBeenCalledWith('Conv2d');
+    });
+});

--- a/tests/PerfReport.spec.tsx
+++ b/tests/PerfReport.spec.tsx
@@ -10,7 +10,7 @@ import { TypedPerfTableRow } from '../src/definitions/PerfTable';
 import { OpType } from '../src/definitions/Performance';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { useGetNPEManifest, useOpToPerfIdFiltered, useOperationsList, usePerfMeta } from '../src/hooks/useAPI';
-import { comparisonPerformanceReportListAtom } from '../src/store/app';
+import { comparisonPerformanceReportListAtom, rawOpCodeFilterListAtom } from '../src/store/app';
 import { TestProviders } from './helpers/TestProviders';
 
 vi.mock('../src/hooks/useAPI.tsx', () => ({
@@ -22,7 +22,7 @@ vi.mock('../src/hooks/useAPI.tsx', () => ({
 
 const COMPARISON_REPORT = 'report-b';
 
-const row = (opCode: string): TypedPerfTableRow =>
+const row = (opCode: string, id = 1): TypedPerfTableRow =>
     ({
         op_type: OpType.DEVICE_OP,
         op_code: opCode,
@@ -30,7 +30,7 @@ const row = (opCode: string): TypedPerfTableRow =>
         advice: [],
         bound: null,
         isFirstHashOccurrence: true,
-        id: 1,
+        id,
     }) as unknown as TypedPerfTableRow;
 
 interface RenderOptions {
@@ -38,6 +38,8 @@ interface RenderOptions {
     isComparisonLoading?: boolean;
     comparisonData?: TypedPerfTableRow[][];
     comparisonReports?: string[] | null;
+    data?: TypedPerfTableRow[];
+    rawOpCodeFilterList?: string[];
 }
 
 function renderReport({
@@ -45,13 +47,24 @@ function renderReport({
     isComparisonLoading = false,
     comparisonData = [],
     comparisonReports = null,
+    data = [row('Matmul')],
+    rawOpCodeFilterList = [],
 }: RenderOptions = {}) {
+    const initialAtomValues: [typeof comparisonPerformanceReportListAtom | typeof rawOpCodeFilterListAtom, unknown][] =
+        [];
+
+    if (comparisonReports) {
+        initialAtomValues.push([comparisonPerformanceReportListAtom, comparisonReports]);
+    }
+
+    if (rawOpCodeFilterList.length > 0) {
+        initialAtomValues.push([rawOpCodeFilterListAtom, rawOpCodeFilterList]);
+    }
+
     return render(
-        <TestProviders
-            initialAtomValues={comparisonReports ? [[comparisonPerformanceReportListAtom, comparisonReports]] : []}
-        >
+        <TestProviders initialAtomValues={initialAtomValues}>
             <PerformanceReport
-                data={[row('Matmul')]}
+                data={data}
                 comparisonData={comparisonData}
                 stackedData={[]}
                 comparisonStackedData={[]}
@@ -99,5 +112,17 @@ describe('PerformanceReport loading state', () => {
 
         expect(screen.getByTestId(TEST_IDS.PERF_TABLE_SKELETON)).toBeInTheDocument();
         expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+    });
+});
+
+describe('PerformanceReport raw op code filter', () => {
+    it('shows only rows matching the hydrated raw op code filter atom', () => {
+        renderReport({
+            data: [row('Matmul', 1), row('Conv2d', 2)],
+            rawOpCodeFilterList: ['Matmul'],
+        });
+
+        expect(screen.getAllByText('Matmul').length).toBeGreaterThan(0);
+        expect(screen.queryByText('Conv2d')).not.toBeInTheDocument();
     });
 });

--- a/tests/getRawOpCodeFromPlotClick.spec.ts
+++ b/tests/getRawOpCodeFromPlotClick.spec.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { PlotMouseEvent } from 'plotly.js';
+import { getRawOpCodeFromPlotClick } from '../src/functions/getRawOpCodeFromPlotClick';
+
+const clickEvent = (point: Record<string, unknown>): PlotMouseEvent =>
+    ({
+        points: [point],
+    }) as unknown as PlotMouseEvent;
+
+describe('getRawOpCodeFromPlotClick', () => {
+    it('reads a flat customdata string', () => {
+        expect(getRawOpCodeFromPlotClick(clickEvent({ customdata: 'Matmul' }))).toBe('Matmul');
+    });
+
+    it('reads nested customdata arrays from Plotly bar traces', () => {
+        expect(getRawOpCodeFromPlotClick(clickEvent({ customdata: ['OptimizedConvNew'] }))).toBe('OptimizedConvNew');
+    });
+
+    it('falls back to label when customdata is absent', () => {
+        expect(getRawOpCodeFromPlotClick(clickEvent({ label: 'Conv2d' }))).toBe('Conv2d');
+    });
+
+    it('returns null when points are missing', () => {
+        expect(getRawOpCodeFromPlotClick({ points: [] } as unknown as PlotMouseEvent)).toBeNull();
+    });
+
+    it('returns null for empty strings', () => {
+        expect(getRawOpCodeFromPlotClick(clickEvent({ customdata: '' }))).toBeNull();
+    });
+});

--- a/tests/mocks/plotComponent.ts
+++ b/tests/mocks/plotComponent.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import React from 'react';
+import { PlotMouseEvent } from 'plotly.js';
+import { vi } from 'vitest';
+
+const plotState = vi.hoisted(() => ({
+    latest: null as Record<string, unknown> | null,
+    instances: [] as Record<string, unknown>[],
+}));
+
+vi.mock('../../src/libs/PlotComponent', () => ({
+    default: (props: Record<string, unknown>) => {
+        plotState.latest = props;
+        plotState.instances.push(props);
+        return React.createElement('div', { 'data-testid': 'mock-plot' });
+    },
+}));
+
+export function resetPlotPropsCapture() {
+    plotState.latest = null;
+    plotState.instances = [];
+}
+
+export function getLatestPlotOnClick(): ((event: Readonly<PlotMouseEvent>) => void) | undefined {
+    return plotState.latest?.onClick as ((event: Readonly<PlotMouseEvent>) => void) | undefined;
+}
+
+export function getPlotInstances(): Record<string, unknown>[] {
+    return plotState.instances;
+}
+
+export function firePlotClick(event: Readonly<PlotMouseEvent>) {
+    const onClick = getLatestPlotOnClick();
+    if (!onClick) {
+        throw new Error('Plot onClick handler is not set');
+    }
+
+    onClick(event);
+}

--- a/tests/usePrefilterPerfTableByOpCode.spec.tsx
+++ b/tests/usePrefilterPerfTableByOpCode.spec.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useAtomValue } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Button } from '@blueprintjs/core';
+import { PerfTabIds } from '../src/definitions/Performance';
+import { usePrefilterPerfTableByOpCode } from '../src/hooks/usePrefilterPerfTableByOpCode';
+import { perfSelectedTabAtom, rawOpCodeFilterListAtom } from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+function Probe() {
+    const prefilter = usePrefilterPerfTableByOpCode();
+    const rawOpCodeFilter = useAtomValue(rawOpCodeFilterListAtom);
+    const selectedTab = useAtomValue(perfSelectedTabAtom);
+
+    return (
+        <div>
+            <span data-testid='raw-op-filter'>{rawOpCodeFilter.join(',')}</span>
+            <span data-testid='selected-tab'>{String(selectedTab)}</span>
+            <Button
+                type='button'
+                onClick={() => prefilter('Matmul')}
+            >
+                filter-matmul
+            </Button>
+            <Button
+                type='button'
+                onClick={() => prefilter('')}
+            >
+                filter-empty
+            </Button>
+        </div>
+    );
+}
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+        callback(0);
+        return 0;
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+});
+
+describe('usePrefilterPerfTableByOpCode', () => {
+    it('sets the raw op code filter and switches to the table tab', () => {
+        render(
+            <TestProviders
+                initialAtomValues={[
+                    [rawOpCodeFilterListAtom, ['Conv2d', 'Softmax']],
+                    [perfSelectedTabAtom, PerfTabIds.CHARTS],
+                ]}
+            >
+                <Probe />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'filter-matmul' }));
+
+        expect(screen.getByTestId('raw-op-filter')).toHaveTextContent('Matmul');
+        expect(screen.getByTestId('selected-tab')).toHaveTextContent(PerfTabIds.TABLE);
+        expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, left: 0 });
+    });
+
+    it('ignores empty op codes', () => {
+        render(
+            <TestProviders initialAtomValues={[[rawOpCodeFilterListAtom, ['Conv2d']]]}>
+                <Probe />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'filter-empty' }));
+
+        expect(screen.getByTestId('raw-op-filter')).toHaveTextContent('Conv2d');
+    });
+});


### PR DESCRIPTION
## Summary
Chart-driven filtering in the Performance Charts tab is currently pointer-click only. Users can click chart segments/slices to prefilter the table and switch to the Table tab, but there is no equivalent keyboard path.

## Current behaviour
- Filtering is wired through Plot click callbacks in performance chart components.
- The UI hint text advertises click interaction.
- Keyboard users cannot trigger the same filter action via focused controls.

## Why this matters
This introduces an accessibility gap for a primary interaction path in the performance analysis workflow.

## Proposed follow-up
1. Add a keyboard-operable interaction path for chart filtering.
2. Ensure enabled/disabled semantics mirror click availability.
3. Add tests that exercise keyboard activation and verify table prefilter + tab switch behaviour.
4. Keep existing pointer-click behaviour unchanged.

## Acceptance criteria
- A keyboard user can trigger operation filtering from charts without a pointer device.
- Accessibility tests cover the new path.
- Existing chart click tests remain green.

Related work: refactor centralises chart click handler and filter hint rendering in this branch.