### PR TITLE
Shrink MLIR node-details panel and add collapse-to-rail in split view

### DIFF
--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -91,9 +91,9 @@ type MLNodeData = WorkerNode['data'] & {
 
 interface ViewProps {
     data: GraphBundle;
-    // Enables the details panel's collapse-to-rail affordance; the side-by-side
-    // panes make reclaiming the panel's width worthwhile.
-    splitView?: boolean;
+    // Enables the details panel's collapse-to-rail affordance; the split view
+    // opts in because reclaiming a half-pane's width is worthwhile there.
+    detailsCollapsible?: boolean;
 }
 
 type MLNode = Node<MLNodeData>;
@@ -411,7 +411,7 @@ function builtGraphToReactFlow(built: BuiltGraph): { nodes: MLNode[]; edges: Edg
     return { nodes, edges };
 }
 
-const MlGraphInner = ({ data, splitView = false }: ViewProps) => {
+const MlGraphInner = ({ data, detailsCollapsible = false }: ViewProps) => {
     const { fitView, getViewport, setViewport, updateNode } = useReactFlow<MLNode, Edge>();
     // Unique per instance so two side-by-side panes don't emit colliding React
     // Flow marker/DOM ids (both panes can show the same graph.id).
@@ -422,7 +422,7 @@ const MlGraphInner = ({ data, splitView = false }: ViewProps) => {
     const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(() => new Set());
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
     // Persists across selections (the panel remounts per node) but resets on
-    // graph switch via the keyed remount; the split-view rail toggles it.
+    // graph switch via the keyed remount and on close (a full dismissal).
     const [detailsExpanded, setDetailsExpanded] = useState(true);
     // Live op-name filter. `filterQuery` drives the input for instant visual
     // feedback; `appliedFilterQuery` is what the memo chain reads and lags
@@ -1193,6 +1193,9 @@ const MlGraphInner = ({ data, splitView = false }: ViewProps) => {
 
     const closeDetailsPanel = useCallback(() => {
         setSelectedNodeId(null);
+        // Reopen expanded next time: close is a full dismissal, unlike moving
+        // the selection to another node (which keeps the collapse preference).
+        setDetailsExpanded(true);
     }, []);
 
     const toggleDetailsExpanded = useCallback(() => {
@@ -1595,7 +1598,7 @@ const MlGraphInner = ({ data, splitView = false }: ViewProps) => {
                     onClose={closeDetailsPanel}
                     onRecenter={recenterOnSelected}
                     onNavigateToNode={navigateToNode}
-                    collapsible={splitView}
+                    collapsible={detailsCollapsible}
                     expanded={detailsExpanded}
                     onToggleExpand={toggleDetailsExpanded}
                 />

--- a/src/components/mlir/MLIRViewReactFlow.tsx
+++ b/src/components/mlir/MLIRViewReactFlow.tsx
@@ -91,6 +91,9 @@ type MLNodeData = WorkerNode['data'] & {
 
 interface ViewProps {
     data: GraphBundle;
+    // Enables the details panel's collapse-to-rail affordance; the side-by-side
+    // panes make reclaiming the panel's width worthwhile.
+    splitView?: boolean;
 }
 
 type MLNode = Node<MLNodeData>;
@@ -408,7 +411,7 @@ function builtGraphToReactFlow(built: BuiltGraph): { nodes: MLNode[]; edges: Edg
     return { nodes, edges };
 }
 
-const MlGraphInner = ({ data }: ViewProps) => {
+const MlGraphInner = ({ data, splitView = false }: ViewProps) => {
     const { fitView, getViewport, setViewport, updateNode } = useReactFlow<MLNode, Edge>();
     // Unique per instance so two side-by-side panes don't emit colliding React
     // Flow marker/DOM ids (both panes can show the same graph.id).
@@ -418,6 +421,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(() => new Set());
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+    // Persists across selections (the panel remounts per node) but resets on
+    // graph switch via the keyed remount; the split-view rail toggles it.
+    const [detailsExpanded, setDetailsExpanded] = useState(true);
     // Live op-name filter. `filterQuery` drives the input for instant visual
     // feedback; `appliedFilterQuery` is what the memo chain reads and lags
     // by `FILTER_DEBOUNCE_MS` on non-empty queries.
@@ -1189,6 +1195,10 @@ const MlGraphInner = ({ data }: ViewProps) => {
         setSelectedNodeId(null);
     }, []);
 
+    const toggleDetailsExpanded = useCallback(() => {
+        setDetailsExpanded((open) => !open);
+    }, []);
+
     const recenterOnSelected = useCallback(() => {
         if (!selectedNodeId) {
             return;
@@ -1585,6 +1595,9 @@ const MlGraphInner = ({ data }: ViewProps) => {
                     onClose={closeDetailsPanel}
                     onRecenter={recenterOnSelected}
                     onNavigateToNode={navigateToNode}
+                    collapsible={splitView}
+                    expanded={detailsExpanded}
+                    onToggleExpand={toggleDetailsExpanded}
                 />
             )}
         </div>

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -180,6 +180,10 @@ const MlirNodeDetailsPanelInner = ({
 }: MlirNodeDetailsPanelProps) => {
     const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
 
+    // Collapsing needs a toggle handler to be useful; without one, fall back to
+    // the full panel rather than render a dead rail / collapse control.
+    const canCollapse = collapsible && onToggleExpand != null;
+
     const toggleSection = (key: SectionKey) => {
         setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
     };
@@ -220,7 +224,7 @@ const MlirNodeDetailsPanelInner = ({
         return ports;
     }, [outputsMetadata, outgoingEdges]);
 
-    if (collapsible && !expanded) {
+    if (canCollapse && !expanded) {
         return (
             <aside
                 className='mlir-node-details-panel mlir-node-details-rail'
@@ -277,7 +281,7 @@ const MlirNodeDetailsPanelInner = ({
                     </p>
                 </div>
                 <div className='mlir-node-details-actions'>
-                    {collapsible && (
+                    {canCollapse && (
                         <Tooltip content='Collapse details'>
                             <Button
                                 size={Size.SMALL}

--- a/src/components/mlir/MlirNodeDetailsPanel.tsx
+++ b/src/components/mlir/MlirNodeDetailsPanel.tsx
@@ -36,6 +36,11 @@ interface MlirNodeDetailsPanelProps {
      * I/O while peeking at where its neighbours live.
      */
     onNavigateToNode: (nodeId: string) => void;
+    // When true (split view), the panel can collapse to a rail; otherwise it
+    // always renders full and the collapse control is hidden.
+    collapsible?: boolean;
+    expanded?: boolean;
+    onToggleExpand?: () => void;
 }
 
 interface OutputPortView {
@@ -169,6 +174,9 @@ const MlirNodeDetailsPanelInner = ({
     onClose,
     onRecenter,
     onNavigateToNode: handleNavigateToNode,
+    collapsible = false,
+    expanded = true,
+    onToggleExpand,
 }: MlirNodeDetailsPanelProps) => {
     const [collapsed, setCollapsed] = useAtom(mlirNodeDetailsCollapsedAtom);
 
@@ -212,6 +220,47 @@ const MlirNodeDetailsPanelInner = ({
         return ports;
     }, [outputsMetadata, outgoingEdges]);
 
+    if (collapsible && !expanded) {
+        return (
+            <aside
+                className='mlir-node-details-panel mlir-node-details-rail'
+                aria-label='Selected node (collapsed)'
+            >
+                <header className='mlir-node-details-header'>
+                    <div className='mlir-node-details-titles'>
+                        <h2 className='mlir-node-details-label'>{node.label}</h2>
+                        <p
+                            className='mlir-node-details-id'
+                            title={node.id}
+                        >
+                            {node.id}
+                        </p>
+                    </div>
+                    <div className='mlir-node-details-actions'>
+                        <Tooltip content='Expand details'>
+                            <Button
+                                size={Size.SMALL}
+                                variant={ButtonVariant.MINIMAL}
+                                icon={IconNames.MAXIMIZE}
+                                aria-label='Expand node details'
+                                onClick={onToggleExpand}
+                            />
+                        </Tooltip>
+                        <Tooltip content='Close'>
+                            <Button
+                                size={Size.SMALL}
+                                variant={ButtonVariant.MINIMAL}
+                                icon={IconNames.CROSS}
+                                aria-label='Close node details'
+                                onClick={onClose}
+                            />
+                        </Tooltip>
+                    </div>
+                </header>
+            </aside>
+        );
+    }
+
     return (
         <aside
             className='mlir-node-details-panel'
@@ -228,6 +277,17 @@ const MlirNodeDetailsPanelInner = ({
                     </p>
                 </div>
                 <div className='mlir-node-details-actions'>
+                    {collapsible && (
+                        <Tooltip content='Collapse details'>
+                            <Button
+                                size={Size.SMALL}
+                                variant={ButtonVariant.MINIMAL}
+                                icon={IconNames.MINIMIZE}
+                                aria-label='Collapse node details'
+                                onClick={onToggleExpand}
+                            />
+                        </Tooltip>
+                    )}
                     <Tooltip content='Recenter'>
                         <Button
                             size={Size.SMALL}

--- a/src/components/mlir/MlirSplitView.tsx
+++ b/src/components/mlir/MlirSplitView.tsx
@@ -119,7 +119,10 @@ const MlirSplitView = ({ data, onExit }: MlirSplitViewProps) => {
                 style={{ flexBasis: `${leftPct}%` }}
             >
                 {renderHeader('left', safeLeftIndex, setLeftIndex)}
-                <MlGraph data={leftBundle} />
+                <MlGraph
+                    data={leftBundle}
+                    splitView
+                />
             </section>
 
             <div
@@ -134,7 +137,10 @@ const MlirSplitView = ({ data, onExit }: MlirSplitViewProps) => {
 
             <section className='mlir-split-pane mlir-split-pane-right'>
                 {renderHeader('right', safeRightIndex, setRightIndex)}
-                <MlGraph data={rightBundle} />
+                <MlGraph
+                    data={rightBundle}
+                    splitView
+                />
             </section>
         </div>
     );

--- a/src/components/mlir/MlirSplitView.tsx
+++ b/src/components/mlir/MlirSplitView.tsx
@@ -121,7 +121,7 @@ const MlirSplitView = ({ data, onExit }: MlirSplitViewProps) => {
                 {renderHeader('left', safeLeftIndex, setLeftIndex)}
                 <MlGraph
                     data={leftBundle}
-                    splitView
+                    detailsCollapsible
                 />
             </section>
 
@@ -139,7 +139,7 @@ const MlirSplitView = ({ data, onExit }: MlirSplitViewProps) => {
                 {renderHeader('right', safeRightIndex, setRightIndex)}
                 <MlGraph
                     data={rightBundle}
-                    splitView
+                    detailsCollapsible
                 />
             </section>
         </div>

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -34,7 +34,7 @@
 }
 
 // Collapsed form (split view): a compact top-right chip showing just the header
-// (selected op + expand/close) so the pane's canvas stays visible by default.
+// (selected op + expand/close) so the pane's canvas stays mostly uncovered.
 .mlir-node-details-rail {
     width: auto;
     max-width: 280px;

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -18,7 +18,10 @@
     position: absolute;
     top: 0;
     right: 0;
-    width: 450px;
+
+    // Pane-relative width: caps the panel so a narrow split pane keeps a usable
+    // canvas, while a full-width single-view pane still lands at the 450px max.
+    width: clamp(280px, 40%, 450px);
     height: 100%;
     z-index: 10;
     background: rgb(52 52 52 / 95%);
@@ -28,6 +31,15 @@
     display: flex;
     flex-direction: column;
     font-size: 12px;
+}
+
+// Collapsed form (split view): a compact top-right chip showing just the header
+// (selected op + expand/close) so the pane's canvas stays visible by default.
+.mlir-node-details-rail {
+    width: auto;
+    max-width: 280px;
+    height: auto;
+    overflow: hidden;
 }
 
 .mlir-node-details-header {
@@ -353,10 +365,4 @@
     word-break: break-all;
 }
 
-/* On narrower viewports, shrink the panel so the canvas remains usable. */
-@media screen and (width <= 1200px) {
-    .mlir-node-details-panel {
-        width: 360px;
-    }
-}
 /* stylelint-enable selector-class-pattern */

--- a/src/scss/components/MlirNodeDetailsPanel.scss
+++ b/src/scss/components/MlirNodeDetailsPanel.scss
@@ -21,7 +21,9 @@
 
     // Pane-relative width: caps the panel so a narrow split pane keeps a usable
     // canvas, while a full-width single-view pane still lands at the 450px max.
+    // max-width pins it to the pane when it's narrower than the 280px floor.
     width: clamp(280px, 40%, 450px);
+    max-width: 100%;
     height: 100%;
     z-index: 10;
     background: rgb(52 52 52 / 95%);
@@ -37,7 +39,7 @@
 // (selected op + expand/close) so the pane's canvas stays mostly uncovered.
 .mlir-node-details-rail {
     width: auto;
-    max-width: 280px;
+    max-width: min(280px, 100%);
     height: auto;
     overflow: hidden;
 }

--- a/tests/MlirNodeDetailsPanel.spec.tsx
+++ b/tests/MlirNodeDetailsPanel.spec.tsx
@@ -55,6 +55,9 @@ interface RenderPanelOverrides {
     onClose?: () => void;
     onRecenter?: () => void;
     onNavigateToNode?: (nodeId: string) => void;
+    collapsible?: boolean;
+    expanded?: boolean;
+    onToggleExpand?: () => void;
 }
 
 function renderPanel(overrides: RenderPanelOverrides = {}) {
@@ -69,6 +72,9 @@ function renderPanel(overrides: RenderPanelOverrides = {}) {
                 onClose={overrides.onClose ?? (() => {})}
                 onRecenter={overrides.onRecenter ?? (() => {})}
                 onNavigateToNode={overrides.onNavigateToNode ?? (() => {})}
+                collapsible={overrides.collapsible}
+                expanded={overrides.expanded}
+                onToggleExpand={overrides.onToggleExpand ?? (() => {})}
             />
         </TestProviders>,
     );
@@ -327,5 +333,46 @@ describe('MlirNodeDetailsPanel Outputs section', () => {
         expect(within(outputsBody as HTMLElement).getByText('port 1')).toBeInTheDocument();
         expect(outputsBody?.querySelector('.mlir-port-attrs-compact')).toBeNull();
         expect(outputsBody?.querySelector('.mlir-node-details-consumer-list')).toBeNull();
+    });
+});
+
+describe('MlirNodeDetailsPanel collapsible (split view)', () => {
+    it('renders the full panel with a collapse control when collapsible and expanded', () => {
+        const { container } = renderPanel({ collapsible: true, expanded: true });
+        expect(screen.getByRole('button', { name: 'Collapse node details' })).toBeInTheDocument();
+        expect(container.querySelector('.mlir-node-details-rail')).toBeNull();
+        expect(container.querySelector('.mlir-node-details-attrs')).not.toBeNull();
+    });
+
+    it('renders only the compact rail (label + expand + close) when collapsed', () => {
+        const { container } = renderPanel({ collapsible: true, expanded: false });
+        expect(container.querySelector('.mlir-node-details-rail')).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'stablehlo.dot_general' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Expand node details' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Close node details' })).toBeInTheDocument();
+        // The rail drops the body: no sections and no recenter affordance.
+        expect(screen.queryByRole('button', { name: 'Recenter' })).toBeNull();
+        expect(container.querySelector('.mlir-node-details-attrs')).toBeNull();
+    });
+
+    it('calls onToggleExpand from the rail expand button', () => {
+        const onToggleExpand = vi.fn();
+        renderPanel({ collapsible: true, expanded: false, onToggleExpand });
+        fireEvent.click(screen.getByRole('button', { name: 'Expand node details' }));
+        expect(onToggleExpand).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onToggleExpand from the full-panel collapse button', () => {
+        const onToggleExpand = vi.fn();
+        renderPanel({ collapsible: true, expanded: true, onToggleExpand });
+        fireEvent.click(screen.getByRole('button', { name: 'Collapse node details' }));
+        expect(onToggleExpand).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows no collapse control in single view (not collapsible)', () => {
+        const { container } = renderPanel();
+        expect(screen.queryByRole('button', { name: 'Collapse node details' })).toBeNull();
+        expect(container.querySelector('.mlir-node-details-rail')).toBeNull();
+        expect(container.querySelector('.mlir-node-details-attrs')).not.toBeNull();
     });
 });

--- a/tests/MlirSplitView.spec.tsx
+++ b/tests/MlirSplitView.spec.tsx
@@ -58,10 +58,18 @@ const stubRect = (element: HTMLElement, width: number): void => {
 // guard test below pins it to TEST_IDS.MLIR_GRAPH so the two can't drift.
 const { MLIR_GRAPH_TEST_ID } = vi.hoisted(() => ({ MLIR_GRAPH_TEST_ID: 'mlir-graph' }));
 
-// The real MlGraph spins up a layout worker + React Flow; stub it to just echo
-// the graph id it was handed so the test can assert per-pane wiring.
+// The real MlGraph spins up a layout worker + React Flow; stub it to echo the
+// graph id and the collapsible flag it was handed so the test can assert
+// per-pane wiring.
 vi.mock('../src/components/mlir/MLIRViewReactFlow', () => ({
-    default: ({ data }: { data: GraphBundle }) => <div data-testid={MLIR_GRAPH_TEST_ID}>{data.graphs[0]?.id}</div>,
+    default: ({ data, detailsCollapsible }: { data: GraphBundle; detailsCollapsible?: boolean }) => (
+        <div
+            data-testid={MLIR_GRAPH_TEST_ID}
+            data-details-collapsible={String(!!detailsCollapsible)}
+        >
+            {data.graphs[0]?.id}
+        </div>
+    ),
 }));
 
 afterEach(cleanup);
@@ -76,6 +84,18 @@ const paneGraphIds = (): [string, string] => {
 describe('MlirSplitView', () => {
     it('keeps the MlGraph stub test id in sync with the shared constant', () => {
         expect(MLIR_GRAPH_TEST_ID).toBe(TEST_IDS.MLIR_GRAPH);
+    });
+
+    it('marks both panes details-collapsible so the panel can collapse to a rail', () => {
+        render(
+            <MlirSplitView
+                data={makeData(['g0', 'g1'])}
+                onExit={() => {}}
+            />,
+        );
+        const panes = screen.getAllByTestId(TEST_IDS.MLIR_GRAPH);
+        expect(panes).toHaveLength(2);
+        panes.forEach((pane) => expect(pane).toHaveAttribute('data-details-collapsible', 'true'));
     });
 
     it('opens both panes on the same (first) graph', () => {


### PR DESCRIPTION
## Summary

The MLIR node-details panel is a fixed 450px right-docked overlay inside each pane. In the split-pane view (#1721) each pane is ~half the viewport, so an open panel buried the graph.

- **Responsive width (both views)** — width is now `clamp(280px, 40%, 450px)`. The panel is `position: absolute` inside `.mlir-view-pane`, so the `40%` term is pane-relative: it narrows in a split pane and still caps at 450px in single view. Drops the redundant `<=1200px` media query.
- **Collapse-to-rail (split view only)** — a `detailsCollapsible` prop threads `MlirSplitView -> MlGraph`; the panel gains optional `collapsible`/`expanded`/`onToggleExpand` and renders a compact top-right rail (op label + expand + close) when collapsed, plus a collapse control on the full panel. Expand state is per-pane, persists across selections, and resets on graph switch or panel close.
- **Single view** is unchanged apart from the responsive width.

Per the #1789 discussion the default was changed from "rail-by-default" to **start expanded** with an opt-in collapse.

Closes #1789.

## Screenshot

<img width="1024" height="635" alt="image" src="https://github.com/user-attachments/assets/c534cab3-2f7d-4a74-b670-0d369e8d8330" />

## Test plan

- [x] `tsc --noEmit`, `eslint`, `stylelint` green on touched files
- [x] `MlirNodeDetailsPanel.spec.tsx` — rail vs full states, toggle callbacks, single-view no-control (5 new cases)
- [x] `MlirSplitView.spec.tsx` — asserts both panes receive `detailsCollapsible`
- [x] Manual: single + split view, collapse/expand, close-then-reselect reopens expanded