### PR TITLE
Link memory and performance reports without pre-collapsing multi-device ops

### DIFF
--- a/src/components/OperationListPerfData.tsx
+++ b/src/components/OperationListPerfData.tsx
@@ -6,8 +6,9 @@ import classNames from 'classnames';
 import { Fragment } from 'react/jsx-runtime';
 import { formatPercentage, formatSize } from '../functions/math';
 import { getCoreColour, getOpToOpGapColour } from '../functions/perfFunctions';
-import { DeviceOperationMapping, useGetDeviceOperationListPerf } from '../hooks/useAPI';
+import { useGetDeviceOperationListPerf } from '../hooks/useAPI';
 import { OperationDescription } from '../model/APIData';
+import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
 
 interface OperationListPerfDataProps {
     operation: OperationDescription;

--- a/src/functions/deviceOperationMatching.ts
+++ b/src/functions/deviceOperationMatching.ts
@@ -17,7 +17,9 @@ export const collapseMultideviceOperations = (
     deviceOperations: DeviceOperationMapping[],
     numDevices: number,
 ): DeviceOperationMapping[] => {
-    if (numDevices === 1) {
+    // A single device has no per-device duplicates, and an unknown device count
+    // (0, before the devices query settles) gives no count to collapse on.
+    if (numDevices <= 1) {
         return deviceOperations;
     }
 
@@ -89,9 +91,9 @@ export const matchDeviceOperationsToPerf = (
         return directMatch;
     }
 
-    // Single-device reports have nothing to collapse, so the fallback would
-    // repeat the pass that just failed.
-    if (numDevices === 1) {
+    // With nothing to collapse on, the fallback would repeat the pass that just
+    // failed.
+    if (numDevices <= 1) {
         return [];
     }
 

--- a/src/functions/deviceOperationMatching.ts
+++ b/src/functions/deviceOperationMatching.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { PerfTableRow } from '../definitions/PerfTable';
+import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
+
+/**
+ * TODO: remove once memory and performance reports carry a shared run id (#1800)
+ * @description Drop per-device duplicates of the same device operation, keeping
+ * only keys seen exactly once per device. Some multi-device memory reports
+ * record each device op once per device and others record it once, and nothing
+ * in the report distinguishes the two shapes — so this is a fallback for the
+ * duplicated shape rather than an unconditional normalisation. See #1810.
+ */
+export const collapseMultideviceOperations = (
+    deviceOperations: DeviceOperationMapping[],
+    numDevices: number,
+): DeviceOperationMapping[] => {
+    if (numDevices === 1) {
+        return deviceOperations;
+    }
+
+    const operationCountByKey = new Map<string, number>();
+
+    for (const { name, id } of deviceOperations) {
+        const key = `${name}-${id}`;
+        operationCountByKey.set(key, (operationCountByKey.get(key) || 0) + 1);
+    }
+
+    const collapsed: DeviceOperationMapping[] = [];
+    const seen = new Set<string>();
+
+    for (const deviceOperation of deviceOperations) {
+        const key = `${deviceOperation.name}-${deviceOperation.id}`;
+
+        if (!seen.has(key) && operationCountByKey.get(key) === numDevices) {
+            collapsed.push(deviceOperation);
+            seen.add(key);
+        }
+    }
+
+    return collapsed;
+};
+
+/**
+ * @description Pair each device operation with the perf row at the same index,
+ * or return [] if any position disagrees. Trailing perf rows are tolerated so a
+ * report that also lists host ops still matches. Validation runs before any
+ * allocation because callers try more than one candidate list, and the mappings
+ * are copies so a rejected attempt leaves the caller's list untouched.
+ */
+const alignToPerfRows = (
+    deviceOperations: DeviceOperationMapping[],
+    perfRows: PerfTableRow[],
+): DeviceOperationMapping[] => {
+    if (deviceOperations.length === 0 || deviceOperations.length > perfRows.length) {
+        return [];
+    }
+
+    const isAligned = deviceOperations.every(
+        (deviceOperation, index) => perfRows[index].raw_op_code === deviceOperation.name,
+    );
+
+    if (!isAligned) {
+        return [];
+    }
+
+    return deviceOperations.map((deviceOperation, index) => ({ ...deviceOperation, perfData: perfRows[index] }));
+};
+
+/**
+ * @description Match a memory report's device operations against a performance
+ * report's rows, returning the mappings when the two sequences describe the same
+ * run and [] when they don't (the report-link UNLINKED signal).
+ *
+ * The raw list is tried first because it is the shape most reports have; only
+ * when that fails do we assume the memory report duplicated each op per device
+ * and retry against the collapsed list.
+ */
+export const matchDeviceOperationsToPerf = (
+    deviceOperations: DeviceOperationMapping[],
+    perfRows: PerfTableRow[],
+    numDevices: number,
+): DeviceOperationMapping[] => {
+    const directMatch = alignToPerfRows(deviceOperations, perfRows);
+
+    if (directMatch.length > 0) {
+        return directMatch;
+    }
+
+    // Single-device reports have nothing to collapse, so the fallback would
+    // repeat the pass that just failed.
+    if (numDevices === 1) {
+        return [];
+    }
+
+    return alignToPerfRows(collapseMultideviceOperations(deviceOperations, numDevices), perfRows);
+};

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -800,10 +800,9 @@ export const useGetDeviceOperationsListByOp = () => {
  */
 export const useGetDeviceOperationsList = (): DeviceOperationMapping[] => {
     const { data: operations } = useOperationsList();
-    const { data: devices } = useDevices();
 
     return useMemo(() => {
-        if (!operations || !devices) {
+        if (!operations) {
             return [];
         }
 
@@ -814,7 +813,7 @@ export const useGetDeviceOperationsList = (): DeviceOperationMapping[] => {
                 operationName: operation.name,
             })),
         );
-    }, [operations, devices]);
+    }, [operations]);
 };
 
 const useProxyPerformanceReport = (): PerformanceReportResponse => {

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -31,6 +31,8 @@ import parseMemoryConfig, { memoryConfigPattern } from '../functions/parseMemory
 import { MemoryConfig } from '../model/MemoryConfig';
 import getServerConfig from '../functions/getServerConfig';
 import { PerfTableRow } from '../definitions/PerfTable';
+import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
+import { matchDeviceOperationsToPerf } from '../functions/deviceOperationMatching';
 import { L1PressureResult } from '../model/L1Pressure';
 import { buildL1PressureResult } from '../functions/l1Pressure';
 import { StackedGroupBy, StackedPerfRow } from '../definitions/StackedPerfTable';
@@ -791,61 +793,27 @@ export const useGetDeviceOperationsListByOp = () => {
     }, [operations]);
 };
 
