### PR TITLE
Align commit link icon centrally with text

### DIFF
--- a/src/components/operation-details/GitCommitInfo.tsx
+++ b/src/components/operation-details/GitCommitInfo.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ReactNode } from 'react';
 import { buildGitCommitUrl, formatShortSha } from '../../functions/formatting';
+import 'styles/components/GitCommitInfo.scss';
 
 export interface GitMetadataProps {
     gitUrl: string | null;
@@ -25,6 +26,7 @@ function GitCommitInfo({ gitUrl, gitSha }: GitMetadataProps) {
             <strong>Commit:</strong>{' '}
             {commitUrl ? (
                 <a
+                    className='report-git-info-link'
                     href={commitUrl}
                     target='_blank'
                     rel='noreferrer'

--- a/src/scss/components/GitCommitInfo.scss
+++ b/src/scss/components/GitCommitInfo.scss
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+.report-git-info {
+    display: block;
+    font-size: 12px;
+    margin-top: 5px;
+
+    .report-git-info-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0;
+    }
+
+    .report-git-info-icon {
+        margin-left: 3px;
+        margin-bottom: 2px;
+        vertical-align: middle;
+    }
+}

--- a/src/scss/components/GitCommitInfo.scss
+++ b/src/scss/components/GitCommitInfo.scss
@@ -10,12 +10,10 @@
     .report-git-info-link {
         display: inline-flex;
         align-items: center;
-        gap: 0;
     }
 
     .report-git-info-icon {
         margin-left: 3px;
-        margin-bottom: 2px;
-        vertical-align: middle;
+        margin-bottom: 1px;
     }
 }

--- a/src/scss/components/StackTrace.scss
+++ b/src/scss/components/StackTrace.scss
@@ -10,18 +10,6 @@
 $source-path-vertical-padding: 20px;
 $container-border-width: 1px;
 
-@mixin report-git-info {
-    display: block;
-    font-size: 12px;
-    margin-top: 5px;
-
-    .report-git-info-icon {
-        margin-left: 3px;
-        margin-bottom: 2px;
-        vertical-align: middle;
-    }
-}
-
 .stack-trace {
     margin-top: 0;
 
@@ -77,10 +65,6 @@ $container-border-width: 1px;
         margin-top: -($source-path-vertical-padding - $container-border-width);
         margin-right: 30px; // Avoids overlapping with source-file-controls
         margin-bottom: 0;
-
-        .report-git-info {
-            @include report-git-info;
-        }
     }
 
     .code-wrapper {
@@ -138,10 +122,6 @@ $container-border-width: 1px;
             }
         }
     }
-}
-
-.stack-trace-error .stack-trace-path .report-git-info {
-    @include report-git-info;
 }
 
 .source-file-controls {


### PR DESCRIPTION
**Improved alignment**
<img width="378" height="191" alt="Screenshot 2026-07-24 at 12 58 57" src="https://github.com/user-attachments/assets/f5a65e2f-0d4f-4dd3-8bbf-18419eac0e92" />

<img width="378" height="191" alt="Screenshot 2026-07-24 at 12 58 50" src="https://github.com/user-attachments/assets/7cadc72e-3080-492b-a37d-a806dc70869b" />
