### PR TITLE
fix(docs): load tt-search.js / kapa.js from global docs.tenstorrent.com/_static

### DIFF
--- a/docs/shared/_templates/layout.html
+++ b/docs/shared/_templates/layout.html
@@ -191,11 +191,11 @@
 <script src="{{ pathto('_static/docs-toc.js', 1) }}"></script>
 <script src="https://docs.tenstorrent.com/_static/sidebar-scroll.js"></script>
 <script id="tt-search-script"
-        src="{{ pathto('_static/tt-search.js', 1) }}"
+        src="https://docs.tenstorrent.com/_static/tt-search.js"
         data-search-url="{{ pathto('search') }}"
         data-search-api-base="https://csl860x2oj.execute-api.us-east-2.amazonaws.com/prod"
         data-search-source="{{ search_source_id | default('docs-tenstorrent', true) }}"
         data-site-base-url="{{ search_site_base_url | default('https://docs.tenstorrent.com/', true) }}"
-        data-kapa-src="{{ pathto('_static/kapa.js', 1) }}"
+        data-kapa-src="https://docs.tenstorrent.com/_static/kapa.js"
         data-kapa-integration-id="c37e0bab-7623-43d7-bff1-daa52e901bbe"></script>
 {%- endblock %}

--- a/docs/shared/_templates/layout.html
+++ b/docs/shared/_templates/layout.html
@@ -1,10 +1,10 @@
 {%- extends "!layout.html" %}
