### PR TITLE
Load synced remote reports when not connected to host

### DIFF
--- a/backend/ttnn_visualizer/local_remote_reports.py
+++ b/backend/ttnn_visualizer/local_remote_reports.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Discover already-synced remote reports on local disk (no SSH)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from ttnn_visualizer.models import RemoteConnection, RemoteReportFolder
+from ttnn_visualizer.utils import read_last_synced_file
+
+logger = logging.getLogger(__name__)
+
+PROFILER_REQUIRED_FILES = frozenset({"db.sqlite"})
+PERFORMANCE_REQUIRED_FILES = frozenset(
+    {"profile_log_device.csv", "tracy_profile_log_host.tracy"}
+)
+PERFORMANCE_OPS_PERF_PREFIX = "ops_perf_results"
+
+
+def is_valid_local_profiler_report_dir(directory: Path) -> bool:
+    """True when the folder has the files needed to load a memory/profiler report."""
+    return all((directory / name).is_file() for name in PROFILER_REQUIRED_FILES)
+
+
+def is_valid_local_performance_report_dir(directory: Path) -> bool:
+    """True when the folder has the files needed to load a performance report.
+
+    Matches local performance folder listing / upload validation:
+    profile_log_device.csv, tracy_profile_log_host.tracy, and ops_perf_results*.
+    """
+    if not all((directory / name).is_file() for name in PERFORMANCE_REQUIRED_FILES):
+        return False
+    try:
+        entries = directory.iterdir()
+    except OSError:
+        return False
+    return any(
+        entry.is_file() and entry.name.startswith(PERFORMANCE_OPS_PERF_PREFIX)
+        for entry in entries
+    )
+
+
+def _synthetic_remote_path(configured_path: Optional[str], report_name: str) -> str:
+    """Build a remotePath whose final segment is the local folder name (used by /use)."""
+    if configured_path:
+        return f"{configured_path.rstrip('/')}/{report_name}"
+    return report_name
+
+
+def list_local_synced_report_folders(
+    *,
+    remote_data_directory: Path,
+    host: str,
+    report_directory_name: str,
+    configured_remote_path: Optional[str],
+    is_valid_report_dir: Callable[[Path], bool],
+) -> List[RemoteReportFolder]:
+    """
+    List report folders under REMOTE_DATA_DIRECTORY/<host>/<report_directory_name>/.
+
+    Matches the layout written by sync_remote_*_folders / PathResolver.
+    Only directories that pass ``is_valid_report_dir`` are included.
+    """
+    host_reports_dir = remote_data_directory / host / report_directory_name
+    if not host_reports_dir.is_dir():
+        logger.info("No local synced reports directory at %s", host_reports_dir)
+        return []
+
+    folders: List[RemoteReportFolder] = []
+    for entry in sorted(host_reports_dir.iterdir(), key=lambda p: p.name.lower()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        if not is_valid_report_dir(entry):
+            logger.debug("Skipping incomplete local report folder: %s", entry)
+            continue
+
+        last_synced = read_last_synced_file(str(entry))
+        # Without a remote lastModified, treat synced copies as current so select
+        # does not force an SSH refresh while offline.
+        try:
+            mtime = int(entry.stat().st_mtime)
+        except OSError:
+            mtime = 0
+        last_modified = last_synced if last_synced is not None else mtime
+
+        folders.append(
+            RemoteReportFolder(
+                reportName=entry.name,
+                remotePath=_synthetic_remote_path(configured_remote_path, entry.name),
+                lastModified=last_modified,
+                lastSynced=last_synced,
+            )
+        )
+
+    folders.sort(key=lambda folder: folder.lastModified, reverse=True)
+    return folders
+
+
+def list_local_synced_profiler_folders(
+    connection: RemoteConnection,
+    remote_data_directory: Path,
+    profiler_directory_name: str,
+) -> List[RemoteReportFolder]:
+    if not connection.profilerPath:
+        return []
+    return list_local_synced_report_folders(
+        remote_data_directory=remote_data_directory,
+        host=connection.host,
+        report_directory_name=profiler_directory_name,
+        configured_remote_path=connection.profilerPath,
+        is_valid_report_dir=is_valid_local_profiler_report_dir,
+    )
+
+
+def list_local_synced_performance_folders(
+    connection: RemoteConnection,
+    remote_data_directory: Path,
+    performance_directory_name: str,
+) -> List[RemoteReportFolder]:
+    if not connection.performancePath:
+        return []
+    return list_local_synced_report_folders(
+        remote_data_directory=remote_data_directory,
+        host=connection.host,
+        report_directory_name=performance_directory_name,
+        configured_remote_path=connection.performancePath,
+        is_valid_report_dir=is_valid_local_performance_report_dir,
+    )

--- a/backend/ttnn_visualizer/local_remote_reports.py
+++ b/backend/ttnn_visualizer/local_remote_reports.py
@@ -50,7 +50,10 @@ def _is_valid_local_performance_report_dir(directory: Path) -> bool:
     if not all((directory / name).is_file() for name in PERFORMANCE_REQUIRED_FILES):
         return False
     try:
-        return any(directory.glob(f"{PERFORMANCE_OPS_PERF_PREFIX}*"))
+        # Require a matching file — a directory named ops_perf_results* is not enough.
+        return any(
+            path.is_file() for path in directory.glob(f"{PERFORMANCE_OPS_PERF_PREFIX}*")
+        )
     except OSError:
         return False
 

--- a/backend/ttnn_visualizer/local_remote_reports.py
+++ b/backend/ttnn_visualizer/local_remote_reports.py
@@ -22,12 +22,26 @@ PERFORMANCE_REQUIRED_FILES = frozenset(
 PERFORMANCE_OPS_PERF_PREFIX = "ops_perf_results"
 
 
-def is_valid_local_profiler_report_dir(directory: Path) -> bool:
+def local_synced_report_path(
+    remote_data_directory: Path,
+    host: str,
+    report_directory_name: str,
+    report_name: Optional[str] = None,
+) -> Path:
+    """REMOTE_DATA_DIRECTORY/<host>/<report_directory_name>[/<report_name>].
+
+    Must match sync_remote_*_folders / PathResolver remote layout.
+    """
+    base = remote_data_directory / host / report_directory_name
+    return base / report_name if report_name is not None else base
+
+
+def _is_valid_local_profiler_report_dir(directory: Path) -> bool:
     """True when the folder has the files needed to load a memory/profiler report."""
     return all((directory / name).is_file() for name in PROFILER_REQUIRED_FILES)
 
 
-def is_valid_local_performance_report_dir(directory: Path) -> bool:
+def _is_valid_local_performance_report_dir(directory: Path) -> bool:
     """True when the folder has the files needed to load a performance report.
 
     Matches local performance folder listing / upload validation:
@@ -62,7 +76,9 @@ def list_local_synced_report_folders(
     Matches the layout written by sync_remote_*_folders / PathResolver.
     Only directories that pass ``is_valid_report_dir`` are included.
     """
-    host_reports_dir = remote_data_directory / host / report_directory_name
+    host_reports_dir = local_synced_report_path(
+        remote_data_directory, host, report_directory_name
+    )
     if not host_reports_dir.is_dir():
         logger.info("No local synced reports directory at %s", host_reports_dir)
         return []
@@ -84,11 +100,13 @@ def list_local_synced_report_folders(
         last_synced = read_last_synced_file(str(entry))
         # Without a remote lastModified, treat synced copies as current so select
         # does not force an SSH refresh while offline.
-        try:
-            mtime = int(entry.stat().st_mtime)
-        except OSError:
-            mtime = 0
-        last_modified = last_synced if last_synced is not None else mtime
+        if last_synced is not None:
+            last_modified = last_synced
+        else:
+            try:
+                last_modified = int(entry.stat().st_mtime)
+            except OSError:
+                last_modified = 0
 
         folders.append(
             RemoteReportFolder(
@@ -115,7 +133,7 @@ def list_local_synced_profiler_folders(
         host=connection.host,
         report_directory_name=profiler_directory_name,
         configured_remote_path=connection.profilerPath,
-        is_valid_report_dir=is_valid_local_profiler_report_dir,
+        is_valid_report_dir=_is_valid_local_profiler_report_dir,
     )
 
 
@@ -131,5 +149,5 @@ def list_local_synced_performance_folders(
         host=connection.host,
         report_directory_name=performance_directory_name,
         configured_remote_path=connection.performancePath,
-        is_valid_report_dir=is_valid_local_performance_report_dir,
+        is_valid_report_dir=_is_valid_local_performance_report_dir,
     )

--- a/backend/ttnn_visualizer/local_remote_reports.py
+++ b/backend/ttnn_visualizer/local_remote_reports.py
@@ -11,51 +11,17 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 from ttnn_visualizer.models import RemoteConnection, RemoteReportFolder
-from ttnn_visualizer.utils import read_last_synced_file
+from ttnn_visualizer.utils import (
+    is_valid_performance_report_dir,
+    is_valid_profiler_report_dir,
+    read_last_synced_file,
+    remote_host_report_path,
+)
 
 logger = logging.getLogger(__name__)
 
-PROFILER_REQUIRED_FILES = frozenset({"db.sqlite"})
-PERFORMANCE_REQUIRED_FILES = frozenset(
-    {"profile_log_device.csv", "tracy_profile_log_host.tracy"}
-)
-PERFORMANCE_OPS_PERF_PREFIX = "ops_perf_results"
-
-
-def local_synced_report_path(
-    remote_data_directory: Path,
-    host: str,
-    report_directory_name: str,
-    report_name: Optional[str] = None,
-) -> Path:
-    """REMOTE_DATA_DIRECTORY/<host>/<report_directory_name>[/<report_name>].
-
-    Must match sync_remote_*_folders / PathResolver remote layout.
-    """
-    base = remote_data_directory / host / report_directory_name
-    return base / report_name if report_name is not None else base
-
-
-def _is_valid_local_profiler_report_dir(directory: Path) -> bool:
-    """True when the folder has the files needed to load a memory/profiler report."""
-    return all((directory / name).is_file() for name in PROFILER_REQUIRED_FILES)
-
-
-def _is_valid_local_performance_report_dir(directory: Path) -> bool:
-    """True when the folder has the files needed to load a performance report.
-
-    Matches local performance folder listing / upload validation:
-    profile_log_device.csv, tracy_profile_log_host.tracy, and ops_perf_results*.
-    """
-    if not all((directory / name).is_file() for name in PERFORMANCE_REQUIRED_FILES):
-        return False
-    try:
-        # Require a matching file — a directory named ops_perf_results* is not enough.
-        return any(
-            path.is_file() for path in directory.glob(f"{PERFORMANCE_OPS_PERF_PREFIX}*")
-        )
-    except OSError:
-        return False
+# Re-export under the historical name used by views / tests.
+local_synced_report_path = remote_host_report_path
 
 
 def _synthetic_remote_path(configured_path: Optional[str], report_name: str) -> str:
@@ -79,7 +45,7 @@ def list_local_synced_report_folders(
     Matches the layout written by sync_remote_*_folders / PathResolver.
     Only directories that pass ``is_valid_report_dir`` are included.
     """
-    host_reports_dir = local_synced_report_path(
+    host_reports_dir = remote_host_report_path(
         remote_data_directory, host, report_directory_name
     )
     if not host_reports_dir.is_dir():
@@ -101,22 +67,28 @@ def list_local_synced_report_folders(
             continue
 
         last_synced = read_last_synced_file(str(entry))
-        # Without a remote lastModified, treat synced copies as current so select
-        # does not force an SSH refresh while offline.
+        try:
+            mtime = int(entry.stat().st_mtime)
+        except OSError:
+            mtime = 0
+
+        # Without a remote lastModified, treat the local copy as current so the
+        # Sync badge does not claim "needs refresh" for an offline-only row.
+        # Prefer the .last-synced marker when present; otherwise use mtime for
+        # both stamps so isRemoteFolderOutdated sees a consistent pair.
         if last_synced is not None:
             last_modified = last_synced
+            effective_last_synced = last_synced
         else:
-            try:
-                last_modified = int(entry.stat().st_mtime)
-            except OSError:
-                last_modified = 0
+            last_modified = mtime
+            effective_last_synced = mtime
 
         folders.append(
             RemoteReportFolder(
                 reportName=entry.name,
                 remotePath=_synthetic_remote_path(configured_remote_path, entry.name),
                 lastModified=last_modified,
-                lastSynced=last_synced,
+                lastSynced=effective_last_synced,
             )
         )
 
@@ -136,7 +108,7 @@ def list_local_synced_profiler_folders(
         host=connection.host,
         report_directory_name=profiler_directory_name,
         configured_remote_path=connection.profilerPath,
-        is_valid_report_dir=_is_valid_local_profiler_report_dir,
+        is_valid_report_dir=is_valid_profiler_report_dir,
     )
 
 
@@ -152,5 +124,5 @@ def list_local_synced_performance_folders(
         host=connection.host,
         report_directory_name=performance_directory_name,
         configured_remote_path=connection.performancePath,
-        is_valid_report_dir=_is_valid_local_performance_report_dir,
+        is_valid_report_dir=is_valid_performance_report_dir,
     )

--- a/backend/ttnn_visualizer/local_remote_reports.py
+++ b/backend/ttnn_visualizer/local_remote_reports.py
@@ -36,13 +36,9 @@ def is_valid_local_performance_report_dir(directory: Path) -> bool:
     if not all((directory / name).is_file() for name in PERFORMANCE_REQUIRED_FILES):
         return False
     try:
-        entries = directory.iterdir()
+        return any(directory.glob(f"{PERFORMANCE_OPS_PERF_PREFIX}*"))
     except OSError:
         return False
-    return any(
-        entry.is_file() and entry.name.startswith(PERFORMANCE_OPS_PERF_PREFIX)
-        for entry in entries
-    )
 
 
 def _synthetic_remote_path(configured_path: Optional[str], report_name: str) -> str:
@@ -72,7 +68,13 @@ def list_local_synced_report_folders(
         return []
 
     folders: List[RemoteReportFolder] = []
-    for entry in sorted(host_reports_dir.iterdir(), key=lambda p: p.name.lower()):
+    try:
+        entries = host_reports_dir.iterdir()
+    except OSError:
+        logger.warning("Unable to list local synced reports at %s", host_reports_dir)
+        return []
+
+    for entry in entries:
         if not entry.is_dir() or entry.name.startswith("."):
             continue
         if not is_valid_report_dir(entry):

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -238,14 +238,19 @@ class SerializeableModel(BaseModel):
         use_enum_values = True
 
 
-def sanitise_remote_host_segment(value: object) -> str:
-    """Normalise a user-provided host to a single safe path segment."""
+def sanitise_path_segment(value: object) -> str:
+    """Collapse a user-provided path-ish string to a single safe path segment."""
     if not isinstance(value, str):
         return value  # type: ignore[return-value]
-    safe_host = Path(value.replace("\\", "/")).name.strip()
-    if not safe_host or safe_host in {".", ".."}:
+    safe_segment = Path(value.replace("\\", "/")).name.strip()
+    if not safe_segment or safe_segment in {".", ".."}:
         raise ValueError("must not be empty")
-    return safe_host
+    return safe_segment
+
+
+def sanitise_remote_host_segment(value: object) -> str:
+    """Normalise a user-provided host to a single safe path segment."""
+    return sanitise_path_segment(value)
 
 
 class RemoteConnection(SerializeableModel):

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from http import HTTPStatus
+from pathlib import Path
+
+from ttnn_visualizer.local_remote_reports import (
+    list_local_synced_performance_folders,
+    list_local_synced_profiler_folders,
+)
+from ttnn_visualizer.models import RemoteConnection
+from ttnn_visualizer.utils import update_last_synced
+
+
+def _connection(host: str = "bh-lb-01") -> RemoteConnection:
+    return RemoteConnection(
+        name="test",
+        username="user",
+        host=host,
+        port=22,
+        profilerPath="/remote/profiler/reports",
+        performancePath="/remote/performance/reports",
+    )
+
+
+def test_list_local_synced_profiler_folders(tmp_path: Path):
+    host = "bh-lb-01"
+    report_dir = tmp_path / host / "profiler-reports" / "resnet50"
+    report_dir.mkdir(parents=True)
+    (report_dir / "db.sqlite").write_text("x")
+    update_last_synced(report_dir)
+
+    folders = list_local_synced_profiler_folders(
+        _connection(host), tmp_path, "profiler-reports"
+    )
+
+    assert len(folders) == 1
+    assert folders[0].reportName == "resnet50"
+    assert folders[0].remotePath.endswith("/resnet50")
+    assert folders[0].lastSynced is not None
+    assert folders[0].lastModified == folders[0].lastSynced
+
+
+def test_list_local_synced_performance_folders(tmp_path: Path):
+    host = "bh-lb-01"
+    report_dir = tmp_path / host / "performance-reports" / "2026_07_14_18_51_53"
+    report_dir.mkdir(parents=True)
+    (report_dir / "profile_log_device.csv").write_text("x")
+    (report_dir / "tracy_profile_log_host.tracy").write_text("x")
+    (report_dir / "ops_perf_results_2026_07_14_18_51_53.csv").write_text("x")
+    update_last_synced(report_dir)
+
+    folders = list_local_synced_performance_folders(
+        _connection(host), tmp_path, "performance-reports"
+    )
+
+    assert len(folders) == 1
+    assert folders[0].reportName == "2026_07_14_18_51_53"
+    assert folders[0].lastSynced is not None
+
+
+def test_list_local_skips_dirs_without_marker(tmp_path: Path):
+    host = "bh-lb-01"
+    empty = tmp_path / host / "performance-reports" / "empty"
+    empty.mkdir(parents=True)
+
+    folders = list_local_synced_performance_folders(
+        _connection(host), tmp_path, "performance-reports"
+    )
+
+    assert folders == []
+
+
+def test_list_local_skips_incomplete_performance_folder(tmp_path: Path):
+    host = "bh-lb-01"
+    incomplete = tmp_path / host / "performance-reports" / "partial"
+    incomplete.mkdir(parents=True)
+    # Device log alone is not enough — need tracy + ops_perf_results* too.
+    (incomplete / "profile_log_device.csv").write_text("x")
+
+    folders = list_local_synced_performance_folders(
+        _connection(host), tmp_path, "performance-reports"
+    )
+
+    assert folders == []
+
+
+def test_list_local_skips_profiler_folder_without_db(tmp_path: Path):
+    host = "bh-lb-01"
+    incomplete = tmp_path / host / "profiler-reports" / "partial"
+    incomplete.mkdir(parents=True)
+    (incomplete / "config.json").write_text("{}")
+
+    folders = list_local_synced_profiler_folders(
+        _connection(host), tmp_path, "profiler-reports"
+    )
+
+    assert folders == []
+
+
+def test_local_profiler_reports_endpoint(app, client, tmp_path: Path):
+    app.config["REMOTE_DATA_DIRECTORY"] = tmp_path
+    app.config["PROFILER_DIRECTORY_NAME"] = "profiler-reports"
+
+    host = "remote.example.com"
+    report_dir = tmp_path / host / "profiler-reports" / "resnet50"
+    report_dir.mkdir(parents=True)
+    (report_dir / "db.sqlite").write_text("x")
+    update_last_synced(report_dir)
+
+    response = client.post(
+        "/api/remote/local-profiler-reports",
+        json={
+            "name": "test-remote",
+            "username": "tester",
+            "host": host,
+            "port": 22,
+            "profilerPath": "/remote/profiler/reports",
+            "performancePath": "/remote/performance/reports",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]["reportName"] == "resnet50"
+
+
+def test_local_performance_reports_endpoint_204_when_empty(client):
+    response = client.post(
+        "/api/remote/local-performance-reports",
+        json={
+            "name": "test-remote",
+            "username": "tester",
+            "host": "missing-host",
+            "port": 22,
+            "profilerPath": "/remote/profiler/reports",
+            "performancePath": "/remote/performance/reports",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.NO_CONTENT

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from ttnn_visualizer.local_remote_reports import (
     list_local_synced_performance_folders,
     list_local_synced_profiler_folders,
+    local_synced_report_path,
 )
 from ttnn_visualizer.models import RemoteConnection
 from ttnn_visualizer.utils import update_last_synced
@@ -22,6 +23,13 @@ def _connection(host: str = "bh-lb-01") -> RemoteConnection:
         profilerPath="/remote/profiler/reports",
         performancePath="/remote/performance/reports",
     )
+
+
+def _write_valid_performance_report(report_dir: Path) -> None:
+    report_dir.mkdir(parents=True)
+    (report_dir / "profile_log_device.csv").write_text("x")
+    (report_dir / "tracy_profile_log_host.tracy").write_bytes(b"x")
+    (report_dir / "ops_perf_results_0.csv").write_text("x")
 
 
 def test_list_local_synced_profiler_folders(tmp_path: Path):
@@ -170,6 +178,94 @@ def test_local_profiler_reports_endpoint(app, client, tmp_path: Path):
     data = response.get_json()
     assert len(data) == 1
     assert data[0]["reportName"] == "resnet50"
+
+
+def test_local_profiler_reports_endpoint_400_when_connection_invalid(app, client):
+    app.config["SERVER_MODE"] = False
+
+    response = client.post(
+        "/api/remote/local-profiler-reports",
+        json={
+            "name": "test-remote",
+            "username": "tester",
+            # host required; port out of range triggers ValidationError
+            "port": 0,
+            "profilerPath": "/remote/profiler/reports",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.get_json()["error"] == "Invalid connection data"
+
+
+def test_local_profiler_reports_endpoint_400_when_connection_missing(app, client):
+    app.config["SERVER_MODE"] = False
+
+    response = client.post("/api/remote/local-profiler-reports", json={})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.get_json()["error"] == "Missing connection data"
+
+
+def test_local_performance_reports_endpoint(app, client, tmp_path: Path):
+    app.config["SERVER_MODE"] = False
+    app.config["REMOTE_DATA_DIRECTORY"] = tmp_path
+    app.config["PERFORMANCE_DIRECTORY_NAME"] = "performance-reports"
+
+    host = "remote.example.com"
+    report_dir = tmp_path / host / "performance-reports" / "perf-run"
+    _write_valid_performance_report(report_dir)
+    update_last_synced(report_dir)
+
+    response = client.post(
+        "/api/remote/local-performance-reports",
+        json=_local_reports_connection_payload(host),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]["reportName"] == "perf-run"
+
+
+def test_local_profiler_reports_endpoint_contains_crafted_host(
+    app, client, tmp_path: Path
+):
+    """Traversal-looking hosts sanitise to a single segment under REMOTE_DATA_DIRECTORY."""
+    app.config["SERVER_MODE"] = False
+    app.config["REMOTE_DATA_DIRECTORY"] = tmp_path
+    app.config["PROFILER_DIRECTORY_NAME"] = "profiler-reports"
+
+    crafted_host = "../escape"
+    safe_host = "escape"
+    report_dir = tmp_path / safe_host / "profiler-reports" / "resnet50"
+    report_dir.mkdir(parents=True)
+    (report_dir / "db.sqlite").write_text("x")
+
+    resolved = local_synced_report_path(
+        tmp_path, safe_host, "profiler-reports", "resnet50"
+    ).resolve()
+    assert resolved.is_relative_to(tmp_path.resolve())
+
+    response = client.post(
+        "/api/remote/local-profiler-reports",
+        json=_local_reports_connection_payload(crafted_host),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json()[0]["reportName"] == "resnet50"
+
+
+def test_local_profiler_reports_endpoint_400_when_host_is_dotdot(app, client):
+    app.config["SERVER_MODE"] = False
+
+    response = client.post(
+        "/api/remote/local-profiler-reports",
+        json=_local_reports_connection_payload(".."),
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.get_json()["error"] == "Invalid connection data"
 
 
 def test_local_performance_reports_endpoint_204_when_empty(app, client):

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -62,7 +62,26 @@ def test_list_local_uses_mtime_when_last_synced_missing(tmp_path: Path):
     )
 
     assert len(folders) == 1
-    assert folders[0].lastSynced is None
+    # Local-only rows without a marker use mtime for both stamps so the Sync
+    # badge does not treat them as never-synced / always-outdated.
+    assert folders[0].lastSynced == expected_mtime
+    assert folders[0].lastModified == expected_mtime
+
+
+def test_list_local_tolerates_corrupt_last_synced_marker(tmp_path: Path):
+    host = "bh-lb-01"
+    report_dir = tmp_path / host / "profiler-reports" / "resnet50"
+    report_dir.mkdir(parents=True)
+    (report_dir / "db.sqlite").write_text("x")
+    (report_dir / ".last-synced").write_text("not-a-timestamp")
+    expected_mtime = int(report_dir.stat().st_mtime)
+
+    folders = list_local_synced_profiler_folders(
+        _connection(host), tmp_path, "profiler-reports"
+    )
+
+    assert len(folders) == 1
+    assert folders[0].lastSynced == expected_mtime
     assert folders[0].lastModified == expected_mtime
 
 

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -42,6 +42,22 @@ def test_list_local_synced_profiler_folders(tmp_path: Path):
     assert folders[0].lastModified == folders[0].lastSynced
 
 
+def test_list_local_uses_mtime_when_last_synced_missing(tmp_path: Path):
+    host = "bh-lb-01"
+    report_dir = tmp_path / host / "profiler-reports" / "resnet50"
+    report_dir.mkdir(parents=True)
+    (report_dir / "db.sqlite").write_text("x")
+    expected_mtime = int(report_dir.stat().st_mtime)
+
+    folders = list_local_synced_profiler_folders(
+        _connection(host), tmp_path, "profiler-reports"
+    )
+
+    assert len(folders) == 1
+    assert folders[0].lastSynced is None
+    assert folders[0].lastModified == expected_mtime
+
+
 def test_list_local_synced_performance_folders(tmp_path: Path):
     host = "bh-lb-01"
     report_dir = tmp_path / host / "performance-reports" / "2026_07_14_18_51_53"

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -110,6 +110,22 @@ def test_list_local_skips_incomplete_performance_folder(tmp_path: Path):
     assert folders == []
 
 
+def test_list_local_skips_ops_perf_results_directory(tmp_path: Path):
+    """A directory named ops_perf_results* must not satisfy the file marker check."""
+    host = "bh-lb-01"
+    report_dir = tmp_path / host / "performance-reports" / "partial"
+    report_dir.mkdir(parents=True)
+    (report_dir / "profile_log_device.csv").write_text("x")
+    (report_dir / "tracy_profile_log_host.tracy").write_bytes(b"x")
+    (report_dir / "ops_perf_results_0").mkdir()
+
+    folders = list_local_synced_performance_folders(
+        _connection(host), tmp_path, "performance-reports"
+    )
+
+    assert folders == []
+
+
 def test_list_local_skips_profiler_folder_without_db(tmp_path: Path):
     host = "bh-lb-01"
     incomplete = tmp_path / host / "profiler-reports" / "partial"

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -99,7 +99,43 @@ def test_list_local_skips_profiler_folder_without_db(tmp_path: Path):
     assert folders == []
 
 
+def _local_reports_connection_payload(host: str) -> dict:
+    return {
+        "name": "test-remote",
+        "username": "tester",
+        "host": host,
+        "port": 22,
+        "profilerPath": "/remote/profiler/reports",
+        "performancePath": "/remote/performance/reports",
+    }
+
+
+def test_local_profiler_reports_endpoint_forbidden_when_server_mode(app, client):
+    """Disk-only local list APIs are @local_only and must 403 in hosted SERVER_MODE."""
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post(
+        "/api/remote/local-profiler-reports",
+        json=_local_reports_connection_payload("remote.example.com"),
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_local_performance_reports_endpoint_forbidden_when_server_mode(app, client):
+    """Disk-only local list APIs are @local_only and must 403 in hosted SERVER_MODE."""
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post(
+        "/api/remote/local-performance-reports",
+        json=_local_reports_connection_payload("remote.example.com"),
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
 def test_local_profiler_reports_endpoint(app, client, tmp_path: Path):
+    app.config["SERVER_MODE"] = False
     app.config["REMOTE_DATA_DIRECTORY"] = tmp_path
     app.config["PROFILER_DIRECTORY_NAME"] = "profiler-reports"
 
@@ -111,14 +147,7 @@ def test_local_profiler_reports_endpoint(app, client, tmp_path: Path):
 
     response = client.post(
         "/api/remote/local-profiler-reports",
-        json={
-            "name": "test-remote",
-            "username": "tester",
-            "host": host,
-            "port": 22,
-            "profilerPath": "/remote/profiler/reports",
-            "performancePath": "/remote/performance/reports",
-        },
+        json=_local_reports_connection_payload(host),
     )
 
     assert response.status_code == HTTPStatus.OK
@@ -127,17 +156,12 @@ def test_local_profiler_reports_endpoint(app, client, tmp_path: Path):
     assert data[0]["reportName"] == "resnet50"
 
 
-def test_local_performance_reports_endpoint_204_when_empty(client):
+def test_local_performance_reports_endpoint_204_when_empty(app, client):
+    app.config["SERVER_MODE"] = False
+
     response = client.post(
         "/api/remote/local-performance-reports",
-        json={
-            "name": "test-remote",
-            "username": "tester",
-            "host": "missing-host",
-            "port": 22,
-            "profilerPath": "/remote/profiler/reports",
-            "performancePath": "/remote/performance/reports",
-        },
+        json=_local_reports_connection_payload("missing-host"),
     )
 
     assert response.status_code == HTTPStatus.NO_CONTENT

--- a/backend/ttnn_visualizer/tests/test_local_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/test_local_remote_reports.py
@@ -103,16 +103,23 @@ def test_list_local_synced_performance_folders(tmp_path: Path):
     assert folders[0].lastSynced is not None
 
 
-def test_list_local_skips_dirs_without_marker(tmp_path: Path):
+def test_list_local_performance_uses_mtime_when_last_synced_missing(
+    tmp_path: Path,
+):
     host = "bh-lb-01"
-    empty = tmp_path / host / "performance-reports" / "empty"
-    empty.mkdir(parents=True)
+    report_dir = tmp_path / host / "performance-reports" / "2026_07_14_18_51_53"
+    _write_valid_performance_report(report_dir)
+    expected_mtime = int(report_dir.stat().st_mtime)
 
     folders = list_local_synced_performance_folders(
         _connection(host), tmp_path, "performance-reports"
     )
 
-    assert folders == []
+    assert len(folders) == 1
+    # Local-only rows without a marker use mtime for both stamps so the Sync
+    # badge does not treat them as never-synced / always-outdated.
+    assert folders[0].lastSynced == expected_mtime
+    assert folders[0].lastModified == expected_mtime
 
 
 def test_list_local_skips_incomplete_performance_folder(tmp_path: Path):

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -118,3 +118,72 @@ def test_remote_performance_returns_json_when_reports_exist(app, client):
     assert data[0]["lastModified"] == 200
     assert data[0]["lastSynced"] == 456
     read_last_synced.assert_called_once_with(expected_local_path)
+
+
+def test_remote_use_returns_404_when_profiler_not_synced_locally(app, client, tmp_path):
+    app.config["REMOTE_DATA_DIRECTORY"] = str(tmp_path)
+    app.config["SERVER_MODE"] = False
+
+    response = client.post(
+        "/api/remote/use",
+        json={
+            "connection": _remote_connection_payload(),
+            "profiler": {
+                "reportName": "resnet50",
+                "remotePath": "/remote/profiler/reports/resnet50",
+                "lastModified": 1,
+            },
+        },
+    )
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert "not synced locally" in response.get_json()["error"]
+
+
+def test_remote_use_returns_404_when_performance_not_synced_locally(
+    app, client, tmp_path
+):
+    app.config["REMOTE_DATA_DIRECTORY"] = str(tmp_path)
+    app.config["SERVER_MODE"] = False
+
+    response = client.post(
+        "/api/remote/use",
+        json={
+            "connection": _remote_connection_payload(),
+            "performance": {
+                "reportName": "bert",
+                "remotePath": "/remote/performance/reports/bert",
+                "lastModified": 1,
+            },
+        },
+    )
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert "not synced locally" in response.get_json()["error"]
+
+
+def test_remote_use_ok_when_profiler_synced_locally(app, client, tmp_path):
+    app.config["REMOTE_DATA_DIRECTORY"] = str(tmp_path)
+    app.config["SERVER_MODE"] = False
+    report_dir = (
+        tmp_path
+        / "remote.example.com"
+        / app.config["PROFILER_DIRECTORY_NAME"]
+        / "resnet50"
+    )
+    report_dir.mkdir(parents=True)
+    (report_dir / "db.sqlite").write_text("x")
+
+    response = client.post(
+        "/api/remote/use",
+        json={
+            "connection": _remote_connection_payload(),
+            "profiler": {
+                "reportName": "resnet50",
+                "remotePath": "/remote/profiler/reports/resnet50",
+                "lastModified": 1,
+            },
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -40,12 +40,20 @@ def test_remote_profiler_returns_json_when_reports_exist(app, client):
             lastModified=100,
         )
     ]
+    expected_local_path = str(
+        Path(app.config["REMOTE_DATA_DIRECTORY"])
+        / "remote.example.com"
+        / app.config["PROFILER_DIRECTORY_NAME"]
+        / "resnet50"
+    )
 
     with (
         patch(
             "ttnn_visualizer.views.get_remote_profiler_folders", return_value=folders
         ),
-        patch("ttnn_visualizer.views.read_last_synced_file", return_value=123),
+        patch(
+            "ttnn_visualizer.views.read_last_synced_file", return_value=123
+        ) as read_last_synced,
     ):
         response = client.post(
             "/api/remote/profiler-reports", json=_remote_connection_payload()
@@ -59,6 +67,7 @@ def test_remote_profiler_returns_json_when_reports_exist(app, client):
     assert data[0]["remotePath"] == "/remote/profiler/reports/resnet50"
     assert data[0]["lastModified"] == 100
     assert data[0]["lastSynced"] == 123
+    read_last_synced.assert_called_once_with(expected_local_path)
 
 
 def test_remote_performance_returns_204_when_no_reports(client):
@@ -81,12 +90,20 @@ def test_remote_performance_returns_json_when_reports_exist(app, client):
             lastModified=200,
         )
     ]
+    expected_local_path = str(
+        Path(app.config["REMOTE_DATA_DIRECTORY"])
+        / "remote.example.com"
+        / app.config["PERFORMANCE_DIRECTORY_NAME"]
+        / "bert"
+    )
 
     with (
         patch(
             "ttnn_visualizer.views.get_remote_performance_folders", return_value=folders
         ),
-        patch("ttnn_visualizer.views.read_last_synced_file", return_value=456),
+        patch(
+            "ttnn_visualizer.views.read_last_synced_file", return_value=456
+        ) as read_last_synced,
     ):
         response = client.post(
             "/api/remote/performance-reports", json=_remote_connection_payload()
@@ -100,3 +117,4 @@ def test_remote_performance_returns_json_when_reports_exist(app, client):
     assert data[0]["remotePath"] == "/remote/performance/reports/bert"
     assert data[0]["lastModified"] == 200
     assert data[0]["lastSynced"] == 456
+    read_last_synced.assert_called_once_with(expected_local_path)

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -272,3 +272,22 @@ def test_remote_use_rejects_dotdot_report_name(app, client, tmp_path):
 
     assert response.status_code == HTTPStatus.BAD_REQUEST
     assert "Invalid report name" in response.get_json()["error"]
+
+
+def test_remote_use_forbidden_when_server_mode(app, client):
+    """Mounting a locally synced remote report is @local_only under SERVER_MODE."""
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post(
+        "/api/remote/use",
+        json={
+            "connection": _remote_connection_payload(),
+            "performance": {
+                "reportName": "bert",
+                "remotePath": "/remote/performance/reports/bert",
+                "lastModified": 1,
+            },
+        },
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -27,7 +27,9 @@ def _write_valid_performance_report(report_dir: Path) -> None:
     (report_dir / "ops_perf_results_0.csv").write_text("x")
 
 
-def test_remote_profiler_returns_204_when_no_reports(client):
+def test_remote_profiler_returns_204_when_no_reports(app, client):
+    app.config["SERVER_MODE"] = False
+
     with patch("ttnn_visualizer.views.get_remote_profiler_folders", return_value=[]):
         response = client.post(
             "/api/remote/profiler-reports", json=_remote_connection_payload()
@@ -38,6 +40,7 @@ def test_remote_profiler_returns_204_when_no_reports(client):
 
 
 def test_remote_profiler_returns_json_when_reports_exist(app, client):
+    app.config["SERVER_MODE"] = False
     app.config["REMOTE_DATA_DIRECTORY"] = Path(app.config["REMOTE_DATA_DIRECTORY"])
 
     folders = [
@@ -77,7 +80,9 @@ def test_remote_profiler_returns_json_when_reports_exist(app, client):
     read_last_synced.assert_called_once_with(expected_local_path)
 
 
-def test_remote_performance_returns_204_when_no_reports(client):
+def test_remote_performance_returns_204_when_no_reports(app, client):
+    app.config["SERVER_MODE"] = False
+
     with patch("ttnn_visualizer.views.get_remote_performance_folders", return_value=[]):
         response = client.post(
             "/api/remote/performance-reports", json=_remote_connection_payload()
@@ -88,6 +93,7 @@ def test_remote_performance_returns_204_when_no_reports(client):
 
 
 def test_remote_performance_returns_json_when_reports_exist(app, client):
+    app.config["SERVER_MODE"] = False
     app.config["REMOTE_DATA_DIRECTORY"] = Path(app.config["REMOTE_DATA_DIRECTORY"])
 
     folders = [
@@ -285,6 +291,52 @@ def test_remote_use_forbidden_when_server_mode(app, client):
             "performance": {
                 "reportName": "bert",
                 "remotePath": "/remote/performance/reports/bert",
+                "lastModified": 1,
+            },
+        },
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_remote_profiler_reports_forbidden_when_server_mode(app, client):
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post(
+        "/api/remote/profiler-reports", json=_remote_connection_payload()
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_remote_performance_reports_forbidden_when_server_mode(app, client):
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post(
+        "/api/remote/performance-reports", json=_remote_connection_payload()
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_remote_test_forbidden_when_server_mode(app, client):
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post("/api/remote/test", json=_remote_connection_payload())
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_remote_sync_forbidden_when_server_mode(app, client):
+    assert app.config["SERVER_MODE"] is True
+
+    response = client.post(
+        "/api/remote/sync",
+        json={
+            "connection": _remote_connection_payload(),
+            "profiler": {
+                "reportName": "resnet50",
+                "remotePath": "/remote/profiler/reports/resnet50",
                 "lastModified": 1,
             },
         },

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -20,6 +20,13 @@ def _remote_connection_payload():
     }
 
 
+def _write_valid_performance_report(report_dir: Path) -> None:
+    report_dir.mkdir(parents=True)
+    (report_dir / "profile_log_device.csv").write_text("x")
+    (report_dir / "tracy_profile_log_host.tracy").write_bytes(b"x")
+    (report_dir / "ops_perf_results_0.csv").write_text("x")
+
+
 def test_remote_profiler_returns_204_when_no_reports(client):
     with patch("ttnn_visualizer.views.get_remote_profiler_folders", return_value=[]):
         response = client.post(
@@ -187,3 +194,81 @@ def test_remote_use_ok_when_profiler_synced_locally(app, client, tmp_path):
     )
 
     assert response.status_code == HTTPStatus.OK
+
+
+def test_remote_use_ok_when_performance_synced_locally(app, client, tmp_path):
+    app.config["REMOTE_DATA_DIRECTORY"] = str(tmp_path)
+    app.config["SERVER_MODE"] = False
+    report_dir = (
+        tmp_path
+        / "remote.example.com"
+        / app.config["PERFORMANCE_DIRECTORY_NAME"]
+        / "bert"
+    )
+    _write_valid_performance_report(report_dir)
+
+    with patch("ttnn_visualizer.views.update_instance") as update_instance:
+        response = client.post(
+            "/api/remote/use",
+            json={
+                "connection": _remote_connection_payload(),
+                "performance": {
+                    "reportName": "bert",
+                    "remotePath": "/remote/performance/reports/bert",
+                    "lastModified": 1,
+                },
+            },
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    update_instance.assert_called_once()
+    assert update_instance.call_args.kwargs["performance_name"] == "bert"
+
+
+def test_remote_use_sanitises_traversal_performance_report_name(app, client, tmp_path):
+    """Traversal segments must not escape the connection's report base."""
+    app.config["REMOTE_DATA_DIRECTORY"] = str(tmp_path)
+    app.config["SERVER_MODE"] = False
+
+    victim = (
+        tmp_path / "other-host" / app.config["PERFORMANCE_DIRECTORY_NAME"] / "victim"
+    )
+    _write_valid_performance_report(victim)
+
+    with patch("ttnn_visualizer.views.update_instance") as update_instance:
+        response = client.post(
+            "/api/remote/use",
+            json={
+                "connection": _remote_connection_payload(),
+                "performance": {
+                    "reportName": "../../other-host/performance-reports/victim",
+                    "remotePath": "/remote/performance/reports/bert",
+                    "lastModified": 1,
+                },
+            },
+        )
+
+    # Collapses to segment "victim" under remote.example.com — not the other host.
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert "not synced locally" in response.get_json()["error"]
+    update_instance.assert_not_called()
+
+
+def test_remote_use_rejects_dotdot_report_name(app, client, tmp_path):
+    app.config["REMOTE_DATA_DIRECTORY"] = str(tmp_path)
+    app.config["SERVER_MODE"] = False
+
+    response = client.post(
+        "/api/remote/use",
+        json={
+            "connection": _remote_connection_payload(),
+            "performance": {
+                "reportName": "..",
+                "remotePath": "/remote/performance/reports/bert",
+                "lastModified": 1,
+            },
+        },
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "Invalid report name" in response.get_json()["error"]

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -587,6 +587,51 @@ def find_gunicorn_path() -> tuple[str, Optional[str]]:
     return "gunicorn", warning_message
 
 
+PROFILER_REPORT_REQUIRED_FILES = frozenset({"db.sqlite"})
+PERFORMANCE_REPORT_REQUIRED_FILES = frozenset(
+    {"profile_log_device.csv", "tracy_profile_log_host.tracy"}
+)
+PERFORMANCE_OPS_PERF_PREFIX = "ops_perf_results"
+
+
+def remote_host_report_path(
+    remote_data_directory: Path,
+    host: str,
+    report_directory_name: str,
+    report_name: Optional[str] = None,
+) -> Path:
+    """REMOTE_DATA_DIRECTORY/<host>/<report_directory_name>[/<report_name>].
+
+    Canonical on-disk layout for synced remote reports. PathResolver, sync
+    destinations, and offline listing must all go through this helper.
+    """
+    base = Path(remote_data_directory) / host / report_directory_name
+    return base / report_name if report_name is not None else base
+
+
+def is_valid_profiler_report_dir(directory: Path) -> bool:
+    """True when the folder has the files needed to load a memory/profiler report."""
+    return all((directory / name).is_file() for name in PROFILER_REPORT_REQUIRED_FILES)
+
+
+def is_valid_performance_report_dir(directory: Path) -> bool:
+    """True when the folder has the files needed to load a performance report.
+
+    Requires profile_log_device.csv, tracy_profile_log_host.tracy, and at least
+    one ops_perf_results* *file* (a directory with that name is not enough).
+    """
+    if not all(
+        (directory / name).is_file() for name in PERFORMANCE_REPORT_REQUIRED_FILES
+    ):
+        return False
+    try:
+        return any(
+            path.is_file() for path in directory.glob(f"{PERFORMANCE_OPS_PERF_PREFIX}*")
+        )
+    except OSError:
+        return False
+
+
 class PathResolver:
     """Centralized path resolution for both TT-Metal and upload/sync modes."""
 
@@ -619,17 +664,18 @@ class PathResolver:
             local_dir = Path(self.current_app.config["LOCAL_DATA_DIRECTORY"])
             remote_dir = Path(self.current_app.config["REMOTE_DATA_DIRECTORY"])
 
-            if remote_connection:
-                base_dir = remote_dir / remote_connection.host
-            else:
-                base_dir = local_dir
-
             if report_type == "profiler":
-                return base_dir / self.current_app.config["PROFILER_DIRECTORY_NAME"]
+                dir_name = self.current_app.config["PROFILER_DIRECTORY_NAME"]
             elif report_type == "performance":
-                return base_dir / self.current_app.config["PERFORMANCE_DIRECTORY_NAME"]
+                dir_name = self.current_app.config["PERFORMANCE_DIRECTORY_NAME"]
             else:
                 raise ValueError(f"Unknown report type: {report_type}")
+
+            if remote_connection:
+                return remote_host_report_path(
+                    remote_dir, remote_connection.host, dir_name
+                )
+            return local_dir / dir_name
 
     def get_profiler_path(self, profiler_name: str, remote_connection=None):
         """Get the full path to a profiler report's db.sqlite file."""
@@ -849,16 +895,14 @@ def get_available_reports(current_app):
         profiler_base = resolver.get_base_report_path("profiler")
         if profiler_base.exists():
             for report_dir in profiler_base.iterdir():
-                if report_dir.is_dir():
-                    db_file = report_dir / current_app.config["SQLITE_DB_PATH"]
-                    if db_file.exists():
-                        reports["profiler"].append(
-                            {
-                                "name": report_dir.name,
-                                "path": str(report_dir),
-                                "modified": report_dir.stat().st_mtime,
-                            }
-                        )
+                if report_dir.is_dir() and is_valid_profiler_report_dir(report_dir):
+                    reports["profiler"].append(
+                        {
+                            "name": report_dir.name,
+                            "path": str(report_dir),
+                            "modified": report_dir.stat().st_mtime,
+                        }
+                    )
     except Exception as e:
         logger.warning(f"Error reading profiler reports: {e}")
 
@@ -867,24 +911,14 @@ def get_available_reports(current_app):
         performance_base = resolver.get_base_report_path("performance")
         if performance_base.exists():
             for report_dir in performance_base.iterdir():
-                if report_dir.is_dir():
-                    # Check for typical performance files
-                    has_perf_files = any(
-                        (report_dir / filename).exists()
-                        for filename in [
-                            "profile_log_device.csv",
-                            "tracy_profile_log_host.tracy",
-                        ]
-                    ) or any(report_dir.glob("ops_perf_results*.csv"))
-
-                    if has_perf_files:
-                        reports["performance"].append(
-                            {
-                                "name": report_dir.name,
-                                "path": str(report_dir),
-                                "modified": report_dir.stat().st_mtime,
-                            }
-                        )
+                if report_dir.is_dir() and is_valid_performance_report_dir(report_dir):
+                    reports["performance"].append(
+                        {
+                            "name": report_dir.name,
+                            "path": str(report_dir),
+                            "modified": report_dir.stat().st_mtime,
+                        }
+                    )
     except Exception as e:
         logger.warning(f"Error reading performance reports: {e}")
 
@@ -1022,11 +1056,14 @@ def read_last_synced_file(directory: str) -> Optional[int]:
     if not last_synced_path.exists():
         return None
 
-    # Read and return the timestamp as an integer
-    with last_synced_path.open("r") as file:
-        timestamp = int(file.read().strip())
-
-    return timestamp
+    # Corrupt / empty / unreadable markers must not fail the whole listing —
+    # callers fall back to mtime when this returns None.
+    try:
+        with last_synced_path.open("r") as file:
+            return int(file.read().strip())
+    except (ValueError, OSError):
+        logger.warning("Unable to read last-synced marker at %s", last_synced_path)
+        return None
 
 
 def update_last_synced(directory: Path) -> None:

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1571,6 +1571,7 @@ def list_remote_reports_performance():
 
 
 @api.route("/remote/local-profiler-reports", methods=["POST"])
+@local_only
 def list_local_remote_reports_profiler():
     """List profiler reports already synced under REMOTE_DATA_DIRECTORY/<host>/ (no SSH)."""
     connection_data = request.get_json()
@@ -1594,6 +1595,7 @@ def list_local_remote_reports_profiler():
 
 
 @api.route("/remote/local-performance-reports", methods=["POST"])
+@local_only
 def list_local_remote_reports_performance():
     """List performance reports already synced under REMOTE_DATA_DIRECTORY/<host>/ (no SSH)."""
     connection_data = request.get_json()

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -2038,6 +2038,7 @@ def _safe_report_folder_name(
 
 
 @api.route("/remote/use", methods=["POST"])
+@local_only
 def use_remote_folder():
     data = request.get_json(force=True)
     connection_data = data.get("connection")

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -64,6 +64,7 @@ from ttnn_visualizer.models import (
     RemoteReportFolder,
     ReportLocation,
     StatusMessage,
+    sanitise_path_segment,
     sanitise_remote_host_segment,
 )
 from ttnn_visualizer.queries import DatabaseQueries
@@ -2038,6 +2039,22 @@ def sync_remote_folder():
         )
 
 
+_REPORT_NOT_SYNCED_LOCALLY = (
+    "Report is not synced locally. Use Sync to download it first."
+)
+
+
+def _safe_report_folder_name(
+    *, report_name: Optional[str] = None, remote_path: Optional[str] = None
+) -> Optional[str]:
+    """Single-segment folder name for paths under REMOTE_DATA_DIRECTORY."""
+    candidate = report_name or (Path(remote_path).name if remote_path else "")
+    try:
+        return sanitise_path_segment(candidate)
+    except (TypeError, ValueError):
+        return None
+
+
 @api.route("/remote/use", methods=["POST"])
 def use_remote_folder():
     data = request.get_json(force=True)
@@ -2060,12 +2077,15 @@ def use_remote_folder():
             profiler,
             strict=False,
         )
-        profiler_name = remote_profiler_folder.remotePath.split("/")[-1]
+        profiler_name = _safe_report_folder_name(
+            report_name=remote_profiler_folder.reportName,
+            remote_path=remote_profiler_folder.remotePath,
+        )
+        if not profiler_name:
+            return response_bad_request("Invalid report name")
         local_db_path = Path(get_profiler_path(profiler_name, current_app, connection))
         if not is_valid_profiler_report_dir(local_db_path.parent):
-            return response_not_found(
-                "Report is not synced locally. Use Sync to download it first."
-            )
+            return response_not_found(_REPORT_NOT_SYNCED_LOCALLY)
         kwargs["remote_profiler_folder"] = remote_profiler_folder
         kwargs["profiler_name"] = profiler_name
         kwargs["profiler_location"] = ReportLocation.REMOTE.value
@@ -2075,14 +2095,17 @@ def use_remote_folder():
             performance,
             strict=False,
         )
-        performance_name = remote_performance_folder.reportName
+        performance_name = _safe_report_folder_name(
+            report_name=remote_performance_folder.reportName,
+            remote_path=remote_performance_folder.remotePath,
+        )
+        if not performance_name:
+            return response_bad_request("Invalid report name")
         local_perf_path = Path(
             get_performance_path(performance_name, current_app, connection)
         )
         if not is_valid_performance_report_dir(local_perf_path):
-            return response_not_found(
-                "Report is not synced locally. Use Sync to download it first."
-            )
+            return response_not_found(_REPORT_NOT_SYNCED_LOCALLY)
         kwargs["remote_performance_folder"] = remote_performance_folder
         kwargs["performance_name"] = performance_name
         kwargs["performance_location"] = ReportLocation.REMOTE.value

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1484,6 +1484,7 @@ def create_npe_files():
 
 
 @api.route("/remote/profiler-reports", methods=["POST"])
+@local_only
 def list_remote_reports_profiler():
     return _respond_remote_report_list(
         get_remote_profiler_folders, "PROFILER_DIRECTORY_NAME"
@@ -1491,6 +1492,7 @@ def list_remote_reports_profiler():
 
 
 @api.route("/remote/performance-reports", methods=["POST"])
+@local_only
 def list_remote_reports_performance():
     return _respond_remote_report_list(
         get_remote_performance_folders, "PERFORMANCE_DIRECTORY_NAME"
@@ -1527,10 +1529,10 @@ def _annotate_last_synced(
         local_path = local_synced_report_path(
             remote_data, host, dir_name, directory_name
         )
-        logger.info("Checking last synced for %s", directory_name)
+        logger.debug("Checking last synced for %s", directory_name)
         rf.lastSynced = read_last_synced_file(str(local_path))
         if not rf.lastSynced:
-            logger.info("%s not yet synced", directory_name)
+            logger.debug("%s not yet synced", directory_name)
 
 
 def _respond_remote_report_list(fetch_fn, directory_config_key: str):
@@ -1668,6 +1670,7 @@ def get_mesh_descriptor(instance: Instance):
 
 
 @api.route("/remote/test", methods=["POST"])
+@local_only
 def test_remote_folder():
     connection_data = request.json
 
@@ -1947,6 +1950,7 @@ def remote_stack_trace_read(instance: Instance):
 
 
 @api.route("/remote/sync", methods=["POST"])
+@local_only
 def sync_remote_folder():
     remote_dir = current_app.config["REMOTE_DATA_DIRECTORY"]
     request_body = request.get_json()

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -51,6 +51,7 @@ from ttnn_visualizer.instances import get_instances, update_instance
 from ttnn_visualizer.local_remote_reports import (
     list_local_synced_performance_folders,
     list_local_synced_profiler_folders,
+    local_synced_report_path,
 )
 from ttnn_visualizer.mlir import (
     test_mlir_server_connection,
@@ -1508,14 +1509,11 @@ def list_remote_reports_profiler():
 
         for rf in remote_folders:
             directory_name = Path(rf.remotePath).name
-            remote_data_directory = current_app.config["REMOTE_DATA_DIRECTORY"]
-            # Must match sync_remote_profiler_folders / PathResolver:
-            # REMOTE_DATA_DIRECTORY/<host>/profiler-reports/<name>
-            local_path = (
-                remote_data_directory
-                / connection.host
-                / current_app.config["PROFILER_DIRECTORY_NAME"]
-                / directory_name
+            local_path = local_synced_report_path(
+                Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
+                connection.host,
+                current_app.config["PROFILER_DIRECTORY_NAME"],
+                directory_name,
             )
             logger.info(f"Checking last synced for {directory_name}")
             rf.lastSynced = read_last_synced_file(str(local_path))
@@ -1548,14 +1546,11 @@ def list_remote_reports_performance():
 
         for rf in remote_performance_folders:
             performance_name = Path(rf.remotePath).name
-            remote_data_directory = current_app.config["REMOTE_DATA_DIRECTORY"]
-            # Must match sync_remote_performance_folders / PathResolver:
-            # REMOTE_DATA_DIRECTORY/<host>/performance-reports/<name>
-            local_path = (
-                remote_data_directory
-                / connection.host
-                / current_app.config["PERFORMANCE_DIRECTORY_NAME"]
-                / performance_name
+            local_path = local_synced_report_path(
+                Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
+                connection.host,
+                current_app.config["PERFORMANCE_DIRECTORY_NAME"],
+                performance_name,
             )
             logger.info(f"Checking last synced for {performance_name}")
             rf.lastSynced = read_last_synced_file(str(local_path))
@@ -1596,7 +1591,11 @@ def _respond_local_synced_folders(list_fn, directory_config_key: str):
     if not connection_data:
         return response_bad_request("Missing connection data")
 
-    connection = RemoteConnection.model_validate(connection_data, strict=False)
+    try:
+        connection = RemoteConnection.model_validate(connection_data, strict=False)
+    except ValidationError:
+        return response_bad_request("Invalid connection data")
+
     folders = list_fn(
         connection,
         Path(current_app.config["REMOTE_DATA_DIRECTORY"]),

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1485,76 +1485,16 @@ def create_npe_files():
 
 @api.route("/remote/profiler-reports", methods=["POST"])
 def list_remote_reports_profiler():
-    connection_data = request.get_json()
-
-    if not connection_data:
-        return response_bad_request("Missing connection data")
-
-    connection = RemoteConnection.model_validate(connection_data, strict=False)
-
-    try:
-        remote_folders: List[RemoteReportFolder] = get_remote_profiler_folders(
-            connection
-        )
-        if not remote_folders:
-            return Response(status=HTTPStatus.NO_CONTENT)
-
-        for rf in remote_folders:
-            directory_name = Path(rf.remotePath).name
-            local_path = local_synced_report_path(
-                Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
-                connection.host,
-                current_app.config["PROFILER_DIRECTORY_NAME"],
-                directory_name,
-            )
-            logger.info(f"Checking last synced for {directory_name}")
-            rf.lastSynced = read_last_synced_file(str(local_path))
-            if not rf.lastSynced:
-                logger.info(f"{directory_name} not yet synced")
-
-        return Response(
-            orjson.dumps([r.model_dump() for r in remote_folders]),
-            mimetype="application/json",
-        )
-    except RemoteConnectionException as e:
-        return error_response(e.http_status, e.message)
+    return _respond_remote_report_list(
+        get_remote_profiler_folders, "PROFILER_DIRECTORY_NAME"
+    )
 
 
 @api.route("/remote/performance-reports", methods=["POST"])
 def list_remote_reports_performance():
-    connection_data = request.get_json()
-
-    if not connection_data:
-        return response_bad_request("Missing connection data")
-
-    connection = RemoteConnection.model_validate(connection_data, strict=False)
-
-    try:
-        remote_performance_folders: List[RemoteReportFolder] = (
-            get_remote_performance_folders(connection)
-        )
-        if not remote_performance_folders:
-            return Response(status=HTTPStatus.NO_CONTENT)
-
-        for rf in remote_performance_folders:
-            performance_name = Path(rf.remotePath).name
-            local_path = local_synced_report_path(
-                Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
-                connection.host,
-                current_app.config["PERFORMANCE_DIRECTORY_NAME"],
-                performance_name,
-            )
-            logger.info(f"Checking last synced for {performance_name}")
-            rf.lastSynced = read_last_synced_file(str(local_path))
-            if not rf.lastSynced:
-                logger.info(f"{performance_name} not yet synced")
-
-        return Response(
-            orjson.dumps([r.model_dump() for r in remote_performance_folders]),
-            mimetype="application/json",
-        )
-    except RemoteConnectionException as e:
-        return error_response(e.http_status, e.message)
+    return _respond_remote_report_list(
+        get_remote_performance_folders, "PERFORMANCE_DIRECTORY_NAME"
+    )
 
 
 @api.route("/remote/local-profiler-reports", methods=["POST"])
@@ -1575,6 +1515,48 @@ def list_local_remote_reports_performance():
         list_local_synced_performance_folders,
         "PERFORMANCE_DIRECTORY_NAME",
     )
+
+
+def _annotate_last_synced(
+    folders: List[RemoteReportFolder], host: str, directory_config_key: str
+) -> None:
+    remote_data = Path(current_app.config["REMOTE_DATA_DIRECTORY"])
+    dir_name = current_app.config[directory_config_key]
+    for rf in folders:
+        directory_name = Path(rf.remotePath).name
+        local_path = local_synced_report_path(
+            remote_data, host, dir_name, directory_name
+        )
+        logger.info("Checking last synced for %s", directory_name)
+        rf.lastSynced = read_last_synced_file(str(local_path))
+        if not rf.lastSynced:
+            logger.info("%s not yet synced", directory_name)
+
+
+def _respond_remote_report_list(fetch_fn, directory_config_key: str):
+    connection_data = request.get_json()
+
+    if not connection_data:
+        return response_bad_request("Missing connection data")
+
+    try:
+        connection = RemoteConnection.model_validate(connection_data, strict=False)
+    except ValidationError:
+        return response_bad_request("Invalid connection data")
+
+    try:
+        remote_folders: List[RemoteReportFolder] = fetch_fn(connection)
+        if not remote_folders:
+            return Response(status=HTTPStatus.NO_CONTENT)
+
+        _annotate_last_synced(remote_folders, connection.host, directory_config_key)
+
+        return Response(
+            orjson.dumps([folder.model_dump() for folder in remote_folders]),
+            mimetype="application/json",
+        )
+    except RemoteConnectionException as e:
+        return error_response(e.http_status, e.message)
 
 
 def _respond_local_synced_folders(list_fn, directory_config_key: str):

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -48,6 +48,10 @@ from ttnn_visualizer.file_uploads import (
     validate_files,
 )
 from ttnn_visualizer.instances import get_instances, update_instance
+from ttnn_visualizer.local_remote_reports import (
+    list_local_synced_performance_folders,
+    list_local_synced_profiler_folders,
+)
 from ttnn_visualizer.mlir import (
     test_mlir_server_connection,
     upload_and_convert_mlir,
@@ -1505,10 +1509,12 @@ def list_remote_reports_profiler():
         for rf in remote_folders:
             directory_name = Path(rf.remotePath).name
             remote_data_directory = current_app.config["REMOTE_DATA_DIRECTORY"]
+            # Must match sync_remote_profiler_folders / PathResolver:
+            # REMOTE_DATA_DIRECTORY/<host>/profiler-reports/<name>
             local_path = (
                 remote_data_directory
-                / current_app.config["PROFILER_DIRECTORY_NAME"]
                 / connection.host
+                / current_app.config["PROFILER_DIRECTORY_NAME"]
                 / directory_name
             )
             logger.info(f"Checking last synced for {directory_name}")
@@ -1543,10 +1549,12 @@ def list_remote_reports_performance():
         for rf in remote_performance_folders:
             performance_name = Path(rf.remotePath).name
             remote_data_directory = current_app.config["REMOTE_DATA_DIRECTORY"]
+            # Must match sync_remote_performance_folders / PathResolver:
+            # REMOTE_DATA_DIRECTORY/<host>/performance-reports/<name>
             local_path = (
                 remote_data_directory
-                / current_app.config["PERFORMANCE_DIRECTORY_NAME"]
                 / connection.host
+                / current_app.config["PERFORMANCE_DIRECTORY_NAME"]
                 / performance_name
             )
             logger.info(f"Checking last synced for {performance_name}")
@@ -1560,6 +1568,52 @@ def list_remote_reports_performance():
         )
     except RemoteConnectionException as e:
         return error_response(e.http_status, e.message)
+
+
+@api.route("/remote/local-profiler-reports", methods=["POST"])
+def list_local_remote_reports_profiler():
+    """List profiler reports already synced under REMOTE_DATA_DIRECTORY/<host>/ (no SSH)."""
+    connection_data = request.get_json()
+
+    if not connection_data:
+        return response_bad_request("Missing connection data")
+
+    connection = RemoteConnection.model_validate(connection_data, strict=False)
+    folders = list_local_synced_profiler_folders(
+        connection,
+        Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
+        current_app.config["PROFILER_DIRECTORY_NAME"],
+    )
+    if not folders:
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    return Response(
+        orjson.dumps([folder.model_dump() for folder in folders]),
+        mimetype="application/json",
+    )
+
+
+@api.route("/remote/local-performance-reports", methods=["POST"])
+def list_local_remote_reports_performance():
+    """List performance reports already synced under REMOTE_DATA_DIRECTORY/<host>/ (no SSH)."""
+    connection_data = request.get_json()
+
+    if not connection_data:
+        return response_bad_request("Missing connection data")
+
+    connection = RemoteConnection.model_validate(connection_data, strict=False)
+    folders = list_local_synced_performance_folders(
+        connection,
+        Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
+        current_app.config["PERFORMANCE_DIRECTORY_NAME"],
+    )
+    if not folders:
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    return Response(
+        orjson.dumps([folder.model_dump() for folder in folders]),
+        mimetype="application/json",
+    )
 
 
 @api.route("/cluster-descriptor", methods=["GET"])

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -101,6 +101,10 @@ from ttnn_visualizer.stack_trace_source import (
 from ttnn_visualizer.utils import (
     create_path_resolver,
     get_mlir_path,
+    get_performance_path,
+    get_profiler_path,
+    is_valid_performance_report_dir,
+    is_valid_profiler_report_dir,
     pick_cluster_descriptor_path,
     pick_mesh_descriptor_path,
     pick_profiler_config_paths,
@@ -951,18 +955,12 @@ def get_profiler_data_list(instance: Instance):
 
     for dir_name in directory_names:
         dir_path = Path(path) / dir_name
-        if not dir_path.is_dir():
+        if not dir_path.is_dir() or not is_valid_profiler_report_dir(dir_path):
             continue
-        files = list(dir_path.glob("**/*"))
-        report_name = None
         if pick_profiler_config_paths(dir_path):
             report_name = read_profiler_report_name(dir_path)
         else:
             report_name = dir_path.name
-
-        # Would like to use the existing validate_files function but there's a type difference I'm not sure how to handle
-        if not any(file.name == "db.sqlite" for file in files):
-            continue
 
         valid_dirs.append({"path": dir_path.name, "reportName": report_name})
 
@@ -1069,14 +1067,7 @@ def get_performance_data_list(instance: Instance):
 
     for dir_name in directory_names:
         dir_path = Path(path) / dir_name
-        files = list(dir_path.glob("**/*"))
-
-        # Would like to use the existing validate_files function but there's a type difference I'm not sure how to handle
-        if not any(file.name == "profile_log_device.csv" for file in files):
-            continue
-        if not any(file.name == "tracy_profile_log_host.tracy" for file in files):
-            continue
-        if not any(file.name.startswith("ops_perf_results") for file in files):
+        if not dir_path.is_dir() or not is_valid_performance_report_dir(dir_path):
             continue
 
         valid_dirs.append(
@@ -2069,8 +2060,14 @@ def use_remote_folder():
             profiler,
             strict=False,
         )
+        profiler_name = remote_profiler_folder.remotePath.split("/")[-1]
+        local_db_path = Path(get_profiler_path(profiler_name, current_app, connection))
+        if not is_valid_profiler_report_dir(local_db_path.parent):
+            return response_not_found(
+                "Report is not synced locally. Use Sync to download it first."
+            )
         kwargs["remote_profiler_folder"] = remote_profiler_folder
-        kwargs["profiler_name"] = remote_profiler_folder.remotePath.split("/")[-1]
+        kwargs["profiler_name"] = profiler_name
         kwargs["profiler_location"] = ReportLocation.REMOTE.value
 
     if performance:
@@ -2078,8 +2075,16 @@ def use_remote_folder():
             performance,
             strict=False,
         )
+        performance_name = remote_performance_folder.reportName
+        local_perf_path = Path(
+            get_performance_path(performance_name, current_app, connection)
+        )
+        if not is_valid_performance_report_dir(local_perf_path):
+            return response_not_found(
+                "Report is not synced locally. Use Sync to download it first."
+            )
         kwargs["remote_performance_folder"] = remote_performance_folder
-        kwargs["performance_name"] = remote_performance_folder.reportName
+        kwargs["performance_name"] = performance_name
         kwargs["performance_location"] = ReportLocation.REMOTE.value
 
     update_instance(**kwargs)

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1574,23 +1574,9 @@ def list_remote_reports_performance():
 @local_only
 def list_local_remote_reports_profiler():
     """List profiler reports already synced under REMOTE_DATA_DIRECTORY/<host>/ (no SSH)."""
-    connection_data = request.get_json()
-
-    if not connection_data:
-        return response_bad_request("Missing connection data")
-
-    connection = RemoteConnection.model_validate(connection_data, strict=False)
-    folders = list_local_synced_profiler_folders(
-        connection,
-        Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
-        current_app.config["PROFILER_DIRECTORY_NAME"],
-    )
-    if not folders:
-        return Response(status=HTTPStatus.NO_CONTENT)
-
-    return Response(
-        orjson.dumps([folder.model_dump() for folder in folders]),
-        mimetype="application/json",
+    return _respond_local_synced_folders(
+        list_local_synced_profiler_folders,
+        "PROFILER_DIRECTORY_NAME",
     )
 
 
@@ -1598,16 +1584,23 @@ def list_local_remote_reports_profiler():
 @local_only
 def list_local_remote_reports_performance():
     """List performance reports already synced under REMOTE_DATA_DIRECTORY/<host>/ (no SSH)."""
+    return _respond_local_synced_folders(
+        list_local_synced_performance_folders,
+        "PERFORMANCE_DIRECTORY_NAME",
+    )
+
+
+def _respond_local_synced_folders(list_fn, directory_config_key: str):
     connection_data = request.get_json()
 
     if not connection_data:
         return response_bad_request("Missing connection data")
 
     connection = RemoteConnection.model_validate(connection_data, strict=False)
-    folders = list_local_synced_performance_folders(
+    folders = list_fn(
         connection,
         Path(current_app.config["REMOTE_DATA_DIRECTORY"]),
-        current_app.config["PERFORMANCE_DIRECTORY_NAME"],
+        current_app.config[directory_config_key],
     )
     if not folders:
         return Response(status=HTTPStatus.NO_CONTENT)

--- a/src/components/ReportLinkStatus.tsx
+++ b/src/components/ReportLinkStatus.tsx
@@ -17,7 +17,7 @@ import {
     activeProfilerReportAtom,
     performanceReportLocationAtom,
     profilerReportLocationAtom,
-    successfulReportLinksAtom,
+    reportLinksAtom,
 } from '../store/app';
 
 const ReportLinkStatus = () => {
@@ -28,7 +28,7 @@ const ReportLinkStatus = () => {
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const profilerLocation = useAtomValue(profilerReportLocationAtom);
     const performanceLocation = useAtomValue(performanceReportLocationAtom);
-    const setReportLinks = useSetAtom(successfulReportLinksAtom);
+    const setReportLinks = useSetAtom(reportLinksAtom);
     const { persistentState } = useRemoteConnection();
 
     const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;

--- a/src/components/ReportLinkStatus.tsx
+++ b/src/components/ReportLinkStatus.tsx
@@ -7,7 +7,11 @@ import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
-import { useGetDeviceOperationListPerf } from '../hooks/useAPI';
+import { ReportLocation } from '../definitions/Reports';
+import { ReportLinkMatchResult, ReportPairLinkStatus, getReportId, upsertReportLink } from '../functions/reportLinks';
+import getServerConfig from '../functions/getServerConfig';
+import useRemoteConnection from '../hooks/useRemote';
+import { useReportLinkMatch } from '../hooks/useReportLinkMatch';
 import {
     activePerformanceReportAtom,
     activeProfilerReportAtom,
@@ -15,27 +19,25 @@ import {
     profilerReportLocationAtom,
     successfulReportLinksAtom,
 } from '../store/app';
-import { addReportLink } from '../functions/reportLinks';
-import getServerConfig from '../functions/getServerConfig';
 
 const ReportLinkStatus = () => {
-    const useGetDeviceOperationListPerfResult = useGetDeviceOperationListPerf();
-    const canMatchOperations = useGetDeviceOperationListPerfResult.length > 0;
+    const matchResult = useReportLinkMatch();
+    const isLinked = matchResult === ReportLinkMatchResult.LINKED;
 
     const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
     const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
     const profilerLocation = useAtomValue(profilerReportLocationAtom);
     const performanceLocation = useAtomValue(performanceReportLocationAtom);
     const setReportLinks = useSetAtom(successfulReportLinksAtom);
+    const { persistentState } = useRemoteConnection();
 
     const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
 
-    // Lazily record the active pair whenever it links successfully, so the report
-    // selection lists can later badge known counterparts of the active report.
+    // Persist LINKED / UNLINKED once the live comparison settles so pickers can
+    // badge known counterparts (including failed pairs).
     useEffect(() => {
         if (
             !isReportLinkingEnabled ||
-            !canMatchOperations ||
             !activeProfilerReport ||
             !activePerformanceReport ||
             !profilerLocation ||
@@ -44,26 +46,52 @@ const ReportLinkStatus = () => {
             return;
         }
 
+        if (matchResult !== ReportLinkMatchResult.LINKED && matchResult !== ReportLinkMatchResult.UNLINKED) {
+            return;
+        }
+
+        const profilerId = getReportId(activeProfilerReport.path, activeProfilerReport.reportName);
+        const performanceId = getReportId(activePerformanceReport.path, activePerformanceReport.reportName);
+
+        if (!profilerId || !performanceId) {
+            return;
+        }
+
+        const remoteHost = persistentState.selectedConnection?.host ?? null;
+
         setReportLinks((links) =>
-            addReportLink(links, {
-                profilerPath: activeProfilerReport.path,
-                profilerLocation,
-                performancePath: activePerformanceReport.path,
-                performanceLocation,
+            upsertReportLink(links, {
+                profilerId,
+                performanceId,
+                status:
+                    matchResult === ReportLinkMatchResult.LINKED
+                        ? ReportPairLinkStatus.LINKED
+                        : ReportPairLinkStatus.UNLINKED,
+                recordedAt: Date.now(),
+                profilerAccess: {
+                    location: profilerLocation,
+                    path: activeProfilerReport.path,
+                    host: profilerLocation === ReportLocation.REMOTE ? remoteHost : null,
+                },
+                performanceAccess: {
+                    location: performanceLocation,
+                    path: activePerformanceReport.path,
+                    host: performanceLocation === ReportLocation.REMOTE ? remoteHost : null,
+                },
             }),
         );
     }, [
-        canMatchOperations,
+        matchResult,
         activeProfilerReport,
         activePerformanceReport,
         profilerLocation,
         performanceLocation,
         setReportLinks,
         isReportLinkingEnabled,
+        persistentState.selectedConnection?.host,
     ]);
 
-    // Compute icon and messaging
-    const tooltipContent = canMatchOperations ? (
+    const tooltipContent = isLinked ? (
         'Data linked between memory and performance reports'
     ) : (
         <>
@@ -72,8 +100,6 @@ const ReportLinkStatus = () => {
             Please select reports generated from the same run to see additional data across the visualizer
         </>
     );
-    const icon = canMatchOperations ? IconNames.LINK : IconNames.UNLINK;
-    const intent = canMatchOperations ? Intent.SUCCESS : Intent.NONE;
 
     return (
         <Tooltip
@@ -81,9 +107,9 @@ const ReportLinkStatus = () => {
             position={Position.TOP}
         >
             <Icon
-                className={classNames({ 'no-sync-status-icon': !canMatchOperations })}
-                icon={icon}
-                intent={intent}
+                className={classNames({ 'no-sync-status-icon': !isLinked })}
+                icon={isLinked ? IconNames.LINK : IconNames.UNLINK}
+                intent={isLinked ? Intent.SUCCESS : Intent.NONE}
             />
         </Tooltip>
     );

--- a/src/components/report-selection/FolderLinkStatusIcon.tsx
+++ b/src/components/report-selection/FolderLinkStatusIcon.tsx
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Icon, Position, Tooltip } from '@blueprintjs/core';
+import { FOLDER_LINK_STATUS, FolderLinkState } from '../../definitions/FolderLinkStatus';
+
+interface FolderLinkStatusIconProps {
+    linkState: FolderLinkState;
+}
+
+const FolderLinkStatusIcon = ({ linkState }: FolderLinkStatusIconProps) => {
+    const linkStatus = FOLDER_LINK_STATUS[linkState];
+
+    return (
+        <Tooltip
+            content={linkStatus.tooltip}
+            position={Position.RIGHT}
+        >
+            <Icon
+                className={linkState === FolderLinkState.UNKNOWN ? 'folder-link-status-unknown' : undefined}
+                icon={linkStatus.icon}
+                intent={linkStatus.intent}
+            />
+        </Tooltip>
+    );
+};
+
+export default FolderLinkStatusIcon;

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -3,14 +3,17 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { useMemo, useState } from 'react';
-import { Alert, Button, ButtonVariant, Icon, Intent, MenuItem, Position, Tooltip } from '@blueprintjs/core';
+import { Alert, Button, ButtonVariant, Intent, MenuItem, Position, Tooltip } from '@blueprintjs/core';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { useInstance } from '../../hooks/useAPI';
 import 'styles/components/FolderPicker.scss';
+import { compareByFolderLinkState, getFolderLinkState } from '../../definitions/FolderLinkStatus';
 import { ReportFolder } from '../../definitions/Reports';
 import getServerConfig from '../../functions/getServerConfig';
+import { getReportId } from '../../functions/reportLinks';
 import HighlightedText from '../HighlightedText';
+import FolderLinkStatusIcon from './FolderLinkStatusIcon';
 
 interface LocalFolderPickerProps {
     items: ReportFolder[];
@@ -20,8 +23,10 @@ interface LocalFolderPickerProps {
     defaultLabel?: string;
     valueLabel?: string | null;
     showReportName?: boolean;
-    /** Paths of items previously observed to link with the active counterpart report. */
-    linkedPaths?: Set<string>;
+    /** Canonical ids previously observed to link with the active counterpart. */
+    linkedIds?: Set<string>;
+    /** Canonical ids previously observed to fail linking with the active counterpart. */
+    unlinkedIds?: Set<string>;
 }
 
 const LocalFolderPicker = ({
@@ -32,7 +37,8 @@ const LocalFolderPicker = ({
     defaultLabel = 'Select a report...',
     valueLabel,
     showReportName,
-    linkedPaths,
+    linkedIds,
+    unlinkedIds,
 }: LocalFolderPickerProps) => {
     const { data: instance } = useInstance();
 
@@ -42,23 +48,30 @@ const LocalFolderPicker = ({
     const activePath = value;
     const activeName = value ? (valueLabel ?? value) : null;
     const isDeleteDisabled = getServerConfig()?.SERVER_MODE;
+    const showLinkStatus = linkedIds !== undefined || unlinkedIds !== undefined;
 
-    // Surface reports that linked with the active counterpart first, preserving the
-    // server-provided order (most-recently-modified) within each group.
+    // Linked first, unknown next, failed links last — preserve server order within each group.
     const sortedItems = useMemo(() => {
-        if (!items || !linkedPaths?.size) {
+        if (!items || (!linkedIds?.size && !unlinkedIds?.size)) {
             return items ?? [];
         }
 
-        return [...items].sort((a, b) => Number(linkedPaths.has(b.path)) - Number(linkedPaths.has(a.path)));
-    }, [items, linkedPaths]);
+        return [...items].sort((a, b) =>
+            compareByFolderLinkState(
+                getReportId(a.path, a.reportName),
+                getReportId(b.path, b.reportName),
+                linkedIds,
+                unlinkedIds,
+            ),
+        );
+    }, [items, linkedIds, unlinkedIds]);
 
     const renderItem: ItemRenderer<ReportFolder> = (folder, { handleClick, handleFocus, modifiers, query }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
 
-        const isLinked = linkedPaths?.has(folder.path) ?? false;
+        const folderId = getReportId(folder.path, folder.reportName);
 
         return (
             <div
@@ -82,16 +95,8 @@ const LocalFolderPicker = ({
                     onFocus={handleFocus}
                     icon={folder.path === activePath ? IconNames.SAVED : IconNames.DOCUMENT}
                     labelElement={
-                        isLinked ? (
-                            <Tooltip
-                                content='Previously linked with the active report'
-                                position={Position.RIGHT}
-                            >
-                                <Icon
-                                    icon={IconNames.LINK}
-                                    intent={Intent.SUCCESS}
-                                />
-                            </Tooltip>
+                        showLinkStatus ? (
+                            <FolderLinkStatusIcon linkState={getFolderLinkState(folderId, linkedIds, unlinkedIds)} />
                         ) : undefined
                     }
                 />

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -8,7 +8,11 @@ import { ItemRenderer, Select } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { useInstance } from '../../hooks/useAPI';
 import 'styles/components/FolderPicker.scss';
-import { compareByFolderLinkState, getFolderLinkState } from '../../definitions/FolderLinkStatus';
+import {
+    getFolderLinkState,
+    shouldShowFolderLinkStatus,
+    sortByFolderLinkState,
+} from '../../definitions/FolderLinkStatus';
 import { ReportFolder } from '../../definitions/Reports';
 import getServerConfig from '../../functions/getServerConfig';
 import { getReportId } from '../../functions/reportLinks';
@@ -23,10 +27,12 @@ interface LocalFolderPickerProps {
     defaultLabel?: string;
     valueLabel?: string | null;
     showReportName?: boolean;
+    /** When true, the picker cannot open or change selection. */
+    disabled?: boolean;
     /** Canonical ids previously observed to link with the active counterpart. */
-    linkedIds?: Set<string>;
+    linkedIds?: Set<string> | null;
     /** Canonical ids previously observed to fail linking with the active counterpart. */
-    unlinkedIds?: Set<string>;
+    unlinkedIds?: Set<string> | null;
 }
 
 const LocalFolderPicker = ({
@@ -37,6 +43,7 @@ const LocalFolderPicker = ({
     defaultLabel = 'Select a report...',
     valueLabel,
     showReportName,
+    disabled = false,
     linkedIds,
     unlinkedIds,
 }: LocalFolderPickerProps) => {
@@ -44,27 +51,23 @@ const LocalFolderPicker = ({
 
     const [folderToDelete, setFolderToDelete] = useState<ReportFolder | null>(null);
 
-    const isDisabled = !items || items.length === 0;
+    const isDisabled = disabled || !items || items.length === 0 || !instance;
     const activePath = value;
     const activeName = value ? (valueLabel ?? value) : null;
     const isDeleteDisabled = getServerConfig()?.SERVER_MODE;
-    const showLinkStatus = linkedIds !== undefined || unlinkedIds !== undefined;
+    const showLinkStatus = shouldShowFolderLinkStatus(linkedIds, unlinkedIds);
 
     // Linked first, unknown next, failed links last — preserve server order within each group.
-    const sortedItems = useMemo(() => {
-        if (!items || (!linkedIds?.size && !unlinkedIds?.size)) {
-            return items ?? [];
-        }
-
-        return [...items].sort((a, b) =>
-            compareByFolderLinkState(
-                getReportId(a.path, a.reportName),
-                getReportId(b.path, b.reportName),
+    const sortedItems = useMemo(
+        () =>
+            sortByFolderLinkState(
+                items ?? [],
+                (folder) => getReportId(folder.path, folder.reportName),
                 linkedIds,
                 unlinkedIds,
             ),
-        );
-    }, [items, linkedIds, unlinkedIds]);
+        [items, linkedIds, unlinkedIds],
+    );
 
     const renderItem: ItemRenderer<ReportFolder> = (folder, { handleClick, handleFocus, modifiers, query }) => {
         if (!modifiers.matchesPredicate) {
@@ -151,7 +154,7 @@ const LocalFolderPicker = ({
                 />
             }
             onItemSelect={handleSelect}
-            disabled={!items || !instance}
+            disabled={isDisabled}
         >
             <Tooltip
                 content={`/${activePath}`}
@@ -162,7 +165,7 @@ const LocalFolderPicker = ({
                 <Button
                     className='folder-picker-button'
                     text={activeName || defaultLabel}
-                    disabled={isDisabled || !instance}
+                    disabled={isDisabled}
                     alignText='start'
                     icon={IconNames.DOCUMENT_OPEN}
                     endIcon={IconNames.CARET_DOWN}

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -7,22 +7,14 @@ import { IconNames } from '@blueprintjs/icons';
 import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import useLocalConnection from '../../hooks/useLocal';
 import {
     activePerformanceReportAtom,
     activeProfilerReportAtom,
     performanceReportLocationAtom,
     profilerReportLocationAtom,
-    successfulReportLinksAtom,
 } from '../../store/app';
-import {
-    getReportId,
-    linkedPerformanceIds,
-    linkedProfilerIds,
-    unlinkedPerformanceIds,
-    unlinkedProfilerIds,
-} from '../../functions/reportLinks';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
 import getResponseError from '../../functions/getResponseError';
@@ -37,6 +29,7 @@ import {
     useReportFolderList,
     useReportMetadata,
 } from '../../hooks/useAPI';
+import { useReportLinkBadgeIds } from '../../hooks/useReportLinkBadgeIds';
 import LocalFolderPicker from './LocalFolderPicker';
 import { ReportFolder, ReportLocation } from '../../definitions/Reports';
 import {
@@ -144,53 +137,9 @@ const LocalFolderOptions = () => {
         [activePerformanceReport, perfFolderList, isPerformanceLocal],
     );
 
-    const reportLinks = useAtomValue(successfulReportLinksAtom);
-
     const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
-    const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
-
-    // Performance reports that have linked / failed to link with the active memory report
-    // (and vice versa). Empty Sets still enable UNKNOWN badges when the feature is on.
-    const linkedPerfIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? linkedPerformanceIds(
-                      reportLinks,
-                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
-                  )
-                : undefined,
-        [reportLinks, activeProfilerReport, isReportLinkingEnabled],
-    );
-    const unlinkedPerfIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? unlinkedPerformanceIds(
-                      reportLinks,
-                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
-                  )
-                : undefined,
-        [reportLinks, activeProfilerReport, isReportLinkingEnabled],
-    );
-    const linkedProfilerReportIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? linkedProfilerIds(
-                      reportLinks,
-                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
-                  )
-                : undefined,
-        [reportLinks, activePerformanceReport, isReportLinkingEnabled],
-    );
-    const unlinkedProfilerReportIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? unlinkedProfilerIds(
-                      reportLinks,
-                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
-                  )
-                : undefined,
-        [reportLinks, activePerformanceReport, isReportLinkingEnabled],
-    );
+    const { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds } =
+        useReportLinkBadgeIds();
 
     const handleReportDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
         if (!e.target.files) {

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -16,7 +16,13 @@ import {
     profilerReportLocationAtom,
     successfulReportLinksAtom,
 } from '../../store/app';
-import { linkedPerformancePaths, linkedProfilerPaths } from '../../functions/reportLinks';
+import {
+    getReportId,
+    linkedPerformanceIds,
+    linkedProfilerIds,
+    unlinkedPerformanceIds,
+    unlinkedProfilerIds,
+} from '../../functions/reportLinks';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
 import getResponseError from '../../functions/getResponseError';
@@ -143,21 +149,47 @@ const LocalFolderOptions = () => {
     const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
     const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
 
-    // Performance reports that have linked with the active memory report (and vice versa).
-    // Experimental: only surfaced in development builds.
-    const linkedPerfPaths = useMemo(
+    // Performance reports that have linked / failed to link with the active memory report
+    // (and vice versa). Empty Sets still enable UNKNOWN badges when the feature is on.
+    const linkedPerfIds = useMemo(
         () =>
             isReportLinkingEnabled
-                ? linkedPerformancePaths(reportLinks, activeProfilerReport?.path, profilerReportLocation)
+                ? linkedPerformanceIds(
+                      reportLinks,
+                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
+                  )
                 : undefined,
-        [reportLinks, activeProfilerReport, profilerReportLocation, isReportLinkingEnabled],
+        [reportLinks, activeProfilerReport, isReportLinkingEnabled],
     );
-    const linkedProfilerReportPaths = useMemo(
+    const unlinkedPerfIds = useMemo(
         () =>
             isReportLinkingEnabled
-                ? linkedProfilerPaths(reportLinks, activePerformanceReport?.path, performanceReportLocation)
+                ? unlinkedPerformanceIds(
+                      reportLinks,
+                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
+                  )
                 : undefined,
-        [reportLinks, activePerformanceReport, performanceReportLocation, isReportLinkingEnabled],
+        [reportLinks, activeProfilerReport, isReportLinkingEnabled],
+    );
+    const linkedProfilerReportIds = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? linkedProfilerIds(
+                      reportLinks,
+                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
+                  )
+                : undefined,
+        [reportLinks, activePerformanceReport, isReportLinkingEnabled],
+    );
+    const unlinkedProfilerReportIds = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? unlinkedProfilerIds(
+                      reportLinks,
+                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
+                  )
+                : undefined,
+        [reportLinks, activePerformanceReport, isReportLinkingEnabled],
     );
 
     const handleReportDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -307,7 +339,8 @@ const LocalFolderOptions = () => {
                     valueLabel={activeProfilerReport?.reportName ?? null}
                     handleSelect={handleSelectProfiler}
                     handleDelete={handleDeleteProfiler}
-                    linkedPaths={linkedProfilerReportPaths}
+                    linkedIds={linkedProfilerReportIds}
+                    unlinkedIds={unlinkedProfilerReportIds}
                     showReportName
                 />
             </FormGroup>
@@ -356,7 +389,8 @@ const LocalFolderOptions = () => {
                     valueLabel={activePerformanceReport?.reportName ?? null}
                     handleSelect={handleSelectPerformance}
                     handleDelete={handleDeletePerformance}
-                    linkedPaths={linkedPerfPaths}
+                    linkedIds={linkedPerfIds}
+                    unlinkedIds={unlinkedPerfIds}
                 />
             </FormGroup>
 

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -16,6 +16,10 @@ import {
     profilerReportLocationAtom,
 } from '../../store/app';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
+import {
+    ACTIVE_MEMORY_REPORT_TOAST_TITLE,
+    ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE,
+} from '../../definitions/notifyActiveReport';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
 import getResponseError from '../../functions/getResponseError';
 import getServerConfig from '../../functions/getServerConfig';
@@ -29,6 +33,7 @@ import {
     useReportFolderList,
     useReportMetadata,
 } from '../../hooks/useAPI';
+import { useActivatingReport } from '../../hooks/useActivatingReport';
 import { useReportLinkBadgeIds } from '../../hooks/useReportLinkBadgeIds';
 import LocalFolderPicker from './LocalFolderPicker';
 import { ReportFolder, ReportLocation } from '../../definitions/Reports';
@@ -82,6 +87,7 @@ const LocalFolderOptions = () => {
     const [performanceReportLocation, setPerformanceReportLocation] = useAtom(performanceReportLocationAtom);
     const [activeProfilerReport, setActiveProfilerReport] = useAtom(activeProfilerReportAtom);
     const [activePerformanceReport, setActivePerformanceReport] = useAtom(activePerformanceReportAtom);
+    const { isActivatingReport, withActivatingReport } = useActivatingReport();
 
     const {
         uploadLocalFolder,
@@ -173,7 +179,7 @@ const LocalFolderOptions = () => {
             };
 
             setActiveProfilerReport(updatedReport);
-            createToastNotification('Active memory report', updatedReport.reportName, ToastType.SUCCESS);
+            createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, updatedReport.reportName, ToastType.SUCCESS);
             setProfilerReportLocation(ReportLocation.LOCAL);
             setProfilerFolder(connectionOkStatus);
         } catch (err: unknown) {
@@ -211,7 +217,7 @@ const LocalFolderOptions = () => {
                 setPerformanceDataUploadLabel(`${files.length} files uploaded`);
                 setPerformanceReportLocation(ReportLocation.LOCAL);
                 setActivePerformanceReport({ path: fileName, reportName: fileName });
-                createToastNotification('Active performance report', fileName, ToastType.SUCCESS);
+                createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, fileName, ToastType.SUCCESS);
                 setPerformanceFolder(connectionOkStatus);
             }
         } catch (err: unknown) {
@@ -224,18 +230,20 @@ const LocalFolderOptions = () => {
     };
 
     const handleSelectProfiler = async (folder: ReportFolder) => {
-        // Backend handles updating only the specific parts of active_report
-        await updateInstance({
-            active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
+        await withActivatingReport(async () => {
+            // Backend handles updating only the specific parts of active_report
+            await updateInstance({
+                active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
+            });
+
+            if (hasBeenNormalised(folder)) {
+                createDataIntegrityWarning(folder);
+            }
+
+            createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, folder.reportName ?? '', ToastType.SUCCESS);
+            setActiveProfilerReport(folder);
+            setProfilerReportLocation(ReportLocation.LOCAL);
         });
-
-        if (hasBeenNormalised(folder)) {
-            createDataIntegrityWarning(folder);
-        }
-
-        createToastNotification('Active memory report', folder.reportName ?? '', ToastType.SUCCESS);
-        setActiveProfilerReport(folder);
-        setProfilerReportLocation(ReportLocation.LOCAL);
     };
 
     const handleDeleteProfiler = async (folder: ReportFolder) => {
@@ -252,14 +260,16 @@ const LocalFolderOptions = () => {
     };
 
     const handleSelectPerformance = async (folder: ReportFolder) => {
-        // Backend handles updating only the specific parts of active_report
-        await updateInstance({
-            active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },
-        });
+        await withActivatingReport(async () => {
+            // Backend handles updating only the specific parts of active_report
+            await updateInstance({
+                active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },
+            });
 
-        createToastNotification('Active performance report', folder.reportName, ToastType.SUCCESS);
-        setActivePerformanceReport(folder);
-        setPerformanceReportLocation(ReportLocation.LOCAL);
+            createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
+            setActivePerformanceReport(folder);
+            setPerformanceReportLocation(ReportLocation.LOCAL);
+        });
     };
 
     const handleDeletePerformance = async (folder: ReportFolder) => {
@@ -288,6 +298,7 @@ const LocalFolderOptions = () => {
                     valueLabel={activeProfilerReport?.reportName ?? null}
                     handleSelect={handleSelectProfiler}
                     handleDelete={handleDeleteProfiler}
+                    disabled={isActivatingReport}
                     linkedIds={linkedProfilerReportIds}
                     unlinkedIds={unlinkedProfilerReportIds}
                     showReportName
@@ -338,6 +349,7 @@ const LocalFolderOptions = () => {
                     valueLabel={activePerformanceReport?.reportName ?? null}
                     handleSelect={handleSelectPerformance}
                     handleDelete={handleDeletePerformance}
+                    disabled={isActivatingReport}
                     linkedIds={linkedPerfIds}
                     unlinkedIds={unlinkedPerfIds}
                 />

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -7,7 +7,11 @@ import { IconName, IconNames } from '@blueprintjs/icons';
 import { type ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
 import { type ReactNode, useMemo } from 'react';
 import 'styles/components/FolderPicker.scss';
-import { compareByFolderLinkState, getFolderLinkState } from '../../definitions/FolderLinkStatus';
+import {
+    getFolderLinkState,
+    shouldShowFolderLinkStatus,
+    sortByFolderLinkState,
+} from '../../definitions/FolderLinkStatus';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { TEST_IDS } from '../../definitions/TestIds';
 import { getReportId } from '../../functions/reportLinks';
@@ -23,8 +27,8 @@ interface RemoteFolderRendererOptions {
     connection?: RemoteConnection;
     showReportName?: boolean;
     showLinkStatus?: boolean;
-    linkedIds?: Set<string>;
-    unlinkedIds?: Set<string>;
+    linkedIds?: Set<string> | null;
+    unlinkedIds?: Set<string> | null;
 }
 
 const remoteFolderRenderer =
@@ -84,8 +88,8 @@ interface RemoteFolderSelectorProps {
     onSelectFolder: (folder: RemoteFolder) => void;
     type: FolderTypes;
     showReportName?: boolean;
-    linkedIds?: Set<string>;
-    unlinkedIds?: Set<string>;
+    linkedIds?: Set<string> | null;
+    unlinkedIds?: Set<string> | null;
     children?: ReactNode;
 }
 
@@ -105,24 +109,20 @@ const RemoteFolderSelector = ({
 }: RemoteFolderSelectorProps) => {
     const { persistentState } = useRemoteConnection();
     const remoteConnection = persistentState.selectedConnection;
-    const showLinkStatus = linkedIds !== undefined || unlinkedIds !== undefined;
+    const showLinkStatus = shouldShowFolderLinkStatus(linkedIds, unlinkedIds);
 
     const isDisabled = loading || remoteFolderList?.length === 0 || disabled;
 
-    const sortedFolderList = useMemo(() => {
-        if (!linkedIds?.size && !unlinkedIds?.size) {
-            return remoteFolderList ?? [];
-        }
-
-        return [...(remoteFolderList ?? [])].sort((a, b) =>
-            compareByFolderLinkState(
-                getReportId(a.remotePath, a.reportName),
-                getReportId(b.remotePath, b.reportName),
+    const sortedFolderList = useMemo(
+        () =>
+            sortByFolderLinkState(
+                remoteFolderList ?? [],
+                (folder) => getReportId(folder.remotePath, folder.reportName),
                 linkedIds,
                 unlinkedIds,
             ),
-        );
-    }, [remoteFolderList, linkedIds, unlinkedIds]);
+        [remoteFolderList, linkedIds, unlinkedIds],
+    );
 
     return (
         <div className='form-container'>

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -43,7 +43,7 @@ const remoteFolderRenderer =
         }
 
         const { lastSynced, lastModified, reportName, remotePath } = folder;
-        const folderId = getReportId(reportName, remotePath);
+        const folderId = getReportId(remotePath, reportName);
 
         return (
             <div
@@ -116,8 +116,8 @@ const RemoteFolderSelector = ({
 
         return [...(remoteFolderList ?? [])].sort((a, b) =>
             compareByFolderLinkState(
-                getReportId(a.reportName, a.remotePath),
-                getReportId(b.reportName, b.remotePath),
+                getReportId(a.remotePath, a.reportName),
+                getReportId(b.remotePath, b.reportName),
                 linkedIds,
                 unlinkedIds,
             ),

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -2,61 +2,48 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Button, Icon, Intent, MenuItem, PopoverPosition, Tooltip } from '@blueprintjs/core';
+import { Button, MenuItem } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import { type ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import 'styles/components/FolderPicker.scss';
-import {
-    NEVER_SYNCED_LABEL,
-    REPORT_OUTDATED_LABEL,
-    REPORT_UP_TO_DATE_LABEL,
-    RemoteConnection,
-    RemoteFolder,
-    SYNC_DATE_FORMATTER,
-    getUTCFromEpoch,
-} from '../../definitions/RemoteConnection';
+import { compareByFolderLinkState, getFolderLinkState } from '../../definitions/FolderLinkStatus';
+import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { TEST_IDS } from '../../definitions/TestIds';
-import isRemoteFolderOutdated from '../../functions/isRemoteFolderOutdated';
+import { getReportId } from '../../functions/reportLinks';
 import useRemoteConnection from '../../hooks/useRemote';
 import HighlightedText from '../HighlightedText';
+import FolderLinkStatusIcon from './FolderLinkStatusIcon';
 
 type FolderTypes = 'performance' | 'profiler';
 
+interface RemoteFolderRendererOptions {
+    type: FolderTypes;
+    selectedFolder?: RemoteFolder;
+    connection?: RemoteConnection;
+    showReportName?: boolean;
+    showLinkStatus?: boolean;
+    linkedIds?: Set<string>;
+    unlinkedIds?: Set<string>;
+}
+
 const remoteFolderRenderer =
-    (
-        type: FolderTypes,
-        selectedFolder?: RemoteFolder,
-        connection?: RemoteConnection,
-        showReportName?: boolean,
-    ): ItemRenderer<RemoteFolder> =>
+    ({
+        type,
+        selectedFolder,
+        connection,
+        showReportName,
+        showLinkStatus,
+        linkedIds,
+        unlinkedIds,
+    }: RemoteFolderRendererOptions): ItemRenderer<RemoteFolder> =>
     (folder, { handleClick, modifiers, query }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
 
         const { lastSynced, lastModified, reportName, remotePath } = folder;
-        const isReportOutdated = isRemoteFolderOutdated(folder);
-
-        const statusIcon = (
-            <Tooltip
-                content={
-                    <>
-                        {isReportOutdated ? REPORT_OUTDATED_LABEL : REPORT_UP_TO_DATE_LABEL}
-                        <br />
-                        <strong>
-                            {lastSynced ? SYNC_DATE_FORMATTER.format(getUTCFromEpoch(lastSynced)) : NEVER_SYNCED_LABEL}
-                        </strong>
-                    </>
-                }
-                placement={PopoverPosition.TOP}
-            >
-                <Icon
-                    icon={isReportOutdated ? IconNames.UPDATED : IconNames.HISTORY}
-                    intent={isReportOutdated ? Intent.WARNING : Intent.SUCCESS}
-                />
-            </Tooltip>
-        );
+        const folderId = getReportId(reportName, remotePath);
 
         return (
             <div
@@ -77,7 +64,11 @@ const remoteFolderRenderer =
                         </>
                     }
                     icon={selectedFolder?.remotePath === remotePath ? IconNames.SAVED : IconNames.DOCUMENT}
-                    labelElement={<span className='status-icon'>{statusIcon}</span>}
+                    labelElement={
+                        showLinkStatus ? (
+                            <FolderLinkStatusIcon linkState={getFolderLinkState(folderId, linkedIds, unlinkedIds)} />
+                        ) : undefined
+                    }
                 />
             </div>
         );
@@ -93,6 +84,8 @@ interface RemoteFolderSelectorProps {
     onSelectFolder: (folder: RemoteFolder) => void;
     type: FolderTypes;
     showReportName?: boolean;
+    linkedIds?: Set<string>;
+    unlinkedIds?: Set<string>;
     children?: ReactNode;
 }
 
@@ -107,18 +100,44 @@ const RemoteFolderSelector = ({
     icon = IconNames.DOCUMENT_OPEN,
     type,
     showReportName,
+    linkedIds,
+    unlinkedIds,
 }: RemoteFolderSelectorProps) => {
     const { persistentState } = useRemoteConnection();
     const remoteConnection = persistentState.selectedConnection;
+    const showLinkStatus = linkedIds !== undefined || unlinkedIds !== undefined;
 
     const isDisabled = loading || remoteFolderList?.length === 0 || disabled;
+
+    const sortedFolderList = useMemo(() => {
+        if (!linkedIds?.size && !unlinkedIds?.size) {
+            return remoteFolderList ?? [];
+        }
+
+        return [...(remoteFolderList ?? [])].sort((a, b) =>
+            compareByFolderLinkState(
+                getReportId(a.reportName, a.remotePath),
+                getReportId(b.reportName, b.remotePath),
+                linkedIds,
+                unlinkedIds,
+            ),
+        );
+    }, [remoteFolderList, linkedIds, unlinkedIds]);
 
     return (
         <div className='form-container'>
             <Select
                 className='remote-select'
-                items={remoteFolderList ?? []}
-                itemRenderer={remoteFolderRenderer(type, remoteFolder, remoteConnection, showReportName)}
+                items={sortedFolderList}
+                itemRenderer={remoteFolderRenderer({
+                    type,
+                    selectedFolder: remoteFolder,
+                    connection: remoteConnection,
+                    showReportName,
+                    showLinkStatus,
+                    linkedIds,
+                    unlinkedIds,
+                })}
                 filterable
                 itemPredicate={filterFolders(type, remoteConnection)}
                 noResults={
@@ -133,7 +152,7 @@ const RemoteFolderSelector = ({
             >
                 <Button
                     icon={icon}
-                    endIcon={remoteFolderList?.length > 0 ? IconNames.CARET_DOWN : undefined}
+                    endIcon={sortedFolderList.length > 0 ? IconNames.CARET_DOWN : undefined}
                     disabled={isDisabled}
                     text={remoteFolder?.reportName ?? fallbackLabel}
                     data-testid={TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON}

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -387,109 +387,124 @@ const RemoteSyncConfigurator = () => {
         notifyFolderSyncError(err);
     };
 
-    const syncSelectedReportFolder = async (folder?: RemoteFolder) => {
-        const selectedReport = folder ?? selectedReportFolder;
-
+    const syncSelectedFolder = async ({
+        selected,
+        setSyncing,
+        sync,
+        getSaved,
+        updateSaved,
+        mount,
+        activateWithToast,
+        applySelection,
+    }: {
+        selected: RemoteFolder | undefined;
+        setSyncing: (syncing: boolean) => void;
+        sync: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse<RemoteFolder>>;
+        getSaved: (connection: RemoteConnection) => RemoteFolder[];
+        updateSaved: (connection: RemoteConnection, folders: RemoteFolder[]) => RemoteFolder[];
+        mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
+        activateWithToast: (folder: RemoteFolder) => void;
+        applySelection: (folder: RemoteFolder) => void;
+    }) => {
         try {
-            setIsSyncingReportFolder(true);
+            setSyncing(true);
 
-            if (remote.persistentState.selectedConnection) {
-                const { data: updatedFolder } = await remote.syncRemoteFolder(
-                    remote.persistentState.selectedConnection,
-                    selectedReport,
-                );
+            const connection = remote.persistentState.selectedConnection;
+            if (!connection || !selected) {
+                return;
+            }
 
-                if (hasBeenNormalised(updatedFolder)) {
-                    createDataIntegrityWarning(updatedFolder);
-                }
+            const { data: updatedFolder } = await sync(connection, selected);
 
-                const savedRemoteFolders = remote.persistentState.getSavedReportFolders(
-                    remote.persistentState.selectedConnection,
-                );
+            if (hasBeenNormalised(updatedFolder)) {
+                createDataIntegrityWarning(updatedFolder);
+            }
 
-                const updatedFolders = savedRemoteFolders.map((f) =>
-                    f.remotePath === updatedFolder?.remotePath ? updatedFolder : f,
-                );
+            const updatedFolders = getSaved(connection).map((f) =>
+                f.remotePath === updatedFolder?.remotePath ? updatedFolder : f,
+            );
 
-                updateSavedReportFolders(remote.persistentState.selectedConnection, updatedFolders);
+            updateSaved(connection, updatedFolders);
 
-                if (selectedReport) {
-                    const mountResponse = await remote.mountRemoteFolder(
-                        remote.persistentState.selectedConnection,
-                        updatedFolder,
-                    );
+            if (updatedFolder) {
+                const mountResponse = await mount(connection, updatedFolder);
 
-                    if (mountResponse.status === HttpStatusCode.Ok) {
-                        updateReportSelection(updatedFolder);
-                    }
+                if (mountResponse.status === HttpStatusCode.Ok) {
+                    activateWithToast(updatedFolder);
                 }
             }
         } catch (err: unknown) {
-            await handleSyncFailure(err, selectedReport, (report, syncErr) =>
+            await handleSyncFailure(err, selected, (report, syncErr) =>
                 mountLocalFolderOnSyncFailure(
                     report,
                     syncErr,
-                    (connection) => remote.mountRemoteFolder(connection, report),
-                    applyProfilerReportSelection,
+                    (connection) => mount(connection, report),
+                    applySelection,
                 ),
             );
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
-            setIsSyncingReportFolder(false);
+            setSyncing(false);
         }
     };
 
-    const syncSelectedPerfReportFolder = async (folder?: RemoteFolder) => {
-        const selectedReport = folder ?? selectedPerformanceFolder;
+    const syncSelectedReportFolder = (folder?: RemoteFolder) =>
+        syncSelectedFolder({
+            selected: folder ?? selectedReportFolder,
+            setSyncing: setIsSyncingReportFolder,
+            sync: (connection, report) => remote.syncRemoteFolder(connection, report),
+            getSaved: remote.persistentState.getSavedReportFolders,
+            updateSaved: updateSavedReportFolders,
+            mount: (connection, report) => remote.mountRemoteFolder(connection, report),
+            activateWithToast: updateReportSelection,
+            applySelection: applyProfilerReportSelection,
+        });
+
+    const syncSelectedPerfReportFolder = (folder?: RemoteFolder) =>
+        syncSelectedFolder({
+            selected: folder ?? selectedPerformanceFolder,
+            setSyncing: setIsSyncingPerformanceFolder,
+            sync: (connection, report) => remote.syncRemoteFolder(connection, undefined, report),
+            getSaved: remote.persistentState.getSavedPerformanceFolders,
+            updateSaved: updateSavedPerformanceFolders,
+            mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
+            activateWithToast: updatePerformanceSelection,
+            applySelection: applyPerformanceReportSelection,
+        });
+
+    const mountAndActivateFolder = async (
+        folder: RemoteFolder,
+        {
+            setSelected,
+            mount,
+            activateWithToast,
+        }: {
+            setSelected: (folder: RemoteFolder) => void;
+            mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
+            activateWithToast: (folder: RemoteFolder) => void;
+        },
+    ) => {
+        // Mount the local copy only — never SSH-sync on select so offline /
+        // unreachable hosts still load previously synced reports. Refresh via Sync.
+        const connection = remote.persistentState.selectedConnection;
+        if (!connection) {
+            return;
+        }
+
+        setSelected(folder);
 
         try {
-            setIsSyncingPerformanceFolder(true);
+            const response = await mount(connection, folder);
 
-            if (remote.persistentState.selectedConnection) {
-                const { data: updatedFolder } = await remote.syncRemoteFolder(
-                    remote.persistentState.selectedConnection,
-                    undefined,
-                    selectedReport,
-                );
+            if (response.status === HttpStatusCode.Ok) {
+                activateWithToast(folder);
 
-                if (hasBeenNormalised(updatedFolder)) {
-                    createDataIntegrityWarning(updatedFolder);
-                }
-
-                const savedRemoteFolders = remote.persistentState.getSavedPerformanceFolders(
-                    remote.persistentState.selectedConnection,
-                );
-
-                const updatedFolders = savedRemoteFolders.map((f) =>
-                    f.remotePath === updatedFolder?.remotePath ? updatedFolder : f,
-                );
-
-                updateSavedPerformanceFolders(remote.persistentState.selectedConnection, updatedFolders);
-
-                if (updatedFolder) {
-                    const mountResponse = await remote.mountRemoteFolder(
-                        remote.persistentState.selectedConnection,
-                        undefined,
-                        updatedFolder,
-                    );
-
-                    if (mountResponse.status === HttpStatusCode.Ok) {
-                        updatePerformanceSelection(updatedFolder);
-                    }
+                if (hasBeenNormalised(folder)) {
+                    createDataIntegrityWarning(folder);
                 }
             }
         } catch (err: unknown) {
-            await handleSyncFailure(err, selectedReport, (report, syncErr) =>
-                mountLocalFolderOnSyncFailure(
-                    report,
-                    syncErr,
-                    (connection) => remote.mountRemoteFolder(connection, undefined, report),
-                    applyPerformanceReportSelection,
-                ),
-            );
-        } finally {
-            // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
-            setIsSyncingPerformanceFolder(false);
+            notifyRemoteFolderMountError(err);
         }
     };
 
@@ -629,30 +644,13 @@ const RemoteSyncConfigurator = () => {
                     remoteFolderList={reportFolderList}
                     loading={isLoading || isFetching}
                     disabled={isDisabled}
-                    onSelectFolder={async (folder) => {
-                        // Mount the local copy only — never SSH-sync on select so offline /
-                        // unreachable hosts still load previously synced reports. Refresh via Sync.
-                        if (remote.persistentState.selectedConnection) {
-                            setSelectedReportFolder(folder);
-
-                            try {
-                                const response = await remote.mountRemoteFolder(
-                                    remote.persistentState.selectedConnection,
-                                    folder,
-                                );
-
-                                if (response.status === HttpStatusCode.Ok) {
-                                    updateReportSelection(folder);
-
-                                    if (hasBeenNormalised(folder)) {
-                                        createDataIntegrityWarning(folder);
-                                    }
-                                }
-                            } catch (err: unknown) {
-                                notifyRemoteFolderMountError(err);
-                            }
-                        }
-                    }}
+                    onSelectFolder={(folder) =>
+                        mountAndActivateFolder(folder, {
+                            setSelected: setSelectedReportFolder,
+                            mount: (connection, report) => remote.mountRemoteFolder(connection, report),
+                            activateWithToast: updateReportSelection,
+                        })
+                    }
                     type='profiler'
                     showReportName
                 >
@@ -678,31 +676,13 @@ const RemoteSyncConfigurator = () => {
                     remoteFolderList={remotePerformanceFolderList}
                     loading={isLoading || isFetching}
                     disabled={isDisabled}
-                    onSelectFolder={async (folder) => {
-                        // Mount the local copy only — never SSH-sync on select so offline /
-                        // unreachable hosts still load previously synced reports. Refresh via Sync.
-                        if (remote.persistentState.selectedConnection) {
-                            setSelectedPerformanceFolder(folder);
-
-                            try {
-                                const response = await remote.mountRemoteFolder(
-                                    remote.persistentState.selectedConnection,
-                                    undefined,
-                                    folder,
-                                );
-
-                                if (response.status === HttpStatusCode.Ok) {
-                                    updatePerformanceSelection(folder);
-
-                                    if (hasBeenNormalised(folder)) {
-                                        createDataIntegrityWarning(folder);
-                                    }
-                                }
-                            } catch (err: unknown) {
-                                notifyRemoteFolderMountError(err);
-                            }
-                        }
-                    }}
+                    onSelectFolder={(folder) =>
+                        mountAndActivateFolder(folder, {
+                            setSelected: setSelectedPerformanceFolder,
+                            mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
+                            activateWithToast: updatePerformanceSelection,
+                        })
+                    }
                     type='performance'
                 >
                     {(isPerformanceRemote || isSyncingPerformanceFolder) && selectedPerformanceFolder && (

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -10,6 +10,10 @@ import { AxiosResponse, HttpStatusCode } from 'axios';
 import { useAtom } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
+import {
+    ACTIVE_MEMORY_REPORT_TOAST_TITLE,
+    ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE,
+} from '../../definitions/notifyActiveReport';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
 import getRemoteSyncFailureAction, { RemoteSyncFailureAction } from '../../functions/getRemoteSyncFailureAction';
 import getResponseError from '../../functions/getResponseError';
@@ -24,6 +28,7 @@ import notifyFolderSyncLocalFallback, {
     notifyLocalSyncedReportsListFallback,
 } from '../../functions/notifyFolderSyncLocalFallback';
 import { createDataIntegrityWarning, hasBeenNormalised } from '../../functions/validateReportFolder';
+import { useActivatingReport } from '../../hooks/useActivatingReport';
 import useRemoteConnection from '../../hooks/useRemote';
 import { useReportLinkBadgeIds } from '../../hooks/useReportLinkBadgeIds';
 import {
@@ -50,6 +55,7 @@ const RemoteSyncConfigurator = () => {
     const [performanceReportLocation, setPerformanceReportLocation] = useAtom(performanceReportLocationAtom);
     const [activeProfilerReport, setActiveProfilerReport] = useAtom(activeProfilerReportAtom);
     const [activePerformanceReport, setActivePerformanceReport] = useAtom(activePerformanceReportAtom);
+    const { isActivatingReport, withActivatingReport } = useActivatingReport();
 
     const { data: reportMetadata, error: reportMetadataError } = useReportMetadata();
     useEffect(() => {
@@ -121,6 +127,9 @@ const RemoteSyncConfigurator = () => {
         });
     };
 
+    const isCurrentLocalScan = (abortController: AbortController, signal: AbortSignal) =>
+        !signal.aborted && localSyncedFoldersAbortRef.current === abortController;
+
     const loadLocalSyncedFolders = async (connection: RemoteConnection) => {
         localSyncedFoldersAbortRef.current?.abort();
         const abortController = new AbortController();
@@ -135,7 +144,7 @@ const RemoteSyncConfigurator = () => {
                     : Promise.resolve([]),
             ]);
 
-            if (signal.aborted || localSyncedFoldersAbortRef.current !== abortController) {
+            if (!isCurrentLocalScan(abortController, signal)) {
                 return;
             }
 
@@ -154,9 +163,6 @@ const RemoteSyncConfigurator = () => {
             }
         }
     };
-
-    const isCurrentLocalScan = (abortController: AbortController, signal: AbortSignal) =>
-        !signal.aborted && localSyncedFoldersAbortRef.current === abortController;
 
     const applyRemoteOrLocalFolderList = async (
         remoteResult: PromiseSettledResult<RemoteFolder[]>,
@@ -328,12 +334,12 @@ const RemoteSyncConfigurator = () => {
 
     const updateReportSelection = (folder: RemoteFolder) => {
         applyProfilerReportSelection(folder);
-        createToastNotification('Active memory report', folder.reportName, ToastType.SUCCESS);
+        createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
     };
 
     const updatePerformanceSelection = (folder: RemoteFolder) => {
         applyPerformanceReportSelection(folder);
-        createToastNotification('Active performance report', folder.reportName, ToastType.SUCCESS);
+        createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
     };
 
     const mountLocalFolderOnSyncFailure = async (
@@ -407,42 +413,46 @@ const RemoteSyncConfigurator = () => {
         activateWithToast: (folder: RemoteFolder) => void;
         applySelection: (folder: RemoteFolder) => void;
     }) => {
+        setSyncing(true);
+
         try {
-            setSyncing(true);
+            await withActivatingReport(async () => {
+                try {
+                    const connection = remote.persistentState.selectedConnection;
+                    if (!connection || !selected) {
+                        return;
+                    }
 
-            const connection = remote.persistentState.selectedConnection;
-            if (!connection || !selected) {
-                return;
-            }
+                    const { data: updatedFolder } = await sync(connection, selected);
 
-            const { data: updatedFolder } = await sync(connection, selected);
+                    if (hasBeenNormalised(updatedFolder)) {
+                        createDataIntegrityWarning(updatedFolder);
+                    }
 
-            if (hasBeenNormalised(updatedFolder)) {
-                createDataIntegrityWarning(updatedFolder);
-            }
+                    const updatedFolders = getSaved(connection).map((f) =>
+                        f.remotePath === updatedFolder?.remotePath ? updatedFolder : f,
+                    );
 
-            const updatedFolders = getSaved(connection).map((f) =>
-                f.remotePath === updatedFolder?.remotePath ? updatedFolder : f,
-            );
+                    updateSaved(connection, updatedFolders);
 
-            updateSaved(connection, updatedFolders);
+                    if (updatedFolder) {
+                        const mountResponse = await mount(connection, updatedFolder);
 
-            if (updatedFolder) {
-                const mountResponse = await mount(connection, updatedFolder);
-
-                if (mountResponse.status === HttpStatusCode.Ok) {
-                    activateWithToast(updatedFolder);
+                        if (mountResponse.status === HttpStatusCode.Ok) {
+                            activateWithToast(updatedFolder);
+                        }
+                    }
+                } catch (err: unknown) {
+                    await handleSyncFailure(err, selected, (report, syncErr) =>
+                        mountLocalFolderOnSyncFailure(
+                            report,
+                            syncErr,
+                            (connection) => mount(connection, report),
+                            applySelection,
+                        ),
+                    );
                 }
-            }
-        } catch (err: unknown) {
-            await handleSyncFailure(err, selected, (report, syncErr) =>
-                mountLocalFolderOnSyncFailure(
-                    report,
-                    syncErr,
-                    (connection) => mount(connection, report),
-                    applySelection,
-                ),
-            );
+            });
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
             setSyncing(false);
@@ -494,24 +504,26 @@ const RemoteSyncConfigurator = () => {
 
         setSelected(folder);
 
-        try {
-            const response = await mount(connection, folder);
+        await withActivatingReport(async () => {
+            try {
+                const response = await mount(connection, folder);
 
-            if (response.status === HttpStatusCode.Ok) {
-                activateWithToast(folder);
+                if (response.status === HttpStatusCode.Ok) {
+                    activateWithToast(folder);
 
-                if (hasBeenNormalised(folder)) {
-                    createDataIntegrityWarning(folder);
+                    if (hasBeenNormalised(folder)) {
+                        createDataIntegrityWarning(folder);
+                    }
                 }
+            } catch (err: unknown) {
+                notifyRemoteFolderMountError(err);
             }
-        } catch (err: unknown) {
-            notifyRemoteFolderMountError(err);
-        }
+        });
     };
 
     const isProfilerRemote = profilerReportLocation === ReportLocation.REMOTE;
     const isPerformanceRemote = performanceReportLocation === ReportLocation.REMOTE;
-    const isLoading = isSyncingReportFolder || isSyncingPerformanceFolder;
+    const isLoading = isSyncingReportFolder || isSyncingPerformanceFolder || isActivatingReport;
     const isDisabled = isFetching || isLoading || disableRemoteSync;
 
     const selectedRemoteHost = remote.persistentState.selectedConnection?.host ?? null;

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -15,8 +15,13 @@ import getRemoteSyncFailureAction, { RemoteSyncFailureAction } from '../../funct
 import getResponseError from '../../functions/getResponseError';
 import getServerConfig from '../../functions/getServerConfig';
 import isRemoteFolderOutdated from '../../functions/isRemoteFolderOutdated';
-import notifyFolderSyncError from '../../functions/notifyFolderSyncError';
-import notifyFolderSyncLocalFallback from '../../functions/notifyFolderSyncLocalFallback';
+import notifyFolderSyncError, {
+    notifyFolderListSyncError,
+    notifyRemoteFolderMountError,
+} from '../../functions/notifyFolderSyncError';
+import notifyFolderSyncLocalFallback, {
+    notifyLocalSyncedReportsListFallback,
+} from '../../functions/notifyFolderSyncLocalFallback';
 import { createDataIntegrityWarning, hasBeenNormalised } from '../../functions/validateReportFolder';
 import useRemoteConnection from '../../hooks/useRemote';
 import {
@@ -32,11 +37,6 @@ import RemoteSyncButton from './RemoteSyncButton';
 import { updateInstance, useReportMetadata } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation, evaluateDbVersion } from '../../functions/compareDbVersion';
-
-export const LOCAL_SYNCED_REPORTS_TOAST_TITLE = 'Loaded local synced reports';
-export const LOCAL_SYNCED_REPORTS_TOAST_DETAIL =
-    'Remote host unreachable; showing reports already synced on this machine.';
-export const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
 
 function mergeRemoteFolders(savedFolders: RemoteFolder[] | undefined, updatedFolders: RemoteFolder[]): RemoteFolder[] {
     return (updatedFolders ?? []).map((updatedFolder) => {
@@ -146,7 +146,7 @@ const RemoteSyncConfigurator = () => {
                     : Promise.resolve([]),
             ]);
 
-            if (signal.aborted) {
+            if (signal.aborted || localSyncedFoldersAbortRef.current !== abortController) {
                 return;
             }
 
@@ -224,11 +224,7 @@ const RemoteSyncConfigurator = () => {
             ]);
 
             if (profilerOutcome.usedLocalFallback || performanceOutcome.usedLocalFallback) {
-                createToastNotification(
-                    LOCAL_SYNCED_REPORTS_TOAST_TITLE,
-                    LOCAL_SYNCED_REPORTS_TOAST_DETAIL,
-                    ToastType.WARNING,
-                );
+                notifyLocalSyncedReportsListFallback();
             }
 
             const fetchErrors = [profilerOutcome.error, performanceOutcome.error].filter(
@@ -236,10 +232,10 @@ const RemoteSyncConfigurator = () => {
             );
 
             if (fetchErrors.length > 0) {
-                createToastNotification(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE, fetchErrors.join('; '), ToastType.ERROR);
+                notifyFolderListSyncError(fetchErrors.join('; '));
             }
         } catch (err: unknown) {
-            createToastNotification(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE, getResponseError(err), ToastType.ERROR);
+            notifyFolderListSyncError(getResponseError(err));
         } finally {
             setIsFetching(false);
         }
@@ -615,17 +611,21 @@ const RemoteSyncConfigurator = () => {
                         if (remote.persistentState.selectedConnection) {
                             setSelectedReportFolder(folder);
 
-                            const response = await remote.mountRemoteFolder(
-                                remote.persistentState.selectedConnection,
-                                folder,
-                            );
+                            try {
+                                const response = await remote.mountRemoteFolder(
+                                    remote.persistentState.selectedConnection,
+                                    folder,
+                                );
 
-                            if (response.status === HttpStatusCode.Ok) {
-                                updateReportSelection(folder);
+                                if (response.status === HttpStatusCode.Ok) {
+                                    updateReportSelection(folder);
 
-                                if (hasBeenNormalised(folder)) {
-                                    createDataIntegrityWarning(folder);
+                                    if (hasBeenNormalised(folder)) {
+                                        createDataIntegrityWarning(folder);
+                                    }
                                 }
+                            } catch (err: unknown) {
+                                notifyRemoteFolderMountError(err);
                             }
                         }
                     }}
@@ -660,18 +660,22 @@ const RemoteSyncConfigurator = () => {
                         if (remote.persistentState.selectedConnection) {
                             setSelectedPerformanceFolder(folder);
 
-                            const response = await remote.mountRemoteFolder(
-                                remote.persistentState.selectedConnection,
-                                undefined,
-                                folder,
-                            );
+                            try {
+                                const response = await remote.mountRemoteFolder(
+                                    remote.persistentState.selectedConnection,
+                                    undefined,
+                                    folder,
+                                );
 
-                            if (response.status === HttpStatusCode.Ok) {
-                                updatePerformanceSelection(folder);
+                                if (response.status === HttpStatusCode.Ok) {
+                                    updatePerformanceSelection(folder);
 
-                                if (hasBeenNormalised(folder)) {
-                                    createDataIntegrityWarning(folder);
+                                    if (hasBeenNormalised(folder)) {
+                                        createDataIntegrityWarning(folder);
+                                    }
                                 }
+                            } catch (err: unknown) {
+                                notifyRemoteFolderMountError(err);
                             }
                         }
                     }}

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -480,18 +480,21 @@ const RemoteSyncConfigurator = () => {
 
     // On mount (and when SERVER_MODE is off), seed dropdowns from on-disk synced copies
     // for the currently selected host so offline use works without clicking Fetch.
+    // Cleanup aborts any in-flight scan so unmount cannot call setState after teardown.
     useEffect(() => {
-        if (disableRemoteSync) {
-            return;
+        if (!disableRemoteSync) {
+            const connection = remote.persistentState.selectedConnection;
+
+            if (connection) {
+                loadLocalSyncedFolders(connection).catch(() => {
+                    // Local scan is best-effort; cached folders remain if it fails.
+                });
+            }
         }
 
-        const connection = remote.persistentState.selectedConnection;
-
-        if (connection) {
-            loadLocalSyncedFolders(connection).catch(() => {
-                // Local scan is best-effort; cached folders remain if it fails.
-            });
-        }
+        return () => {
+            localSyncedFoldersAbortRef.current?.abort();
+        };
         // Intentionally once on mount for the persisted selection; connection changes go
         // through updateSelectedConnection which also calls loadLocalSyncedFolders.
         // eslint-disable-next-line react-hooks/exhaustive-deps -- mount seed only

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -10,10 +10,12 @@ import { useAtom } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
+import getRemoteSyncFailureAction, { RemoteSyncFailureAction } from '../../functions/getRemoteSyncFailureAction';
 import getResponseError from '../../functions/getResponseError';
 import getServerConfig from '../../functions/getServerConfig';
 import isRemoteFolderOutdated from '../../functions/isRemoteFolderOutdated';
 import notifyFolderSyncError from '../../functions/notifyFolderSyncError';
+import notifyFolderSyncLocalFallback from '../../functions/notifyFolderSyncLocalFallback';
 import { createDataIntegrityWarning, hasBeenNormalised } from '../../functions/validateReportFolder';
 import useRemoteConnection from '../../hooks/useRemote';
 import {
@@ -29,6 +31,9 @@ import RemoteSyncButton from './RemoteSyncButton';
 import { updateInstance, useReportMetadata } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation, evaluateDbVersion } from '../../functions/compareDbVersion';
+
+const LOCAL_SYNCED_REPORTS_TOAST_TITLE = 'Loaded local synced reports';
+const LOCAL_SYNCED_REPORTS_TOAST_DETAIL = 'Remote host unreachable; showing reports already synced on this machine.';
 
 const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
@@ -101,6 +106,88 @@ const RemoteSyncConfigurator = () => {
                 active_report: activeReport,
             });
         }
+
+        // Populate report dropdowns from on-disk synced copies for this host (no SSH).
+        await loadLocalSyncedFolders(connection);
+    };
+
+    const loadLocalSyncedFolders = async (connection: RemoteConnection) => {
+        const [localProfilerFolders, localPerformanceFolders] = await Promise.allSettled([
+            connection.profilerPath ? remote.listLocalProfilerReports(connection) : Promise.resolve([]),
+            connection.performancePath ? remote.listLocalPerformanceReports(connection) : Promise.resolve([]),
+        ]);
+
+        // Always replace cached lists on a successful scan — including []. Otherwise
+        // never-synced / empty local dirs from an older remote fetch stay visible.
+        if (localProfilerFolders.status === 'fulfilled') {
+            updateSavedReportFolders(connection, localProfilerFolders.value);
+        }
+
+        if (localPerformanceFolders.status === 'fulfilled') {
+            updateSavedPerformanceFolders(connection, localPerformanceFolders.value);
+        }
+    };
+
+    const fetchRemoteFolderLists = async (connection: RemoteConnection) => {
+        try {
+            setIsFetching(true);
+
+            const [reportFolders, performanceFolders] = await Promise.allSettled([
+                connection.profilerPath ? remote.listProfilerReports(connection) : Promise.resolve([]),
+                connection.performancePath ? remote.listPerformanceReports(connection) : Promise.resolve([]),
+            ]);
+
+            const fetchErrors: string[] = [];
+            let usedLocalFallback = false;
+
+            if (reportFolders.status === 'fulfilled') {
+                updateSavedReportFolders(connection, reportFolders.value);
+            } else if (connection.profilerPath) {
+                try {
+                    const localProfilerFolders = await remote.listLocalProfilerReports(connection);
+                    updateSavedReportFolders(connection, localProfilerFolders);
+                    if (localProfilerFolders.length > 0) {
+                        usedLocalFallback = true;
+                    } else {
+                        fetchErrors.push(getResponseError(reportFolders.reason));
+                    }
+                } catch {
+                    fetchErrors.push(getResponseError(reportFolders.reason));
+                }
+            }
+
+            if (performanceFolders.status === 'fulfilled') {
+                updateSavedPerformanceFolders(connection, performanceFolders.value);
+            } else if (connection.performancePath) {
+                try {
+                    const localPerformanceFolders = await remote.listLocalPerformanceReports(connection);
+                    updateSavedPerformanceFolders(connection, localPerformanceFolders);
+                    if (localPerformanceFolders.length > 0) {
+                        usedLocalFallback = true;
+                    } else {
+                        fetchErrors.push(getResponseError(performanceFolders.reason));
+                    }
+                } catch {
+                    fetchErrors.push(getResponseError(performanceFolders.reason));
+                }
+            }
+
+            if (usedLocalFallback) {
+                createToastNotification(
+                    LOCAL_SYNCED_REPORTS_TOAST_TITLE,
+                    LOCAL_SYNCED_REPORTS_TOAST_DETAIL,
+                    ToastType.WARNING,
+                );
+            }
+
+            if (fetchErrors.length > 0) {
+                createToastNotification('Folder list sync error', fetchErrors.join('; '), ToastType.ERROR);
+            }
+        } catch (err: unknown) {
+            createToastNotification('Folder list sync error', getResponseError(err), ToastType.ERROR);
+        } finally {
+            setIsFetching(false);
+        }
     };
 
     const updateSavedReportFolders = (connection: RemoteConnection, updatedFolders: RemoteFolder[]) => {
@@ -115,6 +202,8 @@ const RemoteSyncConfigurator = () => {
             return {
                 ...existingFolder,
                 ...updatedFolder,
+                // Prefer fresh stamp from disk; keep cached value if the list response omitted it.
+                lastSynced: updatedFolder.lastSynced ?? existingFolder?.lastSynced,
             };
         });
 
@@ -136,6 +225,8 @@ const RemoteSyncConfigurator = () => {
             return {
                 ...existingFolder,
                 ...updatedFolder,
+                // Prefer fresh stamp from disk; keep cached value if the list response omitted it.
+                lastSynced: updatedFolder.lastSynced ?? existingFolder?.lastSynced,
             };
         });
 
@@ -155,30 +246,94 @@ const RemoteSyncConfigurator = () => {
         });
     };
 
-    const updateReportSelection = (folder: RemoteFolder) => {
+    const applyProfilerReportSelection = (folder: RemoteFolder) => {
         queryClient.clear();
         setProfilerReportLocation(ReportLocation.REMOTE);
         setActiveProfilerReport({
             path: folder.remotePath,
             reportName: folder.reportName,
         });
-        createToastNotification('Active memory report', folder.reportName, ToastType.SUCCESS);
     };
 
-    const updatePerformanceSelection = (folder: RemoteFolder) => {
+    const applyPerformanceReportSelection = (folder: RemoteFolder) => {
         queryClient.clear();
         setPerformanceReportLocation(ReportLocation.REMOTE);
         setActivePerformanceReport({
             path: folder.remotePath,
             reportName: folder.reportName,
         });
+    };
+
+    const updateReportSelection = (folder: RemoteFolder) => {
+        applyProfilerReportSelection(folder);
+        createToastNotification('Active memory report', folder.reportName, ToastType.SUCCESS);
+    };
+
+    const updatePerformanceSelection = (folder: RemoteFolder) => {
+        applyPerformanceReportSelection(folder);
         createToastNotification('Active performance report', folder.reportName, ToastType.SUCCESS);
     };
 
-    const syncSelectedReportFolder = async (folder?: RemoteFolder) => {
-        try {
-            const selectedReport = folder ?? selectedReportFolder;
+    const mountLocalProfilerFolderOnSyncFailure = async (selectedReport: RemoteFolder, err: unknown) => {
+        const connection = remote.persistentState.selectedConnection;
 
+        if (!connection) {
+            notifyFolderSyncError(err);
+            return;
+        }
+
+        try {
+            const mountResponse = await remote.mountRemoteFolder(connection, selectedReport);
+
+            if (mountResponse.status === 200) {
+                applyProfilerReportSelection(selectedReport);
+                notifyFolderSyncLocalFallback(err);
+
+                if (hasBeenNormalised(selectedReport)) {
+                    createDataIntegrityWarning(selectedReport);
+                }
+
+                return;
+            }
+        } catch {
+            // Mount itself failed; surface the original sync error below.
+        }
+
+        notifyFolderSyncError(err);
+    };
+
+    const mountLocalPerformanceFolderOnSyncFailure = async (selectedReport: RemoteFolder, err: unknown) => {
+        const connection = remote.persistentState.selectedConnection;
+
+        if (!connection) {
+            notifyFolderSyncError(err);
+            return;
+        }
+
+        try {
+            const mountResponse = await remote.mountRemoteFolder(connection, undefined, selectedReport);
+
+            if (mountResponse.status === 200) {
+                applyPerformanceReportSelection(selectedReport);
+                notifyFolderSyncLocalFallback(err);
+
+                if (hasBeenNormalised(selectedReport)) {
+                    createDataIntegrityWarning(selectedReport);
+                }
+
+                return;
+            }
+        } catch {
+            // Mount itself failed; surface the original sync error below.
+        }
+
+        notifyFolderSyncError(err);
+    };
+
+    const syncSelectedReportFolder = async (folder?: RemoteFolder) => {
+        const selectedReport = folder ?? selectedReportFolder;
+
+        try {
             setIsSyncingReportFolder(true);
 
             if (remote.persistentState.selectedConnection) {
@@ -214,6 +369,17 @@ const RemoteSyncConfigurator = () => {
                 }
             }
         } catch (err: unknown) {
+            const failureAction = getRemoteSyncFailureAction(err, selectedReport);
+
+            if (failureAction === RemoteSyncFailureAction.IGNORE_CANCEL) {
+                return;
+            }
+
+            if (failureAction === RemoteSyncFailureAction.FALLBACK_LOCAL && selectedReport) {
+                await mountLocalProfilerFolderOnSyncFailure(selectedReport, err);
+                return;
+            }
+
             notifyFolderSyncError(err);
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
@@ -222,9 +388,9 @@ const RemoteSyncConfigurator = () => {
     };
 
     const syncSelectedPerfReportFolder = async (folder?: RemoteFolder) => {
-        try {
-            const selectedReport = folder ?? selectedPerformanceFolder;
+        const selectedReport = folder ?? selectedPerformanceFolder;
 
+        try {
             setIsSyncingPerformanceFolder(true);
 
             if (remote.persistentState.selectedConnection) {
@@ -262,6 +428,17 @@ const RemoteSyncConfigurator = () => {
                 }
             }
         } catch (err: unknown) {
+            const failureAction = getRemoteSyncFailureAction(err, selectedReport);
+
+            if (failureAction === RemoteSyncFailureAction.IGNORE_CANCEL) {
+                return;
+            }
+
+            if (failureAction === RemoteSyncFailureAction.FALLBACK_LOCAL && selectedReport) {
+                await mountLocalPerformanceFolderOnSyncFailure(selectedReport, err);
+                return;
+            }
+
             notifyFolderSyncError(err);
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
@@ -273,6 +450,25 @@ const RemoteSyncConfigurator = () => {
     const isPerformanceRemote = performanceReportLocation === ReportLocation.REMOTE;
     const isLoading = isSyncingReportFolder || isSyncingPerformanceFolder;
     const isDisabled = isFetching || isLoading || disableRemoteSync;
+
+    // On mount (and when SERVER_MODE is off), seed dropdowns from on-disk synced copies
+    // for the currently selected host so offline use works without clicking Fetch.
+    useEffect(() => {
+        if (disableRemoteSync) {
+            return;
+        }
+
+        const connection = remote.persistentState.selectedConnection;
+
+        if (connection) {
+            loadLocalSyncedFolders(connection).catch(() => {
+                // Local scan is best-effort; cached folders remain if it fails.
+            });
+        }
+        // Intentionally once on mount for the persisted selection; connection changes go
+        // through updateSelectedConnection which also calls loadLocalSyncedFolders.
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- mount seed only
+    }, []);
 
     // Populates the selectedReportFolder if there is a stored activeProfilerReport
     useEffect(() => {
@@ -366,51 +562,8 @@ const RemoteSyncConfigurator = () => {
                         await updateSelectedConnection(connection);
                     }}
                     onSyncRemoteFolderList={async () => {
-                        try {
-                            setIsFetching(true);
-
-                            if (remote.persistentState.selectedConnection) {
-                                const [reportFolders, performanceFolders] = await Promise.allSettled([
-                                    remote.persistentState.selectedConnection.profilerPath
-                                        ? remote.listProfilerReports(remote.persistentState.selectedConnection)
-                                        : Promise.resolve([]),
-                                    remote.persistentState.selectedConnection.performancePath
-                                        ? remote.listPerformanceReports(remote.persistentState.selectedConnection)
-                                        : Promise.resolve([]),
-                                ]);
-
-                                const fetchErrors: string[] = [];
-
-                                if (reportFolders.status === 'fulfilled') {
-                                    updateSavedReportFolders(
-                                        remote.persistentState.selectedConnection,
-                                        reportFolders.value,
-                                    );
-                                } else {
-                                    fetchErrors.push(getResponseError(reportFolders.reason));
-                                }
-
-                                if (performanceFolders.status === 'fulfilled') {
-                                    updateSavedPerformanceFolders(
-                                        remote.persistentState.selectedConnection,
-                                        performanceFolders.value,
-                                    );
-                                } else {
-                                    fetchErrors.push(getResponseError(performanceFolders.reason));
-                                }
-
-                                if (fetchErrors.length > 0) {
-                                    createToastNotification(
-                                        'Folder list sync error',
-                                        fetchErrors.join('; '),
-                                        ToastType.ERROR,
-                                    );
-                                }
-                            }
-                        } catch (err: unknown) {
-                            createToastNotification('Folder list sync error', getResponseError(err), ToastType.ERROR);
-                        } finally {
-                            setIsFetching(false);
+                        if (remote.persistentState.selectedConnection) {
+                            await fetchRemoteFolderLists(remote.persistentState.selectedConnection);
                         }
                     }}
                 />
@@ -427,22 +580,21 @@ const RemoteSyncConfigurator = () => {
                     loading={isLoading || isFetching}
                     disabled={isDisabled}
                     onSelectFolder={async (folder) => {
+                        // Mount the local copy only — never SSH-sync on select so offline /
+                        // unreachable hosts still load previously synced reports. Refresh via Sync.
                         if (remote.persistentState.selectedConnection) {
-                            if (isRemoteFolderOutdated(folder)) {
-                                setSelectedReportFolder(folder);
-                                await syncSelectedReportFolder(folder);
-                            } else {
-                                const response = await remote.mountRemoteFolder(
-                                    remote.persistentState.selectedConnection,
-                                    folder,
-                                );
+                            setSelectedReportFolder(folder);
 
-                                if (response.status === 200) {
-                                    updateReportSelection(folder);
+                            const response = await remote.mountRemoteFolder(
+                                remote.persistentState.selectedConnection,
+                                folder,
+                            );
 
-                                    if (hasBeenNormalised(folder)) {
-                                        createDataIntegrityWarning(folder);
-                                    }
+                            if (response.status === 200) {
+                                updateReportSelection(folder);
+
+                                if (hasBeenNormalised(folder)) {
+                                    createDataIntegrityWarning(folder);
                                 }
                             }
                         }
@@ -473,23 +625,22 @@ const RemoteSyncConfigurator = () => {
                     loading={isLoading || isFetching}
                     disabled={isDisabled}
                     onSelectFolder={async (folder) => {
+                        // Mount the local copy only — never SSH-sync on select so offline /
+                        // unreachable hosts still load previously synced reports. Refresh via Sync.
                         if (remote.persistentState.selectedConnection) {
-                            if (isRemoteFolderOutdated(folder)) {
-                                setSelectedPerformanceFolder(folder);
-                                await syncSelectedPerfReportFolder(folder);
-                            } else {
-                                const response = await remote.mountRemoteFolder(
-                                    remote.persistentState.selectedConnection,
-                                    undefined,
-                                    folder,
-                                );
+                            setSelectedPerformanceFolder(folder);
 
-                                if (response.status === 200) {
-                                    updatePerformanceSelection(folder);
+                            const response = await remote.mountRemoteFolder(
+                                remote.persistentState.selectedConnection,
+                                undefined,
+                                folder,
+                            );
 
-                                    if (hasBeenNormalised(folder)) {
-                                        createDataIntegrityWarning(folder);
-                                    }
+                            if (response.status === 200) {
+                                updatePerformanceSelection(folder);
+
+                                if (hasBeenNormalised(folder)) {
+                                    createDataIntegrityWarning(folder);
                                 }
                             }
                         }

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -15,6 +15,7 @@ import getRemoteSyncFailureAction, { RemoteSyncFailureAction } from '../../funct
 import getResponseError from '../../functions/getResponseError';
 import getServerConfig from '../../functions/getServerConfig';
 import isRemoteFolderOutdated from '../../functions/isRemoteFolderOutdated';
+import mergeRemoteFolders from '../../functions/mergeRemoteFolders';
 import notifyFolderSyncError, {
     notifyFolderListSyncError,
     notifyRemoteFolderMountError,
@@ -37,20 +38,6 @@ import RemoteSyncButton from './RemoteSyncButton';
 import { updateInstance, useReportMetadata } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation, evaluateDbVersion } from '../../functions/compareDbVersion';
-
-function mergeRemoteFolders(savedFolders: RemoteFolder[] | undefined, updatedFolders: RemoteFolder[]): RemoteFolder[] {
-    return (updatedFolders ?? []).map((updatedFolder) => {
-        const existingFolder = savedFolders?.find((f) => f.reportName === updatedFolder.reportName);
-
-        return {
-            ...existingFolder,
-            ...updatedFolder,
-            // Prefer fresh stamp from disk; keep cache only when the response omitted the key.
-            // Explicit null means "not synced" and must clear a stale cached stamp.
-            lastSynced: updatedFolder.lastSynced !== undefined ? updatedFolder.lastSynced : existingFolder?.lastSynced,
-        };
-    });
-}
 
 const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
@@ -167,14 +154,22 @@ const RemoteSyncConfigurator = () => {
         }
     };
 
+    const isCurrentLocalScan = (abortController: AbortController, signal: AbortSignal) =>
+        !signal.aborted && localSyncedFoldersAbortRef.current === abortController;
+
     const applyRemoteOrLocalFolderList = async (
         remoteResult: PromiseSettledResult<RemoteFolder[]>,
         connection: RemoteConnection,
         pathPresent: boolean,
-        listLocal: (connection: RemoteConnection) => Promise<RemoteFolder[]>,
+        listLocal: (connection: RemoteConnection, signal?: AbortSignal) => Promise<RemoteFolder[]>,
         updateSaved: (connection: RemoteConnection, folders: RemoteFolder[]) => void,
+        abortController: AbortController,
+        signal: AbortSignal,
     ): Promise<{ usedLocalFallback: boolean; error: string | null }> => {
         if (remoteResult.status === 'fulfilled') {
+            if (!isCurrentLocalScan(abortController, signal)) {
+                return { usedLocalFallback: false, error: null };
+            }
             updateSaved(connection, remoteResult.value);
             return { usedLocalFallback: false, error: null };
         }
@@ -184,7 +179,10 @@ const RemoteSyncConfigurator = () => {
         }
 
         try {
-            const localFolders = await listLocal(connection);
+            const localFolders = await listLocal(connection, signal);
+            if (!isCurrentLocalScan(abortController, signal)) {
+                return { usedLocalFallback: false, error: null };
+            }
             updateSaved(connection, localFolders);
 
             if (localFolders.length > 0) {
@@ -193,18 +191,30 @@ const RemoteSyncConfigurator = () => {
 
             return { usedLocalFallback: false, error: getResponseError(remoteResult.reason) };
         } catch {
+            if (!isCurrentLocalScan(abortController, signal)) {
+                return { usedLocalFallback: false, error: null };
+            }
             return { usedLocalFallback: false, error: getResponseError(remoteResult.reason) };
         }
     };
 
     const fetchRemoteFolderLists = async (connection: RemoteConnection) => {
+        localSyncedFoldersAbortRef.current?.abort();
+        const abortController = new AbortController();
+        localSyncedFoldersAbortRef.current = abortController;
+        const { signal } = abortController;
+
         try {
             setIsFetching(true);
 
             const [reportFolders, performanceFolders] = await Promise.allSettled([
-                connection.profilerPath ? remote.listProfilerReports(connection) : Promise.resolve([]),
-                connection.performancePath ? remote.listPerformanceReports(connection) : Promise.resolve([]),
+                connection.profilerPath ? remote.listProfilerReports(connection, signal) : Promise.resolve([]),
+                connection.performancePath ? remote.listPerformanceReports(connection, signal) : Promise.resolve([]),
             ]);
+
+            if (!isCurrentLocalScan(abortController, signal)) {
+                return;
+            }
 
             // Run local fallbacks in parallel when both SSH lists fail (same dual-failure cost).
             const [profilerOutcome, performanceOutcome] = await Promise.all([
@@ -214,6 +224,8 @@ const RemoteSyncConfigurator = () => {
                     Boolean(connection.profilerPath),
                     remote.listLocalProfilerReports,
                     updateSavedReportFolders,
+                    abortController,
+                    signal,
                 ),
                 applyRemoteOrLocalFolderList(
                     performanceFolders,
@@ -221,8 +233,14 @@ const RemoteSyncConfigurator = () => {
                     Boolean(connection.performancePath),
                     remote.listLocalPerformanceReports,
                     updateSavedPerformanceFolders,
+                    abortController,
+                    signal,
                 ),
             ]);
+
+            if (!isCurrentLocalScan(abortController, signal)) {
+                return;
+            }
 
             if (profilerOutcome.usedLocalFallback || performanceOutcome.usedLocalFallback) {
                 notifyLocalSyncedReportsListFallback();
@@ -236,8 +254,13 @@ const RemoteSyncConfigurator = () => {
                 notifyFolderListSyncError(fetchErrors.join('; '));
             }
         } catch (err: unknown) {
-            notifyFolderListSyncError(getResponseError(err));
+            if (isCurrentLocalScan(abortController, signal)) {
+                notifyFolderListSyncError(getResponseError(err));
+            }
         } finally {
+            if (localSyncedFoldersAbortRef.current === abortController) {
+                localSyncedFoldersAbortRef.current = null;
+            }
             setIsFetching(false);
         }
     };

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -2,10 +2,11 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
+import { AxiosResponse, HttpStatusCode } from 'axios';
 import { useAtom } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
@@ -34,6 +35,7 @@ import { DBVersionValidation, evaluateDbVersion } from '../../functions/compareD
 
 const LOCAL_SYNCED_REPORTS_TOAST_TITLE = 'Loaded local synced reports';
 const LOCAL_SYNCED_REPORTS_TOAST_DETAIL = 'Remote host unreachable; showing reports already synced on this machine.';
+const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
 
 const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
@@ -81,6 +83,8 @@ const RemoteSyncConfigurator = () => {
               )
             : remotePerformanceFolderList[0],
     );
+    // Drops stale loadLocalSyncedFolders completions when the connection changes quickly.
+    const localSyncedFoldersRequestIdRef = useRef(0);
 
     const updateSelectedConnection = async (connection: RemoteConnection) => {
         setPersistentSelectedConnection(connection);
@@ -112,10 +116,15 @@ const RemoteSyncConfigurator = () => {
     };
 
     const loadLocalSyncedFolders = async (connection: RemoteConnection) => {
+        const requestId = ++localSyncedFoldersRequestIdRef.current;
         const [localProfilerFolders, localPerformanceFolders] = await Promise.allSettled([
             connection.profilerPath ? remote.listLocalProfilerReports(connection) : Promise.resolve([]),
             connection.performancePath ? remote.listLocalPerformanceReports(connection) : Promise.resolve([]),
         ]);
+
+        if (requestId !== localSyncedFoldersRequestIdRef.current) {
+            return;
+        }
 
         // Always replace cached lists on a successful scan — including []. Otherwise
         // never-synced / empty local dirs from an older remote fetch stay visible.
@@ -128,6 +137,36 @@ const RemoteSyncConfigurator = () => {
         }
     };
 
+    const applyRemoteOrLocalFolderList = async (
+        remoteResult: PromiseSettledResult<RemoteFolder[]>,
+        connection: RemoteConnection,
+        pathPresent: boolean,
+        listLocal: (connection: RemoteConnection) => Promise<RemoteFolder[]>,
+        updateSaved: (connection: RemoteConnection, folders: RemoteFolder[]) => void,
+    ): Promise<{ usedLocalFallback: boolean; error: string | null }> => {
+        if (remoteResult.status === 'fulfilled') {
+            updateSaved(connection, remoteResult.value);
+            return { usedLocalFallback: false, error: null };
+        }
+
+        if (!pathPresent) {
+            return { usedLocalFallback: false, error: null };
+        }
+
+        try {
+            const localFolders = await listLocal(connection);
+            updateSaved(connection, localFolders);
+
+            if (localFolders.length > 0) {
+                return { usedLocalFallback: true, error: null };
+            }
+
+            return { usedLocalFallback: false, error: getResponseError(remoteResult.reason) };
+        } catch {
+            return { usedLocalFallback: false, error: getResponseError(remoteResult.reason) };
+        }
+    };
+
     const fetchRemoteFolderLists = async (connection: RemoteConnection) => {
         try {
             setIsFetching(true);
@@ -137,42 +176,25 @@ const RemoteSyncConfigurator = () => {
                 connection.performancePath ? remote.listPerformanceReports(connection) : Promise.resolve([]),
             ]);
 
-            const fetchErrors: string[] = [];
-            let usedLocalFallback = false;
+            // Run local fallbacks in parallel when both SSH lists fail (same dual-failure cost).
+            const [profilerOutcome, performanceOutcome] = await Promise.all([
+                applyRemoteOrLocalFolderList(
+                    reportFolders,
+                    connection,
+                    Boolean(connection.profilerPath),
+                    remote.listLocalProfilerReports,
+                    updateSavedReportFolders,
+                ),
+                applyRemoteOrLocalFolderList(
+                    performanceFolders,
+                    connection,
+                    Boolean(connection.performancePath),
+                    remote.listLocalPerformanceReports,
+                    updateSavedPerformanceFolders,
+                ),
+            ]);
 
-            if (reportFolders.status === 'fulfilled') {
-                updateSavedReportFolders(connection, reportFolders.value);
-            } else if (connection.profilerPath) {
-                try {
-                    const localProfilerFolders = await remote.listLocalProfilerReports(connection);
-                    updateSavedReportFolders(connection, localProfilerFolders);
-                    if (localProfilerFolders.length > 0) {
-                        usedLocalFallback = true;
-                    } else {
-                        fetchErrors.push(getResponseError(reportFolders.reason));
-                    }
-                } catch {
-                    fetchErrors.push(getResponseError(reportFolders.reason));
-                }
-            }
-
-            if (performanceFolders.status === 'fulfilled') {
-                updateSavedPerformanceFolders(connection, performanceFolders.value);
-            } else if (connection.performancePath) {
-                try {
-                    const localPerformanceFolders = await remote.listLocalPerformanceReports(connection);
-                    updateSavedPerformanceFolders(connection, localPerformanceFolders);
-                    if (localPerformanceFolders.length > 0) {
-                        usedLocalFallback = true;
-                    } else {
-                        fetchErrors.push(getResponseError(performanceFolders.reason));
-                    }
-                } catch {
-                    fetchErrors.push(getResponseError(performanceFolders.reason));
-                }
-            }
-
-            if (usedLocalFallback) {
+            if (profilerOutcome.usedLocalFallback || performanceOutcome.usedLocalFallback) {
                 createToastNotification(
                     LOCAL_SYNCED_REPORTS_TOAST_TITLE,
                     LOCAL_SYNCED_REPORTS_TOAST_DETAIL,
@@ -180,11 +202,15 @@ const RemoteSyncConfigurator = () => {
                 );
             }
 
+            const fetchErrors = [profilerOutcome.error, performanceOutcome.error].filter(
+                (error): error is string => error !== null,
+            );
+
             if (fetchErrors.length > 0) {
-                createToastNotification('Folder list sync error', fetchErrors.join('; '), ToastType.ERROR);
+                createToastNotification(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE, fetchErrors.join('; '), ToastType.ERROR);
             }
         } catch (err: unknown) {
-            createToastNotification('Folder list sync error', getResponseError(err), ToastType.ERROR);
+            createToastNotification(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE, getResponseError(err), ToastType.ERROR);
         } finally {
             setIsFetching(false);
         }
@@ -274,7 +300,12 @@ const RemoteSyncConfigurator = () => {
         createToastNotification('Active performance report', folder.reportName, ToastType.SUCCESS);
     };
 
-    const mountLocalProfilerFolderOnSyncFailure = async (selectedReport: RemoteFolder, err: unknown) => {
+    const mountLocalFolderOnSyncFailure = async (
+        selectedReport: RemoteFolder,
+        err: unknown,
+        mount: (connection: RemoteConnection) => Promise<AxiosResponse>,
+        applySelection: (folder: RemoteFolder) => void,
+    ) => {
         const connection = remote.persistentState.selectedConnection;
 
         if (!connection) {
@@ -283,10 +314,10 @@ const RemoteSyncConfigurator = () => {
         }
 
         try {
-            const mountResponse = await remote.mountRemoteFolder(connection, selectedReport);
+            const mountResponse = await mount(connection);
 
-            if (mountResponse.status === 200) {
-                applyProfilerReportSelection(selectedReport);
+            if (mountResponse.status === HttpStatusCode.Ok) {
+                applySelection(selectedReport);
                 notifyFolderSyncLocalFallback(err);
 
                 if (hasBeenNormalised(selectedReport)) {
@@ -302,29 +333,20 @@ const RemoteSyncConfigurator = () => {
         notifyFolderSyncError(err);
     };
 
-    const mountLocalPerformanceFolderOnSyncFailure = async (selectedReport: RemoteFolder, err: unknown) => {
-        const connection = remote.persistentState.selectedConnection;
+    const handleSyncFailure = async (
+        err: unknown,
+        selectedReport: RemoteFolder | undefined,
+        mountLocalFallback: (folder: RemoteFolder, err: unknown) => Promise<void>,
+    ) => {
+        const failureAction = getRemoteSyncFailureAction(err, selectedReport);
 
-        if (!connection) {
-            notifyFolderSyncError(err);
+        if (failureAction === RemoteSyncFailureAction.IGNORE_CANCEL) {
             return;
         }
 
-        try {
-            const mountResponse = await remote.mountRemoteFolder(connection, undefined, selectedReport);
-
-            if (mountResponse.status === 200) {
-                applyPerformanceReportSelection(selectedReport);
-                notifyFolderSyncLocalFallback(err);
-
-                if (hasBeenNormalised(selectedReport)) {
-                    createDataIntegrityWarning(selectedReport);
-                }
-
-                return;
-            }
-        } catch {
-            // Mount itself failed; surface the original sync error below.
+        if (failureAction === RemoteSyncFailureAction.FALLBACK_LOCAL && selectedReport) {
+            await mountLocalFallback(selectedReport, err);
+            return;
         }
 
         notifyFolderSyncError(err);
@@ -362,25 +384,21 @@ const RemoteSyncConfigurator = () => {
                         updatedFolder,
                     );
 
-                    if (mountResponse.status === 200) {
+                    if (mountResponse.status === HttpStatusCode.Ok) {
                         updateReportSelection(updatedFolder);
                         queryClient.clear();
                     }
                 }
             }
         } catch (err: unknown) {
-            const failureAction = getRemoteSyncFailureAction(err, selectedReport);
-
-            if (failureAction === RemoteSyncFailureAction.IGNORE_CANCEL) {
-                return;
-            }
-
-            if (failureAction === RemoteSyncFailureAction.FALLBACK_LOCAL && selectedReport) {
-                await mountLocalProfilerFolderOnSyncFailure(selectedReport, err);
-                return;
-            }
-
-            notifyFolderSyncError(err);
+            await handleSyncFailure(err, selectedReport, (report, syncErr) =>
+                mountLocalFolderOnSyncFailure(
+                    report,
+                    syncErr,
+                    (connection) => remote.mountRemoteFolder(connection, report),
+                    applyProfilerReportSelection,
+                ),
+            );
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
             setIsSyncingReportFolder(false);
@@ -421,25 +439,21 @@ const RemoteSyncConfigurator = () => {
                         updatedFolder,
                     );
 
-                    if (mountResponse.status === 200) {
+                    if (mountResponse.status === HttpStatusCode.Ok) {
                         updatePerformanceSelection(updatedFolder);
                         queryClient.clear();
                     }
                 }
             }
         } catch (err: unknown) {
-            const failureAction = getRemoteSyncFailureAction(err, selectedReport);
-
-            if (failureAction === RemoteSyncFailureAction.IGNORE_CANCEL) {
-                return;
-            }
-
-            if (failureAction === RemoteSyncFailureAction.FALLBACK_LOCAL && selectedReport) {
-                await mountLocalPerformanceFolderOnSyncFailure(selectedReport, err);
-                return;
-            }
-
-            notifyFolderSyncError(err);
+            await handleSyncFailure(err, selectedReport, (report, syncErr) =>
+                mountLocalFolderOnSyncFailure(
+                    report,
+                    syncErr,
+                    (connection) => remote.mountRemoteFolder(connection, undefined, report),
+                    applyPerformanceReportSelection,
+                ),
+            );
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
             setIsSyncingPerformanceFolder(false);
@@ -590,7 +604,7 @@ const RemoteSyncConfigurator = () => {
                                 folder,
                             );
 
-                            if (response.status === 200) {
+                            if (response.status === HttpStatusCode.Ok) {
                                 updateReportSelection(folder);
 
                                 if (hasBeenNormalised(folder)) {
@@ -636,7 +650,7 @@ const RemoteSyncConfigurator = () => {
                                 folder,
                             );
 
-                            if (response.status === 200) {
+                            if (response.status === HttpStatusCode.Ok) {
                                 updatePerformanceSelection(folder);
 
                                 if (hasBeenNormalised(folder)) {

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosResponse, HttpStatusCode } from 'axios';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
@@ -23,21 +23,14 @@ import notifyFolderSyncError, {
 import notifyFolderSyncLocalFallback, {
     notifyLocalSyncedReportsListFallback,
 } from '../../functions/notifyFolderSyncLocalFallback';
-import {
-    getReportId,
-    linkedPerformanceIds,
-    linkedProfilerIds,
-    unlinkedPerformanceIds,
-    unlinkedProfilerIds,
-} from '../../functions/reportLinks';
 import { createDataIntegrityWarning, hasBeenNormalised } from '../../functions/validateReportFolder';
 import useRemoteConnection from '../../hooks/useRemote';
+import { useReportLinkBadgeIds } from '../../hooks/useReportLinkBadgeIds';
 import {
     activePerformanceReportAtom,
     activeProfilerReportAtom,
     performanceReportLocationAtom,
     profilerReportLocationAtom,
-    successfulReportLinksAtom,
 } from '../../store/app';
 import AddRemoteConnection from './AddRemoteConnection';
 import RemoteConnectionSelector from './RemoteConnectionSelector';
@@ -521,54 +514,9 @@ const RemoteSyncConfigurator = () => {
     const isLoading = isSyncingReportFolder || isSyncingPerformanceFolder;
     const isDisabled = isFetching || isLoading || disableRemoteSync;
 
-    const reportLinks = useAtomValue(successfulReportLinksAtom);
-    const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
     const selectedRemoteHost = remote.persistentState.selectedConnection?.host ?? null;
-
-    const linkedPerfIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? linkedPerformanceIds(
-                      reportLinks,
-                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
-                      { remoteHost: selectedRemoteHost },
-                  )
-                : undefined,
-        [reportLinks, activeProfilerReport, isReportLinkingEnabled, selectedRemoteHost],
-    );
-    const unlinkedPerfIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? unlinkedPerformanceIds(
-                      reportLinks,
-                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
-                      { remoteHost: selectedRemoteHost },
-                  )
-                : undefined,
-        [reportLinks, activeProfilerReport, isReportLinkingEnabled, selectedRemoteHost],
-    );
-    const linkedProfilerReportIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? linkedProfilerIds(
-                      reportLinks,
-                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
-                      { remoteHost: selectedRemoteHost },
-                  )
-                : undefined,
-        [reportLinks, activePerformanceReport, isReportLinkingEnabled, selectedRemoteHost],
-    );
-    const unlinkedProfilerReportIds = useMemo(
-        () =>
-            isReportLinkingEnabled
-                ? unlinkedProfilerIds(
-                      reportLinks,
-                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
-                      { remoteHost: selectedRemoteHost },
-                  )
-                : undefined,
-        [reportLinks, activePerformanceReport, isReportLinkingEnabled, selectedRemoteHost],
-    );
+    const { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds } =
+        useReportLinkBadgeIds({ remoteHost: selectedRemoteHost });
 
     // On mount (and when SERVER_MODE is off), seed dropdowns from on-disk synced copies
     // for the currently selected host so offline use works without clicking Fetch.

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -45,8 +45,9 @@ function mergeRemoteFolders(savedFolders: RemoteFolder[] | undefined, updatedFol
         return {
             ...existingFolder,
             ...updatedFolder,
-            // Prefer fresh stamp from disk; keep cached value if the list response omitted it.
-            lastSynced: updatedFolder.lastSynced ?? existingFolder?.lastSynced,
+            // Prefer fresh stamp from disk; keep cache only when the response omitted the key.
+            // Explicit null means "not synced" and must clear a stale cached stamp.
+            lastSynced: updatedFolder.lastSynced !== undefined ? updatedFolder.lastSynced : existingFolder?.lastSynced,
         };
     });
 }

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -33,9 +33,23 @@ import { updateInstance, useReportMetadata } from '../../hooks/useAPI';
 import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation, evaluateDbVersion } from '../../functions/compareDbVersion';
 
-const LOCAL_SYNCED_REPORTS_TOAST_TITLE = 'Loaded local synced reports';
-const LOCAL_SYNCED_REPORTS_TOAST_DETAIL = 'Remote host unreachable; showing reports already synced on this machine.';
-const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
+export const LOCAL_SYNCED_REPORTS_TOAST_TITLE = 'Loaded local synced reports';
+export const LOCAL_SYNCED_REPORTS_TOAST_DETAIL =
+    'Remote host unreachable; showing reports already synced on this machine.';
+export const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
+
+function mergeRemoteFolders(savedFolders: RemoteFolder[] | undefined, updatedFolders: RemoteFolder[]): RemoteFolder[] {
+    return (updatedFolders ?? []).map((updatedFolder) => {
+        const existingFolder = savedFolders?.find((f) => f.reportName === updatedFolder.reportName);
+
+        return {
+            ...existingFolder,
+            ...updatedFolder,
+            // Prefer fresh stamp from disk; keep cached value if the list response omitted it.
+            lastSynced: updatedFolder.lastSynced ?? existingFolder?.lastSynced,
+        };
+    });
+}
 
 const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
@@ -83,8 +97,8 @@ const RemoteSyncConfigurator = () => {
               )
             : remotePerformanceFolderList[0],
     );
-    // Drops stale loadLocalSyncedFolders completions when the connection changes quickly.
-    const localSyncedFoldersRequestIdRef = useRef(0);
+    // Aborts in-flight local disk scans when the connection changes quickly.
+    const localSyncedFoldersAbortRef = useRef<AbortController | null>(null);
 
     const updateSelectedConnection = async (connection: RemoteConnection) => {
         setPersistentSelectedConnection(connection);
@@ -112,28 +126,43 @@ const RemoteSyncConfigurator = () => {
         }
 
         // Populate report dropdowns from on-disk synced copies for this host (no SSH).
-        await loadLocalSyncedFolders(connection);
+        // Fire-and-forget so connection switch stays cache-fast; abort cancels prior scans.
+        loadLocalSyncedFolders(connection).catch(() => {
+            // Local scan is best-effort; cached folders remain if it fails.
+        });
     };
 
     const loadLocalSyncedFolders = async (connection: RemoteConnection) => {
-        const requestId = ++localSyncedFoldersRequestIdRef.current;
-        const [localProfilerFolders, localPerformanceFolders] = await Promise.allSettled([
-            connection.profilerPath ? remote.listLocalProfilerReports(connection) : Promise.resolve([]),
-            connection.performancePath ? remote.listLocalPerformanceReports(connection) : Promise.resolve([]),
-        ]);
+        localSyncedFoldersAbortRef.current?.abort();
+        const abortController = new AbortController();
+        localSyncedFoldersAbortRef.current = abortController;
+        const { signal } = abortController;
 
-        if (requestId !== localSyncedFoldersRequestIdRef.current) {
-            return;
-        }
+        try {
+            const [localProfilerFolders, localPerformanceFolders] = await Promise.allSettled([
+                connection.profilerPath ? remote.listLocalProfilerReports(connection, signal) : Promise.resolve([]),
+                connection.performancePath
+                    ? remote.listLocalPerformanceReports(connection, signal)
+                    : Promise.resolve([]),
+            ]);
 
-        // Always replace cached lists on a successful scan — including []. Otherwise
-        // never-synced / empty local dirs from an older remote fetch stay visible.
-        if (localProfilerFolders.status === 'fulfilled') {
-            updateSavedReportFolders(connection, localProfilerFolders.value);
-        }
+            if (signal.aborted) {
+                return;
+            }
 
-        if (localPerformanceFolders.status === 'fulfilled') {
-            updateSavedPerformanceFolders(connection, localPerformanceFolders.value);
+            // Always replace cached lists on a successful scan — including []. Otherwise
+            // never-synced / empty local dirs from an older remote fetch stay visible.
+            if (localProfilerFolders.status === 'fulfilled') {
+                updateSavedReportFolders(connection, localProfilerFolders.value);
+            }
+
+            if (localPerformanceFolders.status === 'fulfilled') {
+                updateSavedPerformanceFolders(connection, localPerformanceFolders.value);
+            }
+        } finally {
+            if (localSyncedFoldersAbortRef.current === abortController) {
+                localSyncedFoldersAbortRef.current = null;
+            }
         }
     };
 
@@ -221,17 +250,10 @@ const RemoteSyncConfigurator = () => {
             return [];
         }
 
-        const savedFolders = remote.persistentState.getSavedReportFolders(connection);
-        const mergedFolders = (updatedFolders ?? []).map((updatedFolder) => {
-            const existingFolder = savedFolders?.find((f) => f.reportName === updatedFolder.reportName);
-
-            return {
-                ...existingFolder,
-                ...updatedFolder,
-                // Prefer fresh stamp from disk; keep cached value if the list response omitted it.
-                lastSynced: updatedFolder.lastSynced ?? existingFolder?.lastSynced,
-            };
-        });
+        const mergedFolders = mergeRemoteFolders(
+            remote.persistentState.getSavedReportFolders(connection),
+            updatedFolders,
+        );
 
         remote.persistentState.setSavedReportFolders(connection, mergedFolders);
         setReportFolders(mergedFolders);
@@ -244,17 +266,10 @@ const RemoteSyncConfigurator = () => {
             return [];
         }
 
-        const savedFolders = remote.persistentState.getSavedPerformanceFolders(connection);
-        const mergedFolders = (updatedFolders ?? []).map((updatedFolder) => {
-            const existingFolder = savedFolders?.find((f) => f.reportName === updatedFolder.reportName);
-
-            return {
-                ...existingFolder,
-                ...updatedFolder,
-                // Prefer fresh stamp from disk; keep cached value if the list response omitted it.
-                lastSynced: updatedFolder.lastSynced ?? existingFolder?.lastSynced,
-            };
-        });
+        const mergedFolders = mergeRemoteFolders(
+            remote.persistentState.getSavedPerformanceFolders(connection),
+            updatedFolders,
+        );
 
         remote.persistentState.setSavedPerformanceFolders(connection, mergedFolders);
         setRemotePerformanceFolders(mergedFolders);
@@ -386,7 +401,6 @@ const RemoteSyncConfigurator = () => {
 
                     if (mountResponse.status === HttpStatusCode.Ok) {
                         updateReportSelection(updatedFolder);
-                        queryClient.clear();
                     }
                 }
             }
@@ -441,7 +455,6 @@ const RemoteSyncConfigurator = () => {
 
                     if (mountResponse.status === HttpStatusCode.Ok) {
                         updatePerformanceSelection(updatedFolder);
-                        queryClient.clear();
                     }
                 }
             }

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosResponse, HttpStatusCode } from 'axios';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../definitions/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
 import createToastNotification, { ToastType } from '../../functions/createToastNotification';
@@ -23,6 +23,13 @@ import notifyFolderSyncError, {
 import notifyFolderSyncLocalFallback, {
     notifyLocalSyncedReportsListFallback,
 } from '../../functions/notifyFolderSyncLocalFallback';
+import {
+    getReportId,
+    linkedPerformanceIds,
+    linkedProfilerIds,
+    unlinkedPerformanceIds,
+    unlinkedProfilerIds,
+} from '../../functions/reportLinks';
 import { createDataIntegrityWarning, hasBeenNormalised } from '../../functions/validateReportFolder';
 import useRemoteConnection from '../../hooks/useRemote';
 import {
@@ -30,6 +37,7 @@ import {
     activeProfilerReportAtom,
     performanceReportLocationAtom,
     profilerReportLocationAtom,
+    successfulReportLinksAtom,
 } from '../../store/app';
 import AddRemoteConnection from './AddRemoteConnection';
 import RemoteConnectionSelector from './RemoteConnectionSelector';
@@ -513,6 +521,55 @@ const RemoteSyncConfigurator = () => {
     const isLoading = isSyncingReportFolder || isSyncingPerformanceFolder;
     const isDisabled = isFetching || isLoading || disableRemoteSync;
 
+    const reportLinks = useAtomValue(successfulReportLinksAtom);
+    const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
+    const selectedRemoteHost = remote.persistentState.selectedConnection?.host ?? null;
+
+    const linkedPerfIds = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? linkedPerformanceIds(
+                      reportLinks,
+                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
+                      { remoteHost: selectedRemoteHost },
+                  )
+                : undefined,
+        [reportLinks, activeProfilerReport, isReportLinkingEnabled, selectedRemoteHost],
+    );
+    const unlinkedPerfIds = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? unlinkedPerformanceIds(
+                      reportLinks,
+                      getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName),
+                      { remoteHost: selectedRemoteHost },
+                  )
+                : undefined,
+        [reportLinks, activeProfilerReport, isReportLinkingEnabled, selectedRemoteHost],
+    );
+    const linkedProfilerReportIds = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? linkedProfilerIds(
+                      reportLinks,
+                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
+                      { remoteHost: selectedRemoteHost },
+                  )
+                : undefined,
+        [reportLinks, activePerformanceReport, isReportLinkingEnabled, selectedRemoteHost],
+    );
+    const unlinkedProfilerReportIds = useMemo(
+        () =>
+            isReportLinkingEnabled
+                ? unlinkedProfilerIds(
+                      reportLinks,
+                      getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName),
+                      { remoteHost: selectedRemoteHost },
+                  )
+                : undefined,
+        [reportLinks, activePerformanceReport, isReportLinkingEnabled, selectedRemoteHost],
+    );
+
     // On mount (and when SERVER_MODE is off), seed dropdowns from on-disk synced copies
     // for the currently selected host so offline use works without clicking Fetch.
     // Cleanup aborts any in-flight scan so unmount cannot call setState after teardown.
@@ -644,6 +701,8 @@ const RemoteSyncConfigurator = () => {
                     remoteFolderList={reportFolderList}
                     loading={isLoading || isFetching}
                     disabled={isDisabled}
+                    linkedIds={linkedProfilerReportIds}
+                    unlinkedIds={unlinkedProfilerReportIds}
                     onSelectFolder={(folder) =>
                         mountAndActivateFolder(folder, {
                             setSelected: setSelectedReportFolder,
@@ -676,6 +735,8 @@ const RemoteSyncConfigurator = () => {
                     remoteFolderList={remotePerformanceFolderList}
                     loading={isLoading || isFetching}
                     disabled={isDisabled}
+                    linkedIds={linkedPerfIds}
+                    unlinkedIds={unlinkedPerfIds}
                     onSelectFolder={(folder) =>
                         mountAndActivateFolder(folder, {
                             setSelected: setSelectedPerformanceFolder,

--- a/src/definitions/Endpoints.ts
+++ b/src/definitions/Endpoints.ts
@@ -19,6 +19,10 @@ enum Endpoints {
     PERFORMANCE = '/api/performance',
     PROFILER = '/api/profiler',
     REMOTE = '/api/remote',
+    REMOTE_PROFILER_REPORTS = '/api/remote/profiler-reports',
+    REMOTE_PERFORMANCE_REPORTS = '/api/remote/performance-reports',
+    REMOTE_LOCAL_PROFILER_REPORTS = '/api/remote/local-profiler-reports',
+    REMOTE_LOCAL_PERFORMANCE_REPORTS = '/api/remote/local-performance-reports',
     REPORT_METADATA = '/api/report-metadata',
     SYSTEM_CAPABILITIES = '/api/system-capabilities', // Currently unused
     TENSOR_LIST = '/api/tensors',

--- a/src/definitions/FolderLinkStatus.ts
+++ b/src/definitions/FolderLinkStatus.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Intent } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+
+export enum FolderLinkState {
+    LINKED = 'linked',
+    UNLINKED = 'unlinked',
+    UNKNOWN = 'unknown',
+}
+
+export const FOLDER_LINK_STATUS = {
+    [FolderLinkState.LINKED]: {
+        tooltip: 'Successfully linked with the active report',
+        icon: IconNames.LINK,
+        intent: Intent.SUCCESS,
+    },
+    [FolderLinkState.UNLINKED]: {
+        tooltip: 'Failed to link with the active report',
+        icon: IconNames.UNLINK,
+        intent: Intent.WARNING,
+    },
+    [FolderLinkState.UNKNOWN]: {
+        tooltip: 'Link status unknown',
+        icon: IconNames.LINK,
+        intent: Intent.NONE,
+    },
+} as const;
+
+export const getFolderLinkState = (
+    reportId: string | null,
+    linkedIds?: Set<string>,
+    unlinkedIds?: Set<string>,
+): FolderLinkState => {
+    if (reportId && linkedIds?.has(reportId)) {
+        return FolderLinkState.LINKED;
+    }
+
+    if (reportId && unlinkedIds?.has(reportId)) {
+        return FolderLinkState.UNLINKED;
+    }
+
+    return FolderLinkState.UNKNOWN;
+};
+
+/** Linked first, unknown middle, failed links last — stable within each group. */
+const FOLDER_LINK_SORT_RANK: Record<FolderLinkState, number> = {
+    [FolderLinkState.LINKED]: 0,
+    [FolderLinkState.UNKNOWN]: 1,
+    [FolderLinkState.UNLINKED]: 2,
+};
+
+export const compareByFolderLinkState = (
+    aId: string | null,
+    bId: string | null,
+    linkedIds?: Set<string>,
+    unlinkedIds?: Set<string>,
+): number =>
+    FOLDER_LINK_SORT_RANK[getFolderLinkState(aId, linkedIds, unlinkedIds)] -
+    FOLDER_LINK_SORT_RANK[getFolderLinkState(bId, linkedIds, unlinkedIds)];

--- a/src/definitions/FolderLinkStatus.ts
+++ b/src/definitions/FolderLinkStatus.ts
@@ -31,8 +31,8 @@ export const FOLDER_LINK_STATUS = {
 
 export const getFolderLinkState = (
     reportId: string | null,
-    linkedIds?: Set<string>,
-    unlinkedIds?: Set<string>,
+    linkedIds?: Set<string> | null,
+    unlinkedIds?: Set<string> | null,
 ): FolderLinkState => {
     if (reportId && linkedIds?.has(reportId)) {
         return FolderLinkState.LINKED;
@@ -55,8 +55,25 @@ const FOLDER_LINK_SORT_RANK: Record<FolderLinkState, number> = {
 export const compareByFolderLinkState = (
     aId: string | null,
     bId: string | null,
-    linkedIds?: Set<string>,
-    unlinkedIds?: Set<string>,
+    linkedIds?: Set<string> | null,
+    unlinkedIds?: Set<string> | null,
 ): number =>
     FOLDER_LINK_SORT_RANK[getFolderLinkState(aId, linkedIds, unlinkedIds)] -
     FOLDER_LINK_SORT_RANK[getFolderLinkState(bId, linkedIds, unlinkedIds)];
+
+/** True when badge sets are present and at least one known link/unlinked id exists. */
+export const shouldShowFolderLinkStatus = (linkedIds?: Set<string> | null, unlinkedIds?: Set<string> | null): boolean =>
+    Boolean(linkedIds?.size || unlinkedIds?.size);
+
+export const sortByFolderLinkState = <T>(
+    items: T[],
+    getId: (item: T) => string | null,
+    linkedIds?: Set<string> | null,
+    unlinkedIds?: Set<string> | null,
+): T[] => {
+    if (!shouldShowFolderLinkStatus(linkedIds, unlinkedIds)) {
+        return items;
+    }
+
+    return [...items].sort((a, b) => compareByFolderLinkState(getId(a), getId(b), linkedIds, unlinkedIds));
+};

--- a/src/definitions/notifyActiveReport.ts
+++ b/src/definitions/notifyActiveReport.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+export const ACTIVE_MEMORY_REPORT_TOAST_TITLE = 'Active memory report';
+export const ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE = 'Active performance report';

--- a/src/functions/getRemoteSyncFailureAction.ts
+++ b/src/functions/getRemoteSyncFailureAction.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import axios from 'axios';
+import { RemoteFolder } from '../definitions/RemoteConnection';
+
+export enum RemoteSyncFailureAction {
+    IGNORE_CANCEL = 'ignore-cancel',
+    FALLBACK_LOCAL = 'fallback-local',
+    SHOW_ERROR = 'show-error',
+}
+
+/**
+ * Decides how to handle a failed remote sync.
+ * When a folder was selected, prefer mounting the on-disk copy over a hard error —
+ * lastSynced metadata is often missing even when files were synced earlier.
+ */
+export default function getRemoteSyncFailureAction(
+    err: unknown,
+    folder?: RemoteFolder | null,
+): RemoteSyncFailureAction {
+    if (axios.isCancel(err)) {
+        return RemoteSyncFailureAction.IGNORE_CANCEL;
+    }
+
+    if (folder) {
+        return RemoteSyncFailureAction.FALLBACK_LOCAL;
+    }
+
+    return RemoteSyncFailureAction.SHOW_ERROR;
+}

--- a/src/functions/mergeRemoteFolders.ts
+++ b/src/functions/mergeRemoteFolders.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { RemoteFolder } from '../definitions/RemoteConnection';
+
+/**
+ * Merge a fresh folder list onto cached rows. Prefer the update's lastSynced when the
+ * key is present (including explicit null = not synced); keep the cache only when omitted.
+ */
+export default function mergeRemoteFolders(
+    savedFolders: RemoteFolder[] | undefined,
+    updatedFolders: RemoteFolder[],
+): RemoteFolder[] {
+    return (updatedFolders ?? []).map((updatedFolder) => {
+        const existingFolder = savedFolders?.find((f) => f.reportName === updatedFolder.reportName);
+
+        return {
+            ...existingFolder,
+            ...updatedFolder,
+            lastSynced: updatedFolder.lastSynced !== undefined ? updatedFolder.lastSynced : existingFolder?.lastSynced,
+        };
+    });
+}

--- a/src/functions/notifyFolderSyncError.ts
+++ b/src/functions/notifyFolderSyncError.ts
@@ -7,6 +7,7 @@ import createToastNotification, { ToastType } from './createToastNotification';
 import getResponseError from './getResponseError';
 
 export const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
+export const FOLDER_SYNC_ERROR_TOAST_TITLE = 'Folder sync error';
 export const REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE = 'Unable to open report';
 
 /**
@@ -17,7 +18,7 @@ export default function notifyFolderSyncError(err: unknown): void {
         return;
     }
 
-    createToastNotification('Folder sync error', getResponseError(err), ToastType.ERROR);
+    createToastNotification(FOLDER_SYNC_ERROR_TOAST_TITLE, getResponseError(err), ToastType.ERROR);
 }
 
 /** Surfaces failures when listing remote folders (SSH or transport errors). */

--- a/src/functions/notifyFolderSyncError.ts
+++ b/src/functions/notifyFolderSyncError.ts
@@ -6,6 +6,9 @@ import axios from 'axios';
 import createToastNotification, { ToastType } from './createToastNotification';
 import getResponseError from './getResponseError';
 
+export const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
+export const REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE = 'Unable to open report';
+
 /**
  * Surfaces sync failures except intentional cancels (orphan reconnect abort).
  */
@@ -15,4 +18,18 @@ export default function notifyFolderSyncError(err: unknown): void {
     }
 
     createToastNotification('Folder sync error', getResponseError(err), ToastType.ERROR);
+}
+
+/** Surfaces failures when listing remote folders (SSH or transport errors). */
+export function notifyFolderListSyncError(detail: string): void {
+    createToastNotification(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE, detail, ToastType.ERROR);
+}
+
+/** Surfaces failures when mounting a remote report that is missing locally. */
+export function notifyRemoteFolderMountError(err: unknown): void {
+    if (axios.isCancel(err)) {
+        return;
+    }
+
+    createToastNotification(REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE, getResponseError(err), ToastType.ERROR);
 }

--- a/src/functions/notifyFolderSyncLocalFallback.ts
+++ b/src/functions/notifyFolderSyncLocalFallback.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import createToastNotification, { ToastType } from './createToastNotification';
+import getResponseError from './getResponseError';
+
+/**
+ * Warns that sync failed but a previously synced local copy will be used instead.
+ */
+export default function notifyFolderSyncLocalFallback(err: unknown): void {
+    createToastNotification(
+        'Loaded local copy',
+        `Could not sync from remote; using previously synced report. ${getResponseError(err)}`,
+        ToastType.WARNING,
+    );
+}

--- a/src/functions/notifyFolderSyncLocalFallback.ts
+++ b/src/functions/notifyFolderSyncLocalFallback.ts
@@ -5,13 +5,17 @@
 import createToastNotification, { ToastType } from './createToastNotification';
 import getResponseError from './getResponseError';
 
+export const FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE = 'Loaded local copy';
+export const FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX =
+    'Could not sync from remote; using previously synced report.';
+
 /**
  * Warns that sync failed but a previously synced local copy will be used instead.
  */
 export default function notifyFolderSyncLocalFallback(err: unknown): void {
     createToastNotification(
-        'Loaded local copy',
-        `Could not sync from remote; using previously synced report. ${getResponseError(err)}`,
+        FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
+        `${FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX} ${getResponseError(err)}`,
         ToastType.WARNING,
     );
 }

--- a/src/functions/notifyFolderSyncLocalFallback.ts
+++ b/src/functions/notifyFolderSyncLocalFallback.ts
@@ -9,6 +9,10 @@ export const FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE = 'Loaded local copy';
 export const FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX =
     'Could not sync from remote; using previously synced report.';
 
+export const LOCAL_SYNCED_REPORTS_TOAST_TITLE = 'Loaded local synced reports';
+export const LOCAL_SYNCED_REPORTS_TOAST_DETAIL =
+    'Remote host unreachable; showing reports already synced on this machine.';
+
 /**
  * Warns that sync failed but a previously synced local copy will be used instead.
  */
@@ -18,4 +22,9 @@ export default function notifyFolderSyncLocalFallback(err: unknown): void {
         `${FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX} ${getResponseError(err)}`,
         ToastType.WARNING,
     );
+}
+
+/** Warns that the remote folder list fell back to on-disk synced copies. */
+export function notifyLocalSyncedReportsListFallback(): void {
+    createToastNotification(LOCAL_SYNCED_REPORTS_TOAST_TITLE, LOCAL_SYNCED_REPORTS_TOAST_DETAIL, ToastType.WARNING);
 }

--- a/src/functions/reportLinks.ts
+++ b/src/functions/reportLinks.ts
@@ -4,71 +4,173 @@
 
 import { ReportLocation } from '../definitions/Reports';
 
-/**
- * A memory (profiler) report and a performance report that were observed to link
- * successfully — i.e. their device operation sequences matched while both were active.
- *
- * The match is a heuristic on the operation sequence, so this is intentionally
- * many-to-many: one report can link with several counterparts (including reports from
- * different runs that happen to share an operation sequence). Each distinct pair is
- * stored separately and never collapsed to a single partner.
- */
-export interface ReportLink {
-    profilerPath: string;
-    profilerLocation: ReportLocation;
-    performancePath: string;
-    performanceLocation: ReportLocation;
+/** Persisted outcome of a memory↔performance pair comparison. */
+export enum ReportPairLinkStatus {
+    LINKED = 'linked',
+    UNLINKED = 'unlinked',
 }
 
+/** Live match result used before (or instead of) persisting a pair. */
+export enum ReportLinkMatchResult {
+    LINKED = 'linked',
+    UNLINKED = 'unlinked',
+    PENDING = 'pending',
+    UNAVAILABLE = 'unavailable',
+}
+
+/**
+ * How a report was accessed when a link was observed. Provenance only — matching
+ * uses {@link ReportLink.profilerId} / {@link ReportLink.performanceId}.
+ */
+export interface ReportLinkAccess {
+    location: ReportLocation;
+    /** Active report path at link time (local folder name or remote path). */
+    path: string;
+    /** Remote host when location is remote; omitted for local. */
+    host?: string | null;
+}
+
+/**
+ * A memory (profiler) report and a performance report that were compared while both
+ * were active. Identity is the report folder basename so the same run badges whether
+ * opened locally or via remote sync. Many-to-many by design.
+ */
+export interface ReportLink {
+    profilerId: string;
+    performanceId: string;
+    status: ReportPairLinkStatus;
+    profilerAccess?: ReportLinkAccess;
+    performanceAccess?: ReportLinkAccess;
+    /** Epoch ms; used for LRU capping. */
+    recordedAt: number;
+}
+
+export interface LinkedReportIdOptions {
+    /**
+     * When set (remote picker), drop counterparts recorded only against a
+     * different remote host. Local / unknown-host links still match for mix-and-match.
+     */
+    remoteHost?: string | null;
+}
+
+/** Soft cap on persisted pairs — oldest entries drop first when exceeded. */
+export const MAX_REPORT_LINKS = 200;
+
+export const REPORT_LINKS_STORAGE_KEY = 'reportLinks.v2';
+
+/**
+ * Stable report identity: final path segment (folder basename).
+ * Prefer the filesystem/remote folder name over display reportName.
+ */
+export const getReportId = (...candidates: Array<string | null | undefined>): string | null => {
+    for (const candidate of candidates) {
+        if (candidate) {
+            const id = pathBasename(candidate);
+            if (id && id !== '.' && id !== '..') {
+                return id;
+            }
+        }
+    }
+
+    return null;
+};
+
+const pathBasename = (value: string): string => {
+    const normalised = value.replace(/\\/g, '/');
+    const segments = normalised.split('/').filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1]! : normalised.trim();
+};
+
 const isSamePair = (a: ReportLink, b: ReportLink): boolean =>
-    a.profilerPath === b.profilerPath &&
-    a.profilerLocation === b.profilerLocation &&
-    a.performancePath === b.performancePath &&
-    a.performanceLocation === b.performanceLocation;
+    a.profilerId === b.profilerId && a.performanceId === b.performanceId;
+
+export const capReportLinks = (links: ReportLink[]): ReportLink[] =>
+    links.length <= MAX_REPORT_LINKS ? links : links.slice(links.length - MAX_REPORT_LINKS);
 
 /**
- * Returns the list with `next` appended, deduping on the full pair so a report can
- * accumulate multiple distinct counterparts without duplicate entries.
+ * Insert or update a pair (identity ignores status). Moves the pair to the end so
+ * recency-based capping keeps actively compared pairs. Returns the same reference
+ * when the pair already exists with the same status (avoids jotai update loops).
  */
-export const addReportLink = (links: ReportLink[], next: ReportLink): ReportLink[] =>
-    links.some((link) => isSamePair(link, next)) ? links : [...links, next];
+export const upsertReportLink = (links: ReportLink[], next: ReportLink): ReportLink[] => {
+    const existing = links.find((link) => isSamePair(link, next));
 
-/**
- * Performance report paths recorded as linked with the given (active) memory report.
- */
-export const linkedPerformancePaths = (
+    if (existing && existing.status === next.status) {
+        return links;
+    }
+
+    const without = links.filter((link) => !isSamePair(link, next));
+    return capReportLinks([...without, next]);
+};
+
+const matchesHostScope = (access: ReportLinkAccess | undefined, remoteHost?: string | null): boolean => {
+    if (!remoteHost) {
+        return true;
+    }
+
+    if (!access || access.location === ReportLocation.LOCAL || !access.host) {
+        return true;
+    }
+
+    return access.host === remoteHost;
+};
+
+const idsForActiveProfiler = (
     links: ReportLink[],
-    profilerPath: string | null | undefined,
-    profilerLocation: ReportLocation | null | undefined,
+    status: ReportPairLinkStatus,
+    profilerId: string | null | undefined,
+    options?: LinkedReportIdOptions,
 ): Set<string> => {
-    if (!profilerPath || !profilerLocation) {
+    if (!profilerId) {
         return new Set();
     }
 
     return new Set(
         links
-            .filter((link) => link.profilerPath === profilerPath && link.profilerLocation === profilerLocation)
-            .map((link) => link.performancePath),
+            .filter((link) => link.status === status && link.profilerId === profilerId)
+            .filter((link) => matchesHostScope(link.performanceAccess, options?.remoteHost))
+            .map((link) => link.performanceId),
     );
 };
 
-/**
- * Memory report paths recorded as linked with the given (active) performance report.
- */
-export const linkedProfilerPaths = (
+const idsForActivePerformance = (
     links: ReportLink[],
-    performancePath: string | null | undefined,
-    performanceLocation: ReportLocation | null | undefined,
+    status: ReportPairLinkStatus,
+    performanceId: string | null | undefined,
+    options?: LinkedReportIdOptions,
 ): Set<string> => {
-    if (!performancePath || !performanceLocation) {
+    if (!performanceId) {
         return new Set();
     }
 
     return new Set(
         links
-            .filter(
-                (link) => link.performancePath === performancePath && link.performanceLocation === performanceLocation,
-            )
-            .map((link) => link.profilerPath),
+            .filter((link) => link.status === status && link.performanceId === performanceId)
+            .filter((link) => matchesHostScope(link.profilerAccess, options?.remoteHost))
+            .map((link) => link.profilerId),
     );
 };
+
+export const linkedPerformanceIds = (
+    links: ReportLink[],
+    profilerId: string | null | undefined,
+    options?: LinkedReportIdOptions,
+): Set<string> => idsForActiveProfiler(links, ReportPairLinkStatus.LINKED, profilerId, options);
+
+export const unlinkedPerformanceIds = (
+    links: ReportLink[],
+    profilerId: string | null | undefined,
+    options?: LinkedReportIdOptions,
+): Set<string> => idsForActiveProfiler(links, ReportPairLinkStatus.UNLINKED, profilerId, options);
+
+export const linkedProfilerIds = (
+    links: ReportLink[],
+    performanceId: string | null | undefined,
+    options?: LinkedReportIdOptions,
+): Set<string> => idsForActivePerformance(links, ReportPairLinkStatus.LINKED, performanceId, options);
+
+export const unlinkedProfilerIds = (
+    links: ReportLink[],
+    performanceId: string | null | undefined,
+    options?: LinkedReportIdOptions,
+): Set<string> => idsForActivePerformance(links, ReportPairLinkStatus.UNLINKED, performanceId, options);

--- a/src/functions/reportLinks.ts
+++ b/src/functions/reportLinks.ts
@@ -78,7 +78,8 @@ export const getReportId = (...candidates: Array<string | null | undefined>): st
 const pathBasename = (value: string): string => {
     const normalised = value.replace(/\\/g, '/');
     const segments = normalised.split('/').filter(Boolean);
-    return segments.length > 0 ? segments[segments.length - 1]! : normalised.trim();
+    // Empty after stripping separators (e.g. '/', '\\') — not a usable report id.
+    return segments.length > 0 ? segments[segments.length - 1]! : '';
 };
 
 const isSamePair = (a: ReportLink, b: ReportLink): boolean =>
@@ -88,9 +89,11 @@ export const capReportLinks = (links: ReportLink[]): ReportLink[] =>
     links.length <= MAX_REPORT_LINKS ? links : links.slice(links.length - MAX_REPORT_LINKS);
 
 /**
- * Insert or update a pair (identity ignores status). Moves the pair to the end so
- * recency-based capping keeps actively compared pairs. Returns the same reference
- * when the pair already exists with the same status (avoids jotai update loops).
+ * Insert or update a pair (identity ignores status). On insert or status change,
+ * appends the pair at the end so recency-based capping keeps actively compared
+ * pairs. Returns the same array reference when the pair already exists with the
+ * same status (avoids jotai update loops) — that path does not bump recency or
+ * recordedAt.
  */
 export const upsertReportLink = (links: ReportLink[], next: ReportLink): ReportLink[] => {
     const existing = links.find((link) => isSamePair(link, next));

--- a/src/hooks/useActivatingReport.ts
+++ b/src/hooks/useActivatingReport.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { isActivatingReportAtom } from '../store/app';
+
+/**
+ * Shared lock while a report select/mount awaits confirmation of the active report.
+ * Always clears in `finally` so a missed path cannot stick selectors disabled.
+ */
+export const useActivatingReport = () => {
+    const isActivatingReport = useAtomValue(isActivatingReportAtom);
+    const setIsActivatingReport = useSetAtom(isActivatingReportAtom);
+
+    const withActivatingReport = useCallback(
+        async (action: () => Promise<void>): Promise<void> => {
+            setIsActivatingReport(true);
+
+            try {
+                await action();
+            } finally {
+                setIsActivatingReport(false);
+            }
+        },
+        [setIsActivatingReport],
+    );
+
+    return { isActivatingReport, withActivatingReport };
+};

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -97,17 +97,72 @@ const useRemoteConnection = () => {
         return performanceFolders;
     };
 
+    const listLocalProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
+        if (!connection || !connection.host) {
+            throw new Error('No connection provided');
+        }
+
+        if (!connection.profilerPath) {
+            return [];
+        }
+
+        const response = await axiosInstance.post<RemoteFolder[]>(
+            `${Endpoints.REMOTE}/local-profiler-reports`,
+            connection,
+        );
+
+        if (response.status === HttpStatusCode.NoContent) {
+            return [];
+        }
+
+        const reportFolders = Array.isArray(response.data) ? response.data : [];
+
+        return reportFolders.map(normaliseReportFolder) as RemoteFolder[];
+    };
+
+    const listLocalPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
+        if (!connection || !connection.host) {
+            throw new Error('No connection provided');
+        }
+
+        if (!connection.performancePath) {
+            return [];
+        }
+
+        const response = await axiosInstance.post<RemoteFolder[]>(
+            `${Endpoints.REMOTE}/local-performance-reports`,
+            connection,
+        );
+
+        if (response.status === HttpStatusCode.NoContent) {
+            return [];
+        }
+
+        const performanceFolders = Array.isArray(response.data) ? response.data : [];
+
+        return performanceFolders;
+    };
+
     const syncRemoteFolder = async (
         connection?: RemoteConnection,
         profilerRemoteFolder?: RemoteFolder,
         performanceRemoteFolder?: RemoteFolder,
     ) => {
-        if (!connection || !connection.host || !connection.port || !connection.profilerPath) {
+        if (!connection || !connection.host || !connection.port) {
             throw new Error('No connection provided');
         }
 
         if (!profilerRemoteFolder && !performanceRemoteFolder) {
             throw new Error('No remote folder provided');
+        }
+
+        // Performance-only connections omit profilerPath; require a path for the folder being synced.
+        if (profilerRemoteFolder && !connection.profilerPath) {
+            throw new Error('No profiler path provided');
+        }
+
+        if (performanceRemoteFolder && !connection.performancePath) {
+            throw new Error('No performance path provided');
         }
 
         // Bound the hang and guarantee REMOTE_SYNC cleanup for every caller —
@@ -299,6 +354,8 @@ const useRemoteConnection = () => {
         syncRemoteFolder,
         listProfilerReports,
         listPerformanceReports,
+        listLocalProfilerReports,
+        listLocalPerformanceReports,
         mountRemoteFolder,
         persistentState,
         setPersistentSelectedConnection,

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -39,16 +39,17 @@ export const LOCAL_STORAGE_KEY_SELECTED = 'selectedConnection';
 
 type RemoteFolderPathKey = 'profilerPath' | 'performancePath';
 
-const postRemoteFolderList = async (
-    endpoint: string,
+const fetchRemoteFolderList = async (
+    endpoint: Endpoints,
     connection: RemoteConnection | undefined,
     options: {
         requirePort?: boolean;
         pathKey: RemoteFolderPathKey;
         normalise?: boolean;
+        signal?: AbortSignal;
     },
 ): Promise<RemoteFolder[]> => {
-    const { requirePort = false, pathKey, normalise = false } = options;
+    const { requirePort = false, pathKey, normalise = false, signal } = options;
 
     if (!connection || !connection.host || (requirePort && !connection.port)) {
         throw new Error('No connection provided');
@@ -58,7 +59,7 @@ const postRemoteFolderList = async (
         return [];
     }
 
-    const response = await axiosInstance.post<RemoteFolder[]>(endpoint, connection);
+    const response = await axiosInstance.post<RemoteFolder[]>(endpoint, connection, { signal });
 
     if (response.status === HttpStatusCode.NoContent) {
         return [];
@@ -86,28 +87,41 @@ const useRemoteConnection = () => {
         return connectionTestStates;
     };
 
-    const listProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
-        postRemoteFolderList(Endpoints.REMOTE_PROFILER_REPORTS, connection, {
+    const listProfilerReports = async (connection?: RemoteConnection, signal?: AbortSignal): Promise<RemoteFolder[]> =>
+        fetchRemoteFolderList(Endpoints.REMOTE_PROFILER_REPORTS, connection, {
             requirePort: true,
             pathKey: 'profilerPath',
             normalise: true,
+            signal,
         });
 
-    const listPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
-        postRemoteFolderList(Endpoints.REMOTE_PERFORMANCE_REPORTS, connection, {
+    const listPerformanceReports = async (
+        connection?: RemoteConnection,
+        signal?: AbortSignal,
+    ): Promise<RemoteFolder[]> =>
+        fetchRemoteFolderList(Endpoints.REMOTE_PERFORMANCE_REPORTS, connection, {
             requirePort: true,
             pathKey: 'performancePath',
+            signal,
         });
 
-    const listLocalProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
-        postRemoteFolderList(Endpoints.REMOTE_LOCAL_PROFILER_REPORTS, connection, {
+    const listLocalProfilerReports = async (
+        connection?: RemoteConnection,
+        signal?: AbortSignal,
+    ): Promise<RemoteFolder[]> =>
+        fetchRemoteFolderList(Endpoints.REMOTE_LOCAL_PROFILER_REPORTS, connection, {
             pathKey: 'profilerPath',
             normalise: true,
+            signal,
         });
 
-    const listLocalPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
-        postRemoteFolderList(Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS, connection, {
+    const listLocalPerformanceReports = async (
+        connection?: RemoteConnection,
+        signal?: AbortSignal,
+    ): Promise<RemoteFolder[]> =>
+        fetchRemoteFolderList(Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS, connection, {
             pathKey: 'performancePath',
+            signal,
         });
 
     const syncRemoteFolder = async (
@@ -123,7 +137,7 @@ const useRemoteConnection = () => {
             throw new Error('No remote folder provided');
         }
 
-        // Performance-only connections omit profilerPath; require a path for the folder being synced.
+        // Performance-only connections use empty profilerPath; require a path for the folder being synced.
         if (profilerRemoteFolder && !connection.profilerPath) {
             throw new Error('No profiler path provided');
         }

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -37,6 +37,38 @@ const FAILED_NO_PATH = {
 export const LOCAL_STORAGE_KEY_CONNECTIONS = 'remoteConnections';
 export const LOCAL_STORAGE_KEY_SELECTED = 'selectedConnection';
 
+type RemoteFolderPathKey = 'profilerPath' | 'performancePath';
+
+const postRemoteFolderList = async (
+    endpoint: string,
+    connection: RemoteConnection | undefined,
+    options: {
+        requirePort?: boolean;
+        pathKey: RemoteFolderPathKey;
+        normalise?: boolean;
+    },
+): Promise<RemoteFolder[]> => {
+    const { requirePort = false, pathKey, normalise = false } = options;
+
+    if (!connection || !connection.host || (requirePort && !connection.port)) {
+        throw new Error('No connection provided');
+    }
+
+    if (!connection[pathKey]) {
+        return [];
+    }
+
+    const response = await axiosInstance.post<RemoteFolder[]>(endpoint, connection);
+
+    if (response.status === HttpStatusCode.NoContent) {
+        return [];
+    }
+
+    const folders = Array.isArray(response.data) ? response.data : [];
+
+    return normalise ? (folders.map(normaliseReportFolder) as RemoteFolder[]) : folders;
+};
+
 const useRemoteConnection = () => {
     const { getAppConfig, setAppConfig, deleteAppConfig } = useAppConfig();
 
@@ -54,94 +86,29 @@ const useRemoteConnection = () => {
         return connectionTestStates;
     };
 
-    const listProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
-        if (!connection || !connection.host || !connection.port) {
-            throw new Error('No connection provided');
-        }
+    const listProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
+        postRemoteFolderList(Endpoints.REMOTE_PROFILER_REPORTS, connection, {
+            requirePort: true,
+            pathKey: 'profilerPath',
+            normalise: true,
+        });
 
-        if (!connection.profilerPath) {
-            return [];
-        }
+    const listPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
+        postRemoteFolderList(Endpoints.REMOTE_PERFORMANCE_REPORTS, connection, {
+            requirePort: true,
+            pathKey: 'performancePath',
+        });
 
-        const response = await axiosInstance.post<RemoteFolder[]>(`${Endpoints.REMOTE}/profiler-reports`, connection);
+    const listLocalProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
+        postRemoteFolderList(Endpoints.REMOTE_LOCAL_PROFILER_REPORTS, connection, {
+            pathKey: 'profilerPath',
+            normalise: true,
+        });
 
-        if (response.status === HttpStatusCode.NoContent) {
-            return [];
-        }
-
-        const reportFolders = Array.isArray(response.data) ? response.data : [];
-
-        return reportFolders.map(normaliseReportFolder) as RemoteFolder[];
-    };
-
-    const listPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
-        if (!connection || !connection.host || !connection.port) {
-            throw new Error('No connection provided');
-        }
-
-        if (!connection.performancePath) {
-            return [];
-        }
-
-        const response = await axiosInstance.post<RemoteFolder[]>(
-            `${Endpoints.REMOTE}/performance-reports`,
-            connection,
-        );
-
-        if (response.status === HttpStatusCode.NoContent) {
-            return [];
-        }
-
-        const performanceFolders = Array.isArray(response.data) ? response.data : [];
-
-        return performanceFolders;
-    };
-
-    const listLocalProfilerReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
-        if (!connection || !connection.host) {
-            throw new Error('No connection provided');
-        }
-
-        if (!connection.profilerPath) {
-            return [];
-        }
-
-        const response = await axiosInstance.post<RemoteFolder[]>(
-            `${Endpoints.REMOTE}/local-profiler-reports`,
-            connection,
-        );
-
-        if (response.status === HttpStatusCode.NoContent) {
-            return [];
-        }
-
-        const reportFolders = Array.isArray(response.data) ? response.data : [];
-
-        return reportFolders.map(normaliseReportFolder) as RemoteFolder[];
-    };
-
-    const listLocalPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> => {
-        if (!connection || !connection.host) {
-            throw new Error('No connection provided');
-        }
-
-        if (!connection.performancePath) {
-            return [];
-        }
-
-        const response = await axiosInstance.post<RemoteFolder[]>(
-            `${Endpoints.REMOTE}/local-performance-reports`,
-            connection,
-        );
-
-        if (response.status === HttpStatusCode.NoContent) {
-            return [];
-        }
-
-        const performanceFolders = Array.isArray(response.data) ? response.data : [];
-
-        return performanceFolders;
-    };
+    const listLocalPerformanceReports = async (connection?: RemoteConnection): Promise<RemoteFolder[]> =>
+        postRemoteFolderList(Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS, connection, {
+            pathKey: 'performancePath',
+        });
 
     const syncRemoteFolder = async (
         connection?: RemoteConnection,

--- a/src/hooks/useReportLinkBadgeIds.ts
+++ b/src/hooks/useReportLinkBadgeIds.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import getServerConfig from '../functions/getServerConfig';
+import {
+    LinkedReportIdOptions,
+    getReportId,
+    linkedPerformanceIds,
+    linkedProfilerIds,
+    unlinkedPerformanceIds,
+    unlinkedProfilerIds,
+} from '../functions/reportLinks';
+import { activePerformanceReportAtom, activeProfilerReportAtom, reportLinksAtom } from '../store/app';
+
+export interface ReportLinkBadgeIds {
+    linkedPerfIds: Set<string> | undefined;
+    unlinkedPerfIds: Set<string> | undefined;
+    linkedProfilerReportIds: Set<string> | undefined;
+    unlinkedProfilerReportIds: Set<string> | undefined;
+}
+
+/**
+ * Linked / unlinked counterpart ids for folder pickers. When linking is disabled,
+ * all sets are undefined so pickers hide badges. Pass `remoteHost` from the remote
+ * picker so counterparts recorded only against another host are scoped out.
+ */
+export const useReportLinkBadgeIds = (options?: LinkedReportIdOptions): ReportLinkBadgeIds => {
+    const reportLinks = useAtomValue(reportLinksAtom);
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
+    const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
+    const isReportLinkingEnabled = !!getServerConfig()?.REPORT_LINKING_ENABLED;
+    const remoteHost = options?.remoteHost ?? null;
+
+    const profilerId = getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName);
+    const performanceId = getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName);
+
+    const linkedPerfIds = useMemo(
+        () => (isReportLinkingEnabled ? linkedPerformanceIds(reportLinks, profilerId, { remoteHost }) : undefined),
+        [reportLinks, profilerId, isReportLinkingEnabled, remoteHost],
+    );
+    const unlinkedPerfIds = useMemo(
+        () => (isReportLinkingEnabled ? unlinkedPerformanceIds(reportLinks, profilerId, { remoteHost }) : undefined),
+        [reportLinks, profilerId, isReportLinkingEnabled, remoteHost],
+    );
+    const linkedProfilerReportIds = useMemo(
+        () => (isReportLinkingEnabled ? linkedProfilerIds(reportLinks, performanceId, { remoteHost }) : undefined),
+        [reportLinks, performanceId, isReportLinkingEnabled, remoteHost],
+    );
+    const unlinkedProfilerReportIds = useMemo(
+        () => (isReportLinkingEnabled ? unlinkedProfilerIds(reportLinks, performanceId, { remoteHost }) : undefined),
+        [reportLinks, performanceId, isReportLinkingEnabled, remoteHost],
+    );
+
+    return { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds };
+};

--- a/src/hooks/useReportLinkBadgeIds.ts
+++ b/src/hooks/useReportLinkBadgeIds.ts
@@ -16,15 +16,15 @@ import {
 import { activePerformanceReportAtom, activeProfilerReportAtom, reportLinksAtom } from '../store/app';
 
 export interface ReportLinkBadgeIds {
-    linkedPerfIds: Set<string> | undefined;
-    unlinkedPerfIds: Set<string> | undefined;
-    linkedProfilerReportIds: Set<string> | undefined;
-    unlinkedProfilerReportIds: Set<string> | undefined;
+    linkedPerfIds: Set<string> | null;
+    unlinkedPerfIds: Set<string> | null;
+    linkedProfilerReportIds: Set<string> | null;
+    unlinkedProfilerReportIds: Set<string> | null;
 }
 
 /**
  * Linked / unlinked counterpart ids for folder pickers. When linking is disabled,
- * all sets are undefined so pickers hide badges. Pass `remoteHost` from the remote
+ * all sets are null so pickers hide badges. Pass `remoteHost` from the remote
  * picker so counterparts recorded only against another host are scoped out.
  */
 export const useReportLinkBadgeIds = (options?: LinkedReportIdOptions): ReportLinkBadgeIds => {
@@ -37,22 +37,21 @@ export const useReportLinkBadgeIds = (options?: LinkedReportIdOptions): ReportLi
     const profilerId = getReportId(activeProfilerReport?.path, activeProfilerReport?.reportName);
     const performanceId = getReportId(activePerformanceReport?.path, activePerformanceReport?.reportName);
 
-    const linkedPerfIds = useMemo(
-        () => (isReportLinkingEnabled ? linkedPerformanceIds(reportLinks, profilerId, { remoteHost }) : undefined),
-        [reportLinks, profilerId, isReportLinkingEnabled, remoteHost],
-    );
-    const unlinkedPerfIds = useMemo(
-        () => (isReportLinkingEnabled ? unlinkedPerformanceIds(reportLinks, profilerId, { remoteHost }) : undefined),
-        [reportLinks, profilerId, isReportLinkingEnabled, remoteHost],
-    );
-    const linkedProfilerReportIds = useMemo(
-        () => (isReportLinkingEnabled ? linkedProfilerIds(reportLinks, performanceId, { remoteHost }) : undefined),
-        [reportLinks, performanceId, isReportLinkingEnabled, remoteHost],
-    );
-    const unlinkedProfilerReportIds = useMemo(
-        () => (isReportLinkingEnabled ? unlinkedProfilerIds(reportLinks, performanceId, { remoteHost }) : undefined),
-        [reportLinks, performanceId, isReportLinkingEnabled, remoteHost],
-    );
+    return useMemo(() => {
+        if (!isReportLinkingEnabled) {
+            return {
+                linkedPerfIds: null,
+                unlinkedPerfIds: null,
+                linkedProfilerReportIds: null,
+                unlinkedProfilerReportIds: null,
+            };
+        }
 
-    return { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds };
+        return {
+            linkedPerfIds: linkedPerformanceIds(reportLinks, profilerId, { remoteHost }),
+            unlinkedPerfIds: unlinkedPerformanceIds(reportLinks, profilerId, { remoteHost }),
+            linkedProfilerReportIds: linkedProfilerIds(reportLinks, performanceId, { remoteHost }),
+            unlinkedProfilerReportIds: unlinkedProfilerIds(reportLinks, performanceId, { remoteHost }),
+        };
+    }, [reportLinks, profilerId, performanceId, isReportLinkingEnabled, remoteHost]);
 };

--- a/src/hooks/useReportLinkMatch.ts
+++ b/src/hooks/useReportLinkMatch.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useAtomValue } from 'jotai';
+import { useDevices, useGetDeviceOperationListPerf, useOperationsList, usePerformanceReport } from './useAPI';
+import { activePerformanceReportAtom, activeProfilerReportAtom } from '../store/app';
+import { ReportLinkMatchResult } from '../functions/reportLinks';
+
+/**
+ * Live memory↔performance match outcome. PENDING while underlying queries are in
+ * flight; LINKED/UNLINKED once settled; UNAVAILABLE if a required query errored.
+ */
+export const useReportLinkMatch = (): ReportLinkMatchResult => {
+    const matchedOperations = useGetDeviceOperationListPerf();
+    const activeProfilerReport = useAtomValue(activeProfilerReportAtom);
+    const activePerformanceReport = useAtomValue(activePerformanceReportAtom);
+
+    const {
+        isFetched: isOperationsFetched,
+        isFetching: isOperationsFetching,
+        isError: isOperationsError,
+    } = useOperationsList();
+    const { isFetched: isDevicesFetched, isFetching: isDevicesFetching, isError: isDevicesError } = useDevices();
+    const {
+        isFetched: isPerformanceFetched,
+        isFetching: isPerformanceFetching,
+        isError: isPerformanceError,
+    } = usePerformanceReport(activePerformanceReport?.reportName || null);
+
+    if (!activeProfilerReport || !activePerformanceReport) {
+        return ReportLinkMatchResult.UNAVAILABLE;
+    }
+
+    if (matchedOperations.length > 0) {
+        return ReportLinkMatchResult.LINKED;
+    }
+
+    const comparisonSettled =
+        isOperationsFetched &&
+        !isOperationsFetching &&
+        isDevicesFetched &&
+        !isDevicesFetching &&
+        isPerformanceFetched &&
+        !isPerformanceFetching;
+
+    if (!comparisonSettled) {
+        return ReportLinkMatchResult.PENDING;
+    }
+
+    if (isOperationsError || isDevicesError || isPerformanceError) {
+        return ReportLinkMatchResult.UNAVAILABLE;
+    }
+
+    return ReportLinkMatchResult.UNLINKED;
+};

--- a/src/scss/components/FolderPicker.scss
+++ b/src/scss/components/FolderPicker.scss
@@ -50,4 +50,8 @@ $folder-text-size: 15px;
         line-height: 1.1;
         color: $tt-grey-5;
     }
+
+    .folder-link-status-unknown {
+        opacity: 0.2;
+    }
 }

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -53,9 +53,10 @@ export const operationRangeAtom = atom<NumberRange | null>(null);
 export const selectedOperationRangeAtom = atom<NumberRange | null>(null);
 export const performanceReportLocationAtom = atom<ReportLocation | null>(null);
 export const activePerformanceReportAtom = atom<ReportFolder | null>(null);
-// Persisted memory<->performance report pairs observed to link successfully. Many-to-many
-// by design; surfaced as badges against the active report in the report selection lists.
-export const successfulReportLinksAtom = atomWithStorage<ReportLink[]>('successfulReportLinks', []);
+// Persisted memory<->performance report pairs (linked and unlinked). Many-to-many
+// by canonical folder id; surfaced as linked/unknown/unlinked badges in pickers.
+// Storage key bumped so pre-status / pre-id-scheme entries are discarded (no migration).
+export const successfulReportLinksAtom = atomWithStorage<ReportLink[]>('reportLinks.v2', []);
 export const performanceRangeAtom = atom<NumberRange | null>(null);
 export const selectedPerformanceRangeAtom = atom<NumberRange | null>(null);
 export const activeNpeOpTraceAtom = atom<string | null>(null);

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -11,7 +11,7 @@ import { ListStates } from '../definitions/VirtualLists';
 import { Signpost } from '../functions/perfFunctions';
 import { PerfTabIds } from '../definitions/Performance';
 import { ReportFolder, ReportLocation } from '../definitions/Reports';
-import { ReportLink } from '../functions/reportLinks';
+import { REPORT_LINKS_STORAGE_KEY, ReportLink } from '../functions/reportLinks';
 import { ColumnKeys, TypedPerfTableRow } from '../definitions/PerfTable';
 import { BufferType } from '../model/BufferType';
 import { StackedGroupBy } from '../definitions/StackedPerfTable';
@@ -53,10 +53,10 @@ export const operationRangeAtom = atom<NumberRange | null>(null);
 export const selectedOperationRangeAtom = atom<NumberRange | null>(null);
 export const performanceReportLocationAtom = atom<ReportLocation | null>(null);
 export const activePerformanceReportAtom = atom<ReportFolder | null>(null);
-// Persisted memory<->performance report pairs (linked and unlinked). Many-to-many
+// Persisted memory↔performance report pairs (linked and unlinked). Many-to-many
 // by canonical folder id; surfaced as linked/unknown/unlinked badges in pickers.
 // Storage key bumped so pre-status / pre-id-scheme entries are discarded (no migration).
-export const successfulReportLinksAtom = atomWithStorage<ReportLink[]>('reportLinks.v2', []);
+export const reportLinksAtom = atomWithStorage<ReportLink[]>(REPORT_LINKS_STORAGE_KEY, []);
 export const performanceRangeAtom = atom<NumberRange | null>(null);
 export const selectedPerformanceRangeAtom = atom<NumberRange | null>(null);
 export const activeNpeOpTraceAtom = atom<string | null>(null);

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -53,6 +53,8 @@ export const operationRangeAtom = atom<NumberRange | null>(null);
 export const selectedOperationRangeAtom = atom<NumberRange | null>(null);
 export const performanceReportLocationAtom = atom<ReportLocation | null>(null);
 export const activePerformanceReportAtom = atom<ReportFolder | null>(null);
+/** True while a report select/mount is awaiting confirmation of the active report. */
+export const isActivatingReportAtom = atom(false);
 // Persisted memory↔performance report pairs (linked and unlinked). Many-to-many
 // by canonical folder id; surfaced as linked/unknown/unlinked badges in pickers.
 // Storage key bumped so pre-status / pre-id-scheme entries are discarded (no migration).

--- a/tests/LocalFolderPicker.spec.tsx
+++ b/tests/LocalFolderPicker.spec.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import LocalFolderPicker from '../src/components/report-selection/LocalFolderPicker';
+import { ReportFolder } from '../src/definitions/Reports';
+import testForPortal from './helpers/testForPortal';
+import { TestProviders } from './helpers/TestProviders';
+
+afterEach(cleanup);
+
+vi.mock('../src/hooks/useAPI', () => ({
+    useInstance: () => ({ data: {} }),
+}));
+
+vi.mock('../src/functions/getServerConfig', () => ({
+    default: () => ({ SERVER_MODE: false }),
+}));
+
+const WAIT_FOR_OPTIONS = { timeout: 1000 };
+
+const folders: ReportFolder[] = [
+    { path: 'unknown-run', reportName: 'unknown-run' },
+    { path: 'unlinked-run', reportName: 'unlinked-run' },
+    { path: 'linked-run', reportName: 'linked-run' },
+];
+
+describe('LocalFolderPicker link badges', () => {
+    it('sorts linked first, unknown middle, unlinked last', async () => {
+        render(
+            <TestProviders>
+                <LocalFolderPicker
+                    items={folders}
+                    value={null}
+                    handleSelect={vi.fn()}
+                    linkedIds={new Set(['linked-run'])}
+                    unlinkedIds={new Set(['unlinked-run'])}
+                />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByText('Select a report...'));
+        await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+        const labels = [...document.querySelectorAll('.folder-picker-menu-item .bp6-text-overflow-ellipsis')].map(
+            (el) => el.textContent,
+        );
+
+        expect(labels).toEqual(['/linked-run', '/unknown-run', '/unlinked-run']);
+    });
+
+    it('shows a warning unlink icon on unlinked folders', async () => {
+        render(
+            <TestProviders>
+                <LocalFolderPicker
+                    items={[{ path: 'unlinked-run', reportName: 'unlinked-run' }]}
+                    value={null}
+                    handleSelect={vi.fn()}
+                    linkedIds={new Set()}
+                    unlinkedIds={new Set(['unlinked-run'])}
+                />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByText('Select a report...'));
+        await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+        const unlinkIcon = document.querySelector('.folder-picker-menu-item .bp6-icon-unlink.bp6-intent-warning');
+        expect(unlinkIcon).not.toBeNull();
+    });
+});

--- a/tests/LocalFolderPicker.spec.tsx
+++ b/tests/LocalFolderPicker.spec.tsx
@@ -51,6 +51,21 @@ describe('LocalFolderPicker link badges', () => {
         expect(labels).toEqual(['/linked-run', '/unknown-run', '/unlinked-run']);
     });
 
+    it('disables the picker when disabled is set', () => {
+        render(
+            <TestProviders>
+                <LocalFolderPicker
+                    items={folders}
+                    value={null}
+                    handleSelect={vi.fn()}
+                    disabled
+                />
+            </TestProviders>,
+        );
+
+        expect(screen.getByText('Select a report...').closest('button')).toHaveProperty('disabled', true);
+    });
+
     it('shows a warning unlink icon on unlinked folders', async () => {
         render(
             <TestProviders>

--- a/tests/ReportLinkStatus.spec.tsx
+++ b/tests/ReportLinkStatus.spec.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { useAtomValue } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ReportLinkStatus from '../src/components/ReportLinkStatus';
+import { ReportLocation } from '../src/definitions/Reports';
+import { ReportLinkMatchResult, ReportPairLinkStatus } from '../src/functions/reportLinks';
+import {
+    activePerformanceReportAtom,
+    activeProfilerReportAtom,
+    performanceReportLocationAtom,
+    profilerReportLocationAtom,
+    reportLinksAtom,
+} from '../src/store/app';
+import { TestProviders } from './helpers/TestProviders';
+
+const matchState = vi.hoisted(() => ({
+    result: 'pending' as string,
+}));
+
+vi.mock('../src/hooks/useReportLinkMatch', () => ({
+    useReportLinkMatch: () => matchState.result,
+}));
+
+vi.mock('../src/hooks/useRemote', () => ({
+    default: () => ({
+        persistentState: { selectedConnection: { host: 'n150' } },
+    }),
+}));
+
+vi.mock('../src/functions/getServerConfig', () => ({
+    default: () => ({ REPORT_LINKING_ENABLED: true }),
+}));
+
+const PROFILER = { path: '/data/local/profiler-reports/mem-run', reportName: 'mem-run' };
+const PERFORMANCE = { path: '/data/local/performance-reports/perf-run', reportName: 'perf-run' };
+
+function LinksProbe() {
+    const links = useAtomValue(reportLinksAtom);
+
+    return <pre data-testid='report-links'>{JSON.stringify(links)}</pre>;
+}
+
+function renderWithReports() {
+    return render(
+        <TestProviders
+            initialAtomValues={[
+                [activeProfilerReportAtom, PROFILER],
+                [activePerformanceReportAtom, PERFORMANCE],
+                [profilerReportLocationAtom, ReportLocation.LOCAL],
+                [performanceReportLocationAtom, ReportLocation.LOCAL],
+                [reportLinksAtom, []],
+            ]}
+        >
+            <ReportLinkStatus />
+            <LinksProbe />
+        </TestProviders>,
+    );
+}
+
+describe('ReportLinkStatus', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        matchState.result = ReportLinkMatchResult.PENDING;
+    });
+
+    afterEach(() => {
+        cleanup();
+        window.localStorage.clear();
+    });
+
+    it('does not persist while match is PENDING', async () => {
+        matchState.result = ReportLinkMatchResult.PENDING;
+        renderWithReports();
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('report-links').textContent ?? '[]')).toEqual([]);
+        });
+    });
+
+    it('does not persist when match is UNAVAILABLE', async () => {
+        matchState.result = ReportLinkMatchResult.UNAVAILABLE;
+        renderWithReports();
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('report-links').textContent ?? '[]')).toEqual([]);
+        });
+    });
+
+    it('persists a LINKED pair once the comparison settles', async () => {
+        matchState.result = ReportLinkMatchResult.LINKED;
+        renderWithReports();
+
+        await waitFor(() => {
+            const links = JSON.parse(screen.getByTestId('report-links').textContent ?? '[]');
+            expect(links).toHaveLength(1);
+            expect(links[0]).toMatchObject({
+                profilerId: 'mem-run',
+                performanceId: 'perf-run',
+                status: ReportPairLinkStatus.LINKED,
+            });
+        });
+    });
+
+    it('persists an UNLINKED pair so pickers can badge failed links', async () => {
+        matchState.result = ReportLinkMatchResult.UNLINKED;
+        renderWithReports();
+
+        await waitFor(() => {
+            const links = JSON.parse(screen.getByTestId('report-links').textContent ?? '[]');
+            expect(links).toHaveLength(1);
+            expect(links[0]).toMatchObject({
+                profilerId: 'mem-run',
+                performanceId: 'perf-run',
+                status: ReportPairLinkStatus.UNLINKED,
+            });
+        });
+    });
+});

--- a/tests/getRemoteSyncFailureAction.spec.ts
+++ b/tests/getRemoteSyncFailureAction.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { CanceledError } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { RemoteFolder } from '../src/definitions/RemoteConnection';
+import getRemoteSyncFailureAction, { RemoteSyncFailureAction } from '../src/functions/getRemoteSyncFailureAction';
+
+const NEVER_SYNCED: RemoteFolder = {
+    reportName: 'never',
+    remotePath: '/remote/never',
+    lastModified: 1_700_000_200,
+    lastSynced: null,
+};
+
+const PREVIOUSLY_SYNCED: RemoteFolder = {
+    reportName: 'stale',
+    remotePath: '/remote/stale',
+    lastModified: 1_700_000_200,
+    lastSynced: 1_700_000_100,
+};
+
+describe('getRemoteSyncFailureAction', () => {
+    it('ignores intentional axios cancels', () => {
+        expect(getRemoteSyncFailureAction(new CanceledError('aborted'), PREVIOUSLY_SYNCED)).toBe(
+            RemoteSyncFailureAction.IGNORE_CANCEL,
+        );
+    });
+
+    it('falls back to the local copy when a folder was selected', () => {
+        expect(getRemoteSyncFailureAction(new Error('Unable to establish SSH connection'), PREVIOUSLY_SYNCED)).toBe(
+            RemoteSyncFailureAction.FALLBACK_LOCAL,
+        );
+    });
+
+    it('falls back even when lastSynced metadata is missing', () => {
+        expect(getRemoteSyncFailureAction(new Error('Unable to establish SSH connection'), NEVER_SYNCED)).toBe(
+            RemoteSyncFailureAction.FALLBACK_LOCAL,
+        );
+    });
+
+    it('shows an error when no folder is available', () => {
+        expect(getRemoteSyncFailureAction(new Error('connection refused'), null)).toBe(
+            RemoteSyncFailureAction.SHOW_ERROR,
+        );
+    });
+});

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -12,17 +12,20 @@ import mockPerformanceReportFolders from './data/mockPerformanceReportFolders.js
 import { ReportFolder } from '../src/definitions/Reports';
 import LocalFolderSelector from '../src/components/report-selection/LocalFolderSelector';
 import { TEST_IDS } from '../src/definitions/TestIds';
+import { isActivatingReportAtom } from '../src/store/app';
 import testForPortal from './helpers/testForPortal';
 import createMockFile, { MOCK_FOLDER } from './helpers/createMockFile';
 
 // Scrub the markup after each test
-afterEach(cleanup);
-
 const WAIT_FOR_OPTIONS = { timeout: 1000 };
 const SELECT_REPORT_TEXT = 'Select a report...';
 
 // Data is mutated in the mock of useLocal - eventually this should be set per test as needed
 const mockPerfFolderList = [...mockPerformanceReportFolders];
+
+const { mockUpdateInstance } = vi.hoisted(() => ({
+    mockUpdateInstance: vi.fn(),
+}));
 
 vi.mock('../src/hooks/useLocal', async () => {
     const actual = await import('../src/hooks/useLocal');
@@ -59,29 +62,42 @@ vi.mock('../src/hooks/useAPI', async () => {
         usePerfFolderList: () => ({ data: mockPerfFolderList }),
         useInstance: () => ({ data: mockInstanceEmpty }),
         useReportFolderList: () => ({ data: mockProfilerFolderList }),
-        updateInstance: vi.fn().mockImplementation((updates) => {
-            // Return instance with the updates applied
-            const updatedInstance = {
-                ...mockInstanceEmpty,
-                ...updates,
-            };
-
-            // If it's a profiler report, set the profiler_path
-            if (updates.active_report?.profiler_name) {
-                updatedInstance.profiler_path = `/data/local/profiler-reports/${updates.active_report.profiler_name.path}`;
-            }
-
-            // If it's a performance report, set the performance_path
-            if (updates.active_report?.performance_name) {
-                updatedInstance.performance_path = `/data/local/performance-reports/${updates.active_report.performance_name.path}`;
-            }
-
-            return Promise.resolve(updatedInstance);
-        }),
+        updateInstance: (...args: unknown[]) => mockUpdateInstance(...args),
         deleteProfiler: vi.fn().mockResolvedValue({ success: true }),
         deletePerformance: vi.fn().mockResolvedValue({ success: true }),
     };
 });
+
+const defaultUpdateInstance = (updates: {
+    active_report?: { profiler_name?: string | { path: string }; performance_name?: string | { path: string } };
+}) => {
+    const updatedInstance: Record<string, unknown> = {
+        ...mockInstanceEmpty,
+        ...updates,
+    };
+
+    if (updates.active_report?.profiler_name) {
+        const profilerName = updates.active_report.profiler_name;
+        const path = typeof profilerName === 'string' ? profilerName : profilerName.path;
+        updatedInstance.profiler_path = `/data/local/profiler-reports/${path}`;
+    }
+
+    if (updates.active_report?.performance_name) {
+        const performanceName = updates.active_report.performance_name;
+        const path = typeof performanceName === 'string' ? performanceName : performanceName.path;
+        updatedInstance.performance_path = `/data/local/performance-reports/${path}`;
+    }
+
+    return Promise.resolve(updatedInstance);
+};
+
+afterEach(() => {
+    cleanup();
+    mockUpdateInstance.mockReset();
+    mockUpdateInstance.mockImplementation(defaultUpdateInstance);
+});
+
+mockUpdateInstance.mockImplementation(defaultUpdateInstance);
 
 it('renders the initial folder selector upload field states', async () => {
     render(
@@ -102,6 +118,58 @@ it('renders the initial folder selector upload field states', async () => {
         expect(screen.getByText(folder.reportName)).not.toBeNull();
         expect(screen.getByText(`/${folder.path}`)).not.toBeNull();
     });
+});
+
+it('disables local report selectors while an active report is being confirmed', () => {
+    render(
+        <TestProviders initialAtomValues={[[isActivatingReportAtom, true]]}>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    getAllButtonsWithText(SELECT_REPORT_TEXT).forEach((button) => {
+        expect(button).toHaveProperty('disabled', true);
+    });
+});
+
+it('disables pickers while updateInstance is pending then re-enables', async () => {
+    let resolveUpdate: ((value: unknown) => void) | undefined;
+    mockUpdateInstance.mockImplementationOnce(
+        () =>
+            new Promise((resolve) => {
+                resolveUpdate = resolve;
+            }),
+    );
+
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    getAllButtonsWithText(SELECT_REPORT_TEXT)[0].click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    const { reportName } = mockProfilerFolderList[0];
+    screen.getByText(reportName).click();
+
+    await waitFor(() => {
+        getAllButtonsWithText(SELECT_REPORT_TEXT).forEach((button) => {
+            expect(button).toHaveProperty('disabled', true);
+        });
+    }, WAIT_FOR_OPTIONS);
+
+    expect(resolveUpdate).toBeDefined();
+    resolveUpdate!(mockInstanceEmpty);
+
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(reportName),
+        WAIT_FOR_OPTIONS,
+    );
+
+    await waitFor(() => {
+        expect(getAllButtonsWithText(reportName)[0]).toHaveProperty('disabled', false);
+    }, WAIT_FOR_OPTIONS);
 });
 
 it('updates the instance when a profiler report is selected and creates toast message', async () => {

--- a/tests/mergeRemoteFolders.spec.ts
+++ b/tests/mergeRemoteFolders.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { RemoteFolder } from '../src/definitions/RemoteConnection';
+import mergeRemoteFolders from '../src/functions/mergeRemoteFolders';
+
+const baseFolder = (overrides: Partial<RemoteFolder> = {}): RemoteFolder => ({
+    reportName: 'resnet50',
+    remotePath: '/remote/reports/resnet50',
+    lastModified: 200,
+    ...overrides,
+});
+
+describe('mergeRemoteFolders', () => {
+    it('clears a cached lastSynced when the update sets null', () => {
+        const merged = mergeRemoteFolders([baseFolder({ lastSynced: 100 })], [baseFolder({ lastSynced: null })]);
+
+        expect(merged).toHaveLength(1);
+        expect(merged[0].lastSynced).toBeNull();
+    });
+
+    it('keeps a cached lastSynced when the update omits the key', () => {
+        const updated = baseFolder();
+        delete updated.lastSynced;
+
+        const merged = mergeRemoteFolders([baseFolder({ lastSynced: 100 })], [updated]);
+
+        expect(merged).toHaveLength(1);
+        expect(merged[0].lastSynced).toBe(100);
+    });
+
+    it('prefers a numeric lastSynced from the update', () => {
+        const merged = mergeRemoteFolders([baseFolder({ lastSynced: 100 })], [baseFolder({ lastSynced: 250 })]);
+
+        expect(merged[0].lastSynced).toBe(250);
+    });
+});

--- a/tests/notifyFolderSyncError.spec.ts
+++ b/tests/notifyFolderSyncError.spec.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToastType } from '../src/functions/createToastNotification';
 import notifyFolderSyncError, {
     FOLDER_LIST_SYNC_ERROR_TOAST_TITLE,
+    FOLDER_SYNC_ERROR_TOAST_TITLE,
     REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE,
     notifyFolderListSyncError,
     notifyRemoteFolderMountError,
@@ -41,7 +42,7 @@ describe('notifyFolderSyncError', () => {
         notifyFolderSyncError(new Error('connection refused'));
 
         expect(createToastNotification).toHaveBeenCalledWith(
-            'Folder sync error',
+            FOLDER_SYNC_ERROR_TOAST_TITLE,
             'connection refused',
             ToastType.ERROR,
         );

--- a/tests/notifyFolderSyncError.spec.ts
+++ b/tests/notifyFolderSyncError.spec.ts
@@ -5,7 +5,12 @@
 import { CanceledError } from 'axios';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToastType } from '../src/functions/createToastNotification';
-import notifyFolderSyncError from '../src/functions/notifyFolderSyncError';
+import notifyFolderSyncError, {
+    FOLDER_LIST_SYNC_ERROR_TOAST_TITLE,
+    REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE,
+    notifyFolderListSyncError,
+    notifyRemoteFolderMountError,
+} from '../src/functions/notifyFolderSyncError';
 
 const { createToastNotification } = vi.hoisted(() => ({
     createToastNotification: vi.fn(),
@@ -38,6 +43,36 @@ describe('notifyFolderSyncError', () => {
         expect(createToastNotification).toHaveBeenCalledWith(
             'Folder sync error',
             'connection refused',
+            ToastType.ERROR,
+        );
+    });
+});
+
+describe('notifyFolderListSyncError', () => {
+    it('toasts the list-level sync error detail', () => {
+        notifyFolderListSyncError('SSH timed out');
+
+        expect(createToastNotification).toHaveBeenCalledWith(
+            FOLDER_LIST_SYNC_ERROR_TOAST_TITLE,
+            'SSH timed out',
+            ToastType.ERROR,
+        );
+    });
+});
+
+describe('notifyRemoteFolderMountError', () => {
+    it('skips the toast for axios cancel / abort errors', () => {
+        notifyRemoteFolderMountError(new CanceledError('aborted'));
+
+        expect(createToastNotification).not.toHaveBeenCalled();
+    });
+
+    it('toasts a mount failure', () => {
+        notifyRemoteFolderMountError(new Error('Report is not synced locally'));
+
+        expect(createToastNotification).toHaveBeenCalledWith(
+            REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE,
+            'Report is not synced locally',
             ToastType.ERROR,
         );
     });

--- a/tests/notifyFolderSyncLocalFallback.spec.ts
+++ b/tests/notifyFolderSyncLocalFallback.spec.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ToastType } from '../src/functions/createToastNotification';
+import notifyFolderSyncLocalFallback from '../src/functions/notifyFolderSyncLocalFallback';
+
+const { createToastNotification } = vi.hoisted(() => ({
+    createToastNotification: vi.fn(),
+}));
+
+vi.mock('../src/functions/createToastNotification', async () => {
+    const actual = await vi.importActual<typeof import('../src/functions/createToastNotification')>(
+        '../src/functions/createToastNotification',
+    );
+    return {
+        ...actual,
+        default: createToastNotification,
+    };
+});
+
+afterEach(() => {
+    createToastNotification.mockReset();
+});
+
+describe('notifyFolderSyncLocalFallback', () => {
+    it('warns that a previously synced local copy will be used', () => {
+        notifyFolderSyncLocalFallback(new Error('Unable to establish SSH connection'));
+
+        expect(createToastNotification).toHaveBeenCalledWith(
+            'Loaded local copy',
+            'Could not sync from remote; using previously synced report. Unable to establish SSH connection',
+            ToastType.WARNING,
+        );
+    });
+});

--- a/tests/notifyFolderSyncLocalFallback.spec.ts
+++ b/tests/notifyFolderSyncLocalFallback.spec.ts
@@ -7,6 +7,9 @@ import { ToastType } from '../src/functions/createToastNotification';
 import notifyFolderSyncLocalFallback, {
     FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX,
     FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
+    LOCAL_SYNCED_REPORTS_TOAST_DETAIL,
+    LOCAL_SYNCED_REPORTS_TOAST_TITLE,
+    notifyLocalSyncedReportsListFallback,
 } from '../src/functions/notifyFolderSyncLocalFallback';
 
 const { createToastNotification } = vi.hoisted(() => ({
@@ -34,6 +37,18 @@ describe('notifyFolderSyncLocalFallback', () => {
         expect(createToastNotification).toHaveBeenCalledWith(
             FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
             `${FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX} Unable to establish SSH connection`,
+            ToastType.WARNING,
+        );
+    });
+});
+
+describe('notifyLocalSyncedReportsListFallback', () => {
+    it('warns that the folder list fell back to on-disk copies', () => {
+        notifyLocalSyncedReportsListFallback();
+
+        expect(createToastNotification).toHaveBeenCalledWith(
+            LOCAL_SYNCED_REPORTS_TOAST_TITLE,
+            LOCAL_SYNCED_REPORTS_TOAST_DETAIL,
             ToastType.WARNING,
         );
     });

--- a/tests/notifyFolderSyncLocalFallback.spec.ts
+++ b/tests/notifyFolderSyncLocalFallback.spec.ts
@@ -4,7 +4,10 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToastType } from '../src/functions/createToastNotification';
-import notifyFolderSyncLocalFallback from '../src/functions/notifyFolderSyncLocalFallback';
+import notifyFolderSyncLocalFallback, {
+    FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX,
+    FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
+} from '../src/functions/notifyFolderSyncLocalFallback';
 
 const { createToastNotification } = vi.hoisted(() => ({
     createToastNotification: vi.fn(),
@@ -29,8 +32,8 @@ describe('notifyFolderSyncLocalFallback', () => {
         notifyFolderSyncLocalFallback(new Error('Unable to establish SSH connection'));
 
         expect(createToastNotification).toHaveBeenCalledWith(
-            'Loaded local copy',
-            'Could not sync from remote; using previously synced report. Unable to establish SSH connection',
+            FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
+            `${FOLDER_SYNC_LOCAL_FALLBACK_TOAST_DETAIL_PREFIX} Unable to establish SSH connection`,
             ToastType.WARNING,
         );
     });

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -6,15 +6,16 @@ import { Classes } from '@blueprintjs/core';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { AxiosResponse } from 'axios';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
-import RemoteSyncConfigurator, {
-    FOLDER_LIST_SYNC_ERROR_TOAST_TITLE,
-    LOCAL_SYNCED_REPORTS_TOAST_TITLE,
-} from '../src/components/report-selection/RemoteSyncConfigurator';
+import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyncConfigurator';
 import Endpoints from '../src/definitions/Endpoints';
 import { RemoteConnection, RemoteFolder } from '../src/definitions/RemoteConnection';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { LOCAL_STORAGE_KEY_CONNECTIONS, LOCAL_STORAGE_KEY_SELECTED } from '../src/hooks/useRemote';
-import { FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE } from '../src/functions/notifyFolderSyncLocalFallback';
+import { FOLDER_LIST_SYNC_ERROR_TOAST_TITLE } from '../src/functions/notifyFolderSyncError';
+import {
+    FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
+    LOCAL_SYNCED_REPORTS_TOAST_TITLE,
+} from '../src/functions/notifyFolderSyncLocalFallback';
 import mockInstance from './data/mockInstance.json';
 import mockPerformanceReportFolders from './data/mockPerformanceReportFolders.json';
 import mockProfilerFolderList from './data/mockProfilerFolderList.json';

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -11,7 +11,11 @@ import Endpoints from '../src/definitions/Endpoints';
 import { RemoteConnection, RemoteFolder } from '../src/definitions/RemoteConnection';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { LOCAL_STORAGE_KEY_CONNECTIONS, LOCAL_STORAGE_KEY_SELECTED } from '../src/hooks/useRemote';
-import { FOLDER_LIST_SYNC_ERROR_TOAST_TITLE } from '../src/functions/notifyFolderSyncError';
+import {
+    FOLDER_LIST_SYNC_ERROR_TOAST_TITLE,
+    FOLDER_SYNC_ERROR_TOAST_TITLE,
+    REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE,
+} from '../src/functions/notifyFolderSyncError';
 import {
     FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE,
     LOCAL_SYNCED_REPORTS_TOAST_TITLE,
@@ -359,7 +363,7 @@ it('mounts the local copy and warns when Sync fails for a previously synced fold
 
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(true);
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
-    expect(screen.queryByText('Folder sync error')).toBeNull();
+    expect(screen.queryByText(FOLDER_SYNC_ERROR_TOAST_TITLE)).toBeNull();
 });
 
 it('shows Folder sync error when Sync and local mount both fail', async () => {
@@ -406,7 +410,7 @@ it('shows Folder sync error when Sync and local mount both fail', async () => {
     syncButton.click();
 
     await waitFor(() => {
-        expect(screen.getByText('Folder sync error')).not.toBeNull();
+        expect(screen.getByText(FOLDER_SYNC_ERROR_TOAST_TITLE)).not.toBeNull();
         expect(screen.queryByText(FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE)).toBeNull();
     }, WAIT_FOR_OPTIONS);
 });
@@ -537,6 +541,85 @@ it('seeds folder selects from local synced reports on mount without Fetch', asyn
     }, WAIT_FOR_OPTIONS);
 
     expect(mockPost.mock.calls.some(([url]) => url === Endpoints.REMOTE_PERFORMANCE_REPORTS)).toBe(false);
+});
+
+it('clears cached performance folders when local mount scan returns empty', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const staleFolder: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    mockPost.mockImplementation((url: string) => {
+        if (url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS || url === Endpoints.REMOTE_LOCAL_PROFILER_REPORTS) {
+            return Promise.resolve({ status: 204, data: '' } as AxiosResponse);
+        }
+
+        return Promise.resolve({ status: 200, data: {} } as AxiosResponse);
+    });
+
+    setupConnection(remoteConnection);
+    window.localStorage.setItem(`${remoteConnection[0].name} - performanceFolders`, JSON.stringify([staleFolder]));
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    // Cached folders enable the selector until the empty local scan replaces them.
+    expect(
+        screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON).some((btn) => !btn.hasAttribute(HTML_DISABLED)),
+    ).toBe(true);
+
+    await waitFor(() => {
+        expect(mockPost.mock.calls.some(([url]) => url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS)).toBe(true);
+    }, WAIT_FOR_OPTIONS);
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        expect(selectButtons.every((btn) => btn.hasAttribute(HTML_DISABLED))).toBe(true);
+        expect(
+            JSON.parse(window.localStorage.getItem(`${remoteConnection[0].name} - performanceFolders`) ?? '[]'),
+        ).toEqual([]);
+    }, WAIT_FOR_OPTIONS);
+});
+
+it('toasts Unable to open report when select mount fails without Sync', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const selectedReport: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    mockPost.mockImplementation((url: string) => {
+        if (url.includes('/api/remote/use')) {
+            return Promise.reject(new Error('Report is not synced locally'));
+        }
+
+        return mockRemoteFolderApis(url, selectedReport);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(() => {
+        expect(screen.getByText(REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE)).not.toBeNull();
+    }, WAIT_FOR_OPTIONS);
+
+    expect(screen.queryByText('Active performance report')).toBeNull();
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(false);
 });
 
 it('handles connection with default port (22)', () => {

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -6,8 +6,12 @@ import { Classes } from '@blueprintjs/core';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { AxiosResponse } from 'axios';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
-import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyncConfigurator';
-import { RemoteConnection } from '../src/definitions/RemoteConnection';
+import RemoteSyncConfigurator, {
+    FOLDER_LIST_SYNC_ERROR_TOAST_TITLE,
+    LOCAL_SYNCED_REPORTS_TOAST_TITLE,
+} from '../src/components/report-selection/RemoteSyncConfigurator';
+import Endpoints from '../src/definitions/Endpoints';
+import { RemoteConnection, RemoteFolder } from '../src/definitions/RemoteConnection';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { LOCAL_STORAGE_KEY_CONNECTIONS, LOCAL_STORAGE_KEY_SELECTED } from '../src/hooks/useRemote';
 import { FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE } from '../src/functions/notifyFolderSyncLocalFallback';
@@ -244,7 +248,7 @@ it('sets active performance report by mounting local copy on selection without s
     const axiosInstance = await import('../src/libs/axiosInstance');
     const mockPost = vi.mocked(axiosInstance.default.post);
 
-    const selectedReport = {
+    const selectedReport: RemoteFolder = {
         ...mockRemotePerformanceFolderList[0],
         lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
     };
@@ -280,7 +284,7 @@ it('mounts an outdated performance folder on selection without SSH sync', async 
     const axiosInstance = await import('../src/libs/axiosInstance');
     const mockPost = vi.mocked(axiosInstance.default.post);
 
-    const selectedReport = {
+    const selectedReport: RemoteFolder = {
         ...mockRemotePerformanceFolderList[0],
         lastSynced: mockRemotePerformanceFolderList[0].lastModified - 1000,
     };
@@ -313,7 +317,7 @@ it('mounts the local copy and warns when Sync fails for a previously synced fold
     const axiosInstance = await import('../src/libs/axiosInstance');
     const mockPost = vi.mocked(axiosInstance.default.post);
 
-    const selectedReport = {
+    const selectedReport: RemoteFolder = {
         ...mockRemotePerformanceFolderList[0],
         lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
     };
@@ -355,6 +359,183 @@ it('mounts the local copy and warns when Sync fails for a previously synced fold
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(true);
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
     expect(screen.queryByText('Folder sync error')).toBeNull();
+});
+
+it('shows Folder sync error when Sync and local mount both fail', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const selectedReport: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+    const syncErrorMessage = 'Unable to establish SSH connection';
+    let rejectLocalMount = false;
+
+    mockPost.mockImplementation((url: string) => {
+        if (url.includes('/api/remote/sync')) {
+            return Promise.reject(new Error(syncErrorMessage));
+        }
+
+        if (rejectLocalMount && url.includes('/api/remote/use')) {
+            return Promise.reject(new Error('Local mount failed'));
+        }
+
+        return mockRemoteFolderApis(url, selectedReport);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(selectedReport.reportName),
+        WAIT_FOR_OPTIONS,
+    );
+
+    const syncButton = await screen.findByTestId(TEST_IDS.REMOTE_SYNC_BUTTON, undefined, WAIT_FOR_OPTIONS);
+    mockPost.mockClear();
+    rejectLocalMount = true;
+    syncButton.click();
+
+    await waitFor(() => {
+        expect(screen.getByText('Folder sync error')).not.toBeNull();
+        expect(screen.queryByText(FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE)).toBeNull();
+    }, WAIT_FOR_OPTIONS);
+});
+
+it('loads local synced reports when Fetch remote list fails but local list has folders', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const localFolder: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    mockPost.mockImplementation((url: string) => {
+        if (url === Endpoints.REMOTE_PERFORMANCE_REPORTS) {
+            return Promise.reject(new Error('SSH unreachable'));
+        }
+
+        if (url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS) {
+            return Promise.resolve({ status: 200, data: [localFolder] } as AxiosResponse);
+        }
+
+        if (url === Endpoints.REMOTE_PROFILER_REPORTS || url === Endpoints.REMOTE_LOCAL_PROFILER_REPORTS) {
+            return Promise.resolve({ status: 204, data: '' } as AxiosResponse);
+        }
+
+        return mockRemoteFolderApis(url, localFolder);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    getButtonWithText(FETCH_REMOTE_FOLDERS).click();
+
+    await waitFor(() => {
+        expect(screen.getByText(LOCAL_SYNCED_REPORTS_TOAST_TITLE)).not.toBeNull();
+    }, WAIT_FOR_OPTIONS);
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
+        expect(enabledButtons.length).toBeGreaterThan(0);
+    }, WAIT_FOR_OPTIONS);
+
+    expect(mockPost.mock.calls.some(([url]) => url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS)).toBe(true);
+    expect(screen.queryByText(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE)).toBeNull();
+});
+
+it('shows Folder list sync error when Fetch fails and local list is empty', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    mockPost.mockImplementation((url: string) => {
+        if (url === Endpoints.REMOTE_PERFORMANCE_REPORTS) {
+            return Promise.reject(new Error('SSH unreachable'));
+        }
+
+        if (url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS) {
+            return Promise.resolve({ status: 204, data: '' } as AxiosResponse);
+        }
+
+        if (url === Endpoints.REMOTE_PROFILER_REPORTS || url === Endpoints.REMOTE_LOCAL_PROFILER_REPORTS) {
+            return Promise.resolve({ status: 204, data: '' } as AxiosResponse);
+        }
+
+        return Promise.resolve({ status: 200, data: {} } as AxiosResponse);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    getButtonWithText(FETCH_REMOTE_FOLDERS).click();
+
+    await waitFor(() => {
+        expect(screen.getByText(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE)).not.toBeNull();
+    }, WAIT_FOR_OPTIONS);
+
+    expect(screen.queryByText(LOCAL_SYNCED_REPORTS_TOAST_TITLE)).toBeNull();
+});
+
+it('seeds folder selects from local synced reports on mount without Fetch', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const localFolder: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    mockPost.mockImplementation((url: string) => {
+        if (url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS) {
+            return Promise.resolve({ status: 200, data: [localFolder] } as AxiosResponse);
+        }
+
+        if (url === Endpoints.REMOTE_LOCAL_PROFILER_REPORTS) {
+            return Promise.resolve({ status: 204, data: '' } as AxiosResponse);
+        }
+
+        return mockRemoteFolderApis(url, localFolder);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await waitFor(() => {
+        expect(mockPost.mock.calls.some(([url]) => url === Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS)).toBe(true);
+    }, WAIT_FOR_OPTIONS);
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
+        expect(enabledButtons.length).toBeGreaterThan(0);
+    }, WAIT_FOR_OPTIONS);
+
+    expect(mockPost.mock.calls.some(([url]) => url === Endpoints.REMOTE_PERFORMANCE_REPORTS)).toBe(false);
 });
 
 it('handles connection with default port (22)', () => {
@@ -487,12 +668,18 @@ const setupConnection = (connection: RemoteConnection[], selected?: RemoteConnec
     }
 };
 
-const mockRemoteFolderApis = (url: string, selectedReport: (typeof mockRemotePerformanceFolderList)[0]) => {
-    if (url.includes('/api/remote/profiler-reports')) {
+const mockRemoteFolderApis = (url: string, selectedReport: RemoteFolder) => {
+    if (url.includes('/api/remote/profiler-reports') && !url.includes('local-')) {
         return Promise.resolve({ data: mockRemoteProfilerFolderList } as AxiosResponse);
     }
-    if (url.includes('/api/remote/performance-reports')) {
+    if (url.includes('/api/remote/performance-reports') && !url.includes('local-')) {
         return Promise.resolve({ data: [selectedReport] } as AxiosResponse);
+    }
+    if (url.includes('/api/remote/local-performance-reports')) {
+        return Promise.resolve({ status: 200, data: [selectedReport] } as AxiosResponse);
+    }
+    if (url.includes('/api/remote/local-profiler-reports')) {
+        return Promise.resolve({ status: 200, data: mockRemoteProfilerFolderList } as AxiosResponse);
     }
     if (url.includes('/api/remote/use')) {
         return Promise.resolve({ status: 200, data: {} } as AxiosResponse);

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -239,7 +239,7 @@ it('handles API errors gracefully', () => {
     });
 });
 
-it('sets active performance report and syncs it on selection', async () => {
+it('sets active performance report by mounting local copy on selection without syncing', async () => {
     const axiosInstance = await import('../src/libs/axiosInstance');
     const mockPost = vi.mocked(axiosInstance.default.post);
 
@@ -248,30 +248,8 @@ it('sets active performance report and syncs it on selection', async () => {
         lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
     };
 
-    // Mock the actual API endpoints
-    mockPost.mockImplementation((url: string) => {
-        if (url.includes('/api/remote/profiler-reports')) {
-            return Promise.resolve({ data: mockRemoteProfilerFolderList } as AxiosResponse);
-        }
-        if (url.includes('/api/remote/performance-reports')) {
-            return Promise.resolve({ data: [selectedReport] } as AxiosResponse);
-        }
-        if (url.includes('/api/remote/use')) {
-            return Promise.resolve({ status: 200, data: {} } as AxiosResponse);
-        }
-        if (url.includes('/api/instance/update')) {
-            return Promise.resolve({ status: 200, data: {} } as AxiosResponse);
-        }
-        if (url.includes('/api/remote/sync')) {
-            return Promise.resolve({
-                status: 200,
-                data: selectedReport,
-            } as AxiosResponse);
-        }
-        return Promise.resolve({ data: [] } as AxiosResponse);
-    });
+    mockPost.mockImplementation((url: string) => mockRemoteFolderApis(url, selectedReport));
 
-    // Start with only a connection configured, no folders yet
     setupConnection(remoteConnection);
 
     render(
@@ -280,40 +258,102 @@ it('sets active performance report and syncs it on selection', async () => {
         </TestProviders>,
     );
 
-    // Click the fetch button to load remote folders
-    const fetchButton = getButtonWithText(FETCH_REMOTE_FOLDERS);
-    fetchButton.click();
+    await selectPerformanceFolder(selectedReport.remotePath);
 
-    // Wait for the performance select button to become enabled after fetch completes
-    await waitFor(() => {
-        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
-        const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
-        expect(enabledButtons.length).toBeGreaterThan(0);
-    }, WAIT_FOR_OPTIONS);
-
-    // Click the enabled performance selector button to open the folder list
-    const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
-    const enabledButton = selectButtons.find((btn) => !btn.hasAttribute(HTML_DISABLED));
-    expect(enabledButton).toBeDefined();
-    enabledButton!.click();
-
-    // Wait for the portal to appear with actual content
-    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
-
-    // Select the folder - use the same simple approach as localFolderSelector
     const { remotePath } = selectedReport;
     const formattedPath = remotePath.split('/').slice(-1);
-
-    screen.getByText(remotePath).click();
 
     await waitFor(
         () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(formattedPath),
         WAIT_FOR_OPTIONS,
     );
 
-    // Verify the sync button appears
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(false);
+
     const syncButton = await screen.findByTestId(TEST_IDS.REMOTE_SYNC_BUTTON, undefined, WAIT_FOR_OPTIONS);
     expect(syncButton.classList.contains(Classes.INTENT_SUCCESS)).toBe(true);
+});
+
+it('mounts an outdated performance folder on selection without SSH sync', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const selectedReport = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified - 1000,
+    };
+
+    mockPost.mockImplementation((url: string) => mockRemoteFolderApis(url, selectedReport));
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(selectedReport.reportName),
+        WAIT_FOR_OPTIONS,
+    );
+
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(false);
+
+    const syncButton = await screen.findByTestId(TEST_IDS.REMOTE_SYNC_BUTTON, undefined, WAIT_FOR_OPTIONS);
+    expect(syncButton.classList.contains(Classes.INTENT_WARNING)).toBe(true);
+});
+
+it('mounts the local copy and warns when Sync fails for a previously synced folder', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const selectedReport = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+    const syncErrorMessage = 'Unable to establish SSH connection';
+
+    mockPost.mockImplementation((url: string) => {
+        if (url.includes('/api/remote/sync')) {
+            return Promise.reject(new Error(syncErrorMessage));
+        }
+
+        return mockRemoteFolderApis(url, selectedReport);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(selectedReport.reportName),
+        WAIT_FOR_OPTIONS,
+    );
+
+    const syncButton = await screen.findByTestId(TEST_IDS.REMOTE_SYNC_BUTTON, undefined, WAIT_FOR_OPTIONS);
+    mockPost.mockClear();
+    syncButton.click();
+
+    await waitFor(() => {
+        expect(screen.getByText('Loaded local copy')).not.toBeNull();
+        const toastDetails = screen.getAllByTestId(TEST_IDS.TOAST_FILENAME).map((el) => el.textContent ?? '');
+        expect(toastDetails.some((text) => text.includes(syncErrorMessage))).toBe(true);
+    }, WAIT_FOR_OPTIONS);
+
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(true);
+    expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
+    expect(screen.queryByText('Folder sync error')).toBeNull();
 });
 
 it('handles connection with default port (22)', () => {
@@ -444,6 +484,48 @@ const setupConnection = (connection: RemoteConnection[], selected?: RemoteConnec
     if (initialConnection) {
         window.localStorage.setItem(LOCAL_STORAGE_KEY_SELECTED, JSON.stringify(initialConnection));
     }
+};
+
+const mockRemoteFolderApis = (url: string, selectedReport: (typeof mockRemotePerformanceFolderList)[0]) => {
+    if (url.includes('/api/remote/profiler-reports')) {
+        return Promise.resolve({ data: mockRemoteProfilerFolderList } as AxiosResponse);
+    }
+    if (url.includes('/api/remote/performance-reports')) {
+        return Promise.resolve({ data: [selectedReport] } as AxiosResponse);
+    }
+    if (url.includes('/api/remote/use')) {
+        return Promise.resolve({ status: 200, data: {} } as AxiosResponse);
+    }
+    if (url.includes('/api/instance/update')) {
+        return Promise.resolve({ status: 200, data: {} } as AxiosResponse);
+    }
+    if (url.includes('/api/remote/sync')) {
+        return Promise.resolve({
+            status: 200,
+            data: selectedReport,
+        } as AxiosResponse);
+    }
+    return Promise.resolve({ data: [] } as AxiosResponse);
+};
+
+const selectPerformanceFolder = async (remotePath: string) => {
+    const fetchButton = getButtonWithText(FETCH_REMOTE_FOLDERS);
+    fetchButton.click();
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
+        expect(enabledButtons.length).toBeGreaterThan(0);
+    }, WAIT_FOR_OPTIONS);
+
+    const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+    const enabledButton = selectButtons.find((btn) => !btn.hasAttribute(HTML_DISABLED));
+    expect(enabledButton).toBeDefined();
+    enabledButton!.click();
+
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    screen.getByText(remotePath).click();
 };
 
 // TODO: Add more tests to cover remaining functionality and edge cases

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -8,6 +8,7 @@ import { AxiosResponse } from 'axios';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyncConfigurator';
 import Endpoints from '../src/definitions/Endpoints';
+import { ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE } from '../src/definitions/notifyActiveReport';
 import { RemoteConnection, RemoteFolder } from '../src/definitions/RemoteConnection';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { LOCAL_STORAGE_KEY_CONNECTIONS, LOCAL_STORAGE_KEY_SELECTED } from '../src/hooks/useRemote';
@@ -271,7 +272,7 @@ it('sets active performance report by mounting local copy on selection without s
     await selectPerformanceFolder(selectedReport.remotePath);
 
     const { remotePath } = selectedReport;
-    const formattedPath = remotePath.split('/').slice(-1);
+    const formattedPath = remotePath.split('/').filter(Boolean).at(-1) ?? remotePath;
 
     await waitFor(
         () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(formattedPath),
@@ -283,6 +284,106 @@ it('sets active performance report by mounting local copy on selection without s
 
     const syncButton = await screen.findByTestId(TEST_IDS.REMOTE_SYNC_BUTTON, undefined, WAIT_FOR_OPTIONS);
     expect(syncButton.classList.contains(Classes.INTENT_SUCCESS)).toBe(true);
+});
+
+it('disables remote report selectors while mount is confirming the active report', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const selectedReport: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    let resolveMount: ((value: AxiosResponse) => void) | undefined;
+    mockPost.mockImplementation((url: string) => {
+        if (url.includes('/api/remote/use')) {
+            return new Promise<AxiosResponse>((resolve) => {
+                resolveMount = resolve;
+            });
+        }
+
+        return mockRemoteFolderApis(url, selectedReport);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        expect(selectButtons.length).toBeGreaterThan(0);
+        selectButtons.forEach((button) => {
+            expect(button).toHaveProperty(HTML_DISABLED, true);
+        });
+    }, WAIT_FOR_OPTIONS);
+
+    expect(resolveMount).toBeDefined();
+    resolveMount!({ status: 200, data: {} } as AxiosResponse);
+
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(selectedReport.reportName),
+        WAIT_FOR_OPTIONS,
+    );
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
+        expect(enabledButtons.length).toBeGreaterThan(0);
+    }, WAIT_FOR_OPTIONS);
+});
+
+it('re-enables remote report selectors when mount fails', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+
+    const selectedReport: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    let rejectMount: ((reason?: unknown) => void) | undefined;
+    mockPost.mockImplementation((url: string) => {
+        if (url.includes('/api/remote/use')) {
+            return new Promise<AxiosResponse>((_resolve, reject) => {
+                rejectMount = reject;
+            });
+        }
+
+        return mockRemoteFolderApis(url, selectedReport);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        selectButtons.forEach((button) => {
+            expect(button).toHaveProperty(HTML_DISABLED, true);
+        });
+    }, WAIT_FOR_OPTIONS);
+
+    expect(rejectMount).toBeDefined();
+    rejectMount!(new Error('Unable to establish SSH connection'));
+
+    await waitFor(() => {
+        const selectButtons = screen.queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON);
+        const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
+        expect(enabledButtons.length).toBeGreaterThan(0);
+    }, WAIT_FOR_OPTIONS);
 });
 
 it('mounts an outdated performance folder on selection without SSH sync', async () => {
@@ -618,7 +719,7 @@ it('toasts Unable to open report when select mount fails without Sync', async ()
         expect(screen.getByText(REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE)).not.toBeNull();
     }, WAIT_FOR_OPTIONS);
 
-    expect(screen.queryByText('Active performance report')).toBeNull();
+    expect(screen.queryByText(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE)).toBeNull();
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(false);
 });
 

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -10,6 +10,7 @@ import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyn
 import { RemoteConnection } from '../src/definitions/RemoteConnection';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { LOCAL_STORAGE_KEY_CONNECTIONS, LOCAL_STORAGE_KEY_SELECTED } from '../src/hooks/useRemote';
+import { FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE } from '../src/functions/notifyFolderSyncLocalFallback';
 import mockInstance from './data/mockInstance.json';
 import mockPerformanceReportFolders from './data/mockPerformanceReportFolders.json';
 import mockProfilerFolderList from './data/mockProfilerFolderList.json';
@@ -346,7 +347,7 @@ it('mounts the local copy and warns when Sync fails for a previously synced fold
     syncButton.click();
 
     await waitFor(() => {
-        expect(screen.getByText('Loaded local copy')).not.toBeNull();
+        expect(screen.getByText(FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE)).not.toBeNull();
         const toastDetails = screen.getAllByTestId(TEST_IDS.TOAST_FILENAME).map((el) => el.textContent ?? '');
         expect(toastDetails.some((text) => text.includes(syncErrorMessage))).toBe(true);
     }, WAIT_FOR_OPTIONS);

--- a/tests/reportLinks.spec.ts
+++ b/tests/reportLinks.spec.ts
@@ -14,7 +14,7 @@ import {
     unlinkedProfilerIds,
     upsertReportLink,
 } from '../src/functions/reportLinks';
-import { FolderLinkState, getFolderLinkState } from '../src/definitions/FolderLinkStatus';
+import { FolderLinkState, compareByFolderLinkState, getFolderLinkState } from '../src/definitions/FolderLinkStatus';
 
 const link = (
     profilerId: string,
@@ -47,6 +47,10 @@ describe('getReportId', () => {
     it('falls back to later candidates when earlier are empty', () => {
         expect(getReportId(null, undefined, '/a/b/perf-run')).toBe('perf-run');
     });
+
+    it('prefers path basename over a differing display name', () => {
+        expect(getReportId('/remote/profiler/reports/resnet50', 'Pretty Display Name')).toBe('resnet50');
+    });
 });
 
 describe('getFolderLinkState', () => {
@@ -54,6 +58,22 @@ describe('getFolderLinkState', () => {
         expect(getFolderLinkState('a', new Set(['a']), new Set())).toBe(FolderLinkState.LINKED);
         expect(getFolderLinkState('b', new Set(), new Set(['b']))).toBe(FolderLinkState.UNLINKED);
         expect(getFolderLinkState('c', new Set(['a']), new Set(['b']))).toBe(FolderLinkState.UNKNOWN);
+    });
+
+    it('treats linked as winning over unlinked for the same id', () => {
+        expect(getFolderLinkState('a', new Set(['a']), new Set(['a']))).toBe(FolderLinkState.LINKED);
+    });
+});
+
+describe('compareByFolderLinkState', () => {
+    it('orders linked before unknown before unlinked', () => {
+        const linkedIds = new Set(['linked']);
+        const unlinkedIds = new Set(['unlinked']);
+
+        expect(compareByFolderLinkState('linked', 'unknown', linkedIds, unlinkedIds)).toBeLessThan(0);
+        expect(compareByFolderLinkState('unknown', 'unlinked', linkedIds, unlinkedIds)).toBeLessThan(0);
+        expect(compareByFolderLinkState('linked', 'unlinked', linkedIds, unlinkedIds)).toBeLessThan(0);
+        expect(compareByFolderLinkState('unlinked', 'linked', linkedIds, unlinkedIds)).toBeGreaterThan(0);
     });
 });
 

--- a/tests/reportLinks.spec.ts
+++ b/tests/reportLinks.spec.ts
@@ -14,7 +14,13 @@ import {
     unlinkedProfilerIds,
     upsertReportLink,
 } from '../src/functions/reportLinks';
-import { FolderLinkState, compareByFolderLinkState, getFolderLinkState } from '../src/definitions/FolderLinkStatus';
+import {
+    FolderLinkState,
+    compareByFolderLinkState,
+    getFolderLinkState,
+    shouldShowFolderLinkStatus,
+    sortByFolderLinkState,
+} from '../src/definitions/FolderLinkStatus';
 
 const link = (
     profilerId: string,
@@ -51,6 +57,12 @@ describe('getReportId', () => {
     it('prefers path basename over a differing display name', () => {
         expect(getReportId('/remote/profiler/reports/resnet50', 'Pretty Display Name')).toBe('resnet50');
     });
+
+    it('rejects separator-only paths so they do not become shared ids', () => {
+        expect(getReportId('/')).toBeNull();
+        expect(getReportId('\\')).toBeNull();
+        expect(getReportId('/', 'resnet50')).toBe('resnet50');
+    });
 });
 
 describe('getFolderLinkState', () => {
@@ -74,6 +86,21 @@ describe('compareByFolderLinkState', () => {
         expect(compareByFolderLinkState('unknown', 'unlinked', linkedIds, unlinkedIds)).toBeLessThan(0);
         expect(compareByFolderLinkState('linked', 'unlinked', linkedIds, unlinkedIds)).toBeLessThan(0);
         expect(compareByFolderLinkState('unlinked', 'linked', linkedIds, unlinkedIds)).toBeGreaterThan(0);
+    });
+});
+
+describe('shouldShowFolderLinkStatus / sortByFolderLinkState', () => {
+    it('hides badges when both sets are empty or null', () => {
+        expect(shouldShowFolderLinkStatus(new Set(), new Set())).toBe(false);
+        expect(shouldShowFolderLinkStatus(null, null)).toBe(false);
+        expect(shouldShowFolderLinkStatus(new Set(['a']), new Set())).toBe(true);
+    });
+
+    it('sorts items by link state using getId', () => {
+        const items = [{ id: 'unknown' }, { id: 'unlinked' }, { id: 'linked' }];
+        const sorted = sortByFolderLinkState(items, (item) => item.id, new Set(['linked']), new Set(['unlinked']));
+
+        expect(sorted.map((item) => item.id)).toEqual(['linked', 'unknown', 'unlinked']);
     });
 });
 

--- a/tests/reportLinks.spec.ts
+++ b/tests/reportLinks.spec.ts
@@ -4,73 +4,129 @@
 
 import { describe, expect, it } from 'vitest';
 import { ReportLocation } from '../src/definitions/Reports';
-import { ReportLink, addReportLink, linkedPerformancePaths, linkedProfilerPaths } from '../src/functions/reportLinks';
+import {
+    ReportLink,
+    ReportPairLinkStatus,
+    getReportId,
+    linkedPerformanceIds,
+    linkedProfilerIds,
+    unlinkedPerformanceIds,
+    unlinkedProfilerIds,
+    upsertReportLink,
+} from '../src/functions/reportLinks';
+import { FolderLinkState, getFolderLinkState } from '../src/definitions/FolderLinkStatus';
 
-const link = (profilerPath: string, performancePath: string): ReportLink => ({
-    profilerPath,
-    profilerLocation: ReportLocation.LOCAL,
-    performancePath,
-    performanceLocation: ReportLocation.LOCAL,
+const link = (
+    profilerId: string,
+    performanceId: string,
+    options: {
+        status?: ReportPairLinkStatus;
+        performanceHost?: string | null;
+        recordedAt?: number;
+    } = {},
+): ReportLink => ({
+    profilerId,
+    performanceId,
+    status: options.status ?? ReportPairLinkStatus.LINKED,
+    recordedAt: options.recordedAt ?? 1,
+    performanceAccess: options.performanceHost
+        ? {
+              location: ReportLocation.REMOTE,
+              path: `/remote/${performanceId}`,
+              host: options.performanceHost,
+          }
+        : { location: ReportLocation.LOCAL, path: performanceId },
+});
+
+describe('getReportId', () => {
+    it('uses the final path segment', () => {
+        expect(getReportId('/remote/profiler/reports/resnet50')).toBe('resnet50');
+        expect(getReportId('resnet50')).toBe('resnet50');
+    });
+
+    it('falls back to later candidates when earlier are empty', () => {
+        expect(getReportId(null, undefined, '/a/b/perf-run')).toBe('perf-run');
+    });
+});
+
+describe('getFolderLinkState', () => {
+    it('returns linked, unlinked, or unknown', () => {
+        expect(getFolderLinkState('a', new Set(['a']), new Set())).toBe(FolderLinkState.LINKED);
+        expect(getFolderLinkState('b', new Set(), new Set(['b']))).toBe(FolderLinkState.UNLINKED);
+        expect(getFolderLinkState('c', new Set(['a']), new Set(['b']))).toBe(FolderLinkState.UNKNOWN);
+    });
 });
 
 describe('reportLinks', () => {
-    describe('addReportLink', () => {
+    describe('upsertReportLink', () => {
         it('appends a new pair', () => {
-            const result = addReportLink([], link('mem-a', 'perf-a'));
+            const result = upsertReportLink([], link('mem-a', 'perf-a'));
             expect(result).toHaveLength(1);
+            expect(result[0].status).toBe(ReportPairLinkStatus.LINKED);
         });
 
-        it('dedupes an identical pair', () => {
+        it('updates status on an existing pair', () => {
             const links = [link('mem-a', 'perf-a')];
-            const result = addReportLink(links, link('mem-a', 'perf-a'));
-            expect(result).toBe(links);
+            const result = upsertReportLink(
+                links,
+                link('mem-a', 'perf-a', { status: ReportPairLinkStatus.UNLINKED, recordedAt: 99 }),
+            );
             expect(result).toHaveLength(1);
+            expect(result[0].status).toBe(ReportPairLinkStatus.UNLINKED);
+        });
+
+        it('returns the same reference when status is unchanged', () => {
+            const links = [link('mem-a', 'perf-a')];
+            expect(upsertReportLink(links, link('mem-a', 'perf-a', { recordedAt: 99 }))).toBe(links);
         });
 
         it('keeps distinct pairs that share one side (many-to-many)', () => {
-            let links = addReportLink([], link('mem-a', 'perf-a'));
-            links = addReportLink(links, link('mem-a', 'perf-b'));
-            links = addReportLink(links, link('mem-b', 'perf-a'));
+            let links = upsertReportLink([], link('mem-a', 'perf-a'));
+            links = upsertReportLink(links, link('mem-a', 'perf-b'));
+            links = upsertReportLink(links, link('mem-b', 'perf-a'));
             expect(links).toHaveLength(3);
         });
-
-        it('treats a differing location as a distinct pair', () => {
-            const links = [link('mem-a', 'perf-a')];
-            const result = addReportLink(links, {
-                ...link('mem-a', 'perf-a'),
-                performanceLocation: ReportLocation.REMOTE,
-            });
-            expect(result).toHaveLength(2);
-        });
     });
 
-    describe('linkedPerformancePaths', () => {
-        const links = [link('mem-a', 'perf-a'), link('mem-a', 'perf-b'), link('mem-b', 'perf-c')];
+    describe('linked / unlinked id lookups', () => {
+        const links = [
+            link('mem-a', 'perf-a'),
+            link('mem-a', 'perf-b', { status: ReportPairLinkStatus.UNLINKED }),
+            link('mem-b', 'perf-c'),
+        ];
 
-        it('returns every performance counterpart of the given memory report', () => {
-            const result = linkedPerformancePaths(links, 'mem-a', ReportLocation.LOCAL);
-            expect(result).toEqual(new Set(['perf-a', 'perf-b']));
+        it('returns linked performance counterparts', () => {
+            expect(linkedPerformanceIds(links, 'mem-a')).toEqual(new Set(['perf-a']));
         });
 
-        it('returns an empty set when no memory report is active', () => {
-            expect(linkedPerformancePaths(links, null, null).size).toBe(0);
+        it('returns unlinked performance counterparts', () => {
+            expect(unlinkedPerformanceIds(links, 'mem-a')).toEqual(new Set(['perf-b']));
         });
 
-        it('does not match when the location differs', () => {
-            expect(linkedPerformancePaths(links, 'mem-a', ReportLocation.REMOTE).size).toBe(0);
-        });
-    });
-
-    describe('linkedProfilerPaths', () => {
-        const links = [link('mem-a', 'perf-a'), link('mem-b', 'perf-a'), link('mem-c', 'perf-b')];
-
-        it('returns every memory counterpart of the given performance report', () => {
-            const result = linkedProfilerPaths(links, 'perf-a', ReportLocation.LOCAL);
-            expect(result).toEqual(new Set(['mem-a', 'mem-b']));
+        it('matches across local/remote — location is not part of the key', () => {
+            const mixed = [
+                link('mem-a', 'perf-a', {
+                    performanceHost: 'h1',
+                }),
+            ];
+            expect(linkedPerformanceIds(mixed, 'mem-a')).toEqual(new Set(['perf-a']));
         });
 
-        it('returns an empty set when no performance report is active', () => {
-            expect(linkedProfilerPaths(links, undefined, undefined).size).toBe(0);
+        it('scopes out counterparts recorded only on another remote host', () => {
+            const withHosts = [
+                link('mem-a', 'perf-local'),
+                link('mem-a', 'perf-h1', { performanceHost: 'host-1' }),
+                link('mem-a', 'perf-h2', { performanceHost: 'host-2' }),
+            ];
+
+            expect(linkedPerformanceIds(withHosts, 'mem-a', { remoteHost: 'host-1' })).toEqual(
+                new Set(['perf-local', 'perf-h1']),
+            );
+        });
+
+        it('returns linked profiler counterparts', () => {
+            expect(linkedProfilerIds(links, 'perf-c')).toEqual(new Set(['mem-b']));
+            expect(unlinkedProfilerIds(links, 'perf-b')).toEqual(new Set(['mem-a']));
         });
     });
 });

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -7,6 +7,7 @@ import type { AxiosResponse } from 'axios';
 import { getDefaultStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileTransferSource } from '../src/definitions/FileTransferSource';
+import Endpoints from '../src/definitions/Endpoints';
 import { REMOTE_SYNC_REQUEST_TIMEOUT_MS } from '../src/definitions/RemoteSync';
 import { StackSourceOrigin } from '../src/definitions/StackTrace';
 import {
@@ -240,6 +241,7 @@ describe('useRemoteConnection - syncRemoteFolder timeout', () => {
             host: 'h',
             port: 22,
             username: 'u',
+            profilerPath: '',
             performancePath: '/perf',
         };
         const performanceFolder = { remotePath: '/perf/r', reportName: 'r', lastModified: 1 };
@@ -265,7 +267,14 @@ describe('useRemoteConnection - syncRemoteFolder timeout', () => {
 
         await expect(
             result.current.syncRemoteFolder(
-                { name: 'c', host: 'h', port: 22, username: 'u', performancePath: '/perf' },
+                {
+                    name: 'c',
+                    host: 'h',
+                    port: 22,
+                    username: 'u',
+                    profilerPath: '',
+                    performancePath: '/perf',
+                },
                 profilerFolder,
             ),
         ).rejects.toThrow('No profiler path provided');
@@ -369,7 +378,9 @@ describe('useRemoteConnection - listLocal reports', () => {
         const { result } = renderHook(() => useRemoteConnection());
         const folders = await result.current.listLocalProfilerReports(connection);
 
-        expect(mockPost).toHaveBeenCalledWith('/api/remote/local-profiler-reports', connection);
+        expect(mockPost).toHaveBeenCalledWith(Endpoints.REMOTE_LOCAL_PROFILER_REPORTS, connection, {
+            signal: undefined,
+        });
         expect(folders).toHaveLength(1);
         expect(folders[0].reportName).toBe('r');
     });
@@ -385,7 +396,9 @@ describe('useRemoteConnection - listLocal reports', () => {
         const { result } = renderHook(() => useRemoteConnection());
         const folders = await result.current.listLocalPerformanceReports(connection);
 
-        expect(mockPost).toHaveBeenCalledWith('/api/remote/local-performance-reports', connection);
+        expect(mockPost).toHaveBeenCalledWith(Endpoints.REMOTE_LOCAL_PERFORMANCE_REPORTS, connection, {
+            signal: undefined,
+        });
         expect(folders).toEqual([{ remotePath: '/perf/r', reportName: 'r', lastModified: 1, lastSynced: null }]);
     });
 
@@ -418,6 +431,7 @@ describe('useRemoteConnection - listLocal reports', () => {
                 host: 'h',
                 port: 22,
                 username: 'u',
+                profilerPath: '',
                 performancePath: '/perf',
             }),
         ).resolves.toEqual([]);

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -230,6 +230,55 @@ describe('useRemoteConnection - syncRemoteFolder timeout', () => {
         );
     });
 
+    it('syncs a performance-only connection without requiring profilerPath', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+        mockPost.mockResolvedValue({ data: { remotePath: '/perf', reportName: 'perf' } } as AxiosResponse);
+
+        const performanceOnlyConnection = {
+            name: 'c',
+            host: 'h',
+            port: 22,
+            username: 'u',
+            performancePath: '/perf',
+        };
+        const performanceFolder = { remotePath: '/perf/r', reportName: 'r', lastModified: 1 };
+
+        const { result } = renderHook(() => useRemoteConnection());
+        await result.current.syncRemoteFolder(performanceOnlyConnection, undefined, performanceFolder);
+
+        expect(mockPost).toHaveBeenCalledWith(
+            '/api/remote/sync',
+            {
+                connection: performanceOnlyConnection,
+                profiler: undefined,
+                performance: performanceFolder,
+            },
+            expect.objectContaining({
+                timeout: REMOTE_SYNC_REQUEST_TIMEOUT_MS,
+            }),
+        );
+    });
+
+    it('throws when syncing a profiler folder without profilerPath', async () => {
+        const { result } = renderHook(() => useRemoteConnection());
+
+        await expect(
+            result.current.syncRemoteFolder(
+                { name: 'c', host: 'h', port: 22, username: 'u', performancePath: '/perf' },
+                profilerFolder,
+            ),
+        ).rejects.toThrow('No profiler path provided');
+    });
+
+    it('throws when syncing a performance folder without performancePath', async () => {
+        const { result } = renderHook(() => useRemoteConnection());
+
+        await expect(result.current.syncRemoteFolder(connection, undefined, profilerFolder)).rejects.toThrow(
+            'No performance path provided',
+        );
+    });
+
     it('clears the REMOTE_SYNC slot when sync rejects', async () => {
         const axiosInstance = await import('../src/libs/axiosInstance');
         const mockPost = vi.mocked(axiosInstance.default.post);
@@ -296,5 +345,113 @@ describe('useRemoteConnection - syncRemoteFolder timeout', () => {
 
         await expect(syncPromise).rejects.toThrow('aborted');
         expect(getDefaultStore().get(fileTransferRegistryAtom)[FileTransferSource.REMOTE_SYNC]).toBeUndefined();
+    });
+});
+
+describe('useRemoteConnection - listLocal reports', () => {
+    const connection = {
+        name: 'c',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        profilerPath: '/p',
+        performancePath: '/perf',
+    };
+
+    it('listLocalProfilerReports posts the local profiler endpoint and normalises folders', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+        mockPost.mockResolvedValue({
+            status: 200,
+            data: [{ remotePath: '/p/r', reportName: 'r', lastModified: 1, lastSynced: null }],
+        } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        const folders = await result.current.listLocalProfilerReports(connection);
+
+        expect(mockPost).toHaveBeenCalledWith('/api/remote/local-profiler-reports', connection);
+        expect(folders).toHaveLength(1);
+        expect(folders[0].reportName).toBe('r');
+    });
+
+    it('listLocalPerformanceReports posts the local performance endpoint', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+        mockPost.mockResolvedValue({
+            status: 200,
+            data: [{ remotePath: '/perf/r', reportName: 'r', lastModified: 1, lastSynced: null }],
+        } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        const folders = await result.current.listLocalPerformanceReports(connection);
+
+        expect(mockPost).toHaveBeenCalledWith('/api/remote/local-performance-reports', connection);
+        expect(folders).toEqual([{ remotePath: '/perf/r', reportName: 'r', lastModified: 1, lastSynced: null }]);
+    });
+
+    it('listLocalProfilerReports returns [] on 204 without treating the body as folders', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+        mockPost.mockResolvedValue({ status: 204, data: '' } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        await expect(result.current.listLocalProfilerReports(connection)).resolves.toEqual([]);
+    });
+
+    it('listLocalPerformanceReports returns [] on 204', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+        mockPost.mockResolvedValue({ status: 204, data: '' } as AxiosResponse);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        await expect(result.current.listLocalPerformanceReports(connection)).resolves.toEqual([]);
+    });
+
+    it('listLocalProfilerReports returns [] without posting when profilerPath is missing', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        await expect(
+            result.current.listLocalProfilerReports({
+                name: 'c',
+                host: 'h',
+                port: 22,
+                username: 'u',
+                performancePath: '/perf',
+            }),
+        ).resolves.toEqual([]);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('listLocalPerformanceReports skips POST when performancePath is absent', async () => {
+        const axiosInstance = await import('../src/libs/axiosInstance');
+        const mockPost = vi.mocked(axiosInstance.default.post);
+
+        const { result } = renderHook(() => useRemoteConnection());
+        await expect(
+            result.current.listLocalPerformanceReports({
+                name: 'c',
+                host: 'h',
+                port: 22,
+                username: 'u',
+                profilerPath: '/p',
+            }),
+        ).resolves.toEqual([]);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('listLocalProfilerReports throws when host is missing', async () => {
+        const { result } = renderHook(() => useRemoteConnection());
+
+        await expect(
+            result.current.listLocalProfilerReports({
+                name: 'c',
+                host: '',
+                port: 22,
+                username: 'u',
+                profilerPath: '/p',
+            }),
+        ).rejects.toThrow('No connection provided');
     });
 });

--- a/tests/useReportLinkBadgeIds.spec.tsx
+++ b/tests/useReportLinkBadgeIds.spec.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useReportLinkBadgeIds } from '../src/hooks/useReportLinkBadgeIds';
+import { AtomProvider } from './helpers/atomProvider';
+
+vi.mock('../src/functions/getServerConfig', () => ({
+    default: () => ({ REPORT_LINKING_ENABLED: false }),
+}));
+
+describe('useReportLinkBadgeIds', () => {
+    it('returns null badge sets when report linking is disabled', () => {
+        const { result } = renderHook(() => useReportLinkBadgeIds(), {
+            wrapper: ({ children }: { children: ReactNode }) => (
+                <AtomProvider initialValues={[]}>{children}</AtomProvider>
+            ),
+        });
+
+        expect(result.current).toEqual({
+            linkedPerfIds: null,
+            unlinkedPerfIds: null,
+            linkedProfilerReportIds: null,
+            unlinkedProfilerReportIds: null,
+        });
+    });
+});

--- a/tests/useReportLinkMatch.spec.tsx
+++ b/tests/useReportLinkMatch.spec.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReportLinkMatchResult } from '../src/functions/reportLinks';
+import { useReportLinkMatch } from '../src/hooks/useReportLinkMatch';
+import { activePerformanceReportAtom, activeProfilerReportAtom } from '../src/store/app';
+import { AtomProvider, type AtomProviderInitialValues } from './helpers/atomProvider';
+
+const apiState = vi.hoisted(() => ({
+    matchedOperations: [] as unknown[],
+    operations: { isFetched: true, isFetching: false, isError: false },
+    devices: { isFetched: true, isFetching: false, isError: false },
+    performance: { isFetched: true, isFetching: false, isError: false },
+}));
+
+vi.mock('../src/hooks/useAPI', () => ({
+    useGetDeviceOperationListPerf: () => apiState.matchedOperations,
+    useOperationsList: () => apiState.operations,
+    useDevices: () => apiState.devices,
+    usePerformanceReport: () => apiState.performance,
+}));
+
+const PROFILER = { path: 'mem-run', reportName: 'mem-run' };
+const PERFORMANCE = { path: 'perf-run', reportName: 'perf-run' };
+
+const settledOk = () => {
+    apiState.matchedOperations = [];
+    apiState.operations = { isFetched: true, isFetching: false, isError: false };
+    apiState.devices = { isFetched: true, isFetching: false, isError: false };
+    apiState.performance = { isFetched: true, isFetching: false, isError: false };
+};
+
+const wrapperWithReports =
+    (initialValues: AtomProviderInitialValues = []) =>
+    ({ children }: { children: ReactNode }) => (
+        <AtomProvider
+            initialValues={[
+                [activeProfilerReportAtom, PROFILER],
+                [activePerformanceReportAtom, PERFORMANCE],
+                ...initialValues,
+            ]}
+        >
+            {children}
+        </AtomProvider>
+    );
+
+describe('useReportLinkMatch', () => {
+    beforeEach(() => {
+        settledOk();
+    });
+
+    it('returns UNAVAILABLE when either active report is missing', () => {
+        const { result } = renderHook(() => useReportLinkMatch(), {
+            wrapper: ({ children }) => (
+                <AtomProvider initialValues={[[activeProfilerReportAtom, PROFILER]]}>{children}</AtomProvider>
+            ),
+        });
+
+        expect(result.current).toBe(ReportLinkMatchResult.UNAVAILABLE);
+    });
+
+    it('returns LINKED when matched operations exist, even while queries are fetching', () => {
+        apiState.matchedOperations = [{ id: 1 }];
+        apiState.operations = { isFetched: false, isFetching: true, isError: false };
+
+        const { result } = renderHook(() => useReportLinkMatch(), {
+            wrapper: wrapperWithReports(),
+        });
+
+        expect(result.current).toBe(ReportLinkMatchResult.LINKED);
+    });
+
+    it('returns PENDING while queries are in flight and there are no matches', () => {
+        apiState.operations = { isFetched: false, isFetching: true, isError: false };
+
+        const { result } = renderHook(() => useReportLinkMatch(), {
+            wrapper: wrapperWithReports(),
+        });
+
+        expect(result.current).toBe(ReportLinkMatchResult.PENDING);
+    });
+
+    it('returns PENDING when fetched but still fetching', () => {
+        apiState.performance = { isFetched: true, isFetching: true, isError: false };
+
+        const { result } = renderHook(() => useReportLinkMatch(), {
+            wrapper: wrapperWithReports(),
+        });
+
+        expect(result.current).toBe(ReportLinkMatchResult.PENDING);
+    });
+
+    it('returns UNLINKED when settled with no matches and no errors', () => {
+        const { result } = renderHook(() => useReportLinkMatch(), {
+            wrapper: wrapperWithReports(),
+        });
+
+        expect(result.current).toBe(ReportLinkMatchResult.UNLINKED);
+    });
+
+    it('returns UNAVAILABLE when settled with a query error', () => {
+        apiState.devices = { isFetched: true, isFetching: false, isError: true };
+
+        const { result } = renderHook(() => useReportLinkMatch(), {
+            wrapper: wrapperWithReports(),
+        });
+
+        expect(result.current).toBe(ReportLinkMatchResult.UNAVAILABLE);
+    });
+});


### PR DESCRIPTION
Allows a user to load any synced reports from remote hosts even when not connected to the host.

Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1767.