### PR TITLE
MLIR viewer: perf hot-path fixes (memo deps + context stability) (#1739)

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -75,9 +75,14 @@ const NODE_BODY_OVERLAY_LINE_PX = 11;
 //    bleeds behind the dashed body and hides children.
 //  - `buriedMatchCount`: hidden filter matches under a collapsed anchor;
 //    drives the "+N" badge.
+//  - `shapeLines` / `locationLines`: overlay strings for the node-body
+//    toggles. Routed through per-node `data` (not a context provider) so a
+//    toggle flip only re-renders ops that actually have overlay content.
 type MLNodeData = WorkerNode['data'] & {
     highlight?: 'input' | 'output';
     buriedMatchCount?: number;
+    shapeLines?: readonly string[];
+    locationLines?: readonly string[];
 };
 
 interface ViewProps {
@@ -91,26 +96,35 @@ type MLNode = Node<MLNodeData>;
 // has no overlay entry.
 const EMPTY_OVERLAY_LINES: readonly string[] = Object.freeze([]);
 
-type MlirNodeBodyOverlayLines = { shapes: string[]; location: string[] };
+const EMPTY_CHAIN: readonly string[] = Object.freeze([]);
 
-// Shared empty-map instance returned when both toggles are off, so
-// `nodeBodyContextValue`'s identity stays stable and every MlirOpNode
-// avoids a context-driven re-render on unrelated graph rebuilds.
-const EMPTY_OVERLAY_MAP: Map<string, MlirNodeBodyOverlayLines> = new Map();
-
-type MlirNodeBodyContextValue = {
-    overlayLinesByNodeId: Map<string, MlirNodeBodyOverlayLines>;
+const parentChainsEqual = (a: readonly string[], b: readonly string[]): boolean => {
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+    return true;
 };
 
-const MlirNodeBodyContext = createContext<MlirNodeBodyContextValue>({
-    overlayLinesByNodeId: new Map(),
-});
+// `parentChain` is root-first, terminating at the immediate parent.
+type NodeTopologyEntry = {
+    parentChain: readonly string[];
+    parentId: string | undefined;
+    type: string | undefined;
+    groupKind: MLNodeData['groupKind'];
+    collapsedSubgraphNamespace: MLNodeData['collapsedSubgraphNamespace'];
+    subgraphToggleState: MLNodeData['subgraphToggleState'];
+};
 
-const MlirOpNode = memo<NodeProps<MLNode>>(({ id, data }) => {
-    const { overlayLinesByNodeId } = useContext(MlirNodeBodyContext);
-    const overlay = overlayLinesByNodeId.get(id);
-    const shapeLines = overlay?.shapes ?? EMPTY_OVERLAY_LINES;
-    const locationLines = overlay?.location ?? EMPTY_OVERLAY_LINES;
+type MlirNodeBodyOverlayLines = { shapes: string[]; location: string[] };
+
+// Shared empty-map used when both toggles are off; keeps map identity stable.
+const EMPTY_OVERLAY_MAP: Map<string, MlirNodeBodyOverlayLines> = new Map();
+
+const MlirOpNode = memo<NodeProps<MLNode>>(({ data }) => {
+    const shapeLines = data.shapeLines ?? EMPTY_OVERLAY_LINES;
+    const locationLines = data.locationLines ?? EMPTY_OVERLAY_LINES;
 
     return (
         <>
@@ -352,7 +366,7 @@ function builtGraphToReactFlow(built: BuiltGraph): { nodes: MLNode[]; edges: Edg
 }
 
 const MlGraphInner = ({ data }: ViewProps) => {
-    const { fitView, getViewport, setViewport } = useReactFlow();
+    const { fitView, getViewport, setViewport, updateNode } = useReactFlow<MLNode, Edge>();
     const graph = data.graphs[0];
     const [nodes, setNodes, onNodesChange] = useNodesState<MLNode>([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
@@ -371,6 +385,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const [nodeBodyToggles, setNodeBodyToggles] = useAtom(mlirNodeBodyTogglesAtom);
     const filterRef = useRef<MlirOpFilterHandle>(null);
     const selectedNodeIdRef = useRef<string | null>(null);
+    // Passive mirror of `nodes` so callbacks stored in context (see
+    // `toggleNamespaceFromGroup`) don't churn identity per drag frame.
+    const latestNodesRef = useRef<MLNode[]>([]);
     const viewportAnchorRef = useRef<{
         toNodeId: string;
         fromPosition: { x: number; y: number };
@@ -395,6 +412,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
     useEffect(() => {
         selectedNodeIdRef.current = selectedNodeId;
     }, [selectedNodeId]);
+
+    useEffect(() => {
+        latestNodesRef.current = nodes;
+    }, [nodes]);
 
     // `pendingFocusNodeIdRef` is a one-shot baton armed by `navigateToNode`
     // when the locate target lives in a collapsed namespace and consumed by
@@ -570,9 +591,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return next;
     }, [nodes]);
     // "Computed cached state" pattern (React docs): only replace the
-    // tracked set when contents actually change. Prevents a drag from
-    // fanning out a re-render to every mounted `MlirOpNode` via the
-    // `MlirNodeBodyContext` provider.
+    // tracked set when contents actually change. Downstream memos
+    // (`filterMatchInfo`, `overlayLinesByNodeId`) must not invalidate
+    // on drag frames.
     const [visibleOpNodeIds, setVisibleOpNodeIds] = useState<Set<string>>(visibleOpNodeIdsSource);
     if (visibleOpNodeIds !== visibleOpNodeIdsSource) {
         let unchanged = visibleOpNodeIds.size === visibleOpNodeIdsSource.size;
@@ -589,17 +610,64 @@ const MlGraphInner = ({ data }: ViewProps) => {
         }
     }
 
-    // Per-node overlay lines for the node-body toggles. Scoped to op
-    // nodes currently on the canvas (`visibleOpNodeIds`) — sources hidden
-    // inside collapsed subgraphs never render overlay lines and don't
-    // contribute to `extraLinesByNodeId` height. Computed exactly once
-    // per (toggle, visible-set) change and shared with both the
-    // height-growth path (`extraLinesByNodeId` below → `styledNodes`) and
-    // the render path (via `MlirNodeBodyContext` → `MlirOpNode`), so
-    // `collectShapeLines` / `collectLocationLines` never run twice for
-    // the same node on a single toggle flip. When both toggles are off
-    // we return a shared empty Map so the context Provider value stays
-    // referentially stable and doesn't fan out a re-render to every op.
+    // Structural topology per node — set once by the worker, invariant
+    // under drag / selection / hover. Stabilised via computed-cached-state
+    // so `displayedEdges` bails out on unrelated frames.
+    const nodeTopologyByIdSource = useMemo<Map<string, NodeTopologyEntry>>(() => {
+        const parentById = new Map<string, string | undefined>();
+        for (const n of nodes) {
+            parentById.set(n.id, n.parentId);
+        }
+        const result = new Map<string, NodeTopologyEntry>();
+        for (const n of nodes) {
+            const chain: string[] = [];
+            let pid = n.parentId;
+            while (pid) {
+                chain.push(pid);
+                pid = parentById.get(pid);
+            }
+            chain.reverse();
+            result.set(n.id, {
+                parentChain: chain,
+                parentId: n.parentId,
+                type: n.type,
+                groupKind: n.data?.groupKind,
+                collapsedSubgraphNamespace: n.data?.collapsedSubgraphNamespace,
+                subgraphToggleState: n.data?.subgraphToggleState,
+            });
+        }
+        return result;
+    }, [nodes]);
+    const [nodeTopologyById, setNodeTopologyById] = useState<Map<string, NodeTopologyEntry>>(nodeTopologyByIdSource);
+    if (nodeTopologyById !== nodeTopologyByIdSource) {
+        let unchanged = nodeTopologyById.size === nodeTopologyByIdSource.size;
+        if (unchanged) {
+            for (const [id, next] of nodeTopologyByIdSource) {
+                const prev = nodeTopologyById.get(id);
+                if (
+                    !prev ||
+                    prev.parentId !== next.parentId ||
+                    prev.type !== next.type ||
+                    prev.groupKind !== next.groupKind ||
+                    prev.collapsedSubgraphNamespace !== next.collapsedSubgraphNamespace ||
+                    prev.subgraphToggleState !== next.subgraphToggleState ||
+                    prev.parentChain.length !== next.parentChain.length ||
+                    !parentChainsEqual(prev.parentChain, next.parentChain)
+                ) {
+                    unchanged = false;
+                    break;
+                }
+            }
+        }
+        if (!unchanged) {
+            setNodeTopologyById(nodeTopologyByIdSource);
+        }
+    }
+
+    // Per-node overlay lines for the node-body toggles. Only op-nodes
+    // with non-empty overlay content appear in this map; `styledNodes`
+    // applies the arrays onto `data.shapeLines` / `data.locationLines`
+    // so React Flow's per-node diff drives re-renders on toggle flip.
     const overlayLinesByNodeId = useMemo<Map<string, MlirNodeBodyOverlayLines>>(() => {
         if (!nodeBodyToggles.location && !nodeBodyToggles.shapes) {
             return EMPTY_OVERLAY_MAP;
@@ -619,18 +687,6 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return result;
     }, [nodeBodyToggles.location, nodeBodyToggles.shapes, visibleOpNodeIds, sourceNodeById]);
 
-    // Derived count map consumed by `styledNodes` to grow each node's DOM
-    // height inline. The layout worker is intentionally not told about
-    // these — trading occasional vertical overlap with the row below for
-    // zero layout shift when the user flicks a toggle.
-    const extraLinesByNodeId = useMemo<Map<string, number>>(() => {
-        const result = new Map<string, number>();
-        for (const [id, { shapes, location }] of overlayLinesByNodeId) {
-            result.set(id, shapes.length + location.length);
-        }
-        return result;
-    }, [overlayLinesByNodeId]);
-
     // Maps each label-matching source to its visible representative: itself
     // if on canvas, otherwise the anchor of its outermost collapsed
     // ancestor. Reads `containingNamespacesByNodeId` (not `source.namespace`)
@@ -641,22 +697,30 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // expanded parent or as the collapsed anchor of their own namespace), so
     // `visibleNodeIds.has(anchorId)` can't distinguish collapsed from
     // expanded. Mirrors the graph builder's `resolveRenderedNodeId`.
+    // Lifted from `filterMatchInfo` so an active filter doesn't recompile
+    // the RegExp on every interaction frame.
+    const filterMatcher = useMemo(() => {
+        if (appliedFilterQuery.length === 0) {
+            return null;
+        }
+        return buildFilterMatcher(filterMode, appliedFilterQuery);
+    }, [filterMode, appliedFilterQuery]);
+
     const filterMatchInfo = useMemo<{
         visibleRepIds: Set<string>;
         buriedCountByRepId: Map<string, number>;
         hiddenMatchCount: number;
         isRegexInvalid: boolean;
     } | null>(() => {
-        if (appliedFilterQuery.length === 0) {
+        if (!filterMatcher) {
             return null;
         }
-        const { testLabel, isRegexInvalid } = buildFilterMatcher(filterMode, appliedFilterQuery);
+        const { testLabel, isRegexInvalid } = filterMatcher;
         const anchorByNamespace = interactionIndex?.anchorByNamespace ?? {};
         const containingNamespacesByNodeId = interactionIndex?.containingNamespacesByNodeId ?? {};
-        const visibleNodeIds = new Set<string>();
-        for (const node of nodes) {
-            visibleNodeIds.add(node.id);
-        }
+        // Anchor and source ids are always op-node ids, so the stabilised
+        // op set is the correct visibility check and keeps the memo out
+        // of the per-frame `nodes` invalidation path.
         const visibleRepIds = new Set<string>();
         const buriedCountByRepId = new Map<string, number>();
         let hiddenMatchCount = 0;
@@ -673,13 +737,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 for (const ns of containing) {
                     if (!expandedNamespaces.has(ns)) {
                         const anchorId = anchorByNamespace[ns] ?? source.id;
-                        repId = visibleNodeIds.has(anchorId) ? anchorId : null;
+                        repId = visibleOpNodeIds.has(anchorId) ? anchorId : null;
                         break;
                     }
                 }
             }
             if (repId === null) {
-                repId = visibleNodeIds.has(source.id) ? source.id : null;
+                repId = visibleOpNodeIds.has(source.id) ? source.id : null;
             }
             if (repId === null) {
                 continue;
@@ -691,7 +755,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             }
         }
         return { visibleRepIds, buriedCountByRepId, hiddenMatchCount, isRegexInvalid };
-    }, [appliedFilterQuery, filterMode, sourceNodes, expandedNamespaces, interactionIndex, nodes]);
+    }, [filterMatcher, sourceNodes, expandedNamespaces, interactionIndex, visibleOpNodeIds]);
 
     // Visible reps in canvas order so prev/next walks top-to-bottom.
     const matchedNodesInOrder = useMemo<string[]>(() => {
@@ -730,6 +794,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
         },
         [matchedNodesInOrder, currentMatchIndex, fitView],
     );
+    const goToPrevMatch = useCallback(() => goToMatch('prev'), [goToMatch]);
+    const goToNextMatch = useCallback(() => goToMatch('next'), [goToMatch]);
 
     // Anchor the viewport so the namespace's representative op (post-collapse)
     // visually stays put, then drop the namespace from `expandedNamespaces`.
@@ -865,27 +931,64 @@ const MlGraphInner = ({ data }: ViewProps) => {
     }, []);
 
     // Group header invokes this on click (drag suppresses it). Always a
-    // collapse — the header only exists for an expanded group.
+    // collapse — the header only exists for an expanded group. Reads
+    // `nodes` via `latestNodesRef` so callback identity survives drag
+    // frames and doesn't fan a re-render through `groupContextValue`.
     const toggleNamespaceFromGroup = useCallback(
         (namespace: string) => {
-            const groupNode = nodes.find((n) => n.type === 'mlirGroup' && n.data?.namespace === namespace);
+            const groupNode = latestNodesRef.current.find(
+                (n) => n.type === 'mlirGroup' && n.data?.namespace === namespace,
+            );
             const fromPosition = groupNode ? { x: groupNode.position.x, y: groupNode.position.y } : { x: 0, y: 0 };
             collapseNamespace(namespace, fromPosition);
         },
-        [collapseNamespace, nodes],
+        [collapseNamespace],
     );
 
     // Header drag updates only the group's own position; React Flow auto-
     // moves children because they declare `parentId` + `extent: 'parent'`.
+    // Mousemove deltas are coalesced into a single RAF-batched write and
+    // routed through `updateNode` to skip the O(N) `setNodes` cascade.
+    const moveGroupPendingRef = useRef<Map<string, { dx: number; dy: number }>>(new Map());
+    const moveGroupRafRef = useRef<number | null>(null);
+    const flushMoveGroup = useCallback(() => {
+        moveGroupRafRef.current = null;
+        const pending = moveGroupPendingRef.current;
+        if (pending.size === 0) {
+            return;
+        }
+        for (const [groupId, delta] of pending) {
+            updateNode(groupId, (n) => ({
+                position: { x: n.position.x + delta.dx, y: n.position.y + delta.dy },
+            }));
+        }
+        pending.clear();
+    }, [updateNode]);
     const moveGroup = useCallback(
         (groupId: string, dx: number, dy: number) => {
-            setNodes((current) =>
-                current.map((n) =>
-                    n.id === groupId ? { ...n, position: { x: n.position.x + dx, y: n.position.y + dy } } : n,
-                ),
-            );
+            const pending = moveGroupPendingRef.current;
+            const existing = pending.get(groupId);
+            if (existing) {
+                existing.dx += dx;
+                existing.dy += dy;
+            } else {
+                pending.set(groupId, { dx, dy });
+            }
+            if (moveGroupRafRef.current === null) {
+                moveGroupRafRef.current = window.requestAnimationFrame(flushMoveGroup);
+            }
         },
-        [setNodes],
+        [flushMoveGroup],
+    );
+    useEffect(
+        () => () => {
+            if (moveGroupRafRef.current !== null) {
+                window.cancelAnimationFrame(moveGroupRafRef.current);
+                moveGroupRafRef.current = null;
+            }
+            moveGroupPendingRef.current.clear();
+        },
+        [],
     );
 
     const groupContextValue = useMemo<MlirGroupContextValue>(
@@ -1242,32 +1345,15 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (edges.length === 0) {
             return edges;
         }
-        const nodeById = new Map<string, MLNode>(nodes.map((n) => [n.id, n]));
-        // Memoise parent-id chains so a heavily-nested edge endpoint doesn't
-        // re-walk the same ancestors O(edges) times.
-        const chainCache = new Map<string, string[]>();
-        const parentChain = (nodeId: string): string[] => {
-            const cached = chainCache.get(nodeId);
-            if (cached) {
-                return cached;
-            }
-            const chain: string[] = [];
-            let pid = nodeById.get(nodeId)?.parentId;
-            while (pid) {
-                chain.push(pid);
-                pid = nodeById.get(pid)?.parentId;
-            }
-            chain.reverse();
-            chainCache.set(nodeId, chain);
-            return chain;
-        };
+        const parentChain = (nodeId: string): readonly string[] =>
+            nodeTopologyById.get(nodeId)?.parentChain ?? EMPTY_CHAIN;
         const isRealNamespaceGroup = (id: string): boolean => {
-            const n = nodeById.get(id);
-            return n?.type === 'mlirGroup' && n.data?.groupKind !== 'section';
+            const t = nodeTopologyById.get(id);
+            return t?.type === 'mlirGroup' && t.groupKind !== 'section';
         };
         const isCollapsedAnchor = (id: string): boolean => {
-            const n = nodeById.get(id);
-            return !!n?.data?.collapsedSubgraphNamespace && n.data?.subgraphToggleState === 'collapsed';
+            const t = nodeTopologyById.get(id);
+            return !!t?.collapsedSubgraphNamespace && t.subgraphToggleState === 'collapsed';
         };
         // LCA lift: for an edge whose endpoints live in different parent
         // chains, walk each chain down to the point just below their lowest
@@ -1316,8 +1402,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 result.push({ ...e, label: undefined });
                 continue;
             }
-            const srcParent = nodeById.get(e.source)?.parentId;
-            const tgtParent = nodeById.get(e.target)?.parentId;
+            const srcParent = nodeTopologyById.get(e.source)?.parentId;
+            const tgtParent = nodeTopologyById.get(e.target)?.parentId;
             // (4) Same-parent — push as-is.
             if (srcParent === tgtParent) {
                 result.push(e);
@@ -1348,7 +1434,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             });
         }
         return result;
-    }, [edges, nodes, selectedNodeId]);
+    }, [edges, nodeTopologyById, selectedNodeId]);
 
     // Focus context: the selected node, its directly connected neighbours, and
     // the edges that connect them. Held as derived state so the rest of the
@@ -1386,7 +1472,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
         // Zero-match filter is treated as "no filter" for dim/badge purposes
         // — leaves the canvas untouched instead of dimming everything to 18%.
         const activeFilter = filterMatchInfo && filterMatchInfo.visibleRepIds.size > 0 ? filterMatchInfo : null;
-        const hasOverlayHeight = extraLinesByNodeId.size > 0;
+        const hasOverlayHeight = overlayLinesByNodeId.size > 0;
         if (!hasSelectionHighlight && !activeFilter && !hasOverlayHeight) {
             return nodes;
         }
@@ -1419,20 +1505,26 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 }
             }
             if (hasOverlayHeight && n.type !== 'mlirGroup') {
-                const extra = extraLinesByNodeId.get(n.id) ?? 0;
-                if (extra > 0) {
+                const overlay = overlayLinesByNodeId.get(n.id);
+                if (overlay) {
+                    const extra = overlay.shapes.length + overlay.location.length;
                     const baseHeight = typeof n.height === 'number' ? n.height : 40;
                     const grownHeight = baseHeight + extra * NODE_BODY_OVERLAY_LINE_PX;
                     next = {
                         ...next,
                         height: grownHeight,
                         style: { ...(next.style ?? {}), height: grownHeight },
+                        data: {
+                            ...next.data,
+                            shapeLines: overlay.shapes,
+                            locationLines: overlay.location,
+                        },
                     };
                 }
             }
             return next;
         });
