### PR TITLE
Align footer infobar heights

### DIFF
--- a/src/scss/components/FooterInfobar.scss
+++ b/src/scss/components/FooterInfobar.scss
@@ -26,6 +26,7 @@
         flex-grow: 1;
         gap: 10px;
         margin-right: 10px;
+        height: 20px;
     }
 
     .version-container {
@@ -50,6 +51,7 @@
         align-items: center;
         justify-content: space-between;
         gap: 12px;
+        height: 24px;
     }
 
     .report-source-tag {


### PR DESCRIPTION
Adds fixed heights to some elements so text doesn't change aligment when reports are loaded.