-export interface DeviceOperationMapping {
-    name: string;
-    id: number;
-    operationName: string;
-    perfData?: PerfTableRow;
-}
-
+/**
+ * @description Every device operation in the memory report, flattened in report
+ * order. Multi-device collapsing happens at match time, not here, because only
+ * the performance report reveals which shape this report has (#1810).
+ */
 export const useGetDeviceOperationsList = (): DeviceOperationMapping[] => {
     const { data: operations } = useOperationsList();
     const { data: devices } = useDevices();
-
-    /**
-     * TODO: update when device op data is device bound
-     * @description Collapse multi-device operations into single entry temporary logic, this can under certain circumstances lead to false positives
-     * @param data
-     * @param numDevices
-     */
-    const collapseMultideviceOPs = (data: DeviceOperationMapping[], numDevices: number): DeviceOperationMapping[] => {
-        if (numDevices === 1) {
-            return data;
-        }
-
-        const result: DeviceOperationMapping[] = [];
-        const operationCountByKey = new Map<string, number>();
-
-        for (const { name, id } of data) {
-            const key = `${name}-${id}`;
-            operationCountByKey.set(key, (operationCountByKey.get(key) || 0) + 1);
-        }
-
-        const seen = new Set<string>();
-
-        for (const item of data) {
-            const key = `${item.name}-${item.id}`;
-            if (!seen.has(key) && operationCountByKey.get(key) === numDevices) {
-                result.push(item);
-                seen.add(key);
-            }
-        }
-
-        return result;
-    };
 
     return useMemo(() => {
         if (!operations || !devices) {
             return [];
         }
-        const result = operations.flatMap((operation) =>
+
+        return operations.flatMap((operation) =>
             operation.deviceOperationNameList.map((name) => ({
                 name,
                 id: operation.id,
                 operationName: operation.name,
             })),
         );
-        return collapseMultideviceOPs(result, devices.length);
     }, [operations, devices]);
 };
 
@@ -863,22 +831,13 @@ const useProxyPerformanceReport = (): PerformanceReportResponse => {
 
 export const useGetDeviceOperationListPerf = () => {
     const deviceOperations: DeviceOperationMapping[] = useGetDeviceOperationsList();
+    const { data: devices } = useDevices();
     const data = useProxyPerformanceReport();
 
-    return useMemo(() => {
-        const isValid = deviceOperations.every((deviceOperation, index) => {
-            const perfData = data.report[index];
-
-            if (perfData && perfData.raw_op_code === deviceOperation.name) {
-                deviceOperation.perfData = perfData;
-                return true;
-            }
-
-            return false;
-        });
-
-        return isValid ? deviceOperations : [];
-    }, [data, deviceOperations]);
+    return useMemo(
+        () => matchDeviceOperationsToPerf(deviceOperations, data.report, devices?.length ?? 0),
+        [data, deviceOperations, devices],
+    );
 };
 
 /**

--- a/src/hooks/useOpPerfRowScores.ts
+++ b/src/hooks/useOpPerfRowScores.ts
@@ -4,7 +4,8 @@
 
 import { useMemo } from 'react';
 import { PerfOverlaySource, aggregatePerfByOp, scoreOps } from '../functions/perfOverlay';
-import { DeviceOperationMapping, useGetDeviceOperationListPerf } from './useAPI';
+import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
+import { useGetDeviceOperationListPerf } from './useAPI';
 
 export interface OpPerfRowScore {
     /** Worst-case device-kernel duration across this op's perf rows (ns). */

--- a/src/model/DeviceOperationMapping.ts
+++ b/src/model/DeviceOperationMapping.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { PerfTableRow } from '../definitions/PerfTable';
+
+/**
+ * One device operation from the memory report, optionally paired with the
+ * performance-report row it was matched to.
+ */
+export interface DeviceOperationMapping {
+    name: string;
+    id: number;
+    operationName: string;
+    perfData?: PerfTableRow;
+}

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { collapseMultideviceOperations, matchDeviceOperationsToPerf } from '../src/functions/deviceOperationMatching';
+import { PerfTableRow } from '../src/definitions/PerfTable';
+import { DeviceOperationMapping } from '../src/model/DeviceOperationMapping';
+
+const mapping = (name: string, id: number): DeviceOperationMapping => ({
+    name,
+    id,
+    operationName: `ttnn.${name.toLowerCase()}`,
+});
+
+const perfRow = (rawOpCode: string, id: number): PerfTableRow =>
+    ({ id: String(id), raw_op_code: rawOpCode, device_time: '1' }) as unknown as PerfTableRow;
+
+const perfRowsFor = (names: string[]): PerfTableRow[] => names.map((name, index) => perfRow(name, index));
+
+/** Each op recorded once per device, as `numDevices` consecutive entries. */
+const duplicatedPerDevice = (names: string[], numDevices: number): DeviceOperationMapping[] =>
+    names.flatMap((name, index) => Array.from({ length: numDevices }, () => mapping(name, index + 1)));
+
+describe('matchDeviceOperationsToPerf', () => {
+    it('matches a multi-device report that records each device op once (#1810)', () => {
+        // Shape of resnet50_jul28_1524: two devices, one entry per device op, and
+        // op 5 genuinely repeats `Pad` twice — which the collapse heuristic
+        // mistakes for per-device duplication and keeps in isolation.
+        const deviceOperations = [
+            mapping('PadDeviceOperation', 5),
+            mapping('TransposeDeviceOperation', 5),
+            mapping('PadDeviceOperation', 5),
+            mapping('MatmulDeviceOperation', 6),
+        ];
+        const perfRows = perfRowsFor([
+            'PadDeviceOperation',
+            'TransposeDeviceOperation',
+            'PadDeviceOperation',
+            'MatmulDeviceOperation',
+        ]);
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRows, 2);
+
+        expect(matched).toHaveLength(4);
+        expect(matched.map((deviceOperation) => deviceOperation.perfData?.id)).toEqual(['0', '1', '2', '3']);
+        // The collapse heuristic alone keeps only the twice-seen `Pad` key, so
+        // this report only links via the direct pass.
+        expect(collapseMultideviceOperations(deviceOperations, 2)).toHaveLength(1);
+    });
+
+    it('falls back to collapsing when the report records each device op once per device', () => {
+        const deviceOperations = duplicatedPerDevice(['Alpha', 'Beta', 'Gamma'], 2);
+        const perfRows = perfRowsFor(['Alpha', 'Beta', 'Gamma']);
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRows, 2);
+
+        expect(matched.map(({ name, id }) => [name, id])).toEqual([
+            ['Alpha', 1],
+            ['Beta', 2],
+            ['Gamma', 3],
+        ]);
+        expect(matched.map((deviceOperation) => deviceOperation.perfData?.id)).toEqual(['0', '1', '2']);
+    });
+
+    it('collapses a 32-device report down to the merged perf rows', () => {
+        const deviceOperations = duplicatedPerDevice(['Alpha', 'Beta'], 32);
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Beta']), 32);
+
+        expect(matched).toHaveLength(2);
+    });
+
+    it('matches when the devices table is empty, which no collapse count can satisfy', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2)];
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Beta']), 0);
+
+        expect(matched).toHaveLength(2);
+    });
+
+    it('matches a single-device report without collapsing repeated ops', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Alpha', 1), mapping('Beta', 2)];
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Alpha', 'Beta']), 1);
+
+        expect(matched).toHaveLength(3);
+    });
+
+    it('tolerates trailing perf rows the memory report does not describe, such as host ops', () => {
+        const matched = matchDeviceOperationsToPerf(
+            [mapping('Alpha', 1)],
+            perfRowsFor(['Alpha', 'HostOp', 'HostOp']),
+            1,
+        );
+
+        expect(matched).toHaveLength(1);
+        expect(matched[0].perfData?.id).toBe('0');
+    });
+
+    it('returns an empty list when the sequences disagree', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2)];
+
+        expect(matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Gamma']), 1)).toEqual([]);
+        expect(matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Gamma']), 2)).toEqual([]);
+    });
+
+    it('returns an empty list when the perf report has fewer rows than device operations', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2), mapping('Gamma', 3)];
+
+        expect(matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Beta']), 1)).toEqual([]);
+    });
+
+    it('returns an empty list when there are no device operations', () => {
+        expect(matchDeviceOperationsToPerf([], perfRowsFor(['Alpha']), 1)).toEqual([]);
+    });
+
+    it('leaves the caller list untouched so a rejected attempt cannot leak perf data', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2)];
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Beta']), 1);
+
+        expect(deviceOperations.every(({ perfData }) => perfData === undefined)).toBe(true);
+        expect(matched[0]).not.toBe(deviceOperations[0]);
+    });
+
+    it('does not attach perf data when only part of a multi-device report aligns', () => {
+        // The direct pass matches the first two entries before failing; the
+        // collapsed fallback then rejects the report outright.
+        const deviceOperations = duplicatedPerDevice(['Alpha', 'Beta'], 2);
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRowsFor(['Alpha', 'Alpha']), 2);
+
+        expect(matched).toEqual([]);
+        expect(deviceOperations.every(({ perfData }) => perfData === undefined)).toBe(true);
+    });
+});
+
+describe('collapseMultideviceOperations', () => {
+    it('returns the list unchanged for a single device', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Alpha', 1)];
+
+        expect(collapseMultideviceOperations(deviceOperations, 1)).toBe(deviceOperations);
+    });
+
+    it('keeps one entry per key seen exactly once per device and drops the rest', () => {
+        const deviceOperations = [
+            mapping('Alpha', 1),
+            mapping('Alpha', 1),
+            // Seen once, so not per-device duplication under this heuristic.
+            mapping('Beta', 2),
+        ];
+
+        expect(collapseMultideviceOperations(deviceOperations, 2).map(({ name }) => name)).toEqual(['Alpha']);
+    });
+});

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -137,10 +137,11 @@ describe('matchDeviceOperationsToPerf', () => {
 });
 
 describe('collapseMultideviceOperations', () => {
-    it('returns the list unchanged for a single device', () => {
+    it('returns the list unchanged when there is nothing to collapse on', () => {
         const deviceOperations = [mapping('Alpha', 1), mapping('Alpha', 1)];
 
         expect(collapseMultideviceOperations(deviceOperations, 1)).toBe(deviceOperations);
+        expect(collapseMultideviceOperations(deviceOperations, 0)).toBe(deviceOperations);
     });
 
     it('keeps one entry per key seen exactly once per device and drops the rest', () => {

--- a/tests/useOpPerfRowScores.spec.ts
+++ b/tests/useOpPerfRowScores.spec.ts
@@ -5,7 +5,8 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useOpPerfRowScores } from '../src/hooks/useOpPerfRowScores';
-import { DeviceOperationMapping, useGetDeviceOperationListPerf } from '../src/hooks/useAPI';
+import { useGetDeviceOperationListPerf } from '../src/hooks/useAPI';
+import { DeviceOperationMapping } from '../src/model/DeviceOperationMapping';
 import { PerfTableRow } from '../src/definitions/PerfTable';
 
 vi.mock('../src/hooks/useAPI', () => ({


### PR DESCRIPTION
Closes #1810.

## Summary

Multi-device memory reports come in two shapes and nothing in the report distinguishes them: some record each device operation once per device, others record it once. `collapseMultideviceOPs` assumed the former unconditionally and kept only `name-id` keys occurring exactly `numDevices` times, so reports of the latter shape lost almost every device operation before the positional match ran, and the report-link badge said "Failed to link" even though the two sequences were identical element for element.

The fix tries the raw device-operation list first and only falls back to collapsing when that fails, so both shapes link. Both passes are O(n).

- New `src/functions/deviceOperationMatching.ts` holds the matching logic as pure functions: `collapseMultideviceOperations` (moved verbatim, now a fallback) and `matchDeviceOperationsToPerf` (direct pass, then collapsed fallback). Alignment is validated before anything is allocated, and mappings are returned as copies rather than mutating the memoised list — that is what makes a second attempt safe.
- `useGetDeviceOperationsList` now returns the flattened list, and `useGetDeviceOperationListPerf` delegates to the matcher.
- `DeviceOperationMapping` moves to `src/model/DeviceOperationMapping.ts` so the pure helper does not import from a hooks module.

## Why this is wider than the link badge

The matched list also drives `useOpToPerfIdFiltered` -> `enrichRowData` (the perf table's Op column, the L1-pressure column, tensor-drawer gating), the graph perf overlay, top-N annotations, op-row perf scores, and memory/perf range synchronisation. On an affected report all of those were degraded, not just the badge.

Reports that link today take the fallback path and get the identical collapsed list, so they are unaffected.

## Verification

Against the pair from the issue (`resnet50_jul28_1524` + `2026_07_28_15_27_43`, 2 devices), driving the real API payloads through the new matcher:

| | |
|---|---|
| Flattened memory device ops | 324 |
| Perf rows (devices merged, the default) | 324 |
| First positional mismatch | none |
| Matched under collapse-only (before) | 3, then rejected -> UNLINKED |
| Matched now | 324, distinct op ids 240 |

Against a known-duplicated report (`llama_attn_32l_10iterations_30jan`, 8 devices): 1600 flattened memory ops versus ~244 merged perf rows, so the direct pass exits immediately on the length check and the collapse fallback runs exactly as before.

Also `pnpm test` (130 files), `pnpm lint`, `pnpm lint:ts`, `pnpm lint:spdx`. New unit tests in `tests/deviceOperationMatching.spec.ts` cover the one-per-op shape, the duplicated shape at 2 and 32 devices, an empty devices table (`numDevices === 0`, which no collapse count can satisfy), single-device passthrough, trailing host-op perf rows, divergent sequences, and non-mutation of the caller's list.

## Trade-offs

- Direct-first matching could in principle match a duplicated report spuriously if the perf rows repeated the same `raw_op_code` in the aligned positions. Checked empirically on the llama pair with devices unmerged: host-op rows break the alignment at index 160, so it does not happen there.
- With **Merge devices** off, a duplicated report could align directly against per-device rows and flip from UNLINKED to LINKED with per-device mappings. That is a plausible pairing rather than a wrong one, but it is a behaviour change worth naming.
- Matching remains strictly positional and still consumes `usePerformanceReport`, so link status still depends on the perf-tab view filters. That is the caveat noted in #1810; I will file it separately.
- Both would be moot with the explicit shared run id from #1800.

## Test plan

- [ ] Load `resnet50_jul28_1524` with `2026_07_28_15_27_43`: link badge reports linked, perf table Op column populated, graph overlay and top-N annotations available.
- [ ] Load a known-duplicated multi-device pair (for example the llama 8-device pair) and confirm linking and per-op perf data are unchanged.
- [ ] Load a single-device pair and confirm nothing changed.
