### PR TITLE
MLIR viewer: make minimap pannable and zoomable (#1771)

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -1523,7 +1523,11 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     connectionLineType={ConnectionLineType.SmoothStep}
                     selectNodesOnDrag={false}
                 >
-                    <MiniMap nodeColor={minimapNodeColor} />
+                    <MiniMap
+                        nodeColor={minimapNodeColor}
+                        pannable
+                        zoomable
+                    />
                     <Controls />
                     <Background />
                 </ReactFlow>

--- a/tests/MLIRViewMiniMap.spec.tsx
+++ b/tests/MLIRViewMiniMap.spec.tsx
@@ -46,6 +46,9 @@ vi.mock('../src/components/mlir/useMlirLayoutWorker', () => ({
     useMlirLayoutWorker: () => ({ interactionIndex: null, runBuild: vi.fn() }),
 }));
 
+// The component under test is imported here, after the `vi.mock` factories above, so the
+// mocked `@xyflow/react` and layout-worker modules are registered before it loads. That
+// ordering is deliberate and required, which is why `import/first` is disabled for this line.
 // eslint-disable-next-line import/first
 import MLIRViewReactFlow from '../src/components/mlir/MLIRViewReactFlow';
 

--- a/tests/MLIRViewMiniMap.spec.tsx
+++ b/tests/MLIRViewMiniMap.spec.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { ReactNode } from 'react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import type { GraphBundle } from '../src/model/MLIRJsonModel';
+
+// The MiniMap is a declarative pass-through to React Flow, so the seam we lock
+// here is "what props does the view hand it". We stub the whole `@xyflow/react`
+// surface the component touches and record the props the real MiniMap would
+// have received. `capturedMiniMapProps` is populated on render.
+let capturedMiniMapProps: Record<string, unknown> | null = null;
+
+vi.mock('@xyflow/react', () => {
+    const Passthrough = ({ children }: { children?: ReactNode }) => children ?? null;
+    return {
+        ReactFlow: Passthrough,
+        ReactFlowProvider: Passthrough,
+        Background: () => null,
+        Controls: () => null,
+        Handle: () => null,
+        MiniMap: (props: Record<string, unknown>) => {
+            capturedMiniMapProps = props;
+            return null;
+        },
+        Position: { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' },
+        MarkerType: { ArrowClosed: 'arrowclosed' },
+        ConnectionLineType: { SmoothStep: 'smoothstep' },
+        useReactFlow: () => ({
+            fitView: vi.fn(),
+            getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+            setViewport: vi.fn(),
+            updateNode: vi.fn(),
+        }),
+        useNodesState: () => [[], vi.fn(), vi.fn()],
+        useEdgesState: () => [[], vi.fn(), vi.fn()],
+    };
+});
+
+// Avoid spawning the layout Web Worker (unavailable under jsdom).
+vi.mock('../src/components/mlir/useMlirLayoutWorker', () => ({
+    useMlirLayoutWorker: () => ({ interactionIndex: null, runBuild: vi.fn() }),
+}));
+
+// eslint-disable-next-line import/first
+import MLIRViewReactFlow from '../src/components/mlir/MLIRViewReactFlow';
+
+const emptyBundle: GraphBundle = { graphs: [{ id: 'test.mlir', nodes: [] }] };
+
+afterEach(cleanup);
+beforeEach(() => {
+    capturedMiniMapProps = null;
+});
+
+describe('MLIRViewReactFlow MiniMap', () => {
+    it('renders the MiniMap as pannable and zoomable', () => {
+        render(<MLIRViewReactFlow data={emptyBundle} />);
+
+        expect(capturedMiniMapProps).not.toBeNull();
+        expect(capturedMiniMapProps?.pannable).toBe(true);
+        expect(capturedMiniMapProps?.zoomable).toBe(true);
+    });
+
+    it('keeps the node-colour callback wired alongside the pan/zoom props', () => {
+        render(<MLIRViewReactFlow data={emptyBundle} />);
+
+        expect(typeof capturedMiniMapProps?.nodeColor).toBe('function');
+    });
+});


### PR DESCRIPTION
## Summary

Closes #1771.

- Pass `pannable` and `zoomable` to the React Flow `<MiniMap>` in the MLIR viewer so the minimap can be dragged to pan the canvas and scrolled to zoom, matching the main viewport controls.
- Existing `nodeColor` wiring is unchanged.

## Changes

- `src/components/mlir/MLIRViewReactFlow.tsx` — add `pannable` + `zoomable` to `<MiniMap>`.
- `tests/MLIRViewMiniMap.spec.tsx` — new test that stubs the `@xyflow/react` surface and the layout worker to capture the props the view hands the MiniMap, locking the pan/zoom affordances (and the `nodeColor` wiring) against regression.

## Test plan

- [x] `vitest run tests/MLIRViewMiniMap.spec.tsx` — 2/2 pass
- [x] ESLint clean (`--report-unused-disable-directives --max-warnings 0`)
- [x] `tsc --noEmit` clean
- [ ] Manual: drag inside the minimap to pan the canvas; scroll over it to zoom; confirm node coloring unchanged