### PR TITLE
Fix graph button colours

### DIFF
--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -8,7 +8,9 @@
 .react-flow {
     --xy-edge-label-color: #{$tt-grey-7};
     --xy-edge-label-background-color: transparent;
+    --xy-controls-button-background-color-hover-props: #{$tt-grey-6};
     --xy-controls-button-color: #{$tt-grey-2};
+    --xy-controls-button-color-hover: #{$tt-grey-2};
     --xy-minimap-node-stroke-color: #{$tt-grey-2};
     --xy-minimap-node-background-color: #{$tt-grey-2};
     --xy-minimap-node-stroke-width: 1px;


### PR DESCRIPTION
Ensures icon colour remains the same on hover and darkens the button background.

<img width="378" height="191" alt="Screenshot 2026-07-28 at 10 32 41" src="https://github.com/user-attachments/assets/782420c9-b800-4a51-9a94-3d25b59b1c15" />

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1779.