### PR TITLE
dev: relax version bound on tt-perf-report

### DIFF
--- a/backend/ttnn_visualizer/tests/test_perf_report_contract.py
+++ b/backend/ttnn_visualizer/tests/test_perf_report_contract.py
@@ -22,7 +22,7 @@ Chain of trust: tt-perf-report  ->  this golden  ->  the frontend.
 
 To refresh the golden after an intentional tt-perf-report change:
 
-    EXPECTED_TT_PERF_REPORT_VERSION  <- bump the constant below to the new version
+    MIN_TT_PERF_REPORT_VERSION       <- bump the floor below if needed
     pnpm run perf:golden             <- regenerates tests/data/perfReportColourContract.json
 
 then run the frontend suite and reconcile any TypeScript differences.
@@ -33,6 +33,7 @@ import os
 from importlib.metadata import version
 from pathlib import Path
 
+from packaging.version import Version
 from tt_perf_report.perf_report import (
     Cell,
     color_row,
@@ -40,9 +41,9 @@ from tt_perf_report.perf_report import (
     evaluate_fidelity,
 )
 
-# Keep in lockstep with the tt-perf-report pin in pyproject.toml. Bumping the pin without
-# bumping this constant fails the version assertion below, forcing a deliberate parity review.
-EXPECTED_TT_PERF_REPORT_VERSION = "1.2.4"
+# Keep in lockstep with the lower bound in pyproject.toml. The golden comparison below
+# still catches behavioural drift when a newer compatible tt-perf-report is installed.
+MIN_TT_PERF_REPORT_VERSION = "1.2.4"
 
 # tt-perf-report defaults (perf_report.py): --min-percentage and the Op-to-Op Gap threshold.
 MIN_PERCENTAGE = 0.5
@@ -385,11 +386,10 @@ def _generate_golden():
     }
 
 
-def test_installed_version_matches_pin():
-    assert version("tt-perf-report") == EXPECTED_TT_PERF_REPORT_VERSION, (
-        "Installed tt-perf-report differs from the version this contract was generated against. "
-        "Bump EXPECTED_TT_PERF_REPORT_VERSION (and the pyproject.toml pin), then regenerate the "
-        "golden with UPDATE_PERF_GOLDEN=1 and reconcile the frontend parity tests."
+def test_installed_version_satisfies_supported_range():
+    assert Version(version("tt-perf-report")) >= Version(MIN_TT_PERF_REPORT_VERSION), (
+        "Installed tt-perf-report is older than the supported minimum. "
+        "Install a compatible version from pyproject.toml."
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pydantic==2.12.5",
     "python-dotenv==1.2.2",
     "PyYAML>=6.0.0,<7.0",
-    "tt-perf-report==1.2.4",
+    "tt-perf-report>=1.2.4,<2.0",
     "zstd>=1.5.7,<2.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3300,7 +3300,7 @@ requires-dist = [
     { name = "pydantic-core", specifier = "==2.41.5" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0" },
-    { name = "tt-perf-report", specifier = "==1.2.4" },
+    { name = "tt-perf-report", specifier = ">=1.2.4,<2.0" },
     { name = "zstd", specifier = ">=1.5.7,<2.0" },
 ]
 


### PR DESCRIPTION
This relaxes the strict version control.
This makes it more convenient for some of the setup I had and also we have uv.lock that can take care of exact versioning.

I could not see any justification on this strict condition so I am not sure about this one hence it being a  draft PR.