### PR TITLE
MLIR viewer: expand-all progress, fitView constants, dagre size-gate

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -48,6 +48,7 @@ import type {
     WorkerNode,
 } from './mlirGraphTypes';
 import { GRAPH_COLORS } from '../../definitions/GraphColors';
+import { MLIR_FIT_VIEW_OPTIONS } from '../../definitions/MlirFitView';
 import { useMlirLayoutWorker } from './useMlirLayoutWorker';
 import MlirNodeDetailsPanel from './MlirNodeDetailsPanel';
 import MlirOpFilter, { MlirOpFilterHandle } from './MlirOpFilter';
@@ -603,12 +604,12 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 // isn't in the build (e.g. synthetic id that never reaches the
                 // canvas) — a missing fitView is preferable to a noisy error.
                 requestAnimationFrame(() => {
-                    void fitView({ nodes: [{ id: pendingFocusId }], padding: 0.3, duration: 200 });
+                    void fitView({ nodes: [{ id: pendingFocusId }], ...MLIR_FIT_VIEW_OPTIONS.localJump });
                 });
             } else if (shouldFitAll || !hasFitInitiallyRef.current) {
                 hasFitInitiallyRef.current = true;
                 requestAnimationFrame(() => {
-                    void fitView({ padding: 0.2, duration: 200 });
+                    void fitView({ ...MLIR_FIT_VIEW_OPTIONS.bulk });
                 });
             }
         },
@@ -643,7 +644,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
         }
         return result;
     }, [sourceNodes]);
-    const { interactionIndex, runBuild } = useMlirLayoutWorker(graph.id, sourceNodes, applyBuiltGraph);
+    const { interactionIndex, runBuild, isBuilding } = useMlirLayoutWorker(graph.id, sourceNodes, applyBuiltGraph);
 
     useEffect(() => {
         runBuild(expandedNamespaces);
@@ -738,7 +739,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
             }
             const targetId = matchedNodesInOrder[nextIdx];
             if (targetId) {
-                void fitView({ nodes: [{ id: targetId }], padding: 0.3, duration: 200 });
+                void fitView({ nodes: [{ id: targetId }], ...MLIR_FIT_VIEW_OPTIONS.localJump });
             }
             setCurrentMatchIndex(nextIdx);
         },
@@ -1187,7 +1188,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
         if (!selectedNodeId) {
             return;
         }
-        void fitView({ nodes: [{ id: selectedNodeId }], padding: 0.3, duration: 200 });
+        void fitView({ nodes: [{ id: selectedNodeId }], ...MLIR_FIT_VIEW_OPTIONS.localJump });
     }, [fitView, selectedNodeId]);
 
     // Click handler for the "locate" affordance next to each producer /
@@ -1220,7 +1221,7 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 }
             }
             if (prefixesToAdd.length === 0) {
-                void fitView({ nodes: [{ id: targetNodeId }], padding: 0.3, duration: 200 });
+                void fitView({ nodes: [{ id: targetNodeId }], ...MLIR_FIT_VIEW_OPTIONS.localJump });
                 return;
             }
             viewportAnchorRef.current = null;