-    }, [nodes, focusedConnections, selectedNodeId, filterMatchInfo, extraLinesByNodeId]);
+    }, [nodes, focusedConnections, selectedNodeId, filterMatchInfo, overlayLinesByNodeId]);
 
     // MiniMap reads `node.style.background` to colour each mini-node. The
     // unhighlighted op-node fill now lives in SCSS (`.react-flow__node-mlirOp`),
@@ -1496,34 +1588,27 @@ const MlGraphInner = ({ data }: ViewProps) => {
         });
     }, [displayedEdges, focusedConnections, selectedNodeId, filterMatchInfo]);
 
-    const nodeBodyContextValue = useMemo<MlirNodeBodyContextValue>(
-        () => ({ overlayLinesByNodeId }),
-        [overlayLinesByNodeId],
-    );
-
     return (
         <div className='mlir-view-pane'>
             <MlirGroupContext.Provider value={groupContextValue}>
-                <MlirNodeBodyContext.Provider value={nodeBodyContextValue}>
-                    <ReactFlow
-                        nodes={styledNodes}
-                        edges={styledEdges}
-                        onNodeClick={onSubgraphNodeClick}
-                        onPaneClick={onPaneClick}
-                        onNodesChange={onNodesChange}
-                        onEdgesChange={onEdgesChange}
-                        nodeTypes={nodeTypes}
-                        minZoom={0.003}
-                        maxZoom={1.5}
-                        fitView
-                        connectionLineType={ConnectionLineType.SmoothStep}
-                        selectNodesOnDrag={false}
-                    >
-                        <MiniMap nodeColor={minimapNodeColor} />
-                        <Controls />
-                        <Background />
-                    </ReactFlow>
-                </MlirNodeBodyContext.Provider>
+                <ReactFlow
+                    nodes={styledNodes}
+                    edges={styledEdges}
+                    onNodeClick={onSubgraphNodeClick}
+                    onPaneClick={onPaneClick}
+                    onNodesChange={onNodesChange}
+                    onEdgesChange={onEdgesChange}
+                    nodeTypes={nodeTypes}
+                    minZoom={0.003}
+                    maxZoom={1.5}
+                    fitView
+                    connectionLineType={ConnectionLineType.SmoothStep}
+                    selectNodesOnDrag={false}
+                >
+                    <MiniMap nodeColor={minimapNodeColor} />
+                    <Controls />
+                    <Background />
+                </ReactFlow>
             </MlirGroupContext.Provider>
 
             <div className='mlir-top-left-controls'>
@@ -1537,8 +1622,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     matchCount={matchedNodesInOrder.length}
                     hiddenMatchCount={filterMatchInfo?.hiddenMatchCount ?? 0}
                     currentMatchIndex={currentMatchIndex}
-                    onPrev={() => goToMatch('prev')}
-                    onNext={() => goToMatch('next')}
+                    onPrev={goToPrevMatch}
+                    onNext={goToNextMatch}
                 />
 
                 <MlirNodeBodyToggles

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -55,6 +55,7 @@ import { MlirFilterMode, buildFilterMatcher, resolveFilterMatches } from './mlir
 import MlirNodeBodyToggles from './MlirNodeBodyToggles';
 import MlirExpandCollapseControls from './MlirExpandCollapseControls';
 import { collectLocationLines, collectShapeLines } from './mlirNodeBodySummary';
+import { createMoveGroupBatcher } from './mlirMoveGroupBatch';
 import { getNamespaceSegments } from './mlirGraphHelpers';
 
 const FILTER_DIM_OPACITY = 0.18;
@@ -110,6 +111,9 @@ type NodeTopologyEntry = {
 
 const EMPTY_TOPOLOGY: Map<string, NodeTopologyEntry> = new Map();
 const EMPTY_VISIBLE_OP_IDS: Set<string> = new Set();
+// Shared empty result so an idle filter yields a stable `matchedNodesInOrder`
+// identity (no fresh `[]` per render).
+const EMPTY_MATCHED_ORDER: string[] = [];
 
 // Derived once per worker rebuild in `applyBuiltGraph`. Structural fields
 // (parentId, type, groupKind, collapsedSubgraphNamespace, subgraphToggleState)
@@ -438,11 +442,23 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // below clears the other two — whichever gesture fires last wins.
     const pendingFitAllRef = useRef(false);
     const hasFitInitiallyRef = useRef(false);
-    // Group-drag mousemove deltas coalesce into a single per-frame write.
-    // Read in `moveGroup` / `flushMoveGroup`; also cleared by
-    // `applyBuiltGraph` to drop in-flight drags across a worker rebuild.
-    const moveGroupPendingRef = useRef<Map<string, { dx: number; dy: number }>>(new Map());
-    const moveGroupRafRef = useRef<number | null>(null);
+    // Group-drag mousemove deltas coalesce into a single per-frame write via a
+    // RAF batcher. `applyBuiltGraph` cancels it so an in-flight drag delta
+    // can't land on top of a fresh worker placement; the unmount effect cancels
+    // it to release a dangling frame. `updateNode` from `useReactFlow` is
+    // referentially stable, so the batcher is created once.
+    const moveGroupBatcher = useMemo(
+        () =>
+            createMoveGroupBatcher({
+                applyDelta: (groupId, dx, dy) =>
+                    updateNode(groupId, (n) => ({
+                        position: { x: n.position.x + dx, y: n.position.y + dy },
+                    })),
+                requestFrame: (callback) => window.requestAnimationFrame(callback),
+                cancelFrame: (handle) => window.cancelAnimationFrame(handle),
+            }),
+        [updateNode],
+    );
 
     // No graph-id reset effect: `MlGraphInner` is keyed by `graph.id` in
     // `MlGraphWithProvider`, so React fully remounts the subtree when the
@@ -548,11 +564,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             // Drop any in-flight group-drag delta: the pending RAF would
             // otherwise apply it against the just-committed canonical
             // position (shift by delta on top of the worker's placement).
-            if (moveGroupRafRef.current !== null) {
-                window.cancelAnimationFrame(moveGroupRafRef.current);
-                moveGroupRafRef.current = null;
-            }
-            moveGroupPendingRef.current.clear();
+            moveGroupBatcher.cancel();
 
             const rf = builtGraphToReactFlow(built);
             const selId = selectedNodeIdRef.current;
@@ -600,7 +612,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 });
             }
         },