+{%- set _home = "https://docs.tenstorrent.com/" %}
 
 {#── Top navbar injected before the RTD grid ─────────────────────#}
 {%- block extrabody %}
 {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
 {%- set _root_doc = root_doc|default(master_doc) %}
-{%- set _home = "https://docs.tenstorrent.com/" %}
 <nav class="tt-top-nav" role="navigation" aria-label="Top navigation">
   <div class="tt-top-nav-left">
     <a href="{{ _home }}" class="tt-nav-logo">
@@ -19,18 +19,18 @@
           <a href="{{ _home }}getting-started/README.html">Installing Tenstorrent Software</a>
           <a href="{{ _home }}getting-started/manual-software-install.html">Manual Installation</a>
           <a href="{{ _home }}getting-started/vLLM-servers.html">Deploy LLMs</a>
-          <a href="https://docs.tenstorrent.com/tt-vscode-toolkit/" target="_blank" rel="noopener">Learn by Building</a>
+          <a href="{{ _home }}tt-vscode-toolkit/" target="_blank" rel="noopener">Learn by Building</a>
         </div>
       </li>
       <li class="has-dropdown">
         <a href="{{ _home }}#software">Software</a>
         <div class="tt-nav-dropdown">
           <a href="{{ _home }}forge/index.html">TT-Forge</a>
-          <a href="https://docs.tenstorrent.com/tt-metal/latest/ttnn/" target="_blank" rel="noopener">TT-NN</a>
-          <a href="https://docs.tenstorrent.com/tt-lang/" target="_blank" rel="noopener">TT-Lang</a>
-          <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
-          <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
-          <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
+          <a href="{{ _home }}tt-metal/latest/ttnn/" target="_blank" rel="noopener">TT-NN</a>
+          <a href="{{ _home }}tt-lang/" target="_blank" rel="noopener">TT-Lang</a>
+          <a href="{{ _home }}tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
+          <a href="{{ _home }}tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
+          <a href="{{ _home }}tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
         </div>
       </li>
       <li class="has-dropdown">
@@ -52,11 +52,11 @@
           <a href="https://github.com/tenstorrent/tt-inference-server" target="_blank" rel="noopener">TT-Inference-Server</a>
           <a href="https://github.com/tenstorrent/tt-studio" target="_blank" rel="noopener">TT-Studio</a>
           <a href="https://github.com/tenstorrent/tt-smi" target="_blank" rel="noopener">TT-SMI</a>
-          <a href="https://docs.tenstorrent.com/tt-toplike/" target="_blank" rel="noopener">TT-Toplike</a>
-          <a href="https://docs.tenstorrent.com/ttnn-visualizer/" target="_blank" rel="noopener">TT-NN Visualizer</a>
+          <a href="{{ _home }}tt-toplike/" target="_blank" rel="noopener">TT-Toplike</a>
+          <a href="{{ _home }}ttnn-visualizer/" target="_blank" rel="noopener">TT-NN Visualizer</a>
           <a href="https://github.com/tenstorrent/tt-topology" target="_blank" rel="noopener">TT-Topology</a>
-          <a href="https://docs.tenstorrent.com/tt-vscode-toolkit" target="_blank" rel="noopener">TT-VSCode-Toolkit</a>
-          <a href="https://docs.tenstorrent.com/tt-blacksmith/" target="_blank" rel="noopener">TT-Blacksmith</a>
+          <a href="{{ _home }}tt-vscode-toolkit" target="_blank" rel="noopener">TT-VSCode-Toolkit</a>
+          <a href="{{ _home }}tt-blacksmith/" target="_blank" rel="noopener">TT-Blacksmith</a>
         </div>
       </li>
       <li class="has-dropdown">
@@ -80,7 +80,7 @@
       <kbd class="tt-nav-search-kbd">⌘K</kbd>
     </button>
     <div class="tt-nav-actions">
-      <a href="https://docs.tenstorrent.com/tt-awesome/" class="tt-nav-btn-cta" target="_blank" rel="noopener">Explore</a>
+      <a href="{{ _home }}tt-awesome/" class="tt-nav-btn-cta" target="_blank" rel="noopener">Explore</a>
       <a href="https://github.com/tenstorrent" class="tt-nav-btn-github" target="_blank" rel="noopener">
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
@@ -189,13 +189,13 @@
 {#── Footer: right-TOC, sidebar-scroll, Search / Ask AI ─────────#}
 {%- block footer %}
 <script src="{{ pathto('_static/docs-toc.js', 1) }}"></script>
-<script src="https://docs.tenstorrent.com/_static/sidebar-scroll.js"></script>
+<script src="{{ _home }}_static/sidebar-scroll.js"></script>
 <script id="tt-search-script"
-        src="https://docs.tenstorrent.com/_static/tt-search.js"
+        src="{{ _home }}_static/tt-search.js"
         data-search-url="{{ pathto('search') }}"
         data-search-api-base="https://csl860x2oj.execute-api.us-east-2.amazonaws.com/prod"
         data-search-source="{{ search_source_id | default('docs-tenstorrent', true) }}"
-        data-site-base-url="{{ search_site_base_url | default('https://docs.tenstorrent.com/', true) }}"
-        data-kapa-src="https://docs.tenstorrent.com/_static/kapa.js"
+        data-site-base-url="{{ search_site_base_url | default(_home, true) }}"
+        data-kapa-src="{{ _home }}_static/kapa.js"
         data-kapa-integration-id="c37e0bab-7623-43d7-bff1-daa52e901bbe"></script>
 {%- endblock %}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "packageManager": "pnpm@11.1.2",
   "scripts": {
-    "build:docs": "sphinx-build ./docs ./docs/output",
+    "build:docs": "uv run --no-default-groups --group docs sphinx-build docs docs/output",
     "build:wheel": "pnpm run build && uv build --wheel",
     "build": "vite build",
     "dev:server": "VITE_SERVER_MODE=1 vite",


### PR DESCRIPTION
## Problem
The docs search bar is broken — the page requests the search script at a per-package path that doesn't exist:
```
GET https://docs.tenstorrent.com/ttnn-visualizer/_static/tt-search.js  → HTTP 404
```
`layout.html` loaded `tt-search.js` (and `kapa.js`) via `{{ pathto('_static/...', 1) }}` (local per-package), but those files are not shipped in this repo's `_static/` — only `docs-toc.js` is. So every page 404s on them.

## Fix
Load them from the **global** shared location on `docs.tenstorrent.com/_static/`, consistent with how this same template already loads `sidebar-scroll.js` and how `conf.py` loads `tt_theme.css`. Verified the global assets exist (HTTP 200):
- `https://docs.tenstorrent.com/_static/tt-search.js` ✅
- `https://docs.tenstorrent.com/_static/kapa.js` ✅
- `https://docs.tenstorrent.com/_static/tt-kapa-chat.js` ✅ (derived by tt-search.js from its own `src`, so Ask AI resolves too)

This is a single source of truth (no per-repo duplication / version drift) and fixes both the **Search** and **Ask AI** tabs.

## Change
- `docs/shared/_templates/layout.html` — `tt-search.js` `src` and `kapa.js` `data-kapa-src` repointed from local `pathto` to the global `docs.tenstorrent.com/_static/` URLs.