@@ -1552,6 +1553,8 @@ const MlGraphInner = ({ data }: ViewProps) => {
                 <MlirExpandCollapseControls
                     namespaceCount={allExpandableNamespaces.length}
                     expandedCount={expandedNamespaces.size}
+                    isBuilding={isBuilding}
+                    nodeCount={sourceNodes.length}
                     onExpandAll={expandAllNamespaces}
                     onCollapseAll={collapseAllNamespaces}
                 />

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { memo } from 'react';
-import { Button, ButtonVariant, Size, Tooltip } from '@blueprintjs/core';
+import { Button, ButtonVariant, Size, Spinner, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import 'styles/components/MlirExpandCollapseControls.scss';
 
@@ -12,6 +12,9 @@ export interface MlirExpandCollapseControlsProps {
     expandedCount: number;
     onExpandAll: () => void;
     onCollapseAll: () => void;
+    // Worker rebuild in flight: lock the buttons and show progress.
+    isBuilding?: boolean;
+    nodeCount?: number;
 }
 
 const MlirExpandCollapseControlsInner = ({
@@ -19,9 +22,11 @@ const MlirExpandCollapseControlsInner = ({
     expandedCount,
     onExpandAll,
     onCollapseAll,
+    isBuilding = false,
+    nodeCount,
 }: MlirExpandCollapseControlsProps) => {
-    const canExpand = namespaceCount > 0 && expandedCount < namespaceCount;
-    const canCollapse = expandedCount > 0;
+    const canExpand = !isBuilding && namespaceCount > 0 && expandedCount < namespaceCount;
+    const canCollapse = !isBuilding && expandedCount > 0;
     return (
         <div className='mlir-expand-collapse-controls'>
             <Tooltip
@@ -52,6 +57,15 @@ const MlirExpandCollapseControlsInner = ({
                     onClick={onCollapseAll}
                 />
             </Tooltip>
+            {isBuilding && (
+                <span
+                    className='mlir-layout-status'
+                    role='status'
+                >
+                    <Spinner size={14} />
+                    <span>Laying out{typeof nodeCount === 'number' ? ` ${nodeCount} nodes` : ''}…</span>
+                </span>
+            )}
         </div>
     );
 };

--- a/src/components/mlir/MlirExpandCollapseControls.tsx
+++ b/src/components/mlir/MlirExpandCollapseControls.tsx
@@ -12,10 +12,17 @@ export interface MlirExpandCollapseControlsProps {
     expandedCount: number;
     onExpandAll: () => void;
     onCollapseAll: () => void;
-    // Worker rebuild in flight: lock the buttons and show progress.
     isBuilding?: boolean;
     nodeCount?: number;
 }
+
+// Single source of truth for the rebuild-in-flight status copy, shared with the
+// specs so the visible text and the assertions cannot drift apart. Co-located
+// with its only consumer; the exported helper is an HMR-only concern, not a
+// second component.
+// eslint-disable-next-line react-refresh/only-export-components
+export const layoutStatusLabel = (nodeCount?: number): string =>
+    `Laying out${typeof nodeCount === 'number' ? ` ${nodeCount} nodes` : ''}…`;
 
 const MlirExpandCollapseControlsInner = ({
     namespaceCount,
@@ -63,7 +70,7 @@ const MlirExpandCollapseControlsInner = ({
                     role='status'
                 >
                     <Spinner size={14} />
-                    <span>Laying out{typeof nodeCount === 'number' ? ` ${nodeCount} nodes` : ''}…</span>
+                    <span>{layoutStatusLabel(nodeCount)}</span>
                 </span>
             )}
         </div>

--- a/src/components/mlir/mlirGraphBuilder.ts
+++ b/src/components/mlir/mlirGraphBuilder.ts
@@ -48,12 +48,14 @@ function dagreLayout(nodes: WorkerNode[], edges: WorkerEdge[]): WorkerNode[] {
     if (nodes.length === 0) {
         return nodes;
     }
-    const opts: DagreOptions =
-        nodes.length > DAGRE_NODE_LIMIT
-            ? { nodesep: 10, ranksep: 50, edgesep: 5, ranker: 'tight-tree' }
-            : { ranker: 'tight-tree' };
+    // Large graphs: single network-simplex pass — tight-tree can throw, and a
+    // retry would double the layout cost at exactly the size that hurts most.
+    if (nodes.length > DAGRE_NODE_LIMIT) {
+        return dagreLayoutCore(nodes, edges, { nodesep: 10, ranksep: 50, edgesep: 5 });
+    }
+    // Smaller graphs: tight-tree for compactness, cheap fallback if it throws.
     try {
-        return dagreLayoutCore(nodes, edges, opts);
+        return dagreLayoutCore(nodes, edges, { ranker: 'tight-tree' });
     } catch {
         return dagreLayoutCore(nodes, edges, { nodesep: 12, ranksep: 50, edgesep: 5 });
     }

--- a/src/components/mlir/mlirGraphBuilder.ts
+++ b/src/components/mlir/mlirGraphBuilder.ts
@@ -21,7 +21,7 @@ const GROUP_PADDING_X = 24;
 const GROUP_PADDING_TOP = 36;
 const GROUP_PADDING_BOTTOM = 20;
 
-const DAGRE_NODE_LIMIT = 2000;
+export const DAGRE_NODE_LIMIT = 2000;
 
 const ARROW_MARKER = { type: 'arrowclosed', height: 20, width: 20 } as const;
 
@@ -44,7 +44,7 @@ type DagreOptions = {
     ranker?: string;
 };
 
-function dagreLayout(nodes: WorkerNode[], edges: WorkerEdge[]): WorkerNode[] {
+export function dagreLayout(nodes: WorkerNode[], edges: WorkerEdge[]): WorkerNode[] {
     if (nodes.length === 0) {
         return nodes;
     }

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -31,6 +31,17 @@ const postWorkerError = (requestId: number, error: unknown) => {
     });
 };
 
+// Both the cache-hit and fresh-build arms emit an identical `built` message; a
+// structured-clone failure on post must degrade to a worker `error` the same way
+// on both paths, so route every `built` through here to keep that gating unified.
+const safePostBuilt = (requestId: number, graphId: string, cacheKey: string, graph: BuiltGraph): void => {
+    try {
+        postMessage({ type: 'built', requestId, graphId, cacheKey, graph });
+    } catch (error) {
+        postWorkerError(requestId, error);
+    }
+};
+
 function processLatestBuild(graphId: string): void {
     if (processingGraphIds.has(graphId)) {
         return;
@@ -64,17 +75,7 @@ function processLatestBuild(graphId: string): void {
             if (cached) {
                 touchGraphCache(cache, request.cacheKey, cached);
                 if (!latestBuildByGraphId.has(graphId)) {
-                    try {
-                        postMessage({
-                            type: 'built',
-                            requestId: request.requestId,
-                            graphId,
-                            cacheKey: request.cacheKey,
-                            graph: cached,
-                        });
-                    } catch (error) {
-                        postWorkerError(request.requestId, error);
-                    }
+                    safePostBuilt(request.requestId, graphId, request.cacheKey, cached);
                 }
                 continue;
             }
@@ -85,13 +86,7 @@ function processLatestBuild(graphId: string): void {
                 const newerRequestExists = latestBuildByGraphId.has(graphId);
                 const graphVersionChanged = request.graphVersion !== getGraphVersion(graphId);
                 if (!newerRequestExists && !graphVersionChanged) {
-                    postMessage({
-                        type: 'built',
-                        requestId: request.requestId,
-                        graphId,
-                        cacheKey: request.cacheKey,
-                        graph: built,
-                    });
+                    safePostBuilt(request.requestId, graphId, request.cacheKey, built);
                 }
             } catch (error) {
                 if (!latestBuildByGraphId.has(graphId)) {

--- a/src/components/mlir/mlirLayoutWorker.ts
+++ b/src/components/mlir/mlirLayoutWorker.ts
@@ -64,13 +64,17 @@ function processLatestBuild(graphId: string): void {
             if (cached) {
                 touchGraphCache(cache, request.cacheKey, cached);
                 if (!latestBuildByGraphId.has(graphId)) {
-                    postMessage({
-                        type: 'built',
-                        requestId: request.requestId,
-                        graphId,
-                        cacheKey: request.cacheKey,
-                        graph: cached,
-                    });
+                    try {
+                        postMessage({
+                            type: 'built',
+                            requestId: request.requestId,
+                            graphId,
+                            cacheKey: request.cacheKey,
+                            graph: cached,
+                        });
+                    } catch (error) {
+                        postWorkerError(request.requestId, error);
+                    }
                 }
                 continue;
             }

--- a/src/components/mlir/useMlirLayoutWorker.ts
+++ b/src/components/mlir/useMlirLayoutWorker.ts
@@ -21,6 +21,10 @@ import type { BuiltGraph, SourceNode, WorkerInteractionIndex, WorkerOutboundMess
  *    expand/collapse behaviour.
  * 5. Hand back a stable `runBuild(expanded)` dispatcher that the consumer
  *    triggers from a `useEffect([expandedNamespaces, runBuild])`.
+ * 6. Own the `isBuilding` flag that gates the expand/collapse controls: set on
+ *    every `build` dispatch and cleared on the matching `built`/`error` reply,
+ *    on a `worker.onerror` crash, and on a synchronous `postMessage` failure —
+ *    so a dead or crashed worker can never strand the controls disabled.
  *
  * `onBuilt` is invoked on the React event loop when a fresh `built` message
  * arrives for the current `graphId`. It deliberately stays in the consumer so

--- a/src/components/mlir/useMlirLayoutWorker.ts
+++ b/src/components/mlir/useMlirLayoutWorker.ts
@@ -126,14 +126,22 @@ export function useMlirLayoutWorker(
             nextRequestIdRef.current = requestId;
             activeRequestIdRef.current = requestId;
             const expandedSorted = Array.from(expanded).sort((a, b) => a.localeCompare(b));
-            worker.postMessage({
-                type: 'build' as const,
-                requestId,
-                graphId,
-                expandedNamespaces: expandedSorted,
-                cacheKey: `${graphId}:${expandedSorted.join('|')}`,
-            });
             setIsBuilding(true);
+            try {
+                worker.postMessage({
+                    type: 'build' as const,
+                    requestId,
+                    graphId,
+                    expandedNamespaces: expandedSorted,
+                    cacheKey: `${graphId}:${expandedSorted.join('|')}`,
+                });
+            } catch (error) {
+                // A crashed/terminated worker throws synchronously on post; keep the
+                // React tree alive and release the controls rather than propagating.
+                setIsBuilding(false);
+                // eslint-disable-next-line no-console
+                console.error('mlir layout worker: build dispatch failed', error);
+            }
         },
         [graphId, indexReadyGraphId],
     );

--- a/src/components/mlir/useMlirLayoutWorker.ts
+++ b/src/components/mlir/useMlirLayoutWorker.ts
@@ -34,6 +34,7 @@ export function useMlirLayoutWorker(
 ): {
     interactionIndex: WorkerInteractionIndex | null;
     runBuild: (expanded: Set<string>) => void;
+    isBuilding: boolean;
 } {
     const workerRef = useRef<Worker | null>(null);
     const nextRequestIdRef = useRef(0);
@@ -41,10 +42,18 @@ export function useMlirLayoutWorker(
     const postedGraphIdRef = useRef<string | null>(null);
     const [indexReadyGraphId, setIndexReadyGraphId] = useState<string | null>(null);
     const [interactionIndex, setInteractionIndex] = useState<WorkerInteractionIndex | null>(null);
+    // True between a `build` dispatch and its `built`/`error` reply.
+    const [isBuilding, setIsBuilding] = useState(false);
 
     useEffect(() => {
         const worker = new Worker(new URL('./mlirLayoutWorker.ts', import.meta.url), { type: 'module' });
         workerRef.current = worker;
+        // A worker-level crash (uncaught throw, structured-clone failure on
+        // post) emits no terminal reply, which would strand `isBuilding` true
+        // and lock the expand/collapse controls with no recovery.
+        worker.onerror = () => {
+            setIsBuilding(false);
+        };
         return () => {
             worker.terminate();
             workerRef.current = null;
@@ -70,6 +79,7 @@ export function useMlirLayoutWorker(
                 if (message.requestId !== 0 && message.requestId !== activeRequestIdRef.current) {
                     return;
                 }
+                setIsBuilding(false);
                 // eslint-disable-next-line no-console
                 console.error('mlir layout worker:', message.error);
                 return;
@@ -80,6 +90,7 @@ export function useMlirLayoutWorker(
             if (message.graphId !== graphId) {
                 return;
             }
+            setIsBuilding(false);
             onBuilt(message.graph);
         };
     }, [graphId, onBuilt]);
@@ -122,9 +133,10 @@ export function useMlirLayoutWorker(
                 expandedNamespaces: expandedSorted,
                 cacheKey: `${graphId}:${expandedSorted.join('|')}`,
             });
+            setIsBuilding(true);
         },
         [graphId, indexReadyGraphId],
     );
 
-    return { interactionIndex, runBuild };
+    return { interactionIndex, runBuild, isBuilding };
 }

--- a/src/definitions/MlirFitView.ts
+++ b/src/definitions/MlirFitView.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { FitViewOptions } from '@xyflow/react';
+
+// bulk = initial + expand/collapse-all (instant); localJump = recenter /
+// navigate / match-cycling (short animation to track the move).
+export const MLIR_FIT_VIEW_OPTIONS = {
+    bulk: { padding: 0.2, duration: 0 },
+    localJump: { padding: 0.3, duration: 200 },
+} as const satisfies Record<'bulk' | 'localJump', FitViewOptions>;

--- a/src/scss/components/MlirExpandCollapseControls.scss
+++ b/src/scss/components/MlirExpandCollapseControls.scss
@@ -19,3 +19,14 @@
         line-height: 1.2;
     }
 }
+
+.mlir-layout-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 4px;
+    font-size: 11px;
+    line-height: 1.2;
+    color: $tt-grey-6;
+    white-space: nowrap;
+}

--- a/tests/MlirExpandCollapseControls.spec.tsx
+++ b/tests/MlirExpandCollapseControls.spec.tsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
-import MlirExpandCollapseControls from '../src/components/mlir/MlirExpandCollapseControls';
+import MlirExpandCollapseControls, { layoutStatusLabel } from '../src/components/mlir/MlirExpandCollapseControls';
 
 afterEach(cleanup);
 
@@ -102,12 +102,12 @@ describe('MlirExpandCollapseControls', () => {
         );
         expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeDisabled();
         expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeDisabled();
-        expect(screen.getByRole('status')).toHaveTextContent('Laying out 42 nodes…');
+        expect(screen.getByRole('status')).toHaveTextContent(layoutStatusLabel(42));
     });
 
     it('omits the count from the status when nodeCount is not provided', () => {
         render(<MlirExpandCollapseControls {...buildProps({ isBuilding: true })} />);
-        expect(screen.getByRole('status')).toHaveTextContent('Laying out…');
+        expect(screen.getByRole('status')).toHaveTextContent(layoutStatusLabel());
     });
 
     it('does not render the layout status when idle', () => {

--- a/tests/MlirExpandCollapseControls.spec.tsx
+++ b/tests/MlirExpandCollapseControls.spec.tsx
@@ -93,4 +93,39 @@ describe('MlirExpandCollapseControls', () => {
         fireEvent.click(screen.getByRole('button', { name: /collapse all subgraphs/i }));
         expect(onCollapseAll).not.toHaveBeenCalled();
     });
+
+    it('locks both buttons and shows the layout status with the node count while building', () => {
+        render(
+            <MlirExpandCollapseControls
+                {...buildProps({ namespaceCount: 4, expandedCount: 2, isBuilding: true, nodeCount: 42 })}
+            />,
+        );
+        expect(screen.getByRole('button', { name: /expand all subgraphs/i })).toBeDisabled();
+        expect(screen.getByRole('button', { name: /collapse all subgraphs/i })).toBeDisabled();
+        expect(screen.getByRole('status')).toHaveTextContent('Laying out 42 nodes…');
+    });
+
+    it('omits the count from the status when nodeCount is not provided', () => {
+        render(<MlirExpandCollapseControls {...buildProps({ isBuilding: true })} />);
+        expect(screen.getByRole('status')).toHaveTextContent('Laying out…');
+    });
+
+    it('does not render the layout status when idle', () => {
+        render(<MlirExpandCollapseControls {...buildProps()} />);
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('does not fire callbacks while a rebuild is in flight', () => {
+        const onExpandAll = vi.fn();
+        const onCollapseAll = vi.fn();
+        render(
+            <MlirExpandCollapseControls
+                {...buildProps({ namespaceCount: 4, expandedCount: 2, isBuilding: true, onExpandAll, onCollapseAll })}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /expand all subgraphs/i }));
+        fireEvent.click(screen.getByRole('button', { name: /collapse all subgraphs/i }));
+        expect(onExpandAll).not.toHaveBeenCalled();
+        expect(onCollapseAll).not.toHaveBeenCalled();
+    });
 });

--- a/tests/MlirFitView.spec.ts
+++ b/tests/MlirFitView.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { MLIR_FIT_VIEW_OPTIONS } from '../src/definitions/MlirFitView';
+
+describe('MLIR_FIT_VIEW_OPTIONS', () => {
+    it('makes bulk fits instant (initial load + expand/collapse-all)', () => {
+        expect(MLIR_FIT_VIEW_OPTIONS.bulk.duration).toBe(0);
+        expect(MLIR_FIT_VIEW_OPTIONS.bulk.padding).toBe(0.2);
+    });
+
+    it('animates local jumps (recenter / navigate / match-cycling)', () => {
+        expect(MLIR_FIT_VIEW_OPTIONS.localJump.duration).toBe(200);
+        expect(MLIR_FIT_VIEW_OPTIONS.localJump.padding).toBe(0.3);
+    });
+});

--- a/tests/mlirDagreSizeGate.spec.ts
+++ b/tests/mlirDagreSizeGate.spec.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// FakeGraph is a minimal dagre stub: most methods are intentionally stateless
+// sinks, so `this`-usage enforcement doesn't apply here.
+/* eslint-disable class-methods-use-this */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAGRE_NODE_LIMIT, dagreLayout } from '../src/components/mlir/mlirGraphBuilder';
+import type { WorkerNode } from '../src/components/mlir/mlirGraphTypes';
+
+// Record the `ranker` handed to every dagre graph so the test can assert which
+// layout strategy the size-gate selected. jsdom has no real dagre needs here —
+// we only care about the option passed to setGraph, not the produced positions.
+const rankers = vi.hoisted(() => [] as string[]);
+
+vi.mock('@dagrejs/dagre', () => {
+    class FakeGraph {
+        private readonly sizes = new Map<string, { width: number; height: number }>();
+
+        setGraph(options: { ranker?: string }): void {
+            rankers.push(options.ranker ?? 'network-simplex');
+        }
+
+        setDefaultEdgeLabel(): void {}
+
+        setNode(id: string, value: { width: number; height: number }): void {
+            this.sizes.set(id, value);
+        }
+
+        setEdge(): void {}
+
+        node(id: string): { x: number; y: number; width: number; height: number } {
+            const size = this.sizes.get(id) ?? { width: 0, height: 0 };
+            return { x: 0, y: 0, ...size };
+        }
+    }
+    return { default: { graphlib: { Graph: FakeGraph }, layout: () => {} } };
+});
+
+const makeNodes = (count: number): WorkerNode[] =>
+    Array.from({ length: count }, (_, i) => ({
+        id: `n${i}`,
+        position: { x: 0, y: 0 },
+        data: { label: 'op', namespace: '', kind: 'op' as const },
+    }));
+
+describe('dagreLayout size-gate', () => {
+    beforeEach(() => {
+        rankers.length = 0;
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('uses tight-tree in a single pass at or below the node limit', () => {
+        dagreLayout(makeNodes(DAGRE_NODE_LIMIT), []);
+        expect(rankers).toEqual(['tight-tree']);
+    });
+
+    it('uses a single default (network-simplex) pass above the node limit', () => {
+        dagreLayout(makeNodes(DAGRE_NODE_LIMIT + 1), []);
+        expect(rankers).toEqual(['network-simplex']);
+    });
+
+    it('never falls back to tight-tree above the node limit (regression guard)', () => {
+        dagreLayout(makeNodes(DAGRE_NODE_LIMIT + 500), []);
+        expect(rankers).not.toContain('tight-tree');
+    });
+});

--- a/tests/mlirGraphBuilder.spec.ts
+++ b/tests/mlirGraphBuilder.spec.ts
@@ -194,7 +194,7 @@ test('buildVisibleGraph runs dagre layout and assigns distinct positions per ran
 });
 
 // 4.2.12 — large graph: above DAGRE_NODE_LIMIT (2000) doesn't crash, all
-// invariants still hold. Uses the high-density density fallback path.
+// invariants still hold. Exercises the size-gated single network-simplex pass.
 test('buildVisibleGraph handles graphs larger than the dagre limit without violating invariants', () => {
     // 2500 root-level ops, no edges. Each one will be its own visible op node.
     const nodes = Array.from({ length: 2500 }, (_, i) => ({

--- a/tests/useMlirLayoutWorker.spec.tsx
+++ b/tests/useMlirLayoutWorker.spec.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMlirLayoutWorker } from '../src/components/mlir/useMlirLayoutWorker';
+import type {
+    BuildMessage,
+    BuiltGraph,
+    SourceNode,
+    WorkerInboundMessage,
+    WorkerInteractionIndex,
+    WorkerOutboundMessage,
+} from '../src/components/mlir/mlirGraphTypes';
+
+const GRAPH_ID = 'g1';
+const SOURCE_NODES: SourceNode[] = [];
+const EMPTY_GRAPH = { nodes: [], edges: [] } satisfies BuiltGraph;
+const EMPTY_INTERACTION_INDEX = {} as WorkerInteractionIndex;
+
+const workers: FakeWorker[] = [];
+
+// Stands in for the layout Web Worker (jsdom has no Worker); lets the test drive
+// the request/response protocol the hook owns.
+class FakeWorker {
+    onmessage: ((event: MessageEvent<WorkerOutboundMessage>) => void) | null = null;
+
+    onerror: ((event: unknown) => void) | null = null;
+
+    readonly posted: WorkerInboundMessage[] = [];
+
+    terminated = false;
+
+    constructor() {
+        workers.push(this);
+    }
+
+    postMessage(message: WorkerInboundMessage): void {
+        this.posted.push(message);
+    }
+
+    terminate(): void {
+        this.terminated = true;
+    }
+
+    emit(data: WorkerOutboundMessage): void {
+        act(() => {
+            this.onmessage?.({ data } as unknown as MessageEvent<WorkerOutboundMessage>);
+        });
+    }
+
+    crash(): void {
+        act(() => {
+            this.onerror?.(new Event('error'));
+        });
+    }
+}
+
+const worker = (): FakeWorker => {
+    const instance = workers.at(-1);
+    if (!instance) {
+        throw new Error('worker not constructed');
+    }
+    return instance;
+};
+
+const lastBuildRequestId = (): number => {
+    const build = [...worker().posted].reverse().find((m): m is BuildMessage => m.type === 'build');
+    if (!build) {
+        throw new Error('no build message posted');
+    }
+    return build.requestId;
+};
+
+describe('useMlirLayoutWorker', () => {
+    beforeEach(() => {
+        workers.length = 0;
+        vi.stubGlobal('Worker', FakeWorker);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const setup = () => {
+        const onBuilt = vi.fn();
+        const view = renderHook(() => useMlirLayoutWorker(GRAPH_ID, SOURCE_NODES, onBuilt));
+        // Enable builds: the hook only dispatches once the worker confirms `indexed`.
+        worker().emit({ type: 'indexed', graphId: GRAPH_ID, interactionIndex: EMPTY_INTERACTION_INDEX });
+        return { ...view, onBuilt };
+    };
+
+    it('starts idle and posts set-graph on mount', () => {
+        const { result } = setup();
+        expect(result.current.isBuilding).toBe(false);
+        expect(worker().posted).toContainEqual(expect.objectContaining({ type: 'set-graph', graphId: GRAPH_ID }));
+    });
+
+    it('flips isBuilding true on dispatch and false when the matching built reply lands', () => {
+        const { result, onBuilt } = setup();
+
+        act(() => result.current.runBuild(new Set()));
+        expect(result.current.isBuilding).toBe(true);
+
+        worker().emit({
+            type: 'built',
+            requestId: lastBuildRequestId(),
+            graphId: GRAPH_ID,
+            cacheKey: `${GRAPH_ID}:`,
+            graph: EMPTY_GRAPH,
+        });
+
+        expect(result.current.isBuilding).toBe(false);
+        expect(onBuilt).toHaveBeenCalledWith(EMPTY_GRAPH);
+    });
+
+    it('clears isBuilding when the worker replies with an error', () => {
+        const { result } = setup();
+        act(() => result.current.runBuild(new Set()));
+
+        worker().emit({ type: 'error', requestId: lastBuildRequestId(), error: 'boom' });
+
+        expect(result.current.isBuilding).toBe(false);
+    });
+
+    it('clears isBuilding when the worker crashes (no terminal reply)', () => {
+        const { result, onBuilt } = setup();
+        act(() => result.current.runBuild(new Set()));
+        expect(result.current.isBuilding).toBe(true);
+
+        worker().crash();
+
+        expect(result.current.isBuilding).toBe(false);
+        expect(onBuilt).not.toHaveBeenCalled();
+    });
+
+    it('ignores a stale built reply from a superseded request', () => {
+        const { result, onBuilt } = setup();
+        act(() => result.current.runBuild(new Set()));
+        const staleRequestId = lastBuildRequestId() - 1;
+
+        worker().emit({
+            type: 'built',
+            requestId: staleRequestId,
+            graphId: GRAPH_ID,
+            cacheKey: `${GRAPH_ID}:`,
+            graph: EMPTY_GRAPH,
+        });
+
+        expect(result.current.isBuilding).toBe(true);
+        expect(onBuilt).not.toHaveBeenCalled();
+    });
+});

--- a/tests/useMlirLayoutWorker.spec.tsx
+++ b/tests/useMlirLayoutWorker.spec.tsx
@@ -135,6 +135,19 @@ describe('useMlirLayoutWorker', () => {
         expect(onBuilt).not.toHaveBeenCalled();
     });
 
+    it('swallows a synchronous postMessage failure (dead worker) without crashing', () => {
+        const { result } = setup();
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        worker().postMessage = () => {
+            throw new Error('worker terminated');
+        };
+
+        expect(() => act(() => result.current.runBuild(new Set()))).not.toThrow();
+        expect(result.current.isBuilding).toBe(false);
+
+        consoleError.mockRestore();
+    });
+
     it('ignores a stale built reply from a superseded request', () => {
         const { result, onBuilt } = setup();
         act(() => result.current.runBuild(new Set()));


### PR DESCRIPTION
## Summary

MLIR audit follow-up (#1743). Three independent, low-risk improvements to the MLIR graph viewer:

- **Expand-all progress affordance** — the worker rebuild can take 1–5s with no feedback today. `useMlirLayoutWorker` now exposes `isBuilding`; while a rebuild is in flight the expand/collapse controls disable and show a "Laying out N nodes…" spinner. A `worker.onerror` clears the flag so an uncaught worker failure can't strand the controls disabled with no recovery.
- **Centralized fitView tuning** — `MLIR_FIT_VIEW_OPTIONS` (`bulk` = instant, `localJump` = animated). Initial load and expand/collapse-all fit instantly; recenter / navigate / match-cycling keep the short animation. No more inline padding/duration literals.
- **dagre size-gate** — graphs above `DAGRE_NODE_LIMIT` take a single `network-simplex` pass; smaller graphs keep `tight-tree` with a fallback, avoiding a double layout at the scale that hurts most.

## Test plan

- [x] `tsc --noEmit`, `eslint`, production build all clean
- [x] `useMlirLayoutWorker`: `isBuilding` flips true on dispatch and clears on built / error / worker crash; stale replies ignored
- [x] Controls: buttons lock + status region shows the node count while building; callbacks don't fire mid-build
- [x] `MLIR_FIT_VIEW_OPTIONS`: bulk instant, localJump animated
- [ ] Manual: expand-all on a large graph shows the spinner; initial/bulk fits are instant, local jumps animate

Refs #1743