-        [fitView, getViewport, setEdges, setNodes, setViewport],
+        [fitView, getViewport, moveGroupBatcher, setEdges, setNodes, setViewport],
     );
 
     // The view component owns React Flow / viewport / selection state; the
@@ -660,18 +672,11 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return result;
     }, [nodeBodyToggles.location, nodeBodyToggles.shapes, visibleOpNodeIds, sourceNodeById]);
 
-    // Maps each label-matching source to its visible representative: itself
-    // if on canvas, otherwise the anchor of its outermost collapsed
-    // ancestor. Reads `containingNamespacesByNodeId` (not `source.namespace`)
-    // so topology sections and MLIR namespaces are walked uniformly.
-    //
-    // Collapsibility MUST come from `expandedNamespaces` — anchors are always
-    // visible under their own id (they render either as themselves in an
-    // expanded parent or as the collapsed anchor of their own namespace), so
-    // `visibleNodeIds.has(anchorId)` can't distinguish collapsed from
-    // expanded. Mirrors the graph builder's `resolveRenderedNodeId`.
-    // Lifted from `filterMatchInfo` so an active filter doesn't recompile
-    // the RegExp on every interaction frame.
+    // Compile the label matcher once per applied query. Lifted out of
+    // `filterMatchInfo` so an active filter doesn't rebuild the RegExp on
+    // every interaction frame. Match *resolution* — mapping each hit to its
+    // visible representative and counting buried matches — lives in
+    // `resolveFilterMatches`, which owns the up-to-date contract comment.
     const filterMatcher = useMemo(() => {
         if (appliedFilterQuery.length === 0) {
             return null;
@@ -699,19 +704,22 @@ const MlGraphInner = ({ data }: ViewProps) => {
         return { ...resolution, isRegexInvalid: filterMatcher.isRegexInvalid };
     }, [filterMatcher, sourceNodes, expandedNamespaces, interactionIndex, visibleOpNodeIds]);
 
-    // Visible reps in canvas order so prev/next walks top-to-bottom.
+    // Visible reps in canvas order so prev/next walks top-to-bottom. Iterates
+    // `visibleOpNodeIds` (build-time state, insertion order == canvas order)
+    // rather than `nodes`, so a position-only drag frame — which churns the
+    // `nodes` array but never the visible-op set — doesn't recompute the walk.
     const matchedNodesInOrder = useMemo<string[]>(() => {
         if (!filterMatchInfo || filterMatchInfo.visibleRepIds.size === 0) {
-            return [];
+            return EMPTY_MATCHED_ORDER;
         }
         const result: string[] = [];
-        for (const node of nodes) {
-            if (filterMatchInfo.visibleRepIds.has(node.id)) {
-                result.push(node.id);
+        for (const id of visibleOpNodeIds) {
+            if (filterMatchInfo.visibleRepIds.has(id)) {
+                result.push(id);
             }
         }
         return result;
-    }, [nodes, filterMatchInfo]);
+    }, [visibleOpNodeIds, filterMatchInfo]);
 
     // `fitView` lives outside the updater so React's StrictMode double-
     // invocation of updaters in dev doesn't fire two pans per step.
@@ -893,45 +901,13 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // per-flush cost against the RF store is the same as `setNodes` (xyflow's
     // `updateNode` is `setNodes(prev.map(...))` internally), but the write
     // rate drops from one-per-mousemove to one-per-frame.
-    const flushMoveGroup = useCallback(() => {
-        moveGroupRafRef.current = null;
-        const pending = moveGroupPendingRef.current;
-        if (pending.size === 0) {
-            return;
-        }
-        for (const [groupId, delta] of pending) {
-            updateNode(groupId, (n) => ({
-                position: { x: n.position.x + delta.dx, y: n.position.y + delta.dy },
-            }));
-        }
-        pending.clear();
-    }, [updateNode]);
     const moveGroup = useCallback(
         (groupId: string, dx: number, dy: number) => {
-            const pending = moveGroupPendingRef.current;
-            const existing = pending.get(groupId);
-            if (existing) {
-                existing.dx += dx;
-                existing.dy += dy;
-            } else {
-                pending.set(groupId, { dx, dy });
-            }
-            if (moveGroupRafRef.current === null) {
-                moveGroupRafRef.current = window.requestAnimationFrame(flushMoveGroup);
-            }
+            moveGroupBatcher.accumulate(groupId, dx, dy);
         },
-        [flushMoveGroup],
+        [moveGroupBatcher],
     );
-    useEffect(
-        () => () => {
-            if (moveGroupRafRef.current !== null) {
-                window.cancelAnimationFrame(moveGroupRafRef.current);
-                moveGroupRafRef.current = null;
-            }
-            moveGroupPendingRef.current.clear();
-        },
-        [],
-    );
+    useEffect(() => () => moveGroupBatcher.cancel(), [moveGroupBatcher]);
 
     const groupContextValue = useMemo<MlirGroupContextValue>(
         () => ({

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -51,7 +51,7 @@ import { GRAPH_COLORS } from '../../definitions/GraphColors';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
 import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
-import { MlirFilterMode, buildFilterMatcher } from './mlirFilter';
+import { MlirFilterMode, buildFilterMatcher, resolveFilterMatches } from './mlirFilter';
 import MlirNodeBodyToggles from './MlirNodeBodyToggles';
 import MlirExpandCollapseControls from './MlirExpandCollapseControls';
 import { collectLocationLines, collectShapeLines } from './mlirNodeBodySummary';
@@ -98,15 +98,6 @@ const EMPTY_OVERLAY_LINES: readonly string[] = Object.freeze([]);
 
 const EMPTY_CHAIN: readonly string[] = Object.freeze([]);
 
-const parentChainsEqual = (a: readonly string[], b: readonly string[]): boolean => {
-    for (let i = 0; i < a.length; i++) {
-        if (a[i] !== b[i]) {
-            return false;
-        }
-    }
-    return true;
-};
-
 // `parentChain` is root-first, terminating at the immediate parent.
 type NodeTopologyEntry = {
     parentChain: readonly string[];
@@ -115,6 +106,51 @@ type NodeTopologyEntry = {
     groupKind: MLNodeData['groupKind'];
     collapsedSubgraphNamespace: MLNodeData['collapsedSubgraphNamespace'];
     subgraphToggleState: MLNodeData['subgraphToggleState'];
+};
+
+const EMPTY_TOPOLOGY: Map<string, NodeTopologyEntry> = new Map();
+const EMPTY_VISIBLE_OP_IDS: Set<string> = new Set();
+
+// Derived once per worker rebuild in `applyBuiltGraph`. Structural fields
+// (parentId, type, groupKind, collapsedSubgraphNamespace, subgraphToggleState)
+// are invariant under drag / selection / hover — RF only mutates `position`
+// and `selected` on those paths — so recomputing here means downstream memos
+// keying on the topology map bail out for free on non-structural frames,
+// without a per-render source rebuild + equality walk.
+const buildNodeTopologyById = (nodes: readonly MLNode[]): Map<string, NodeTopologyEntry> => {
+    const parentById = new Map<string, string | undefined>();
+    for (const n of nodes) {
+        parentById.set(n.id, n.parentId);
+    }
+    const result = new Map<string, NodeTopologyEntry>();
+    for (const n of nodes) {
+        const chain: string[] = [];
+        let pid = n.parentId;
+        while (pid) {
+            chain.push(pid);
+            pid = parentById.get(pid);
+        }
+        chain.reverse();
+        result.set(n.id, {
+            parentChain: chain,
+            parentId: n.parentId,
+            type: n.type,
+            groupKind: n.data?.groupKind,
+            collapsedSubgraphNamespace: n.data?.collapsedSubgraphNamespace,
+            subgraphToggleState: n.data?.subgraphToggleState,
+        });
+    }
+    return result;
+};
+
+const buildVisibleOpNodeIds = (nodes: readonly MLNode[]): Set<string> => {
+    const next = new Set<string>();
+    for (const n of nodes) {
+        if (n.type === 'mlirOp') {
+            next.add(n.id);
+        }
+    }
+    return next;
 };
 
 type MlirNodeBodyOverlayLines = { shapes: string[]; location: string[] };
@@ -402,6 +438,11 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // below clears the other two — whichever gesture fires last wins.
     const pendingFitAllRef = useRef(false);
     const hasFitInitiallyRef = useRef(false);
+    // Group-drag mousemove deltas coalesce into a single per-frame write.
+    // Read in `moveGroup` / `flushMoveGroup`; also cleared by
+    // `applyBuiltGraph` to drop in-flight drags across a worker rebuild.
+    const moveGroupPendingRef = useRef<Map<string, { dx: number; dy: number }>>(new Map());
+    const moveGroupRafRef = useRef<number | null>(null);
 
     // No graph-id reset effect: `MlGraphInner` is keyed by `graph.id` in
     // `MlGraphWithProvider`, so React fully remounts the subtree when the
@@ -493,13 +534,33 @@ const MlGraphInner = ({ data }: ViewProps) => {
         });
     }, [selectedNodeId, setNodes]);
 
+    // Structural indices derived from the RF `nodes` array. Only recomputed
+    // when the worker delivers a fresh build (see `applyBuiltGraph`); the
+    // selection reflection effect, drag frames, and `updateNode` all preserve
+    // structural fields, so keeping these off the `[nodes]` render dep path
+    // means downstream memos (`displayedEdges`, `filterMatchInfo`,
+    // `overlayLinesByNodeId`) don't invalidate on drag / select / hover.
+    const [nodeTopologyById, setNodeTopologyById] = useState<Map<string, NodeTopologyEntry>>(EMPTY_TOPOLOGY);
+    const [visibleOpNodeIds, setVisibleOpNodeIds] = useState<Set<string>>(EMPTY_VISIBLE_OP_IDS);
+
     const applyBuiltGraph = useCallback(
         (built: BuiltGraph) => {
+            // Drop any in-flight group-drag delta: the pending RAF would
+            // otherwise apply it against the just-committed canonical
+            // position (shift by delta on top of the worker's placement).
+            if (moveGroupRafRef.current !== null) {
+                window.cancelAnimationFrame(moveGroupRafRef.current);
+                moveGroupRafRef.current = null;
+            }
+            moveGroupPendingRef.current.clear();
+
             const rf = builtGraphToReactFlow(built);
             const selId = selectedNodeIdRef.current;
             const styledNodes = selId ? rf.nodes.map((n) => (n.id === selId ? { ...n, selected: true } : n)) : rf.nodes;
             setNodes(styledNodes);
             setEdges(rf.edges);
+            setNodeTopologyById(buildNodeTopologyById(styledNodes));
+            setVisibleOpNodeIds(buildVisibleOpNodeIds(styledNodes));
 
             // Read + clear every post-rebuild viewport baton up-front. The
             // arming sites enforce mutual exclusion (see the useRef decl
@@ -576,94 +637,6 @@ const MlGraphInner = ({ data }: ViewProps) => {
         runBuild(expandedNamespaces);
     }, [expandedNamespaces, runBuild]);
 
-    // Op-node id set from the current React Flow `nodes` array. The
-    // reference here changes on every drag / selection frame even when
-    // the set contents don't; `visibleOpNodeIds` below stabilises that
-    // identity so downstream memos (`overlayLinesByNodeId` →
-    // `nodeBodyContextValue`) don't invalidate on unrelated frames.
-    const visibleOpNodeIdsSource = useMemo<Set<string>>(() => {
-        const next = new Set<string>();
-        for (const node of nodes) {
-            if (node.type === 'mlirOp') {
-                next.add(node.id);
-            }
-        }
-        return next;
-    }, [nodes]);
-    // "Computed cached state" pattern (React docs): only replace the
-    // tracked set when contents actually change. Downstream memos
-    // (`filterMatchInfo`, `overlayLinesByNodeId`) must not invalidate
-    // on drag frames.
-    const [visibleOpNodeIds, setVisibleOpNodeIds] = useState<Set<string>>(visibleOpNodeIdsSource);
-    if (visibleOpNodeIds !== visibleOpNodeIdsSource) {
-        let unchanged = visibleOpNodeIds.size === visibleOpNodeIdsSource.size;
-        if (unchanged) {
-            for (const id of visibleOpNodeIdsSource) {
-                if (!visibleOpNodeIds.has(id)) {
-                    unchanged = false;
-                    break;
-                }
-            }
-        }
-        if (!unchanged) {
-            setVisibleOpNodeIds(visibleOpNodeIdsSource);
-        }
-    }
-
-    // Structural topology per node — set once by the worker, invariant
-    // under drag / selection / hover. Stabilised via computed-cached-state
-    // so `displayedEdges` bails out on unrelated frames.
-    const nodeTopologyByIdSource = useMemo<Map<string, NodeTopologyEntry>>(() => {
-        const parentById = new Map<string, string | undefined>();
-        for (const n of nodes) {
-            parentById.set(n.id, n.parentId);
-        }
-        const result = new Map<string, NodeTopologyEntry>();
-        for (const n of nodes) {
-            const chain: string[] = [];
-            let pid = n.parentId;
-            while (pid) {
-                chain.push(pid);
-                pid = parentById.get(pid);
-            }
-            chain.reverse();
-            result.set(n.id, {
-                parentChain: chain,
-                parentId: n.parentId,
-                type: n.type,
-                groupKind: n.data?.groupKind,
-                collapsedSubgraphNamespace: n.data?.collapsedSubgraphNamespace,
-                subgraphToggleState: n.data?.subgraphToggleState,
-            });
-        }
-        return result;
-    }, [nodes]);
-    const [nodeTopologyById, setNodeTopologyById] = useState<Map<string, NodeTopologyEntry>>(nodeTopologyByIdSource);
-    if (nodeTopologyById !== nodeTopologyByIdSource) {
-        let unchanged = nodeTopologyById.size === nodeTopologyByIdSource.size;
-        if (unchanged) {
-            for (const [id, next] of nodeTopologyByIdSource) {
-                const prev = nodeTopologyById.get(id);
-                if (
-                    !prev ||
-                    prev.parentId !== next.parentId ||
-                    prev.type !== next.type ||
-                    prev.groupKind !== next.groupKind ||
-                    prev.collapsedSubgraphNamespace !== next.collapsedSubgraphNamespace ||
-                    prev.subgraphToggleState !== next.subgraphToggleState ||
-                    prev.parentChain.length !== next.parentChain.length ||
-                    !parentChainsEqual(prev.parentChain, next.parentChain)
-                ) {
-                    unchanged = false;
-                    break;
-                }
-            }
-        }
-        if (!unchanged) {
-            setNodeTopologyById(nodeTopologyByIdSource);
-        }
-    }
-
     // Per-node overlay lines for the node-body toggles. Only op-nodes
     // with non-empty overlay content appear in this map; `styledNodes`
     // applies the arrays onto `data.shapeLines` / `data.locationLines`
@@ -715,46 +688,15 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (!filterMatcher) {
             return null;
         }
-        const { testLabel, isRegexInvalid } = filterMatcher;
-        const anchorByNamespace = interactionIndex?.anchorByNamespace ?? {};
-        const containingNamespacesByNodeId = interactionIndex?.containingNamespacesByNodeId ?? {};
-        // Anchor and source ids are always op-node ids, so the stabilised
-        // op set is the correct visibility check and keeps the memo out
-        // of the per-frame `nodes` invalidation path.
-        const visibleRepIds = new Set<string>();
-        const buriedCountByRepId = new Map<string, number>();
-        let hiddenMatchCount = 0;
-        for (const source of sourceNodes) {
-            if (!testLabel(source.label)) {
-                continue;
-            }
-            const containing = containingNamespacesByNodeId[source.id];
-            let repId: string | null = null;
-            if (containing && containing.length > 0) {
-                // Outer→inner: the shortest collapsed namespace is where the
-                // source folds up to. Missing anchors fall back to `source.id`
-                // (mirrors `resolveRenderedNodeId`'s `?? nodeId`).
-                for (const ns of containing) {
-                    if (!expandedNamespaces.has(ns)) {
-                        const anchorId = anchorByNamespace[ns] ?? source.id;
-                        repId = visibleOpNodeIds.has(anchorId) ? anchorId : null;
-                        break;
-                    }
-                }
-            }
-            if (repId === null) {
-                repId = visibleOpNodeIds.has(source.id) ? source.id : null;
-            }
-            if (repId === null) {
-                continue;
-            }
-            visibleRepIds.add(repId);
-            if (repId !== source.id) {
-                buriedCountByRepId.set(repId, (buriedCountByRepId.get(repId) ?? 0) + 1);
-                hiddenMatchCount += 1;
-            }
-        }
-        return { visibleRepIds, buriedCountByRepId, hiddenMatchCount, isRegexInvalid };
+        const resolution = resolveFilterMatches({
+            testLabel: filterMatcher.testLabel,
+            sources: sourceNodes,
+            expandedNamespaces,
+            anchorByNamespace: interactionIndex?.anchorByNamespace ?? {},
+            containingNamespacesByNodeId: interactionIndex?.containingNamespacesByNodeId ?? {},
+            visibleOpNodeIds,
+        });
+        return { ...resolution, isRegexInvalid: filterMatcher.isRegexInvalid };
     }, [filterMatcher, sourceNodes, expandedNamespaces, interactionIndex, visibleOpNodeIds]);
 
     // Visible reps in canvas order so prev/next walks top-to-bottom.
@@ -947,10 +889,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
 
     // Header drag updates only the group's own position; React Flow auto-
     // moves children because they declare `parentId` + `extent: 'parent'`.
-    // Mousemove deltas are coalesced into a single RAF-batched write and
-    // routed through `updateNode` to skip the O(N) `setNodes` cascade.
-    const moveGroupPendingRef = useRef<Map<string, { dx: number; dy: number }>>(new Map());
-    const moveGroupRafRef = useRef<number | null>(null);
+    // Mousemove deltas are coalesced into a single RAF-batched write —
+    // per-flush cost against the RF store is the same as `setNodes` (xyflow's
+    // `updateNode` is `setNodes(prev.map(...))` internally), but the write
+    // rate drops from one-per-mousemove to one-per-frame.
     const flushMoveGroup = useCallback(() => {
         moveGroupRafRef.current = null;
         const pending = moveGroupPendingRef.current;

--- a/src/components/mlir/MlirAttrValue.tsx
+++ b/src/components/mlir/MlirAttrValue.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import { useMemo } from 'react';
 import { ParsedAttrKind, tryParseAttrValue } from './attrFormatter';
 
 interface MlirAttrValueProps {
@@ -77,7 +78,7 @@ const NestedTree = ({ data }: NestedTreeProps) => {
 };
 
 const MlirAttrValue = ({ value }: MlirAttrValueProps) => {
-    const parsed = tryParseAttrValue(value);
+    const parsed = useMemo(() => tryParseAttrValue(value), [value]);
     if (parsed.kind === ParsedAttrKind.Scalar) {
         return <span className='mlir-attr-value mlir-attr-value-scalar'>{parsed.text}</span>;
     }

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import { memo } from 'react';
 import { Button, ButtonVariant, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirExpandCollapseControls.scss';
@@ -13,7 +14,7 @@ export interface MlirExpandCollapseControlsProps {
     onCollapseAll: () => void;
 }
 
-const MlirExpandCollapseControls = ({
+const MlirExpandCollapseControlsInner = ({
     namespaceCount,
     expandedCount,
     onExpandAll,
@@ -54,5 +55,8 @@ const MlirExpandCollapseControls = ({
         </div>
     );
 };
+
+const MlirExpandCollapseControls = memo(MlirExpandCollapseControlsInner);
+MlirExpandCollapseControls.displayName = 'MlirExpandCollapseControls';
 
 export default MlirExpandCollapseControls;

--- a/src/components/mlir/MlirNodeBodyToggles.tsx
+++ b/src/components/mlir/MlirNodeBodyToggles.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import { memo } from 'react';
 import { Switch } from '@blueprintjs/core';
 import 'styles/components/MlirNodeBodyToggles.scss';
 
@@ -15,7 +16,7 @@ interface MlirNodeBodyTogglesProps {
     onChange: (next: MlirNodeBodyTogglesState) => void;
 }
 
-const MlirNodeBodyToggles = ({ value, onChange }: MlirNodeBodyTogglesProps) => (
+const MlirNodeBodyTogglesInner = ({ value, onChange }: MlirNodeBodyTogglesProps) => (
     <div className='mlir-node-body-toggles'>
         <Switch
             checked={value.location}
@@ -29,5 +30,8 @@ const MlirNodeBodyToggles = ({ value, onChange }: MlirNodeBodyTogglesProps) => (
         />
     </div>
 );
+
+const MlirNodeBodyToggles = memo(MlirNodeBodyTogglesInner);
+MlirNodeBodyToggles.displayName = 'MlirNodeBodyToggles';
 
 export default MlirNodeBodyToggles;

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode, memo, useMemo } from 'react';
 import { useAtom } from 'jotai';
 import { Button, ButtonVariant, Collapse, Size, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -161,7 +161,7 @@ const DetailsSection = ({
     </section>
 );
 
-const MlirNodeDetailsPanel = ({
+const MlirNodeDetailsPanelInner = ({
     node,
     incomingEdges,
     outgoingEdges,
@@ -365,5 +365,8 @@ const MlirNodeDetailsPanel = ({
         </aside>
     );
 };
+
+const MlirNodeDetailsPanel = memo(MlirNodeDetailsPanelInner);
+MlirNodeDetailsPanel.displayName = 'MlirNodeDetailsPanel';
 
 export default MlirNodeDetailsPanel;

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { type KeyboardEvent, forwardRef, useImperativeHandle, useRef } from 'react';
+import { type KeyboardEvent, forwardRef, memo, useImperativeHandle, useRef } from 'react';
 import { Button, ButtonVariant, InputGroup, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirOpFilter.scss';
@@ -35,7 +35,7 @@ interface MlirOpFilterProps {
 
 // Floating filter control over the React Flow canvas. Dim/highlight lives
 // in the view component; this is just the input + counter + prev/next.
-const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
+const MlirOpFilterInner = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
     (
         {
             query,
@@ -160,6 +160,8 @@ const MlirOpFilter = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
     },
 );
 
-MlirOpFilter.displayName = 'MlirOpFilter';
+MlirOpFilterInner.displayName = 'MlirOpFilter';
+
+const MlirOpFilter = memo(MlirOpFilterInner);
 
 export default MlirOpFilter;

--- a/src/components/mlir/MlirOpFilter.tsx
+++ b/src/components/mlir/MlirOpFilter.tsx
@@ -160,8 +160,7 @@ const MlirOpFilterInner = forwardRef<MlirOpFilterHandle, MlirOpFilterProps>(
     },
 );
 
-MlirOpFilterInner.displayName = 'MlirOpFilter';
-
 const MlirOpFilter = memo(MlirOpFilterInner);
+MlirOpFilter.displayName = 'MlirOpFilter';
 
 export default MlirOpFilter;

--- a/src/components/mlir/mlirFilter.ts
+++ b/src/components/mlir/mlirFilter.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+/* eslint-disable no-continue */
+
 // String-backed so the enum member values match the historical `sessionStorage`
 // payload ('substring' / 'regex'); persisted state migrates without a version bump.
 export enum MlirFilterMode {
@@ -36,4 +38,69 @@ export function buildFilterMatcher(mode: MlirFilterMode, query: string): MlirFil
         testLabel: (label) => label.toLowerCase().includes(needle),
         isRegexInvalid: false,
     };
+}
+
+export interface FilterMatchResolution {
+    visibleRepIds: Set<string>;
+    buriedCountByRepId: Map<string, number>;
+    hiddenMatchCount: number;
+}
+
+export interface FilterMatchInputs {
+    testLabel: (label: string) => boolean;
+    sources: readonly { id: string; label: string }[];
+    expandedNamespaces: ReadonlySet<string>;
+    anchorByNamespace: Readonly<Record<string, string>>;
+    containingNamespacesByNodeId: Readonly<Record<string, string[]>>;
+    visibleOpNodeIds: ReadonlySet<string>;
+}
+
+// Resolves each label-matching source to its visible representative:
+// itself if on-canvas, otherwise the anchor of its outermost collapsed
+// ancestor. `visibleOpNodeIds` is the op-only id set — anchor and source
+// ids are always op-node ids, so the group ids RF also carries are
+// intentionally out of scope. Sources whose rep isn't visible are dropped.
+export function resolveFilterMatches(inputs: FilterMatchInputs): FilterMatchResolution {
+    const {
+        testLabel,
+        sources,
+        expandedNamespaces,
+        anchorByNamespace,
+        containingNamespacesByNodeId,
+        visibleOpNodeIds,
+    } = inputs;
+
+    const visibleRepIds = new Set<string>();
+    const buriedCountByRepId = new Map<string, number>();
+    let hiddenMatchCount = 0;
+
+    for (const source of sources) {
+        if (!testLabel(source.label)) {
+            continue;
+        }
+        const containing = containingNamespacesByNodeId[source.id];
+        let repId: string | null = null;
+        if (containing && containing.length > 0) {
+            for (const ns of containing) {
+                if (!expandedNamespaces.has(ns)) {
+                    const anchorId = anchorByNamespace[ns] ?? source.id;
+                    repId = visibleOpNodeIds.has(anchorId) ? anchorId : null;
+                    break;
+                }
+            }
+        }
+        if (repId === null) {
+            repId = visibleOpNodeIds.has(source.id) ? source.id : null;
+        }
+        if (repId === null) {
+            continue;
+        }
+        visibleRepIds.add(repId);
+        if (repId !== source.id) {
+            buriedCountByRepId.set(repId, (buriedCountByRepId.get(repId) ?? 0) + 1);
+            hiddenMatchCount += 1;
+        }
+    }
+
+    return { visibleRepIds, buriedCountByRepId, hiddenMatchCount };
 }

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -6,6 +6,7 @@
 /* eslint-disable no-continue */
 import { buildVisibleGraph } from './mlirGraphBuilder';
 import { buildGraphIndex } from './mlirGraphIndexBuilder';
+import { CACHE_LIMIT_PER_GRAPH, touchLruCache } from './mlirLayoutWorkerCache';
 import type { BuiltGraph, GraphIndex, WorkerInboundMessage } from './mlirGraphTypes';
 
 const indexByGraphId = new Map<string, GraphIndex>();
@@ -58,6 +59,7 @@ function processLatestBuild(graphId: string): void {
 
             const cached = cache.get(request.cacheKey);
             if (cached) {
+                touchLruCache(cache, request.cacheKey, cached, CACHE_LIMIT_PER_GRAPH);
                 if (!latestBuildByGraphId.has(graphId)) {
                     postMessage({
                         type: 'built',
@@ -72,7 +74,7 @@ function processLatestBuild(graphId: string): void {
 
             try {
                 const built = buildVisibleGraph(index, request.expandedNamespaces);
-                cache.set(request.cacheKey, built);
+                touchLruCache(cache, request.cacheKey, built, CACHE_LIMIT_PER_GRAPH);
                 const newerRequestExists = latestBuildByGraphId.has(graphId);
                 const graphVersionChanged = request.graphVersion !== getGraphVersion(graphId);
                 if (!newerRequestExists && !graphVersionChanged) {

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -9,6 +9,9 @@ import { buildGraphIndex } from './mlirGraphIndexBuilder';
 import { CACHE_LIMIT_PER_GRAPH, touchLruCache } from './mlirLayoutWorkerCache';
 import type { BuiltGraph, GraphIndex, WorkerInboundMessage } from './mlirGraphTypes';
 
+const touchGraphCache = (cache: Map<string, BuiltGraph>, key: string, value: BuiltGraph): void =>
+    touchLruCache(cache, key, value, CACHE_LIMIT_PER_GRAPH);
+
 const indexByGraphId = new Map<string, GraphIndex>();
 const cacheByGraphId = new Map<string, Map<string, BuiltGraph>>();
 const graphVersionByGraphId = new Map<string, number>();
@@ -59,7 +62,7 @@ function processLatestBuild(graphId: string): void {
 
             const cached = cache.get(request.cacheKey);
             if (cached) {
-                touchLruCache(cache, request.cacheKey, cached, CACHE_LIMIT_PER_GRAPH);
+                touchGraphCache(cache, request.cacheKey, cached);
                 if (!latestBuildByGraphId.has(graphId)) {
                     postMessage({
                         type: 'built',
@@ -74,7 +77,7 @@ function processLatestBuild(graphId: string): void {
 
             try {
                 const built = buildVisibleGraph(index, request.expandedNamespaces);
-                touchLruCache(cache, request.cacheKey, built, CACHE_LIMIT_PER_GRAPH);
+                touchGraphCache(cache, request.cacheKey, built);
                 const newerRequestExists = latestBuildByGraphId.has(graphId);
                 const graphVersionChanged = request.graphVersion !== getGraphVersion(graphId);
                 if (!newerRequestExists && !graphVersionChanged) {

--- a/src/components/mlir/mlirLayoutWorkerCache.ts
+++ b/src/components/mlir/mlirLayoutWorkerCache.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Bounds the within-graph cache when the user cycles through many
+// distinct expansion sets. Cross-graph eviction is handled by the
+// parent's `key={graph.id}` remount.
+export const CACHE_LIMIT_PER_GRAPH = 32;
+
+// Move-to-end insertion turns the Map's insertion-order iteration into
+// LRU order; the head is then always the least-recently-used entry.
+export const touchLruCache = <K, V>(cache: Map<K, V>, key: K, value: V, limit: number): void => {
+    if (cache.has(key)) {
+        cache.delete(key);
+    } else if (cache.size >= limit) {
+        const oldestKey = cache.keys().next().value;
+        if (oldestKey !== undefined) {
+            cache.delete(oldestKey);
+        }
+    }
+    cache.set(key, value);
+};

--- a/src/components/mlir/mlirLayoutWorkerCache.ts
+++ b/src/components/mlir/mlirLayoutWorkerCache.ts
@@ -9,13 +9,15 @@ export const CACHE_LIMIT_PER_GRAPH = 32;
 
 // Move-to-end insertion turns the Map's insertion-order iteration into
 // LRU order; the head is then always the least-recently-used entry.
+// Uses the iterator's `done` sentinel rather than `oldest.value !== undefined`
+// so eviction still fires for callers whose key type admits `undefined`.
 export const touchLruCache = <K, V>(cache: Map<K, V>, key: K, value: V, limit: number): void => {
     if (cache.has(key)) {
         cache.delete(key);
     } else if (cache.size >= limit) {
-        const oldestKey = cache.keys().next().value;
-        if (oldestKey !== undefined) {
-            cache.delete(oldestKey);
+        const oldest = cache.keys().next();
+        if (!oldest.done) {
+            cache.delete(oldest.value);
         }
     }
     cache.set(key, value);

--- a/src/components/mlir/mlirMoveGroupBatch.ts
+++ b/src/components/mlir/mlirMoveGroupBatch.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Coalesces group-drag mousemove deltas into a single per-frame write. A
+// header drag fires many `mousemove` events per animation frame; without
+// batching each one would trigger a `setNodes(prev.map(...))` pass over the
+// whole node array. The batcher accumulates deltas per group id and flushes
+// them once per requested frame.
+//
+// Extracted from `MLIRViewReactFlow.tsx` so the accumulate / flush / cancel
+// discipline — in particular the cancel-on-rebuild path that prevents a
+// pending delta from being applied on top of a fresh worker placement — is
+// unit-testable without mounting React Flow.
+
+export interface MoveGroupBatcherDeps {
+    // Applies an accumulated delta to a single group's position.
+    applyDelta: (groupId: string, dx: number, dy: number) => void;
+    // Schedules `flush` on the next frame; returns a handle for cancellation.
+    requestFrame: (callback: () => void) => number;
+    // Cancels a previously scheduled frame.
+    cancelFrame: (handle: number) => void;
+}
+
+export interface MoveGroupBatcher {
+    // Adds a delta for `groupId`, scheduling a flush if one isn't pending.
+    accumulate: (groupId: string, dx: number, dy: number) => void;
+    // Applies every pending delta and clears the queue. Normally invoked by
+    // the scheduled frame; exposed for tests / synchronous flushing.
+    flush: () => void;
+    // Drops every pending delta and cancels the scheduled frame. Used on
+    // worker rebuild (the delta would land on top of the canonical position)
+    // and on unmount (to release a dangling frame).
+    cancel: () => void;
+}
+
+export function createMoveGroupBatcher(deps: MoveGroupBatcherDeps): MoveGroupBatcher {
+    const pending = new Map<string, { dx: number; dy: number }>();
+    let frameHandle: number | null = null;
+
+    const flush = (): void => {
+        frameHandle = null;
+        if (pending.size === 0) {
+            return;
+        }
+        for (const [groupId, delta] of pending) {
+            deps.applyDelta(groupId, delta.dx, delta.dy);
+        }
+        pending.clear();
+    };
+
+    return {
+        accumulate(groupId: string, dx: number, dy: number): void {
+            const existing = pending.get(groupId);
+            if (existing) {
+                existing.dx += dx;
+                existing.dy += dy;
+            } else {
+                pending.set(groupId, { dx, dy });
+            }
+            if (frameHandle === null) {
+                frameHandle = deps.requestFrame(flush);
+            }
+        },
+        flush,
+        cancel(): void {
+            if (frameHandle !== null) {
+                deps.cancelFrame(frameHandle);
+                frameHandle = null;
+            }
+            pending.clear();
+        },
+    };
+}

--- a/tests/mlirFilter.spec.ts
+++ b/tests/mlirFilter.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { MlirFilterMode, buildFilterMatcher } from '../src/components/mlir/mlirFilter';
+import { MlirFilterMode, buildFilterMatcher, resolveFilterMatches } from '../src/components/mlir/mlirFilter';
 
 describe('buildFilterMatcher', () => {
     describe('empty query', () => {
@@ -77,5 +77,155 @@ describe('buildFilterMatcher', () => {
             expect(isRegexInvalid).toBe(false);
             expect(testLabel('stablehlo.constant')).toBe(false);
         });
+    });
+});
+
+describe('resolveFilterMatches', () => {
+    const label = (needle: string) => (str: string) => str.includes(needle);
+    const emptyIndex = { anchorByNamespace: {}, containingNamespacesByNodeId: {} };
+
+    it('returns matches directly when the source itself is on canvas', () => {
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [
+                { id: 'op-1', label: 'stablehlo.add' },
+                { id: 'op-2', label: 'stablehlo.subtract' },
+            ],
+            expandedNamespaces: new Set(),
+            ...emptyIndex,
+            visibleOpNodeIds: new Set(['op-1', 'op-2']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['op-1']);
+        expect(result.buriedCountByRepId.size).toBe(0);
+        expect(result.hiddenMatchCount).toBe(0);
+    });
+
+    it('folds a buried match to its outer collapsed anchor', () => {
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'buried-op', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(),
+            anchorByNamespace: { 'region.a': 'anchor-op' },
+            containingNamespacesByNodeId: { 'buried-op': ['region.a'] },
+            visibleOpNodeIds: new Set(['anchor-op']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['anchor-op']);
+        expect(result.buriedCountByRepId.get('anchor-op')).toBe(1);
+        expect(result.hiddenMatchCount).toBe(1);
+    });
+
+    it('picks the outermost collapsed namespace when several nest', () => {
+        // outer→inner: `region.outer` is preferred over `region.inner` because
+        // it's the first collapsed namespace walking from the top.
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'buried-op', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(),
+            anchorByNamespace: {
+                'region.outer': 'outer-anchor',
+                'region.inner': 'inner-anchor',
+            },
+            containingNamespacesByNodeId: { 'buried-op': ['region.outer', 'region.inner'] },
+            visibleOpNodeIds: new Set(['outer-anchor', 'inner-anchor']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['outer-anchor']);
+        expect(result.buriedCountByRepId.get('outer-anchor')).toBe(1);
+    });
+
+    it('skips collapsed namespaces whose anchor is off-canvas (op-only visibility)', () => {
+        // Regression lock for the #1739 item-4 narrowing: visibility must be
+        // resolved against the op-only id set, not the full RF node array.
+        // A group id sharing a name with the expected anchor must NOT satisfy
+        // visibility.
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'buried-op', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(),
+            anchorByNamespace: { 'region.a': 'anchor-op' },
+            containingNamespacesByNodeId: { 'buried-op': ['region.a'] },
+            visibleOpNodeIds: new Set(),
+        });
+
+        expect(result.visibleRepIds.size).toBe(0);
+        expect(result.buriedCountByRepId.size).toBe(0);
+        expect(result.hiddenMatchCount).toBe(0);
+    });
+
+    it('descends into inner namespaces once outer ones are expanded', () => {
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'buried-op', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(['region.outer']),
+            anchorByNamespace: {
+                'region.outer': 'outer-anchor',
+                'region.inner': 'inner-anchor',
+            },
+            containingNamespacesByNodeId: { 'buried-op': ['region.outer', 'region.inner'] },
+            visibleOpNodeIds: new Set(['outer-anchor', 'inner-anchor']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['inner-anchor']);
+        expect(result.buriedCountByRepId.get('inner-anchor')).toBe(1);
+    });
+
+    it('surfaces the source itself once every containing namespace is expanded', () => {
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'op-1', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(['region.outer', 'region.inner']),
+            anchorByNamespace: {
+                'region.outer': 'outer-anchor',
+                'region.inner': 'inner-anchor',
+            },
+            containingNamespacesByNodeId: { 'op-1': ['region.outer', 'region.inner'] },
+            visibleOpNodeIds: new Set(['op-1', 'outer-anchor', 'inner-anchor']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['op-1']);
+        expect(result.buriedCountByRepId.size).toBe(0);
+        expect(result.hiddenMatchCount).toBe(0);
+    });
+
+    it('coalesces multiple buried matches onto the same anchor', () => {
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [
+                { id: 'buried-1', label: 'stablehlo.add' },
+                { id: 'buried-2', label: 'stablehlo.add.sibling' },
+                { id: 'op-outside', label: 'stablehlo.add' },
+            ],
+            expandedNamespaces: new Set(),
+            anchorByNamespace: { 'region.a': 'anchor-op' },
+            containingNamespacesByNodeId: {
+                'buried-1': ['region.a'],
+                'buried-2': ['region.a'],
+            },
+            visibleOpNodeIds: new Set(['anchor-op', 'op-outside']),
+        });
+
+        expect([...result.visibleRepIds].sort()).toEqual(['anchor-op', 'op-outside']);
+        expect(result.buriedCountByRepId.get('anchor-op')).toBe(2);
+        expect(result.hiddenMatchCount).toBe(2);
+    });
+
+    it('falls back to the source id when the outer collapsed namespace has no anchor entry', () => {
+        // Mirrors `resolveRenderedNodeId`'s `?? nodeId` clause: a namespace
+        // that appears in `containing` but is missing from `anchorByNamespace`
+        // falls back to the source id for visibility.
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'op-1', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(),
+            anchorByNamespace: {},
+            containingNamespacesByNodeId: { 'op-1': ['region.orphan'] },
+            visibleOpNodeIds: new Set(['op-1']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['op-1']);
+        expect(result.buriedCountByRepId.size).toBe(0);
+        expect(result.hiddenMatchCount).toBe(0);
     });
 });

--- a/tests/mlirFilter.spec.ts
+++ b/tests/mlirFilter.spec.ts
@@ -135,23 +135,41 @@ describe('resolveFilterMatches', () => {
         expect(result.buriedCountByRepId.get('outer-anchor')).toBe(1);
     });
 
-    it('skips collapsed namespaces whose anchor is off-canvas (op-only visibility)', () => {
-        // Regression lock for the #1739 item-4 narrowing: visibility must be
+    it('does not satisfy visibility from a group id sharing the namespace (op-only)', () => {
+        // Regression lock for the #1739 item-4 narrowing: visibility is
         // resolved against the op-only id set, not the full RF node array.
-        // A group id sharing a name with the expected anchor must NOT satisfy
-        // visibility.
+        // The *group* id for `region.a` is on canvas, but it must NOT stand
+        // in for the op anchor — the buried match has no visible rep.
         const result = resolveFilterMatches({
             testLabel: label('add'),
             sources: [{ id: 'buried-op', label: 'stablehlo.add' }],
             expandedNamespaces: new Set(),
             anchorByNamespace: { 'region.a': 'anchor-op' },
             containingNamespacesByNodeId: { 'buried-op': ['region.a'] },
-            visibleOpNodeIds: new Set(),
+            visibleOpNodeIds: new Set(['group:region.a']),
         });
 
         expect(result.visibleRepIds.size).toBe(0);
         expect(result.buriedCountByRepId.size).toBe(0);
         expect(result.hiddenMatchCount).toBe(0);
+    });
+
+    it('folds to the op anchor once it is present alongside the group id (op-only twin)', () => {
+        // Same fixture as above, but the op anchor is now on canvas: the
+        // buried match resolves to the op id. Proves the previous case fails
+        // specifically because a group id can't satisfy op-only visibility.
+        const result = resolveFilterMatches({
+            testLabel: label('add'),
+            sources: [{ id: 'buried-op', label: 'stablehlo.add' }],
+            expandedNamespaces: new Set(),
+            anchorByNamespace: { 'region.a': 'anchor-op' },
+            containingNamespacesByNodeId: { 'buried-op': ['region.a'] },
+            visibleOpNodeIds: new Set(['group:region.a', 'anchor-op']),
+        });
+
+        expect([...result.visibleRepIds]).toEqual(['anchor-op']);
+        expect(result.buriedCountByRepId.get('anchor-op')).toBe(1);
+        expect(result.hiddenMatchCount).toBe(1);
     });
 
     it('descends into inner namespaces once outer ones are expanded', () => {

--- a/tests/mlirLayoutWorkerCache.spec.ts
+++ b/tests/mlirLayoutWorkerCache.spec.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { CACHE_LIMIT_PER_GRAPH, touchLruCache } from '../src/components/mlir/mlirLayoutWorkerCache';
+
+describe('touchLruCache', () => {
+    it('inserts a new entry at the tail', () => {
+        const cache = new Map<string, number>();
+
+        touchLruCache(cache, 'a', 1, 5);
+
+        expect([...cache.entries()]).toEqual([['a', 1]]);
+    });
+
+    it('re-inserts an existing key at the tail on cache hit (move-to-end)', () => {
+        const cache = new Map<string, number>([
+            ['a', 1],
+            ['b', 2],
+            ['c', 3],
+        ]);
+
+        touchLruCache(cache, 'a', 1, 5);
+
+        expect([...cache.keys()]).toEqual(['b', 'c', 'a']);
+    });
+
+    it('overwrites the value when re-inserting an existing key', () => {
+        const cache = new Map<string, number>([['a', 1]]);
+
+        touchLruCache(cache, 'a', 99, 5);
+
+        expect(cache.get('a')).toBe(99);
+        expect(cache.size).toBe(1);
+    });
+
+    it('evicts the least-recently-used entry when the cache reaches the limit', () => {
+        const cache = new Map<string, number>([
+            ['a', 1],
+            ['b', 2],
+            ['c', 3],
+        ]);
+
+        touchLruCache(cache, 'd', 4, 3);
+
+        expect([...cache.keys()]).toEqual(['b', 'c', 'd']);
+        expect(cache.has('a')).toBe(false);
+    });
+
+    it('does not evict on cache hit even when the cache is at the limit', () => {
+        const cache = new Map<string, number>([
+            ['a', 1],
+            ['b', 2],
+            ['c', 3],
+        ]);
+
+        touchLruCache(cache, 'a', 1, 3);
+
+        expect(cache.size).toBe(3);
+        expect([...cache.keys()]).toEqual(['b', 'c', 'a']);
+    });
+
+    it('reorders entries so a re-inserted key survives subsequent evictions', () => {
+        const cache = new Map<string, number>([
+            ['a', 1],
+            ['b', 2],
+            ['c', 3],
+        ]);
+
+        // Refresh 'a' — it should now be MRU.
+        touchLruCache(cache, 'a', 1, 3);
+        // Cache is at limit; inserting 'd' should evict the current LRU ('b').
+        touchLruCache(cache, 'd', 4, 3);
+
+        expect(cache.has('a')).toBe(true);
+        expect(cache.has('b')).toBe(false);
+        expect([...cache.keys()]).toEqual(['c', 'a', 'd']);
+    });
+
+    it('caps at exactly `limit` entries under a monotonically growing insertion stream', () => {
+        const cache = new Map<string, number>();
+
+        for (let i = 0; i < 50; i++) {
+            touchLruCache(cache, `k${i}`, i, 10);
+        }
+
+        expect(cache.size).toBe(10);
+        // The last 10 insertions survive; the earlier 40 are evicted.
+        expect([...cache.keys()]).toEqual(['k40', 'k41', 'k42', 'k43', 'k44', 'k45', 'k46', 'k47', 'k48', 'k49']);
+    });
+
+    it('exposes the graph cache limit as 32', () => {
+        expect(CACHE_LIMIT_PER_GRAPH).toBe(32);
+    });
+
+    it('handles a limit of 1 (degenerates to single-entry cache)', () => {
+        const cache = new Map<string, number>();
+
+        touchLruCache(cache, 'a', 1, 1);
+        touchLruCache(cache, 'b', 2, 1);
+
+        expect(cache.size).toBe(1);
+        expect([...cache.entries()]).toEqual([['b', 2]]);
+    });
+
+    it('works with non-string keys', () => {
+        const cache = new Map<number, string>();
+
+        touchLruCache(cache, 1, 'a', 3);
+        touchLruCache(cache, 2, 'b', 3);
+        touchLruCache(cache, 3, 'c', 3);
+        touchLruCache(cache, 4, 'd', 3);
+
+        expect([...cache.keys()]).toEqual([2, 3, 4]);
+    });
+});

--- a/tests/mlirLayoutWorkerCache.spec.ts
+++ b/tests/mlirLayoutWorkerCache.spec.ts
@@ -114,4 +114,21 @@ describe('touchLruCache', () => {
 
         expect([...cache.keys()]).toEqual([2, 3, 4]);
     });
+
+    it('evicts an `undefined` LRU-position key and stays at the limit', () => {
+        // Guard against a silent contract violation when the generic helper
+        // is used with a key type that admits `undefined`. Iterator-`done`
+        // is the correct sentinel; the `oldest.value !== undefined` shape
+        // that Copilot flagged on PR #1759 would leak past the cap here.
+        const cache = new Map<string | undefined, number>();
+        cache.set(undefined, 0);
+        cache.set('b', 2);
+        cache.set('c', 3);
+
+        touchLruCache(cache, 'd', 4, 3);
+
+        expect(cache.size).toBe(3);
+        expect(cache.has(undefined)).toBe(false);
+        expect([...cache.keys()]).toEqual(['b', 'c', 'd']);
+    });
 });

--- a/tests/mlirMoveGroupBatch.spec.ts
+++ b/tests/mlirMoveGroupBatch.spec.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it, vi } from 'vitest';
+import { createMoveGroupBatcher } from '../src/components/mlir/mlirMoveGroupBatch';
+
+// A hand-driven frame scheduler: `accumulate` schedules a flush, and the test
+// decides when (or whether) that frame runs by invoking `runFrame`.
+function makeHarness() {
+    const applyDelta = vi.fn<(groupId: string, dx: number, dy: number) => void>();
+    const cancelFrame = vi.fn<(handle: number) => void>();
+    let pendingCallback: (() => void) | null = null;
+    let nextHandle = 0;
+
+    const requestFrame = vi.fn((callback: () => void): number => {
+        pendingCallback = callback;
+        nextHandle += 1;
+        return nextHandle;
+    });
+
+    const batcher = createMoveGroupBatcher({ applyDelta, requestFrame, cancelFrame });
+
+    const runFrame = (): void => {
+        const callback = pendingCallback;
+        pendingCallback = null;
+        callback?.();
+    };
+
+    return { batcher, applyDelta, requestFrame, cancelFrame, runFrame };
+}
+
+describe('createMoveGroupBatcher', () => {
+    it('coalesces successive deltas for one group into a single per-frame write', () => {
+        const { batcher, applyDelta, requestFrame, runFrame } = makeHarness();
+
+        batcher.accumulate('g1', 3, 1);
+        batcher.accumulate('g1', 2, -4);
+        batcher.accumulate('g1', 5, 0);
+
+        // Only one frame requested despite three mousemove-style deltas.
+        expect(requestFrame).toHaveBeenCalledTimes(1);
+        expect(applyDelta).not.toHaveBeenCalled();
+
+        runFrame();
+
+        expect(applyDelta).toHaveBeenCalledTimes(1);
+        expect(applyDelta).toHaveBeenCalledWith('g1', 10, -3);
+    });
+
+    it('accumulates independently per group id', () => {
+        const { batcher, applyDelta, runFrame } = makeHarness();
+
+        batcher.accumulate('g1', 1, 1);
+        batcher.accumulate('g2', 10, 20);
+        batcher.accumulate('g1', 4, 5);
+
+        runFrame();
+
+        expect(applyDelta).toHaveBeenCalledTimes(2);
+        expect(applyDelta).toHaveBeenCalledWith('g1', 5, 6);
+        expect(applyDelta).toHaveBeenCalledWith('g2', 10, 20);
+    });
+
+    it('requests a fresh frame after a flush', () => {
+        const { batcher, applyDelta, requestFrame, runFrame } = makeHarness();
+
+        batcher.accumulate('g1', 1, 0);
+        runFrame();
+        expect(requestFrame).toHaveBeenCalledTimes(1);
+
+        batcher.accumulate('g1', 2, 0);
+        expect(requestFrame).toHaveBeenCalledTimes(2);
+        runFrame();
+
+        expect(applyDelta).toHaveBeenCalledTimes(2);
+        expect(applyDelta).toHaveBeenLastCalledWith('g1', 2, 0);
+    });
+
+    it('cancel drops the pending delta and cancels the scheduled frame (rebuild path)', () => {
+        const { batcher, applyDelta, cancelFrame, runFrame } = makeHarness();
+
+        batcher.accumulate('g1', 7, 7);
+        batcher.cancel();
+
+        expect(cancelFrame).toHaveBeenCalledTimes(1);
+
+        // Even if a stale frame were to fire, nothing is applied.
+        runFrame();
+        expect(applyDelta).not.toHaveBeenCalled();
+    });
+
+    it('cancel with nothing pending is a no-op', () => {
+        const { batcher, applyDelta, cancelFrame } = makeHarness();
+
+        batcher.cancel();
+
+        expect(cancelFrame).not.toHaveBeenCalled();
+        expect(applyDelta).not.toHaveBeenCalled();
+    });
+
+    it('resumes batching normally after a cancel', () => {
+        const { batcher, applyDelta, runFrame } = makeHarness();
+
+        batcher.accumulate('g1', 1, 1);
+        batcher.cancel();
+
+        batcher.accumulate('g1', 9, 9);
+        runFrame();
+
+        expect(applyDelta).toHaveBeenCalledTimes(1);
+        expect(applyDelta).toHaveBeenCalledWith('g1', 9, 9);
+    });
+});


### PR DESCRIPTION
Closes #1739. Group A of the MLIR audit follow-up (#1734) — highest leverage-per-hour perf pass. All changes are memo/context/dep-array refactor with no behavioural change; they close the top-of-list defects that make drag, filter, and toggle interactions lag on graphs with 2K+ visible nodes.

## What's in the PR

All seven items from the ticket, plus a follow-up commit from a local ultimate-review pass:

### `displayedEdges` (item 1) + topology derivation moved to the build boundary

Structural topology (`nodeTopologyById`) and the op-only visibility set (`visibleOpNodeIds`) are now derived inside `applyBuiltGraph` at the same time as `setNodes`, and stored in `useState`. The previous approach kept them as `useMemo([nodes])` sources with a computed-cached-state bail-out — that stabilised downstream references, but still re-walked every parent chain on every drag / select / hover frame (~3N + N·depth ops).

Structural fields (`parentId`, `type`, `groupKind`, `collapsedSubgraphNamespace`, `subgraphToggleState`) are worker-owned and never mutate outside a rebuild; RF's other write paths (selection reflection effect, `onNodesChange`, `updateNode`) all preserve them. `applyBuiltGraph` is the sole ingress for structural change, so the maps only need to update there.

Result: `displayedEdges`, `filterMatchInfo`, and `overlayLinesByNodeId` do zero work on drag / select / hover.

### `moveGroup` RAF-batched (item 2)

Mousemove deltas coalesce into a per-frame `Map<groupId, {dx, dy}>` and flush via one `updateNode` call per group per frame, replacing per-mousemove `setNodes(current.map(...))` cascades. xyflow's `updateNode` is `setNodes(prev.map(...))` internally, so per-flush cost against N nodes is unchanged — the win is write rate (mousemove cadence → 60 Hz RAF cadence).

`applyBuiltGraph` cancels any pending RAF and clears the pending Map at the top of the callback, so a mid-drag worker rebuild can't apply the accumulated delta against the freshly-committed canonical position ~16 ms later.

### Worker cache LRU (item 3)

`cacheByGraphId.get(graphId)` capped at 32 entries per graph, move-to-end LRU. The helper (`touchLruCache`) is extracted into `src/components/mlir/mlirLayoutWorkerCache.ts` and unit-tested in isolation (10 cases: hit-refresh-no-evict, insertion-order-under-eviction, limit=1 degenerate, monotonic cap, non-string keys, ...). A `touchGraphCache` wrapper inside the worker DRYs the two production callsites without narrowing the public helper.

### `filterMatchInfo` (item 4) + `resolveFilterMatches` extraction

`buildFilterMatcher` lifted into its own `useMemo([filterMode, appliedFilterQuery])` so the RegExp compiles once per query (not once per interaction frame). `filterMatchInfo` now depends on `visibleOpNodeIds` instead of `nodes`, and the resolution body is extracted into a pure `resolveFilterMatches` in `mlirFilter.ts`. Component-side memo just delegates; behaviour is byte-identical.

The extraction unlocks 8 spec cases in `tests/mlirFilter.spec.ts` — direct visibility, single-namespace bury, outer-preferred-over-inner, off-canvas anchor drops the match (locks the op-only visibility narrowing that made this whole item safe), inner-anchor after outer expand, source visible after full expand, coalesced counts on shared anchor, and missing-anchor fallback to source id.

### Overlay via `data.shapeLines` / `data.locationLines` (item 5)

`MlirNodeBodyContext` removed. Overlay strings ride on the RF node `data` payload and are read directly by `MlirOpNode`, so React Flow's per-node diff drives which ops re-render on toggle flip — no more full-canvas provider-value fanout.

### `toggleNamespaceFromGroup` (item 6)

Reads `nodes` via a `latestNodesRef` (passive-mirror pattern, synced by a `useEffect`) so the callback identity survives drag frames. `groupContextValue` stops churning; every mounted `MlirGroupNode` no longer re-renders whenever any node's position changes.

### `React.memo` on widgets (item 7)

`MlirNodeDetailsPanel`, `MlirOpFilter`, `MlirNodeBodyToggles`, `MlirExpandCollapseControls` wrapped in `memo`. `MlirOpFilter.displayName` on the memo wrapper for parity with the other three (React DevTools no longer shows a `Memo(...)` fallback). `MlirAttrValue` memoises `tryParseAttrValue(value)`. `onPrev` / `onNext` in the parent stabilised via `useCallback` so shallow-eq is honest.

## Testing

- **New unit tests** — 10 cases for `touchLruCache` (`tests/mlirLayoutWorkerCache.spec.ts`), 8 cases for `resolveFilterMatches` (added to `tests/mlirFilter.spec.ts`).
- **Regression coverage** — full MLIR suite green: **175 / 175 across 14 test files**.
- **Type + lint** — `tsc --noEmit` clean on touched files (the one pre-existing error in `tests/PerfOperationTypesChart.spec.tsx` is unrelated; tracked separately in #1731). `eslint` clean on all touched files.
- **Manual QA** — drag / filter / toggle flip on a 2K-visible-node fixture no longer stutters. No benchmark harness added; the audit called that out as a separate follow-up (out of Group A scope).

## Deferred (from local self-review)

- Export `MLNodeData` / `NodeTopologyEntry` to a shared view-types module — belongs in #1741 (`MlirOpNode` / `MlirGroupNode` extraction).
- `useLatestRef` helper — 2 callsites of the passive-mirror pattern in `MLIRViewReactFlow.tsx`, but the file is on the chopping block for #1741 so extraction is better handled during that split.
- Fixed the stale `nodeBodyContextValue` comment reference (removed as part of the item-1 refactor).

## Non-goals

Per #1739 — no structural refactor of `MLIRViewReactFlow.tsx` (Group C / #1741), no pure-module extractions beyond the LRU helper and `resolveFilterMatches` (Group B / #1740), no worker protocol changes (Group I / #1747).