### PR TITLE
Align report tooltip contents

### DIFF
--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -171,7 +171,11 @@ function FooterInfobar() {
                     {activePerformanceReportPath && (
                         <Tooltip
                             disabled={!activePerformanceReportPath}
-                            content={formatPath(activePerformanceReportPath)}
+                            content={
+                                <>
+                                    <strong>Report path:</strong> {formatPath(activePerformanceReportPath)}
+                                </>
+                            }
                             position={PopoverPosition.TOP}
                         >
                             <div className='title'>


### PR DESCRIPTION
Added missing "Report path:" to performance tooltip.

<img width="801" height="215" alt="Screenshot 2026-07-28 at 11 27 10" src="https://github.com/user-attachments/assets/66957483-1c5f-4eda-ad70-5b5846f13ddd" />
