### PR TITLE
MLIR viewer: add node colour legend (#1770)

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -1449,8 +1449,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
     // unhighlighted op-node fill now lives in SCSS (`.react-flow__node-mlirOp`),
     // so without this callback the minimap would fall back to its CSS var —
     // which is the same `$tt-grey-2` as the minimap pane background, making
-    // nodes invisible. Group wrappers stay transparent in the minimap because
-    // their visible chrome is the inner `.mlir-group-body`, not the wrapper.
+    // nodes invisible. Group wrappers carry no inline background (their chrome
+    // is the inner `.mlir-group-body`), so we paint them with the shared group
+    // identity colour here.
     const minimapNodeColor = useCallback((node: Node): string => {
         const inlineBg = (node.style as { background?: string } | undefined)?.background;
         if (typeof inlineBg === 'string' && inlineBg !== 'transparent') {

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -54,6 +54,7 @@ import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
 import { MlirFilterMode, buildFilterMatcher, resolveFilterMatches } from './mlirFilter';
 import MlirNodeBodyToggles from './MlirNodeBodyToggles';
 import MlirExpandCollapseControls from './MlirExpandCollapseControls';
+import MlirNodeColorLegend from './MlirNodeColorLegend';
 import { collectLocationLines, collectShapeLines } from './mlirNodeBodySummary';
 import { createMoveGroupBatcher } from './mlirMoveGroupBatch';
 import { getNamespaceSegments } from './mlirGraphHelpers';
@@ -1456,9 +1457,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
             return inlineBg;
         }
         if (node.type === 'mlirGroup') {
-            return 'rgba(125, 125, 125, 0.35)';
+            return GRAPH_COLORS.group;
         }
-        return '#f5f5f5';
+        return GRAPH_COLORS.opNode;
     }, []);
 
     // Selection incoming green / outgoing yellow, then dim when a filter is
@@ -1556,6 +1557,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     onCollapseAll={collapseAllNamespaces}
                 />
             </div>
+
+            <MlirNodeColorLegend />
 
             {selectedSourceNode && (
                 <MlirNodeDetailsPanel

--- a/src/components/mlir/MlirNodeColorLegend.tsx
+++ b/src/components/mlir/MlirNodeColorLegend.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { type CSSProperties, memo, useState } from 'react';
+import classNames from 'classnames';
+import { Button, ButtonVariant, Size } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { GRAPH_COLORS } from '../../definitions/GraphColors';
+import 'styles/components/MlirNodeColorLegend.scss';
+
+// Colours come straight from GRAPH_COLORS so the legend can't drift from what's
+// painted. `swatch: 'ring'` mirrors the selected node's box-shadow (not a fill).
+interface LegendItem {
+    id: string;
+    label: string;
+    color: string;
+    swatch: 'fill' | 'ring';
+}
+
+const LEGEND_ITEMS: readonly LegendItem[] = [
+    { id: 'op', label: 'Operation', color: GRAPH_COLORS.opNode, swatch: 'fill' },
+    { id: 'group', label: 'Subgraph / group', color: GRAPH_COLORS.group, swatch: 'fill' },
+    { id: 'section', label: 'Section group', color: GRAPH_COLORS.sectionGroup, swatch: 'fill' },
+    { id: 'input', label: 'Feeds selection', color: GRAPH_COLORS.inputNode, swatch: 'fill' },
+    { id: 'output', label: 'Consumed by selection', color: GRAPH_COLORS.outputNode, swatch: 'fill' },
+    { id: 'selected', label: 'Selected node', color: GRAPH_COLORS.selected, swatch: 'ring' },
+];
+
+const MlirNodeColorLegendInner = () => {
+    // Default collapsed so it doesn't crowd the graph.
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <div className='mlir-node-color-legend'>
+            <Button
+                className='mlir-node-color-legend-toggle'
+                size={Size.SMALL}
+                variant={ButtonVariant.MINIMAL}
+                icon={expanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_UP}
+                text='Legend'
+                aria-expanded={expanded}
+                aria-label={expanded ? 'Hide node colour legend' : 'Show node colour legend'}
+                onClick={() => setExpanded((value) => !value)}
+            />
+
+            {expanded && (
+                <ul className='mlir-node-color-legend-items'>
+                    {LEGEND_ITEMS.map((item) => (
+                        <li
+                            key={item.id}
+                            className='mlir-node-color-legend-item'
+                        >
+                            <span
+                                className={classNames('mlir-node-color-legend-swatch', {
+                                    'is-ring': item.swatch === 'ring',
+                                })}
+                                style={{ '--legend-swatch-color': item.color } as CSSProperties}
+                            />
+                            <span className='mlir-node-color-legend-label'>{item.label}</span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+const MlirNodeColorLegend = memo(MlirNodeColorLegendInner);
+MlirNodeColorLegend.displayName = 'MlirNodeColorLegend';
+
+export default MlirNodeColorLegend;

--- a/src/definitions/GraphColors.ts
+++ b/src/definitions/GraphColors.ts
@@ -11,6 +11,12 @@ export const GRAPH_COLORS = {
     outputEdge: cssVar(`--graph-output-edge`),
     normal: cssVar(`--graph-normal`),
     focusedNode: cssVar(`--graph-focused-node`),
+    // MLIR node identity colours, shared by the SCSS, the minimap callback and
+    // the on-canvas legend so none of them drift.
+    opNode: cssVar(`--graph-op-node`),
+    group: cssVar(`--graph-group`),
+    sectionGroup: cssVar(`--graph-section-group`),
+    selected: cssVar(`--graph-selected`),
 };
 
 // Perf overlay bins (#1515). Hardcoded hex — these are tuned for the dark

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -18,6 +18,13 @@
     --graph-output-edge: #f6bc42;
     --graph-normal: #e0e0e0;
     --graph-focused-node: #f6bc42;
+
+    /* MLIR node identity colours — shared by the SCSS, the minimap callback and
+     * the colour legend (see GRAPH_COLORS). */
+    --graph-op-node: #f5f5f5;
+    --graph-group: #7d7d7d;
+    --graph-section-group: #9b59b6;
+    --graph-selected: #{$tt-blue-accent};
 }
 
 ::-webkit-scrollbar-track {

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -26,6 +26,13 @@
         bottom: 0;
         right: -15px;
     }
+
+    /* Lift the zoom Controls off the bottom edge so the colour legend can sit
+     * beside them (see MlirNodeColorLegend.scss). */
+    .react-flow__panel.bottom.left {
+        bottom: 32px;
+        left: 12px;
+    }
 }
 
 .mlir-top-left-controls {
@@ -60,7 +67,7 @@
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    background: #f5f5f5;
+    background: var(--graph-op-node);
     color: #222;
     border: 1px solid #999;
     border-radius: 6px;
@@ -129,7 +136,7 @@
     }
 
     &.is-section {
-        border-color: #9b59b6;
+        border-color: var(--graph-section-group);
         background: rgb(155 89 182 / 8%);
     }
 }

--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -27,10 +27,10 @@
         right: -15px;
     }
 
-    /* Lift the zoom Controls off the bottom edge so the colour legend can sit
-     * beside them (see MlirNodeColorLegend.scss). */
+    /* Keep the zoom Controls near the bottom edge, with the colour legend
+     * sitting beside them (see MlirNodeColorLegend.scss). */
     .react-flow__panel.bottom.left {
-        bottom: 32px;
+        bottom: 16px;
         left: 12px;
     }
 }
@@ -74,14 +74,14 @@
     font-size: 12px;
 
     &.selected {
-        box-shadow: 0 0 0 3px $tt-blue-accent;
+        box-shadow: 0 0 0 3px var(--graph-selected);
         outline: none;
     }
 }
 
 .react-flow__node-group.selected,
 .react-flow__node-mlirGroup.selected {
-    box-shadow: 0 0 0 3px $tt-blue-accent;
+    box-shadow: 0 0 0 3px var(--graph-selected);
     outline: none;
 }
 
@@ -124,7 +124,7 @@
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    border: 2px dashed rgb(125 125 125 / 80%);
+    border: 2px dashed var(--graph-group);
     border-radius: 16px;
     background: rgb(90 90 90 / 14%);
     color: #ddd;

--- a/src/scss/components/MlirNodeColorLegend.scss
+++ b/src/scss/components/MlirNodeColorLegend.scss
@@ -8,7 +8,7 @@
  * controls while the expanded list grows upward. */
 .mlir-node-color-legend {
     position: absolute;
-    bottom: 44px;
+    bottom: 28px;
     left: 60px;
     z-index: 6;
     display: flex;
@@ -18,7 +18,7 @@
     max-width: 240px;
 }
 
-.mlir-node-color-legend-toggle.bp5-button {
+.mlir-node-color-legend-toggle.bp6-button {
     background: rgb(30 30 30 / 88%);
     border: 1px solid rgb(255 255 255 / 12%);
     border-radius: 6px;

--- a/src/scss/components/MlirNodeColorLegend.scss
+++ b/src/scss/components/MlirNodeColorLegend.scss
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/* Bottom-left, beside React Flow's zoom Controls — clear of the top-left
+ * controls and the right-docked details panel. `.mlir-view-pane` is the
+ * positioned ancestor. `column-reverse` keeps the toggle chip level with the
+ * controls while the expanded list grows upward. */
+.mlir-node-color-legend {
+    position: absolute;
+    bottom: 44px;
+    left: 60px;
+    z-index: 6;
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: flex-start;
+    gap: 6px;
+    max-width: 240px;
+}
+
+.mlir-node-color-legend-toggle.bp5-button {
+    background: rgb(30 30 30 / 88%);
+    border: 1px solid rgb(255 255 255 / 12%);
+    border-radius: 6px;
+    color: #eee;
+
+    &:hover {
+        background: rgb(45 45 45 / 95%);
+    }
+}
+
+.mlir-node-color-legend-items {
+    margin: 0;
+    padding: 8px 10px;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: rgb(30 30 30 / 88%);
+    border: 1px solid rgb(255 255 255 / 12%);
+    border-radius: 6px;
+    font-size: 11px;
+    line-height: 1.2;
+    color: #eee;
+}
+
+.mlir-node-color-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.mlir-node-color-legend-swatch {
+    flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    background: var(--legend-swatch-color);
+    border: 1px solid rgb(0 0 0 / 35%);
+
+    /* Selected node reads as a ring, not a fill. */
+    &.is-ring {
+        background: var(--graph-op-node);
+        border-color: transparent;
+        box-shadow: 0 0 0 2px var(--legend-swatch-color);
+    }
+}
+
+.mlir-node-color-legend-label {
+    white-space: nowrap;
+}

--- a/tests/MlirNodeColorLegend.spec.tsx
+++ b/tests/MlirNodeColorLegend.spec.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+// Sentinel palette to prove swatches source their colour from GRAPH_COLORS.
+const PALETTE = vi.hoisted(() => ({
+    opNode: '#111111',
+    group: '#222222',
+    sectionGroup: '#333333',
+    inputNode: '#444444',
+    outputNode: '#555555',
+    selected: '#666666',
+}));
+
+vi.mock('../src/definitions/GraphColors', () => ({
+    GRAPH_COLORS: PALETTE,
+}));
+
+// eslint-disable-next-line import/first
+import MlirNodeColorLegend from '../src/components/mlir/MlirNodeColorLegend';
+
+afterEach(cleanup);
+
+const swatchColors = (container: HTMLElement): string[] =>
+    Array.from(container.querySelectorAll<HTMLElement>('.mlir-node-color-legend-swatch')).map((el) =>
+        el.style.getPropertyValue('--legend-swatch-color'),
+    );
+
+describe('MlirNodeColorLegend', () => {
+    it('renders collapsed by default (no category rows until opened)', () => {
+        const { container } = render(<MlirNodeColorLegend />);
+        expect(screen.getByRole('button', { name: /show node colour legend/i })).toBeInTheDocument();
+        expect(container.querySelectorAll('.mlir-node-color-legend-item')).toHaveLength(0);
+    });
+
+    it('expands to reveal every node category label', () => {
+        render(<MlirNodeColorLegend />);
+        fireEvent.click(screen.getByRole('button', { name: /show node colour legend/i }));
+
+        for (const label of [
+            'Operation',
+            'Subgraph / group',
+            'Section group',
+            'Feeds selection',
+            'Consumed by selection',
+            'Selected node',
+        ]) {
+            expect(screen.getByText(label)).toBeInTheDocument();
+        }
+        // Toggle now advertises the collapse affordance.
+        expect(screen.getByRole('button', { name: /hide node colour legend/i })).toBeInTheDocument();
+    });
+
+    it('sources each swatch colour from GRAPH_COLORS (no hard-coded duplicates)', () => {
+        const { container } = render(<MlirNodeColorLegend />);
+        fireEvent.click(screen.getByRole('button', { name: /show node colour legend/i }));
+
+        expect(swatchColors(container)).toEqual([
+            PALETTE.opNode,
+            PALETTE.group,
+            PALETTE.sectionGroup,
+            PALETTE.inputNode,
+            PALETTE.outputNode,
+            PALETTE.selected,
+        ]);
+    });
+
+    it('renders the selected-node swatch as a ring rather than a fill', () => {
+        const { container } = render(<MlirNodeColorLegend />);
+        fireEvent.click(screen.getByRole('button', { name: /show node colour legend/i }));
+
+        const rings = container.querySelectorAll('.mlir-node-color-legend-swatch.is-ring');
+        expect(rings).toHaveLength(1);
+    });
+});

--- a/tests/MlirNodeColorLegend.spec.tsx
+++ b/tests/MlirNodeColorLegend.spec.tsx
@@ -20,6 +20,9 @@ vi.mock('../src/definitions/GraphColors', () => ({
     GRAPH_COLORS: PALETTE,
 }));
 
+// The component import must sit below `vi.mock` so the mocked GraphColors
+// module is registered before the component loads; that ordering trips
+// `import/first`.
 // eslint-disable-next-line import/first
 import MlirNodeColorLegend from '../src/components/mlir/MlirNodeColorLegend';
 
@@ -69,11 +72,38 @@ describe('MlirNodeColorLegend', () => {
         ]);
     });
 
-    it('renders the selected-node swatch as a ring rather than a fill', () => {
+    it('renders the ring swatch only on the "Selected node" row', () => {
         const { container } = render(<MlirNodeColorLegend />);
         fireEvent.click(screen.getByRole('button', { name: /show node colour legend/i }));
 
-        const rings = container.querySelectorAll('.mlir-node-color-legend-swatch.is-ring');
-        expect(rings).toHaveLength(1);
+        const rows = Array.from(container.querySelectorAll<HTMLElement>('.mlir-node-color-legend-item'));
+        const selectedRow = rows.find((row) => row.textContent?.includes('Selected node'));
+        expect(selectedRow).toBeDefined();
+        expect(selectedRow?.querySelector('.mlir-node-color-legend-swatch')).toHaveClass('is-ring');
+
+        // No other row's swatch should be tagged as a ring.
+        const otherRings = rows
+            .filter((row) => row !== selectedRow)
+            .flatMap((row) => Array.from(row.querySelectorAll('.mlir-node-color-legend-swatch.is-ring')));
+        expect(otherRings).toHaveLength(0);
+    });
+
+    it('collapses on a second click and restores the "show" affordance', () => {
+        const { container } = render(<MlirNodeColorLegend />);
+
+        const collapsedToggle = screen.getByRole('button', { name: /show node colour legend/i });
+        expect(collapsedToggle).toHaveAttribute('aria-expanded', 'false');
+
+        fireEvent.click(collapsedToggle);
+        const expandedToggle = screen.getByRole('button', { name: /hide node colour legend/i });
+        expect(expandedToggle).toHaveAttribute('aria-expanded', 'true');
+        expect(container.querySelectorAll('.mlir-node-color-legend-item').length).toBeGreaterThan(0);
+
+        fireEvent.click(expandedToggle);
+        expect(screen.getByRole('button', { name: /show node colour legend/i })).toHaveAttribute(
+            'aria-expanded',
+            'false',
+        );
+        expect(container.querySelectorAll('.mlir-node-color-legend-item')).toHaveLength(0);
     });
 });


### PR DESCRIPTION
## Summary
<img width="513" height="421" alt="image" src="https://github.com/user-attachments/assets/d47213a9-5724-48ed-8eb6-5222ef62dc20" />


Closes #1770.

- Adds a collapsible, corner-anchored **node colour legend** to the MLIR viewer (bottom-left, beside the zoom controls) mapping each node colour to its meaning: Operation, Subgraph / group, Section group, Feeds selection, Consumed by selection, Selected node (rendered as a ring to match the selection box-shadow).
- Establishes a **single source of truth** for node colours: the previously hard-coded op-node / group / section-group / selected colours are promoted to `:root --graph-*` custom properties, so the SCSS node rendering, the minimap `nodeColor` callback, and the legend all read the same palette via `GRAPH_COLORS` — no duplicated hex literals.
- Lifts the React Flow zoom controls off the bottom edge so the legend sits beside them.

## Changes

- `src/scss/_base.scss` — new `--graph-op-node/group/section-group/selected` vars.
- `src/scss/components/MLIRViewReactFlow.scss` — op-node bg + section border now read the vars; zoom controls raised.
- `src/definitions/GraphColors.ts` — `GRAPH_COLORS` gains `opNode/group/sectionGroup/selected`.
- `src/components/mlir/MLIRViewReactFlow.tsx` — `minimapNodeColor` sources from `GRAPH_COLORS`; renders `<MlirNodeColorLegend />`.
- `src/components/mlir/MlirNodeColorLegend.tsx` + `.scss` — new legend component.
- `tests/MlirNodeColorLegend.spec.tsx` — new tests.

## Notes

- One deliberate minor visual change: minimap group mini-nodes go from 35%-translucent grey to solid `#7d7d7d` (the tradeoff for routing through the shared palette).

## Test plan

- [x] `vitest run tests/MlirNodeColorLegend.spec.tsx` — 4/4 (incl. asserting every swatch colour comes from `GRAPH_COLORS`)
- [x] ESLint + Stylelint clean; `tsc --noEmit` clean
- [ ] Manual: open the legend bottom-left; confirm it doesn't collide with the zoom controls / details panel and swatches match the actual node colours