### PR TITLE
NPE: make scrubbing, selection and hover responsive on large reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,16 @@ Open pull requests with **`dev`** as the base branch by default.
 - Backend: **pytest** with `caplog`, `tmp_path`, and the shared **`client`** fixture (Flask's `app.test_client()`, defined in `backend/ttnn_visualizer/tests/conftest.py`) for endpoint tests.
 - For larger test suites — characterisation tests, refactor regressions — build **shared fixture helpers** (see `tests/mlirFixtures/builders.ts`) and **cross-cutting invariant checks** (see `tests/mlirFixtures/invariants.ts`) instead of repeating ad-hoc setup.
 
+### Canvas and rendering performance
+
+Applies on touch to views that draw data-proportional visuals (NPE chip cluster and timeline).
+
+- Never emit one rect or DOM node per datum when the data outnumbers the pixels. Downsample to at most one column per **device** pixel and summarise each column with a **max** — sub-pixel rects blend, so a mean or last-wins reduction hides spikes, which is a correctness bug in a congestion view. Keep the reduction pure and separate from colour mapping (`src/functions/reduceToColumns.ts`).
+- **Cap the raster scale.** Backing stores scale with `devicePixelRatio` × any on-screen scale and grow with the square; uncapped, a multi-chip cluster under a zoom control can ask for hundreds of MB, at which point the browser discards buffers and elements render blank.
+- **High-frequency feedback gets its own layer, never state.** Hover markers and playheads move imperatively via a ref or in CSS; routing pointer/scrub position through React state re-renders the owning view per event. Prefer a positioned element over a second canvas for a single border or line. Cache `getBoundingClientRect()` for hit-testing with a bounded lifetime — reading it per `mousemove` forces a layout flush, and the box can move without resizing.
+- **`memo()` makes prop stability a contract.** Every prop must be a primitive, a `useCallback`-stable handler, or a memoized value; callers must not pass inline lambdas or fresh literals. Prefer a shared frozen constant to `?? []`, and narrow handler props to the narrowest signature that works so the only thing worth passing is already stable.
+- Derive an ancestor's effective scale by **measuring the element**, not by threading the ancestor's zoom down as a prop.
+
 ### Frontend data integrity
 
 - Prefer **client-side JSON validation** for user-uploaded JSON before the backend parses it. Surface validation errors with a friendly UI message rather than a 5xx round-trip. Use `try { JSON.parse(...) } catch (e) { ... }` and shape-check predicates.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -877,6 +877,56 @@ If a patch "isn't taking", the path is almost always pointing at the source modu
 
 ---
 
+## Canvas and rendering performance
+
+Applies on touch, to views that draw data-proportional visuals (NPE chip cluster and
+timeline today). The canonical examples are `src/components/npe/ChipCongestionCanvas.tsx`
+and `src/components/npe/NPETimelineComponent.tsx`.
+
+### Downsample time series to one column per device pixel
+
+Never emit one rect (or one DOM node) per datum when the data outnumbers the pixels.
+Reduce to at most one column per **device** pixel and summarise each column with a
+**max**, not a mean or a last-wins write. Sub-pixel rects are not just wasted work —
+they blend, so an isolated spike disappears, which for a congestion view is a
+correctness bug. Keep the reduction pure and separate from colour mapping
+(`src/functions/reduceToColumns.ts`) so a palette change doesn't rescan the series.
+
+### Cap the raster scale
+
+Backing stores scale with `devicePixelRatio × any on-screen scale`, and area grows
+with the square. Clamp the linear scale (see `MAX_BACKING_SCALE`) — uncapped, a
+multi-chip cluster under a zoom control can ask for hundreds of MB, at which point the
+browser silently discards buffers and elements render blank rather than slow.
+
+### High-frequency feedback goes on its own layer, never through state
+
+Hover markers, playheads and similar per-pointer/per-tick visuals get a separate
+element and are moved imperatively via a ref, or positioned in CSS. Routing pointer
+position or scrub position through React state re-renders the owning view on every
+event. Prefer a positioned element over a second canvas when the visual is a single
+border or line — a full-size backing store buys nothing.
+
+Cache `getBoundingClientRect()` for pointer hit-testing and invalidate it on
+resize/scroll; reading it per `mousemove` forces a synchronous layout flush.
+
+### `memo()` makes prop stability a contract
+
+When a component is wrapped in `memo()`, every prop must be a primitive, a
+`useCallback`-stable handler, or a memoized value — and callers must not pass inline
+lambdas or fresh literals. Two consequences worth applying deliberately:
+
+- Prefer a shared module-level frozen constant to `?? []` for an absent collection.
+  A fresh literal gives every render a new identity and defeats the memo.
+- Narrow handler props to the narrowest signature that works (`onEmptyCellClick: () => void`
+  rather than a wide selection handler), so the only thing worth passing is already stable.
+
+Derive an ancestor's effective scale by measuring the element rather than threading
+the ancestor's zoom down as a prop — one source of truth, and it stays correct if the
+ancestor is ever scaled by another mechanism.
+
+---
+
 ## Frontend data integrity
 
 ### Validate user-uploaded JSON on the client

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -19,11 +19,13 @@ interface CollapsibleProps {
     keepChildrenMounted?: boolean;
     onExpandToggle?: (state: boolean) => void;
     isDisabled?: boolean;
-    // Pass a function to build the content lazily: it is only invoked while the
-    // section is open. Callers whose collapsed content is huge (see the NPE zone
-    // filter, which can hold ~100k rows) use this so the element tree is never
-    // constructed — and never garbage — while the section is shut.
-    children?: React.ReactNode | (() => React.ReactNode);
+    children?: React.ReactNode;
+    // Builds the content only while the section is open, so a caller whose
+    // collapsed content is huge never constructs that element tree (the NPE zone
+    // filter can hold ~100k rows). Mutually exclusive with `children`; supplying
+    // it forces unmount-on-collapse, so `keepChildrenMounted` is ignored — the
+    // whole point is that nothing is retained while shut. #1803
+    renderContent?: () => React.ReactNode;
 }
 
 const Collapsible = ({
@@ -36,13 +38,18 @@ const Collapsible = ({
     keepChildrenMounted = true,
     onExpandToggle,
     children,
+    renderContent,
     isDisabled = false,
 }: CollapsibleProps) => {
     const [isOpenState, setIsOpenState] = React.useState(isOpen);
     const [prevIsOpenProp, setPrevIsOpenProp] = React.useState(isOpen);
     const icon = isOpenState ? IconNames.CARET_UP : IconNames.CARET_DOWN;
-    const isLazy = typeof children === 'function';
-    const content = isLazy ? isOpenState && children() : children;
+    // A section is collapsible if it has content either way; `renderContent` is
+    // only invoked while open, and it opts out of `keepChildrenMounted` so the
+    // wiring matches what the prop comment promises.
+    const hasContent = Boolean(children) || Boolean(renderContent);
+    const content = renderContent ? isOpenState && renderContent() : children;
+    const shouldKeepMounted = keepChildrenMounted && !renderContent;
 
     if (isOpen !== prevIsOpenProp) {
         setPrevIsOpenProp(isOpen);
@@ -52,7 +59,7 @@ const Collapsible = ({
     return (
         <div className={classNames('collapsible-component', collapseClassName)}>
             <div className='collapsible-controls'>
-                {children && (
+                {hasContent && (
                     <Button
                         size={Size.SMALL}
                         variant={ButtonVariant.MINIMAL}
@@ -72,17 +79,17 @@ const Collapsible = ({
                         {label}
                     </Button>
                 )}
-                {!children && (
+                {!hasContent && (
                     <div className='collapsible-label-wrap'>
                         <div className='collapsible-label'>{label}</div>
                     </div>
                 )}
                 {additionalElements && additionalElements}
             </div>
-            {children && (
+            {hasContent && (
                 <Collapse
                     isOpen={isOpenState}
-                    keepChildrenMounted={keepChildrenMounted}
+                    keepChildrenMounted={shouldKeepMounted}
                 >
                     <div
                         className={classNames(contentClassName)}

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -19,7 +19,11 @@ interface CollapsibleProps {
     keepChildrenMounted?: boolean;
     onExpandToggle?: (state: boolean) => void;
     isDisabled?: boolean;
-    children?: React.ReactNode;
+    // Pass a function to build the content lazily: it is only invoked while the
+    // section is open. Callers whose collapsed content is huge (see the NPE zone
+    // filter, which can hold ~100k rows) use this so the element tree is never
+    // constructed — and never garbage — while the section is shut.
+    children?: React.ReactNode | (() => React.ReactNode);
 }
 
 const Collapsible = ({
@@ -37,6 +41,8 @@ const Collapsible = ({
     const [isOpenState, setIsOpenState] = React.useState(isOpen);
     const [prevIsOpenProp, setPrevIsOpenProp] = React.useState(isOpen);
     const icon = isOpenState ? IconNames.CARET_UP : IconNames.CARET_DOWN;
+    const isLazy = typeof children === 'function';
+    const content = isLazy ? isOpenState && children() : children;
 
     if (isOpen !== prevIsOpenProp) {
         setPrevIsOpenProp(isOpen);
@@ -82,7 +88,7 @@ const Collapsible = ({
                         className={classNames(contentClassName)}
                         style={contentStyles}
                     >
-                        {children}
+                        {content}
                     </div>
                 </Collapse>
             )}

--- a/src/components/npe/ChipCongestionCanvas.tsx
+++ b/src/components/npe/ChipCongestionCanvas.tsx
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { MouseEvent, useEffect, useRef } from 'react';
+import {
+    EVENT_TYPE_FILTER,
+    FABRIC_EVENT_SCOPE_OPTIONS,
+    LinkUtilization,
+    NPE_LINK,
+    NoCType,
+} from '../../model/NPEModel';
+import { LinkPoints, NODE_SIZE, calculateFabricColor, calculateLinkCongestionColor, getLinkPoints } from './drawingApi';
+
+// The link tiles used to be one SVG (+ button + label) per link_demand row —
+// up to ~700 per timestep, all reconciled and repainted on every scrub. This
+// draws the whole chip's congestion layer to a single canvas instead, turning
+// a scrub from thousands of DOM mutations into a few hundred canvas ops. #1803.
+
+const GAP = 1; // matches `.tensix-grid { gap: 1px }`
+const CELL_STRIDE = NODE_SIZE + GAP;
+const LABEL_FONT = '9px sans-serif';
+const LABEL_COLOR = 'rgba(255, 255, 255, 0.85)';
+const DIMMED_ALPHA = 0.15;
+
+interface ChipLink {
+    linkUtilization: LinkUtilization;
+    index: number;
+}
+
+interface ChipCongestionCanvasProps {
+    links: ChipLink[];
+    gridWidth: number;
+    gridHeight: number;
+    isFabricMode: boolean;
+    altCongestionColors: boolean;
+    nocFilter: NoCType | null;
+    fabricEventsFilter: EVENT_TYPE_FILTER;
+    dimmed: boolean;
+    zoom: number;
+    onSelectLink: (linkUtilization: LinkUtilization, index: number) => void;
+    onClearSelection: () => void;
+}
+
+const passesFilters = (
+    linkUtilization: LinkUtilization,
+    nocFilter: NoCType | null,
+    fabricEventsFilter: EVENT_TYPE_FILTER,
+): boolean => {
+    const nocOk = nocFilter === null || linkUtilization[NPE_LINK.NOC_ID].indexOf(nocFilter) === 0;
+    if (!nocOk) {
+        return false;
+    }
+    const scope = linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE];
+    if (fabricEventsFilter === EVENT_TYPE_FILTER.FABRIC_EVENTS) {
+        return scope === FABRIC_EVENT_SCOPE_OPTIONS.FABRIC || scope === FABRIC_EVENT_SCOPE_OPTIONS.BOTH;
+    }
+    if (fabricEventsFilter === EVENT_TYPE_FILTER.LOCAL_EVENTS) {
+        return scope === FABRIC_EVENT_SCOPE_OPTIONS.LOCAL || scope === FABRIC_EVENT_SCOPE_OPTIONS.BOTH;
+    }
+    return true;
+};
+
+const ROTATE_RE = /rotate\(\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\)/;
+
+const drawLink = (ctx: CanvasRenderingContext2D, points: LinkPoints, color: string): void => {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(points.x1, points.y1);
+    ctx.lineTo(points.x2, points.y2);
+    ctx.stroke();
+
+    const [p1, p2, p3] = [points.arrow.p1, points.arrow.p2, points.arrow.p3].map((p) => {
+        const [x, y] = p.split(',');
+        return [Number(x), Number(y)] as const;
+    });
+
+    ctx.save();
+    const rotate = ROTATE_RE.exec(points.transform);
+    if (rotate) {
+        const [, angle, cx, cy] = rotate;
+        ctx.translate(Number(cx), Number(cy));
+        ctx.rotate((Number(angle) * Math.PI) / 180);
+        ctx.translate(-Number(cx), -Number(cy));
+    }
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.moveTo(p1[0], p1[1]);
+    ctx.lineTo(p2[0], p2[1]);
+    ctx.lineTo(p3[0], p3[1]);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+};
+
+const ChipCongestionCanvas = ({
+    links,
+    gridWidth,
+    gridHeight,
+    isFabricMode,
+    altCongestionColors,
+    nocFilter,
+    fabricEventsFilter,
+    dimmed,
+    zoom,
+    onSelectLink,
+    onClearSelection,
+}: ChipCongestionCanvasProps) => {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const cssWidth = gridWidth * CELL_STRIDE - GAP;
+    const cssHeight = gridHeight * CELL_STRIDE - GAP;
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const ctx = canvas?.getContext('2d');
+        if (!canvas || !ctx) {
+            return;
+        }
+
+        // Backing store is inflated by dpr × zoom so the raster stays crisp under
+        // the parent's CSS `zoom`; the CSS box stays in pre-zoom tile units.
+        const scale = (window.devicePixelRatio || 1) * zoom;
+        canvas.width = Math.max(1, Math.round(cssWidth * scale));
+        canvas.height = Math.max(1, Math.round(cssHeight * scale));
+        ctx.setTransform(scale, 0, 0, scale, 0, 0);
+        ctx.clearRect(0, 0, cssWidth, cssHeight);
+        ctx.globalAlpha = dimmed ? DIMMED_ALPHA : 1;
+        ctx.font = LABEL_FONT;
+        ctx.textBaseline = 'top';
+
+        links.forEach(({ linkUtilization }) => {
+            if (!passesFilters(linkUtilization, nocFilter, fabricEventsFilter)) {
+                return;
+            }
+            const color = isFabricMode
+                ? calculateFabricColor(linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE])
+                : calculateLinkCongestionColor(linkUtilization[NPE_LINK.DEMAND], 0, altCongestionColors);
+            const originX = linkUtilization[NPE_LINK.X] * CELL_STRIDE;
+            const originY = linkUtilization[NPE_LINK.Y] * CELL_STRIDE;
+
+            ctx.save();
+            ctx.translate(originX, originY);
+            drawLink(ctx, getLinkPoints(linkUtilization[NPE_LINK.NOC_ID], color), color);
+            ctx.fillStyle = LABEL_COLOR;
+            ctx.fillText(`${linkUtilization[NPE_LINK.Y]}-${linkUtilization[NPE_LINK.X]}`, 1, 1);
+            ctx.restore();
+        });
+    }, [links, cssWidth, cssHeight, isFabricMode, altCongestionColors, nocFilter, fabricEventsFilter, dimmed, zoom]);
+
+    const handleClick = (event: MouseEvent<HTMLCanvasElement>) => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            return;
+        }
+        const rect = canvas.getBoundingClientRect();
+        // rect reflects the on-screen (zoomed) size; scale the pointer offset back
+        // into tile-space so the hit-test matches the CSS grid the canvas replaced.
+        const localX = ((event.clientX - rect.left) / rect.width) * cssWidth;
+        const localY = ((event.clientY - rect.top) / rect.height) * cssHeight;
+        const cellX = Math.floor(localX / CELL_STRIDE);
+        const cellY = Math.floor(localY / CELL_STRIDE);
+
+        // Multiple NoC links can stack on one cell; the last drawn is the topmost,
+        // so match the old grid where the last-mounted tile caught the click.
+        let hit: ChipLink | null = null;
+        links.forEach((link) => {
+            if (
+                link.linkUtilization[NPE_LINK.X] === cellX &&
+                link.linkUtilization[NPE_LINK.Y] === cellY &&
+                passesFilters(link.linkUtilization, nocFilter, fabricEventsFilter)
+            ) {
+                hit = link;
+            }
+        });
+
+        if (hit) {
+            onSelectLink((hit as ChipLink).linkUtilization, (hit as ChipLink).index);
+        } else {
+            onClearSelection();
+        }
+    };
+
+    return (
+        <canvas
+            ref={canvasRef}
+            className='congestion-canvas'
+            style={{ width: `${cssWidth}px`, height: `${cssHeight}px` }}
+            onClick={handleClick}
+        />
+    );
+};
+
+export default ChipCongestionCanvas;

--- a/src/components/npe/ChipCongestionCanvas.tsx
+++ b/src/components/npe/ChipCongestionCanvas.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { MouseEvent, useCallback, useEffect, useMemo, useRef } from 'react';
+import { MouseEvent, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
     EVENT_TYPE_FILTER,
     FABRIC_EVENT_SCOPE_OPTIONS,
@@ -26,6 +26,19 @@ const DIMMED_ALPHA = 0.15;
 const HOVER_COLOR = '#f5e2ba';
 
 const cellKey = (x: number, y: number): string => `${x}-${y}`;
+
+// Assigning `canvas.width`/`height` reallocates and zeroes the whole backing store
+// (and forces a GPU re-upload) even when the value is unchanged — ~2.8 MB per chip
+// at dpr 2, so ~22 MB of pointless churn per scrub across an 8-chip cluster. Resize
+// only on a real geometry change; callers still clear explicitly. #1803.
+const resizeCanvas = (canvas: HTMLCanvasElement, cssWidth: number, cssHeight: number, scale: number): void => {
+    const width = Math.max(1, Math.round(cssWidth * scale));
+    const height = Math.max(1, Math.round(cssHeight * scale));
+    if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+    }
+};
 
 interface ChipLink {
     linkUtilization: LinkUtilization;
@@ -161,16 +174,15 @@ const ChipCongestionCanvas = ({
         [scale, cssWidth, cssHeight],
     );
 
-    // Resize the hover layer alongside the base canvas. Setting width/height also
-    // clears it, so drop any stale hover: the pointer may now be over a different
-    // cell, and the next move repaints anyway.
+    // Resize the hover layer alongside the base canvas. A resize also clears it, so
+    // drop any stale hover: the pointer may now be over a different cell, and the
+    // next move repaints anyway.
     useEffect(() => {
         const canvas = hoverCanvasRef.current;
         if (!canvas) {
             return;
         }
-        canvas.width = Math.max(1, Math.round(cssWidth * scale));
-        canvas.height = Math.max(1, Math.round(cssHeight * scale));
+        resizeCanvas(canvas, cssWidth, cssHeight, scale);
         hoveredCellRef.current = null;
     }, [cssWidth, cssHeight, scale]);
 
@@ -192,8 +204,7 @@ const ChipCongestionCanvas = ({
             return;
         }
 
-        canvas.width = Math.max(1, Math.round(cssWidth * scale));
-        canvas.height = Math.max(1, Math.round(cssHeight * scale));
+        resizeCanvas(canvas, cssWidth, cssHeight, scale);
         ctx.setTransform(scale, 0, 0, scale, 0, 0);
         ctx.clearRect(0, 0, cssWidth, cssHeight);
         ctx.globalAlpha = dimmed ? DIMMED_ALPHA : 1;
@@ -289,4 +300,8 @@ const ChipCongestionCanvas = ({
     );
 };
 
-export default ChipCongestionCanvas;
+// Every prop is either a primitive, a referentially stable callback, or a per-chip
+// bucket that only changes when that chip's data does — so on a scrub that leaves a
+// chip idle this skips the subtree entirely instead of re-rendering two canvases
+// per chip across the cluster.
+export default memo(ChipCongestionCanvas);

--- a/src/components/npe/ChipCongestionCanvas.tsx
+++ b/src/components/npe/ChipCongestionCanvas.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { MouseEvent, useEffect, useRef } from 'react';
+import { MouseEvent, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
     EVENT_TYPE_FILTER,
     FABRIC_EVENT_SCOPE_OPTIONS,
@@ -22,6 +22,10 @@ const CELL_STRIDE = NODE_SIZE + GAP;
 const LABEL_FONT = '9px sans-serif';
 const LABEL_COLOR = 'rgba(255, 255, 255, 0.85)';
 const DIMMED_ALPHA = 0.15;
+// $tt-yellow-tint-2 — the border the old `.tensix:hover` rule drew on link tiles.
+const HOVER_COLOR = '#f5e2ba';
+
+const cellKey = (x: number, y: number): string => `${x}-${y}`;
 
 interface ChipLink {
     linkUtilization: LinkUtilization;
@@ -108,8 +112,78 @@ const ChipCongestionCanvas = ({
     onClearSelection,
 }: ChipCongestionCanvasProps) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const hoverCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const hoveredCellRef = useRef<{ x: number; y: number } | null>(null);
     const cssWidth = gridWidth * CELL_STRIDE - GAP;
     const cssHeight = gridHeight * CELL_STRIDE - GAP;
+
+    // Backing store is inflated by dpr × zoom so the raster stays crisp under
+    // the parent's CSS `zoom`; the CSS box stays in pre-zoom tile units.
+    const scale = (window.devicePixelRatio || 1) * zoom;
+
+    // Cell → topmost link that passes the current filters. Built once per data or
+    // filter change so hover (which fires on every pointer move) and click both
+    // resolve in O(1) instead of rescanning every link. Last write wins, matching
+    // the draw order where the last link painted is the visible one.
+    const linksByCell = useMemo(() => {
+        const byCell = new Map<string, ChipLink>();
+        links.forEach((link) => {
+            if (passesFilters(link.linkUtilization, nocFilter, fabricEventsFilter)) {
+                byCell.set(cellKey(link.linkUtilization[NPE_LINK.X], link.linkUtilization[NPE_LINK.Y]), link);
+            }
+        });
+        return byCell;
+    }, [links, nocFilter, fabricEventsFilter]);
+
+    // Paints (or clears) the hover border on its own layer, so following the
+    // pointer costs one 1px rect instead of redrawing the chip's whole
+    // congestion layer. Called imperatively from the pointer handlers — routing
+    // the hovered cell through state would re-render NPEView on every mousemove,
+    // which is exactly the churn #1803 is removing.
+    const paintHover = useCallback(
+        (cell: { x: number; y: number } | null) => {
+            const canvas = hoverCanvasRef.current;
+            const ctx = canvas?.getContext('2d');
+            if (!canvas || !ctx) {
+                return;
+            }
+            ctx.setTransform(scale, 0, 0, scale, 0, 0);
+            ctx.clearRect(0, 0, cssWidth, cssHeight);
+            if (!cell) {
+                return;
+            }
+            // Half-pixel inset keeps the 1px stroke on the pixel grid instead of
+            // straddling two rows, mirroring the old CSS border-box edge.
+            ctx.strokeStyle = HOVER_COLOR;
+            ctx.lineWidth = 1;
+            ctx.strokeRect(cell.x * CELL_STRIDE + 0.5, cell.y * CELL_STRIDE + 0.5, NODE_SIZE - 1, NODE_SIZE - 1);
+        },
+        [scale, cssWidth, cssHeight],
+    );
+
+    // Resize the hover layer alongside the base canvas. Setting width/height also
+    // clears it, so drop any stale hover: the pointer may now be over a different
+    // cell, and the next move repaints anyway.
+    useEffect(() => {
+        const canvas = hoverCanvasRef.current;
+        if (!canvas) {
+            return;
+        }
+        canvas.width = Math.max(1, Math.round(cssWidth * scale));
+        canvas.height = Math.max(1, Math.round(cssHeight * scale));
+        hoveredCellRef.current = null;
+    }, [cssWidth, cssHeight, scale]);
+
+    // A scrub swaps the links under a stationary pointer, so a border left on a
+    // cell that no longer has one would be a lie. Re-resolve the held cell
+    // against the new data instead of waiting for the next pointer move.
+    useEffect(() => {
+        const cell = hoveredCellRef.current;
+        if (cell && !linksByCell.has(cellKey(cell.x, cell.y))) {
+            hoveredCellRef.current = null;
+        }
+        paintHover(hoveredCellRef.current);
+    }, [linksByCell, paintHover]);
 
     useEffect(() => {
         const canvas = canvasRef.current;
@@ -118,9 +192,6 @@ const ChipCongestionCanvas = ({
             return;
         }
 
-        // Backing store is inflated by dpr × zoom so the raster stays crisp under
-        // the parent's CSS `zoom`; the CSS box stays in pre-zoom tile units.
-        const scale = (window.devicePixelRatio || 1) * zoom;
         canvas.width = Math.max(1, Math.round(cssWidth * scale));
         canvas.height = Math.max(1, Math.round(cssHeight * scale));
         ctx.setTransform(scale, 0, 0, scale, 0, 0);
@@ -146,48 +217,75 @@ const ChipCongestionCanvas = ({
             ctx.fillText(`${linkUtilization[NPE_LINK.Y]}-${linkUtilization[NPE_LINK.X]}`, 1, 1);
             ctx.restore();
         });
-    }, [links, cssWidth, cssHeight, isFabricMode, altCongestionColors, nocFilter, fabricEventsFilter, dimmed, zoom]);
+    }, [links, cssWidth, cssHeight, isFabricMode, altCongestionColors, nocFilter, fabricEventsFilter, dimmed, scale]);
+
+    const cellFromEvent = useCallback(
+        (event: MouseEvent<HTMLCanvasElement>): { x: number; y: number } | null => {
+            const canvas = canvasRef.current;
+            if (!canvas) {
+                return null;
+            }
+            const rect = canvas.getBoundingClientRect();
+            // rect reflects the on-screen (zoomed) size; scale the pointer offset back
+            // into tile-space so the hit-test matches the CSS grid the canvas replaced.
+            const localX = ((event.clientX - rect.left) / rect.width) * cssWidth;
+            const localY = ((event.clientY - rect.top) / rect.height) * cssHeight;
+            return { x: Math.floor(localX / CELL_STRIDE), y: Math.floor(localY / CELL_STRIDE) };
+        },
+        [cssWidth, cssHeight],
+    );
 
     const handleClick = (event: MouseEvent<HTMLCanvasElement>) => {
-        const canvas = canvasRef.current;
-        if (!canvas) {
-            return;
-        }
-        const rect = canvas.getBoundingClientRect();
-        // rect reflects the on-screen (zoomed) size; scale the pointer offset back
-        // into tile-space so the hit-test matches the CSS grid the canvas replaced.
-        const localX = ((event.clientX - rect.left) / rect.width) * cssWidth;
-        const localY = ((event.clientY - rect.top) / rect.height) * cssHeight;
-        const cellX = Math.floor(localX / CELL_STRIDE);
-        const cellY = Math.floor(localY / CELL_STRIDE);
-
-        // Multiple NoC links can stack on one cell; the last drawn is the topmost,
-        // so match the old grid where the last-mounted tile caught the click.
-        let hit: ChipLink | null = null;
-        links.forEach((link) => {
-            if (
-                link.linkUtilization[NPE_LINK.X] === cellX &&
-                link.linkUtilization[NPE_LINK.Y] === cellY &&
-                passesFilters(link.linkUtilization, nocFilter, fabricEventsFilter)
-            ) {
-                hit = link;
-            }
-        });
+        const cell = cellFromEvent(event);
+        // Multiple NoC links can stack on one cell; `linksByCell` holds the last
+        // one drawn, matching the old grid where the last-mounted tile caught the
+        // click.
+        const hit = cell ? linksByCell.get(cellKey(cell.x, cell.y)) : undefined;
 
         if (hit) {
-            onSelectLink((hit as ChipLink).linkUtilization, (hit as ChipLink).index);
+            onSelectLink(hit.linkUtilization, hit.index);
         } else {
             onClearSelection();
         }
     };
 
+    const handleMouseMove = (event: MouseEvent<HTMLCanvasElement>) => {
+        const cell = cellFromEvent(event);
+        // Only cells that actually carry a link are hoverable — the old markup only
+        // mounted a tile (and so only showed a border) where there was one.
+        const target = cell && linksByCell.has(cellKey(cell.x, cell.y)) ? cell : null;
+        const { current } = hoveredCellRef;
+        if (target?.x === current?.x && target?.y === current?.y) {
+            return; // same cell (or still nothing) — nothing to repaint
+        }
+        hoveredCellRef.current = target;
+        paintHover(target);
+    };
+
+    const handleMouseLeave = () => {
+        if (hoveredCellRef.current === null) {
+            return;
+        }
+        hoveredCellRef.current = null;
+        paintHover(null);
+    };
+
     return (
-        <canvas
-            ref={canvasRef}
-            className='congestion-canvas'
-            style={{ width: `${cssWidth}px`, height: `${cssHeight}px` }}
-            onClick={handleClick}
-        />
+        <>
+            <canvas
+                ref={canvasRef}
+                className='congestion-canvas'
+                style={{ width: `${cssWidth}px`, height: `${cssHeight}px` }}
+                onClick={handleClick}
+                onMouseMove={handleMouseMove}
+                onMouseLeave={handleMouseLeave}
+            />
+            <canvas
+                ref={hoverCanvasRef}
+                className='congestion-canvas congestion-canvas--hover'
+                style={{ width: `${cssWidth}px`, height: `${cssHeight}px` }}
+            />
+        </>
     );
 };
 

--- a/src/components/npe/ChipCongestionCanvas.tsx
+++ b/src/components/npe/ChipCongestionCanvas.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { MouseEvent, memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { MouseEvent, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
     EVENT_TYPE_FILTER,
     FABRIC_EVENT_SCOPE_OPTIONS,
@@ -10,43 +10,47 @@ import {
     NPE_LINK,
     NoCType,
 } from '../../model/NPEModel';
-import { LinkPoints, NODE_SIZE, calculateFabricColor, calculateLinkCongestionColor, getLinkPoints } from './drawingApi';
+import {
+    NODE_SIZE,
+    calculateFabricColor,
+    calculateLinkCongestionColor,
+    drawLinkToCanvas,
+    getLinkPoints,
+} from './drawingApi';
 
-// The link tiles used to be one SVG (+ button + label) per link_demand row —
-// up to ~700 per timestep, all reconciled and repainted on every scrub. This
-// draws the whole chip's congestion layer to a single canvas instead, turning
-// a scrub from thousands of DOM mutations into a few hundred canvas ops. #1803.
+// One canvas per chip in place of a DOM tile (button + SVG + label) per link_demand
+// row, of which a busy timestep has hundreds. #1803
 
 const GAP = 1; // matches `.tensix-grid { gap: 1px }`
 const CELL_STRIDE = NODE_SIZE + GAP;
 const LABEL_FONT = '9px sans-serif';
 const LABEL_COLOR = 'rgba(255, 255, 255, 0.85)';
 const DIMMED_ALPHA = 0.15;
-// $tt-yellow-tint-2 — the border the old `.tensix:hover` rule drew on link tiles.
-const HOVER_COLOR = '#f5e2ba';
+// Ceiling on the backing store's linear scale. The raster is inflated by
+// devicePixelRatio × the on-screen scale of the enclosing cluster, and that scale
+// follows a zoom slider that reaches 2 — uncapped, an 8-chip Blackhole cluster at
+// dpr 2 / zoom 2 wants ~542 MB of canvas, past the point where the browser starts
+// discarding buffers and chips render blank. Capping trades slight softness when
+// zoomed in for a bounded allocation, and it also stops most of the churn: above
+// the cap the backing store stops changing size at all, so zooming no longer
+// reallocates it. #1803
+const MAX_BACKING_SCALE = 2;
+// One frame at 60Hz — long enough that the pointer events of a single frame share
+// one layout read, short enough that a moved element is re-measured immediately.
+const RECT_CACHE_MS = 16;
 
-const cellKey = (x: number, y: number): string => `${x}-${y}`;
-
-// Assigning `canvas.width`/`height` reallocates and zeroes the whole backing store
-// (and forces a GPU re-upload) even when the value is unchanged — ~2.8 MB per chip
-// at dpr 2, so ~22 MB of pointless churn per scrub across an 8-chip cluster. Resize
-// only on a real geometry change; callers still clear explicitly. #1803.
-const resizeCanvas = (canvas: HTMLCanvasElement, cssWidth: number, cssHeight: number, scale: number): void => {
-    const width = Math.max(1, Math.round(cssWidth * scale));
-    const height = Math.max(1, Math.round(cssHeight * scale));
-    if (canvas.width !== width || canvas.height !== height) {
-        canvas.width = width;
-        canvas.height = height;
-    }
-};
-
-interface ChipLink {
+export interface ChipLink {
     linkUtilization: LinkUtilization;
     index: number;
 }
 
+interface Cell {
+    x: number;
+    y: number;
+}
+
 interface ChipCongestionCanvasProps {
-    links: ChipLink[];
+    links: readonly ChipLink[];
     gridWidth: number;
     gridHeight: number;
     isFabricMode: boolean;
@@ -54,10 +58,11 @@ interface ChipCongestionCanvasProps {
     nocFilter: NoCType | null;
     fabricEventsFilter: EVENT_TYPE_FILTER;
     dimmed: boolean;
-    zoom: number;
     onSelectLink: (linkUtilization: LinkUtilization, index: number) => void;
     onClearSelection: () => void;
 }
+
+const cellKey = (x: number, y: number): string => `${x}-${y}`;
 
 const passesFilters = (
     linkUtilization: LinkUtilization,
@@ -78,39 +83,6 @@ const passesFilters = (
     return true;
 };
 
-const ROTATE_RE = /rotate\(\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\)/;
-
-const drawLink = (ctx: CanvasRenderingContext2D, points: LinkPoints, color: string): void => {
-    ctx.strokeStyle = color;
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(points.x1, points.y1);
-    ctx.lineTo(points.x2, points.y2);
-    ctx.stroke();
-
-    const [p1, p2, p3] = [points.arrow.p1, points.arrow.p2, points.arrow.p3].map((p) => {
-        const [x, y] = p.split(',');
-        return [Number(x), Number(y)] as const;
-    });
-
-    ctx.save();
-    const rotate = ROTATE_RE.exec(points.transform);
-    if (rotate) {
-        const [, angle, cx, cy] = rotate;
-        ctx.translate(Number(cx), Number(cy));
-        ctx.rotate((Number(angle) * Math.PI) / 180);
-        ctx.translate(-Number(cx), -Number(cy));
-    }
-    ctx.fillStyle = color;
-    ctx.beginPath();
-    ctx.moveTo(p1[0], p1[1]);
-    ctx.lineTo(p2[0], p2[1]);
-    ctx.lineTo(p3[0], p3[1]);
-    ctx.closePath();
-    ctx.fill();
-    ctx.restore();
-};
-
 const ChipCongestionCanvas = ({
     links,
     gridWidth,
@@ -120,82 +92,107 @@ const ChipCongestionCanvas = ({
     nocFilter,
     fabricEventsFilter,
     dimmed,
-    zoom,
     onSelectLink,
     onClearSelection,
 }: ChipCongestionCanvasProps) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const hoverCanvasRef = useRef<HTMLCanvasElement | null>(null);
-    const hoveredCellRef = useRef<{ x: number; y: number } | null>(null);
+    const hoverRef = useRef<HTMLDivElement | null>(null);
+    const hoveredCellRef = useRef<Cell | null>(null);
+    // Pointer hit-testing needs the canvas's on-screen box. Reading it per
+    // mousemove forces a synchronous layout flush, which is expensive while
+    // playback is dirtying layout every frame — so cache it and drop the cache
+    // only when it can actually have moved.
+    const rectRef = useRef<DOMRect | null>(null);
+    const rectReadAtRef = useRef(0);
     const cssWidth = gridWidth * CELL_STRIDE - GAP;
     const cssHeight = gridHeight * CELL_STRIDE - GAP;
 
-    // Backing store is inflated by dpr × zoom so the raster stays crisp under
-    // the parent's CSS `zoom`; the CSS box stays in pre-zoom tile units.
-    const scale = (window.devicePixelRatio || 1) * zoom;
+    // The enclosing cluster is scaled with CSS `zoom`, so the only honest source
+    // for "how big is a tile on screen" is the element itself. Measuring here
+    // instead of taking the ancestor's zoom as a prop keeps one source of truth —
+    // the same one hit-testing uses — and stays correct if the cluster is ever
+    // scaled by some other mechanism.
+    const [onScreenScale, setOnScreenScale] = useState(1);
 
-    // Cell → topmost link that passes the current filters. Built once per data or
-    // filter change so hover (which fires on every pointer move) and click both
-    // resolve in O(1) instead of rescanning every link. Last write wins, matching
-    // the draw order where the last link painted is the visible one.
-    const linksByCell = useMemo(() => {
-        const byCell = new Map<string, ChipLink>();
-        links.forEach((link) => {
-            if (passesFilters(link.linkUtilization, nocFilter, fabricEventsFilter)) {
-                byCell.set(cellKey(link.linkUtilization[NPE_LINK.X], link.linkUtilization[NPE_LINK.Y]), link);
-            }
-        });
-        return byCell;
-    }, [links, nocFilter, fabricEventsFilter]);
+    useLayoutEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            return undefined;
+        }
+        const measure = () => {
+            const rect = canvas.getBoundingClientRect();
+            const next = rect.width > 0 ? rect.width / cssWidth : 1;
+            // Epsilon-guarded so sub-pixel jitter can't drive a render loop.
+            setOnScreenScale((previous) => (Math.abs(previous - next) < 0.001 ? previous : next));
+        };
+        measure();
+        if (typeof window.ResizeObserver !== 'function') {
+            return undefined;
+        }
+        // Feature-detected immediately above, and the initial `measure()` already ran,
+        // so a browser without it just keeps the measured-once scale.
+        // eslint-disable-next-line compat/compat
+        const observer = new window.ResizeObserver(measure);
+        observer.observe(canvas);
+        return () => observer.disconnect();
+    }, [cssWidth]);
 
-    // Paints (or clears) the hover border on its own layer, so following the
-    // pointer costs one 1px rect instead of redrawing the chip's whole
-    // congestion layer. Called imperatively from the pointer handlers — routing
-    // the hovered cell through state would re-render NPEView on every mousemove,
-    // which is exactly the churn #1803 is removing.
-    const paintHover = useCallback(
-        (cell: { x: number; y: number } | null) => {
-            const canvas = hoverCanvasRef.current;
-            const ctx = canvas?.getContext('2d');
-            if (!canvas || !ctx) {
-                return;
-            }
-            ctx.setTransform(scale, 0, 0, scale, 0, 0);
-            ctx.clearRect(0, 0, cssWidth, cssHeight);
-            if (!cell) {
-                return;
-            }
-            // Half-pixel inset keeps the 1px stroke on the pixel grid instead of
-            // straddling two rows, mirroring the old CSS border-box edge.
-            ctx.strokeStyle = HOVER_COLOR;
-            ctx.lineWidth = 1;
-            ctx.strokeRect(cell.x * CELL_STRIDE + 0.5, cell.y * CELL_STRIDE + 0.5, NODE_SIZE - 1, NODE_SIZE - 1);
-        },
-        [scale, cssWidth, cssHeight],
+    // Read the box at most once per frame's worth of pointer events. Each read forces
+    // a synchronous layout flush, and a pointer move fires several times per frame on
+    // a high-refresh display while playback is already dirtying layout. A short time
+    // budget rather than a `requestAnimationFrame` expiry on purpose: the box can move
+    // without resizing (a scroll, or a panel opening beside the cluster) and no resize
+    // signal reports that, while a paint-driven expiry would never fire in a tab that
+    // isn't painting. This bounds staleness without enumerating every layout shift.
+    const rectForThisFrame = useCallback((canvas: HTMLCanvasElement): DOMRect => {
+        const now = performance.now();
+        if (!rectRef.current || now - rectReadAtRef.current > RECT_CACHE_MS) {
+            rectRef.current = canvas.getBoundingClientRect();
+            rectReadAtRef.current = now;
+        }
+        return rectRef.current;
+    }, []);
+
+    const scale = Math.min((window.devicePixelRatio || 1) * onScreenScale, MAX_BACKING_SCALE);
+    const deviceWidth = Math.max(1, Math.round(cssWidth * scale));
+    const deviceHeight = Math.max(1, Math.round(cssHeight * scale));
+
+    // Single source for "which links are visible": the paint loop and the
+    // hit-test index are built from the same filtered, ordered list, so what you
+    // click is necessarily what you see. Filtering twice invited them to drift.
+    const visibleLinks = useMemo(
+        () => links.filter((link) => passesFilters(link.linkUtilization, nocFilter, fabricEventsFilter)),
+        [links, nocFilter, fabricEventsFilter],
     );
 
-    // Resize the hover layer alongside the base canvas. A resize also clears it, so
-    // drop any stale hover: the pointer may now be over a different cell, and the
-    // next move repaints anyway.
-    useEffect(() => {
-        const canvas = hoverCanvasRef.current;
-        if (!canvas) {
+    // Cell → topmost visible link. Last write wins, matching the paint order, so a
+    // stack of NoC links resolves to the one drawn on top. Built once per data or
+    // filter change so hover and click are O(1).
+    const linksByCell = useMemo(() => {
+        const byCell = new Map<string, ChipLink>();
+        visibleLinks.forEach((link) => {
+            byCell.set(cellKey(link.linkUtilization[NPE_LINK.X], link.linkUtilization[NPE_LINK.Y]), link);
+        });
+        return byCell;
+    }, [visibleLinks]);
+
+    // Hover feedback is a positioned element, not a canvas layer: it is a single
+    // 1px border, so a full-grid second backing store bought nothing. Moved via a
+    // ref rather than state — routing pointer position through React would
+    // re-render the owning view on every mousemove, which is the churn #1803
+    // removes.
+    const showHover = useCallback((cell: Cell | null) => {
+        const element = hoverRef.current;
+        if (!element) {
             return;
         }
-        resizeCanvas(canvas, cssWidth, cssHeight, scale);
-        hoveredCellRef.current = null;
-    }, [cssWidth, cssHeight, scale]);
-
-    // A scrub swaps the links under a stationary pointer, so a border left on a
-    // cell that no longer has one would be a lie. Re-resolve the held cell
-    // against the new data instead of waiting for the next pointer move.
-    useEffect(() => {
-        const cell = hoveredCellRef.current;
-        if (cell && !linksByCell.has(cellKey(cell.x, cell.y))) {
-            hoveredCellRef.current = null;
+        if (!cell) {
+            element.style.display = 'none';
+            return;
         }
-        paintHover(hoveredCellRef.current);
-    }, [linksByCell, paintHover]);
+        element.style.display = 'block';
+        element.style.transform = `translate(${cell.x * CELL_STRIDE}px, ${cell.y * CELL_STRIDE}px)`;
+    }, []);
 
     useEffect(() => {
         const canvas = canvasRef.current;
@@ -204,17 +201,16 @@ const ChipCongestionCanvas = ({
             return;
         }
 
-        resizeCanvas(canvas, cssWidth, cssHeight, scale);
+        // The backing store is sized declaratively via the width/height attributes,
+        // so React only reallocates it when the geometry genuinely changes. This
+        // transform lets the drawing below stay in logical (pre-scale) tile units.
         ctx.setTransform(scale, 0, 0, scale, 0, 0);
         ctx.clearRect(0, 0, cssWidth, cssHeight);
         ctx.globalAlpha = dimmed ? DIMMED_ALPHA : 1;
         ctx.font = LABEL_FONT;
         ctx.textBaseline = 'top';
 
-        links.forEach(({ linkUtilization }) => {
-            if (!passesFilters(linkUtilization, nocFilter, fabricEventsFilter)) {
-                return;
-            }
+        visibleLinks.forEach(({ linkUtilization }) => {
             const color = isFabricMode
                 ? calculateFabricColor(linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE])
                 : calculateLinkCongestionColor(linkUtilization[NPE_LINK.DEMAND], 0, altCongestionColors);
@@ -223,34 +219,49 @@ const ChipCongestionCanvas = ({
 
             ctx.save();
             ctx.translate(originX, originY);
-            drawLink(ctx, getLinkPoints(linkUtilization[NPE_LINK.NOC_ID], color), color);
+            drawLinkToCanvas(ctx, getLinkPoints(linkUtilization[NPE_LINK.NOC_ID]), color);
             ctx.fillStyle = LABEL_COLOR;
             ctx.fillText(`${linkUtilization[NPE_LINK.Y]}-${linkUtilization[NPE_LINK.X]}`, 1, 1);
             ctx.restore();
         });
-    }, [links, cssWidth, cssHeight, isFabricMode, altCongestionColors, nocFilter, fabricEventsFilter, dimmed, scale]);
+    }, [visibleLinks, cssWidth, cssHeight, isFabricMode, altCongestionColors, dimmed, scale]);
+
+    // Only cells carrying a link are hoverable — the old markup only mounted a tile,
+    // and so only showed a border, where there was one.
+    const hoverableCell = useCallback(
+        (cell: Cell | null) => (cell && linksByCell.has(cellKey(cell.x, cell.y)) ? cell : null),
+        [linksByCell],
+    );
+
+    // A scrub swaps the links under a stationary pointer. `hoveredCellRef` holds
+    // wherever the pointer actually is — not whether that cell was hoverable — so
+    // hoverability can be re-derived here: the marker disappears when its link goes
+    // away and appears when one arrives, neither needing the pointer to move.
+    useEffect(() => {
+        showHover(hoverableCell(hoveredCellRef.current));
+    }, [hoverableCell, showHover]);
 
     const cellFromEvent = useCallback(
-        (event: MouseEvent<HTMLCanvasElement>): { x: number; y: number } | null => {
+        (event: MouseEvent<HTMLCanvasElement>): Cell | null => {
             const canvas = canvasRef.current;
             if (!canvas) {
                 return null;
             }
-            const rect = canvas.getBoundingClientRect();
-            // rect reflects the on-screen (zoomed) size; scale the pointer offset back
-            // into tile-space so the hit-test matches the CSS grid the canvas replaced.
+            const rect = rectForThisFrame(canvas);
+            if (rect.width === 0 || rect.height === 0) {
+                return null;
+            }
+            // rect is the on-screen (scaled) box; scale the pointer offset back into
+            // tile space so the hit-test matches the grid the canvas replaced.
             const localX = ((event.clientX - rect.left) / rect.width) * cssWidth;
             const localY = ((event.clientY - rect.top) / rect.height) * cssHeight;
             return { x: Math.floor(localX / CELL_STRIDE), y: Math.floor(localY / CELL_STRIDE) };
         },
-        [cssWidth, cssHeight],
+        [cssWidth, cssHeight, rectForThisFrame],
     );
 
     const handleClick = (event: MouseEvent<HTMLCanvasElement>) => {
         const cell = cellFromEvent(event);
-        // Multiple NoC links can stack on one cell; `linksByCell` holds the last
-        // one drawn, matching the old grid where the last-mounted tile caught the
-        // click.
         const hit = cell ? linksByCell.get(cellKey(cell.x, cell.y)) : undefined;
 
         if (hit) {
@@ -262,15 +273,12 @@ const ChipCongestionCanvas = ({
 
     const handleMouseMove = (event: MouseEvent<HTMLCanvasElement>) => {
         const cell = cellFromEvent(event);
-        // Only cells that actually carry a link are hoverable — the old markup only
-        // mounted a tile (and so only showed a border) where there was one.
-        const target = cell && linksByCell.has(cellKey(cell.x, cell.y)) ? cell : null;
         const { current } = hoveredCellRef;
-        if (target?.x === current?.x && target?.y === current?.y) {
-            return; // same cell (or still nothing) — nothing to repaint
+        if (cell?.x === current?.x && cell?.y === current?.y) {
+            return; // still the same cell — nothing to repaint
         }
-        hoveredCellRef.current = target;
-        paintHover(target);
+        hoveredCellRef.current = cell;
+        showHover(hoverableCell(cell));
     };
 
     const handleMouseLeave = () => {
@@ -278,7 +286,7 @@ const ChipCongestionCanvas = ({
             return;
         }
         hoveredCellRef.current = null;
-        paintHover(null);
+        showHover(null);
     };
 
     return (
@@ -286,22 +294,24 @@ const ChipCongestionCanvas = ({
             <canvas
                 ref={canvasRef}
                 className='congestion-canvas'
+                width={deviceWidth}
+                height={deviceHeight}
                 style={{ width: `${cssWidth}px`, height: `${cssHeight}px` }}
                 onClick={handleClick}
                 onMouseMove={handleMouseMove}
                 onMouseLeave={handleMouseLeave}
             />
-            <canvas
-                ref={hoverCanvasRef}
-                className='congestion-canvas congestion-canvas--hover'
-                style={{ width: `${cssWidth}px`, height: `${cssHeight}px` }}
+            <div
+                ref={hoverRef}
+                className='congestion-hover'
+                style={{ width: `${NODE_SIZE}px`, height: `${NODE_SIZE}px` }}
             />
         </>
     );
 };
 
-// Every prop is either a primitive, a referentially stable callback, or a per-chip
-// bucket that only changes when that chip's data does — so on a scrub that leaves a
-// chip idle this skips the subtree entirely instead of re-rendering two canvases
-// per chip across the cluster.
+// Every prop is a primitive, a referentially stable callback, or a per-chip bucket.
+// The bucket arrays are rebuilt each scrub, so chips carrying links still re-render
+// (their canvas genuinely needs repainting); what this skips is the idle chips,
+// which share a single empty-bucket constant and so keep their prop identity.
 export default memo(ChipCongestionCanvas);

--- a/src/components/npe/EmptyChipRenderer.tsx
+++ b/src/components/npe/EmptyChipRenderer.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { JSX } from 'react';
+import { JSX, memo, useMemo } from 'react';
 import classNames from 'classnames';
 import { NPE_COORDINATES, NPE_COORDINATE_INDEX } from '../../model/NPEModel';
 
@@ -21,75 +21,95 @@ interface EmptyChipRendererProps {
     renderChipId: boolean;
 }
 
-export const EmptyChipRenderer = ({
-    id,
-    width,
-    height,
-    cores,
-    dram,
-    eth,
-    pcie,
-    showActiveTransfers,
-    selectedZoneAddress,
-    isAnnotatingCores,
-    TENSIX_SIZE,
-    renderChipId = true,
-}: EmptyChipRendererProps) => {
-    const getNodeType = (location: number[]): JSX.Element => {
-        const [y, x] = location;
-        if (cores?.some((loc) => loc[0] === y && loc[1] === x)) {
-            return <div className='node-type-label node-type-c'>T</div>;
-        }
-        if (dram?.some((loc) => loc[0] === y && loc[1] === x)) {
-            return <div className='node-type-label node-type-d'>d</div>;
-        }
-        if (eth?.some((loc) => loc[0] === y && loc[1] === x)) {
-            return <div className='node-type-label node-type-e'>e</div>;
-        }
-        if (pcie?.some((loc) => loc[0] === y && loc[1] === x)) {
-            return <div className='node-type-label node-type-p'>p</div>;
-        }
-        return <div className='node-type-label' />;
-    };
-
-    return (
-        <div
-            className='tensix-grid empty'
-            style={{
-                display: 'grid',
-                gridTemplateColumns: `repeat(${width || 0}, ${TENSIX_SIZE}px)`,
-                gridTemplateRows: `repeat(${height || 0}, ${TENSIX_SIZE}px)`,
-            }}
-        >
-            {renderChipId && <div className='chip-id'>{id}</div>}
-
-            {Array.from({ length: width }).map((_, x) =>
-                Array.from({ length: height }).map((__, y) => {
-                    const isSelectedZone =
-                        selectedZoneAddress &&
-                        selectedZoneAddress[NPE_COORDINATE_INDEX.CHIP_ID] === id &&
-                        selectedZoneAddress[NPE_COORDINATE_INDEX.Y] === y &&
-                        selectedZoneAddress[NPE_COORDINATE_INDEX.X] === x;
-                    return (
-                        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-                        <div
-                            className={classNames('tensix empty-tensix', {
-                                'selected-zone': isSelectedZone,
-                            })}
-                            onClick={() => showActiveTransfers(null)}
-                            style={{
-                                gridColumn: x + 1,
-                                gridRow: y + 1,
-                                width: `${TENSIX_SIZE}px`,
-                                height: `${TENSIX_SIZE}px`,
-                            }}
-                            key={`${x}-${y}`}
-                        >
-                            {isAnnotatingCores ? getNodeType([y, x]) : ''}
-                        </div>
-                    );
-                }),
-            )}
-        </div>
-    );
+const NODE_TYPE_CLASS: Record<string, string> = {
+    c: 'node-type-label node-type-c',
+    d: 'node-type-label node-type-d',
+    e: 'node-type-label node-type-e',
+    p: 'node-type-label node-type-p',
 };
+const NODE_TYPE_LABEL: Record<string, string> = { c: 'T', d: 'd', e: 'e', p: 'p' };
+
+// This backdrop is static across timesteps, so it's memoized to skip re-rendering
+// its width×height cells on every scrub — the dominant data-independent cost of
+// timeline navigation (#1803). It only re-renders when the layout/annotation
+// inputs actually change, so the handler prop must stay referentially stable.
+export const EmptyChipRenderer = memo(
+    ({
+        id,
+        width,
+        height,
+        cores,
+        dram,
+        eth,
+        pcie,
+        showActiveTransfers,
+        selectedZoneAddress,
+        isAnnotatingCores,
+        TENSIX_SIZE,
+        renderChipId = true,
+    }: EmptyChipRendererProps) => {
+        // Flatten the four node-type location lists into one `${y}-${x}` lookup so a
+        // cell resolves in O(1) instead of scanning all four arrays per cell.
+        const nodeTypeByCoord = useMemo(() => {
+            const byCoord = new Map<string, string>();
+            const add = (locations: number[][] | undefined, kind: string) =>
+                locations?.forEach((loc) => byCoord.set(`${loc[0]}-${loc[1]}`, kind));
+            add(cores, 'c');
+            add(dram, 'd');
+            add(eth, 'e');
+            add(pcie, 'p');
+            return byCoord;
+        }, [cores, dram, eth, pcie]);
+
+        const getNodeType = (location: number[]): JSX.Element => {
+            const kind = nodeTypeByCoord.get(`${location[0]}-${location[1]}`);
+            return kind ? (
+                <div className={NODE_TYPE_CLASS[kind]}>{NODE_TYPE_LABEL[kind]}</div>
+            ) : (
+                <div className='node-type-label' />
+            );
+        };
+
+        return (
+            <div
+                className='tensix-grid empty'
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: `repeat(${width || 0}, ${TENSIX_SIZE}px)`,
+                    gridTemplateRows: `repeat(${height || 0}, ${TENSIX_SIZE}px)`,
+                }}
+            >
+                {renderChipId && <div className='chip-id'>{id}</div>}
+
+                {Array.from({ length: width }).map((_, x) =>
+                    Array.from({ length: height }).map((__, y) => {
+                        const isSelectedZone =
+                            selectedZoneAddress &&
+                            selectedZoneAddress[NPE_COORDINATE_INDEX.CHIP_ID] === id &&
+                            selectedZoneAddress[NPE_COORDINATE_INDEX.Y] === y &&
+                            selectedZoneAddress[NPE_COORDINATE_INDEX.X] === x;
+                        return (
+                            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+                            <div
+                                className={classNames('tensix empty-tensix', {
+                                    'selected-zone': isSelectedZone,
+                                })}
+                                onClick={() => showActiveTransfers(null)}
+                                style={{
+                                    gridColumn: x + 1,
+                                    gridRow: y + 1,
+                                    width: `${TENSIX_SIZE}px`,
+                                    height: `${TENSIX_SIZE}px`,
+                                }}
+                                key={`${x}-${y}`}
+                            >
+                                {isAnnotatingCores ? getNodeType([y, x]) : ''}
+                            </div>
+                        );
+                    }),
+                )}
+            </div>
+        );
+    },
+);
+EmptyChipRenderer.displayName = 'EmptyChipRenderer';

--- a/src/components/npe/EmptyChipRenderer.tsx
+++ b/src/components/npe/EmptyChipRenderer.tsx
@@ -14,7 +14,10 @@ interface EmptyChipRendererProps {
     dram?: number[][];
     eth?: number[][];
     pcie?: number[][];
-    showActiveTransfers: (arg: null) => void;
+    // Narrow on purpose: clicking bare backdrop can only clear a selection. A wider
+    // handler would tempt callers into passing the per-scrub-unstable
+    // `showActiveTransfers`, which would silently void the memo below.
+    onEmptyCellClick: () => void;
     selectedZoneAddress?: NPE_COORDINATES | null;
     isAnnotatingCores: boolean;
     TENSIX_SIZE: number;
@@ -42,7 +45,7 @@ export const EmptyChipRenderer = memo(
         dram,
         eth,
         pcie,
-        showActiveTransfers,
+        onEmptyCellClick,
         selectedZoneAddress,
         isAnnotatingCores,
         TENSIX_SIZE,
@@ -52,8 +55,16 @@ export const EmptyChipRenderer = memo(
         // cell resolves in O(1) instead of scanning all four arrays per cell.
         const nodeTypeByCoord = useMemo(() => {
             const byCoord = new Map<string, string>();
+            // First match wins, matching the original cores → dram → eth → pcie
+            // lookup chain. A plain `set` would make it last-wins and silently
+            // relabel any coordinate that appeared in two arch lists.
             const add = (locations: number[][] | undefined, kind: string) =>
-                locations?.forEach((loc) => byCoord.set(`${loc[0]}-${loc[1]}`, kind));
+                locations?.forEach((loc) => {
+                    const key = `${loc[0]}-${loc[1]}`;
+                    if (!byCoord.has(key)) {
+                        byCoord.set(key, kind);
+                    }
+                });
             add(cores, 'c');
             add(dram, 'd');
             add(eth, 'e');
@@ -94,7 +105,7 @@ export const EmptyChipRenderer = memo(
                                 className={classNames('tensix empty-tensix', {
                                     'selected-zone': isSelectedZone,
                                 })}
-                                onClick={() => showActiveTransfers(null)}
+                                onClick={onEmptyCellClick}
                                 style={{
                                     gridColumn: x + 1,
                                     gridRow: y + 1,

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -55,7 +55,12 @@ const NPETimelineComponent = ({
     navigationCallback,
 }: NPEHeatMapProps) => {
     const altCongestionColors = useAtomValue(altCongestionColorsAtom);
-    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    // Two stacked canvases: the heatmap repaints only when its pixels change
+    // (data / width / zones), while the playhead — the only thing a scrub moves —
+    // gets its own overlay so a tick is one clear + one fillRect, not a full
+    // repaint of 4 × n_timesteps heat cells. See #1803.
+    const heatmapCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const playheadCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const [hoverMap, setHoverMap] = useState<Map<string, Rect>>(new Map());
 
     const getZoneDrawingModel = useCallback(
@@ -155,7 +160,7 @@ const NPETimelineComponent = ({
     }, [nocType, timestepList, altCongestionColors]);
 
     useEffect(() => {
-        const canvas = canvasRef.current;
+        const canvas = heatmapCanvasRef.current;
         const ctx = canvas?.getContext('2d');
         if (!canvas || !ctx) {
             return;
@@ -228,9 +233,6 @@ const NPETimelineComponent = ({
                 });
             }
         });
-        const x = (currentTimestep ?? 0) * chunkWidth;
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.75)';
-        ctx.fillRect(x, 0, 2, HEATMAP_HEIGHT + canvasZoneHeight);
 
         setHoverMap(hovermap);
     }, [
@@ -240,11 +242,31 @@ const NPETimelineComponent = ({
         canvasZoneHeight,
         selectedZoneList,
         zoneRanges,
-        currentTimestep,
     ]);
 
+    // Playhead overlay: the only per-scrub paint. Clears its own canvas and draws
+    // a single 2px line, so scrubbing cost is O(1) instead of O(n_timesteps).
+    useEffect(() => {
+        const canvas = playheadCanvasRef.current;
+        const ctx = canvas?.getContext('2d');
+        if (!canvas || !ctx) {
+            return;
+        }
+
+        ctx.clearRect(0, 0, canvas.width, HEATMAP_HEIGHT + canvasZoneHeight);
+        const dataSize = congestionMapPerTimestamp.worst.length;
+        if (!dataSize) {
+            return;
+        }
+
+        const chunkWidth = canvas.width / dataSize;
+        const x = (currentTimestep ?? 0) * chunkWidth;
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.75)';
+        ctx.fillRect(x, 0, 2, HEATMAP_HEIGHT + canvasZoneHeight);
+    }, [currentTimestep, canvasWidth, canvasZoneHeight, congestionMapPerTimestamp.worst.length]);
+
     const handleTimelineClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-        const canvas = canvasRef.current;
+        const canvas = playheadCanvasRef.current;
         if (canvas) {
             const rect = canvas.getBoundingClientRect();
             const chunkWidth = rect.width / congestionMapPerTimestamp.worst.length;
@@ -253,7 +275,7 @@ const NPETimelineComponent = ({
         }
     };
     const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
-        const canvas = canvasRef.current;
+        const canvas = playheadCanvasRef.current;
         if (canvas) {
             const rect = canvas.getBoundingClientRect();
             const scaleX = canvas.width / rect.width;
@@ -354,7 +376,30 @@ const NPETimelineComponent = ({
     };
 
     return (
-        <>
+        // The tooltip's Blueprint target lives inside this relative, fixed-height
+        // wrapper on purpose: as an inline element it would otherwise force its own
+        // line box above the block canvas stack and shove the timeline down when it
+        // mounts on hover. Contained here (canvases are absolute), it can't reflow
+        // anything, and the absolute anchor is positioned relative to the timeline.
+        <div
+            className='npe-timeline-canvas-stack'
+            style={{ position: 'relative', width: '100%', height: `${HEATMAP_HEIGHT + canvasZoneHeight}px` }}
+        >
+            <canvas
+                style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+                ref={heatmapCanvasRef}
+                width={canvasWidth}
+                height={HEATMAP_HEIGHT + canvasZoneHeight}
+            />
+            <canvas
+                style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+                ref={playheadCanvasRef}
+                width={canvasWidth}
+                height={HEATMAP_HEIGHT + canvasZoneHeight}
+                onMouseMove={handleMouseMove}
+                onMouseLeave={handleMouseLeave}
+                onClick={handleTimelineClick}
+            />
             {tooltip && (
                 <Tooltip
                     content={tooltip.text}
@@ -381,16 +426,7 @@ const NPETimelineComponent = ({
                     />
                 </Tooltip>
             )}
-            <canvas
-                style={{ width: '100%', height: `${HEATMAP_HEIGHT + canvasZoneHeight}px` }}
-                ref={canvasRef}
-                width={canvasWidth}
-                height={HEATMAP_HEIGHT + canvasZoneHeight}
-                onMouseMove={handleMouseMove}
-                onMouseLeave={handleMouseLeave}
-                onClick={handleTimelineClick}
-            />
-        </>
+        </div>
     );
 };
 

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -137,13 +137,18 @@ const NPETimelineComponent = ({
 
     const dataSize = metricValues.worst.length;
 
-    // One column per device pixel at most. Beyond that the old code emitted a
-    // fillRect per timestep — ~0.008px wide at 196k steps — so each screen pixel
-    // was written hundreds of times and only the last (blended) write survived.
-    // That was both wasteful and lossy: an isolated congestion spike could be
-    // averaged into invisibility. Reducing each column to the MAX of the steps it
-    // covers keeps spikes visible, which is the point of a congestion heat bar.
-    const columnCount = Math.max(1, Math.min(Math.round(canvasWidth), dataSize));
+    // One column per *device* pixel — the finest resolution the screen can actually
+    // show. The heat bar is only redrawn on data/size/zone changes (the playhead is
+    // a separate div), so resolution is cheap: it costs one pass over the values,
+    // not per-scrub work. Going finer than a device pixel would put several rects
+    // back on the same physical pixel, where they blend and hide spikes — exactly
+    // the lossy overdraw that made 196k per-timestep rects both slow and wrong.
+    // Each column is the MAX of the steps it covers, so spikes survive being
+    // summarised, which is the point of a congestion heat bar. #1803
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const deviceWidth = Math.max(1, Math.round(canvasWidth * devicePixelRatio));
+    const deviceHeight = Math.max(1, Math.round((HEATMAP_HEIGHT + canvasZoneHeight) * devicePixelRatio));
+    const columnCount = Math.max(1, Math.min(deviceWidth, dataSize));
 
     const heatColumns = useMemo(() => {
         const color = (v: number) => calculateLinkCongestionColor(v, 0, altCongestionColors);
@@ -187,11 +192,15 @@ const NPETimelineComponent = ({
             return;
         }
 
-        ctx.clearRect(0, 0, canvas.width, HEATMAP_HEIGHT + canvasZoneHeight);
+        // The backing store is dpr-scaled for resolution; this transform lets all the
+        // drawing below stay in logical (canvasWidth) units, which is also the space
+        // `hoverMap` rects are compared against on mouse move.
+        ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+        ctx.clearRect(0, 0, canvasWidth, HEATMAP_HEIGHT + canvasZoneHeight);
 
         const numLines = heatColumns.length;
         const rowHeight = HEATMAP_HEIGHT / numLines;
-        const columnWidth = canvas.width / columnCount;
+        const columnWidth = canvasWidth / columnCount;
 
         // A report with no timesteps has no heat rows to draw — zones below still do.
         for (let row = 0; dataSize > 0 && row < numLines; row++) {
@@ -201,20 +210,20 @@ const NPETimelineComponent = ({
 
             // Coalesce neighbouring columns that resolved to the same colour into
             // one rect. Long idle stretches collapse to a handful of fills, and it
-            // avoids per-column `fillStyle` churn.
+            // avoids per-column `fillStyle` churn. Runs abut exactly, so no rounding
+            // is needed to avoid seams — a column is one device pixel wide.
             for (let col = 0; col < columnCount; col++) {
                 const isLast = col === columnCount - 1;
                 if (isLast || columns[col + 1] !== columns[runStart]) {
                     ctx.fillStyle = columns[runStart];
                     const x = runStart * columnWidth;
-                    // Ceil the span so sub-pixel column widths can't leave seams.
-                    ctx.fillRect(x, y, Math.ceil((col + 1) * columnWidth - x), rowHeight);
+                    ctx.fillRect(x, y, (col + 1) * columnWidth - x, rowHeight);
                     runStart = col + 1;
                 }
             }
         }
 
-        const chunkWidth = canvas.width / dataSize;
+        const chunkWidth = canvasWidth / dataSize;
 
         const groupBaseY = new Map<number, number>();
         {
@@ -268,6 +277,8 @@ const NPETimelineComponent = ({
         dataSize,
         canvasWidth,
         canvasZoneHeight,
+        devicePixelRatio,
+        deviceHeight,
         selectedZoneList,
         zoneRanges,
     ]);
@@ -403,8 +414,8 @@ const NPETimelineComponent = ({
             <canvas
                 style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
                 ref={heatmapCanvasRef}
-                width={canvasWidth}
-                height={HEATMAP_HEIGHT + canvasZoneHeight}
+                width={deviceWidth}
+                height={deviceHeight}
             />
             <div
                 className='npe-timeline-playhead'

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../model/NPEModel';
 import { altCongestionColorsAtom } from '../../store/app';
 import getWorstLinkDemand from '../../functions/getWorstLinkDemand';
+import reduceToColumns from '../../functions/reduceToColumns';
 import { formatPercentage } from '../../functions/math';
 
 interface Rect {
@@ -36,7 +37,7 @@ interface NPEHeatMapProps {
     nocType?: NoCType | null;
     navigationCallback: (timestepIndex: number) => void;
 }
-const HEATMAP_HEIGHT = 30;
+export const HEATMAP_HEIGHT = 30;
 const ZONE_HEIGHT = 10;
 
 const NPETimelineComponent = ({
@@ -150,40 +151,27 @@ const NPETimelineComponent = ({
     const deviceHeight = Math.max(1, Math.round((HEATMAP_HEIGHT + canvasZoneHeight) * devicePixelRatio));
     const columnCount = Math.max(1, Math.min(deviceWidth, dataSize));
 
-    const heatColumns = useMemo(() => {
-        const color = (v: number) => calculateLinkCongestionColor(v, 0, altCongestionColors);
-        // `undefined` (mcast N/A) has no colour of its own — it shares the -1
-        // "no data" ramp entry, matching the previous `color(mcast ?? -1)`.
-        const maxOf = (values: (number | undefined)[], start: number, end: number): number | undefined => {
-            let max: number | undefined;
-            for (let i = start; i < end; i++) {
-                const value = values[i];
-                if (value !== undefined && (max === undefined || value > max)) {
-                    max = value;
-                }
-            }
-            return max;
-        };
+    // Reduction is separate from colouring so switching palettes doesn't rescan the
+    // whole series — only the far smaller per-column result is recoloured.
+    const columnValues = useMemo(
+        () => [
+            reduceToColumns(metricValues.worst, columnCount),
+            reduceToColumns(metricValues.utilization, columnCount),
+            reduceToColumns(metricValues.demand, columnCount),
+            reduceToColumns(metricValues.mcast, columnCount),
+        ],
+        [metricValues, columnCount],
+    );
 
-        const reduce = (values: (number | undefined)[]): string[] => {
-            const columns: string[] = [];
-            for (let col = 0; col < columnCount; col++) {
-                const start = Math.floor((col * dataSize) / columnCount);
-                // Always cover at least one step so a column can't come out empty
-                // when columnCount and dataSize are close.
-                const end = Math.max(start + 1, Math.floor(((col + 1) * dataSize) / columnCount));
-                columns.push(color(maxOf(values, start, Math.min(end, dataSize)) ?? -1));
-            }
-            return columns;
-        };
-
-        return [
-            reduce(metricValues.worst),
-            reduce(metricValues.utilization),
-            reduce(metricValues.demand),
-            reduce(metricValues.mcast),
-        ];
-    }, [metricValues, columnCount, dataSize, altCongestionColors]);
+    const heatColumns = useMemo(
+        () =>
+            columnValues.map((column) =>
+                // A column with no data shares the -1 "no data" ramp entry, which is
+                // also how an N/A multicast value is drawn.
+                column.map((value) => calculateLinkCongestionColor(value ?? -1, 0, altCongestionColors)),
+            ),
+        [columnValues, altCongestionColors],
+    );
 
     useEffect(() => {
         const canvas = heatmapCanvasRef.current;
@@ -203,27 +191,29 @@ const NPETimelineComponent = ({
         const columnWidth = canvasWidth / columnCount;
 
         // A report with no timesteps has no heat rows to draw — zones below still do.
-        for (let row = 0; dataSize > 0 && row < numLines; row++) {
-            const y = row * rowHeight;
-            const columns = heatColumns[row];
-            let runStart = 0;
+        if (dataSize > 0) {
+            for (let row = 0; row < numLines; row++) {
+                const y = row * rowHeight;
+                const columns = heatColumns[row];
+                let runStart = 0;
 
-            // Coalesce neighbouring columns that resolved to the same colour into
-            // one rect. Long idle stretches collapse to a handful of fills, and it
-            // avoids per-column `fillStyle` churn. Runs abut exactly, so no rounding
-            // is needed to avoid seams — a column is one device pixel wide.
-            for (let col = 0; col < columnCount; col++) {
-                const isLast = col === columnCount - 1;
-                if (isLast || columns[col + 1] !== columns[runStart]) {
-                    ctx.fillStyle = columns[runStart];
-                    const x = runStart * columnWidth;
-                    ctx.fillRect(x, y, (col + 1) * columnWidth - x, rowHeight);
-                    runStart = col + 1;
+                // Coalesce neighbouring columns that resolved to the same colour into
+                // one rect. Long idle stretches collapse to a handful of fills, and it
+                // avoids per-column `fillStyle` churn. Runs abut exactly, so no rounding
+                // is needed to avoid seams — a column is one device pixel wide.
+                for (let col = 0; col < columnCount; col++) {
+                    const isLast = col === columnCount - 1;
+                    if (isLast || columns[col + 1] !== columns[runStart]) {
+                        ctx.fillStyle = columns[runStart];
+                        const x = runStart * columnWidth;
+                        ctx.fillRect(x, y, (col + 1) * columnWidth - x, rowHeight);
+                        runStart = col + 1;
+                    }
                 }
             }
         }
 
-        const chunkWidth = canvasWidth / dataSize;
+        const chunkWidth = dataSize > 0 ? canvasWidth / dataSize : 0;
 
         const groupBaseY = new Map<number, number>();
         {
@@ -278,24 +268,25 @@ const NPETimelineComponent = ({
         canvasWidth,
         canvasZoneHeight,
         devicePixelRatio,
-        deviceHeight,
-        selectedZoneList,
         zoneRanges,
     ]);
 
-    // The playhead is a positioned div rather than a canvas layer: a scrub then
-    // changes one style value the compositor can act on, instead of clearing and
-    // repainting a full-width canvas every tick. Percent-based so it needs no
-    // measurement and stays correct as the timeline is resized.
+    // The playhead is a positioned div rather than a canvas layer, so a scrub costs
+    // one element's layout + paint instead of clearing and repainting a full-width
+    // canvas every tick. Percent-based so it needs no measurement and stays correct
+    // as the timeline is resized.
     const playheadPercent = dataSize ? ((currentTimestep ?? 0) / dataSize) * 100 : 0;
+
+    // Clamped because a pointer at the extreme right edge (reachable with a
+    // fractional clientX under browser zoom) yields `dataSize`, and an out-of-range
+    // timestep throws during NPEView's render. #1803
+    const timestepAt = (clientX: number, rect: DOMRect): number =>
+        Math.min(dataSize - 1, Math.max(0, Math.floor(((clientX - rect.left) / rect.width) * dataSize)));
 
     const handleTimelineClick = (event: React.MouseEvent<HTMLDivElement>) => {
         const stack = stackRef.current;
         if (stack && dataSize) {
-            const rect = stack.getBoundingClientRect();
-            const chunkWidth = rect.width / dataSize;
-            const index = Math.floor((event.clientX - rect.left) / chunkWidth);
-            navigationCallback(index);
+            navigationCallback(timestepAt(event.clientX, stack.getBoundingClientRect()));
         }
     };
     const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -306,8 +297,7 @@ const NPETimelineComponent = ({
             // it for zone hit-testing while the index stays in CSS space.
             const scaleX = canvasWidth / rect.width;
             const mouseX = (event.clientX - rect.left) * scaleX;
-            const chunkWidth = rect.width / dataSize;
-            const hoveredIndex = Math.floor((event.clientX - rect.left) / chunkWidth);
+            const hoveredIndex = timestepAt(event.clientX, rect);
             const y = event.clientY - rect.top;
             const x = mouseX;
 

--- a/src/components/npe/NPETimelineComponent.tsx
+++ b/src/components/npe/NPETimelineComponent.tsx
@@ -19,11 +19,6 @@ import { altCongestionColorsAtom } from '../../store/app';
 import getWorstLinkDemand from '../../functions/getWorstLinkDemand';
 import { formatPercentage } from '../../functions/math';
 
-interface MetricPoint {
-    value: number;
-    color: string;
-}
-
 interface Rect {
     x: number;
     y: number;
@@ -55,12 +50,11 @@ const NPETimelineComponent = ({
     navigationCallback,
 }: NPEHeatMapProps) => {
     const altCongestionColors = useAtomValue(altCongestionColorsAtom);
-    // Two stacked canvases: the heatmap repaints only when its pixels change
-    // (data / width / zones), while the playhead — the only thing a scrub moves —
-    // gets its own overlay so a tick is one clear + one fillRect, not a full
-    // repaint of 4 × n_timesteps heat cells. See #1803.
+    // The heatmap canvas repaints only when its pixels change (data / width /
+    // zones). The playhead — the only thing a scrub moves — is a positioned div
+    // above it, so a tick costs one style update rather than any canvas work. #1803.
     const heatmapCanvasRef = useRef<HTMLCanvasElement | null>(null);
-    const playheadCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const stackRef = useRef<HTMLDivElement | null>(null);
     const [hoverMap, setHoverMap] = useState<Map<string, Rect>>(new Map());
 
     const getZoneDrawingModel = useCallback(
@@ -108,14 +102,16 @@ const NPETimelineComponent = ({
     const canvasZoneHeight = zoneRanges.maxZoneDepth * ZONE_HEIGHT;
     const [tooltip, setTooltip] = useState<{ x: number; y: number; text: React.JSX.Element } | null>(null);
 
-    const congestionMapPerTimestamp = useMemo(() => {
-        const result = {
-            worst: [] as MetricPoint[],
-            utilization: [] as MetricPoint[],
-            demand: [] as MetricPoint[],
-            mcast: [] as MetricPoint[],
-        };
-        const color = (v: number) => calculateLinkCongestionColor(v, 0, altCongestionColors);
+    // Per-timestep metric values only — no colours. The tooltip needs a value for
+    // whichever step is hovered, but colourising all of them cost one
+    // `calculateLinkCongestionColor` call per step per row (4 × n_timesteps, ~780k
+    // on a 196k-step report) to produce pixels that were then thrown away by
+    // sub-pixel overdraw. Colours are now computed per drawn column instead. #1803.
+    const metricValues = useMemo(() => {
+        const worst: number[] = [];
+        const utilization: number[] = [];
+        const demand: number[] = [];
+        const mcast: (number | undefined)[] = [];
 
         for (const timestep of timestepList) {
             const links = nocType
@@ -128,36 +124,61 @@ const NPETimelineComponent = ({
             // non-visited `noc` aggregates are stubbed to 0, so with a NOC filter
             // active the heat rows for non-visited steps are approximate until the
             // summary carries per-NOC aggregates. Unfiltered view is exact.
-            const worst = getWorstLinkDemand(links, timestep.max_link_demand);
-
-            result.worst.push({
-                value: worst,
-                color: color(worst),
-            });
+            worst.push(getWorstLinkDemand(links, timestep.max_link_demand));
 
             const nocData = nocType ? timestep.noc?.[nocType] : undefined;
-
-            const utilization = nocData?.avg_link_util ?? timestep.avg_link_util;
-            result.utilization.push({
-                value: utilization,
-                color: color(utilization),
-            });
-
-            const demand = nocData?.avg_link_demand ?? timestep.avg_link_demand;
-            result.demand.push({
-                value: demand,
-                color: color(demand),
-            });
-
-            const mcast = timestep.mcast_write_link_util;
-            result.mcast.push({
-                value: mcast,
-                color: color(mcast ?? -1),
-            });
+            utilization.push(nocData?.avg_link_util ?? timestep.avg_link_util);
+            demand.push(nocData?.avg_link_demand ?? timestep.avg_link_demand);
+            mcast.push(timestep.mcast_write_link_util);
         }
 
-        return result;
-    }, [nocType, timestepList, altCongestionColors]);
+        return { worst, utilization, demand, mcast };
+    }, [nocType, timestepList]);
+
+    const dataSize = metricValues.worst.length;
+
+    // One column per device pixel at most. Beyond that the old code emitted a
+    // fillRect per timestep — ~0.008px wide at 196k steps — so each screen pixel
+    // was written hundreds of times and only the last (blended) write survived.
+    // That was both wasteful and lossy: an isolated congestion spike could be
+    // averaged into invisibility. Reducing each column to the MAX of the steps it
+    // covers keeps spikes visible, which is the point of a congestion heat bar.
+    const columnCount = Math.max(1, Math.min(Math.round(canvasWidth), dataSize));
+
+    const heatColumns = useMemo(() => {
+        const color = (v: number) => calculateLinkCongestionColor(v, 0, altCongestionColors);
+        // `undefined` (mcast N/A) has no colour of its own — it shares the -1
+        // "no data" ramp entry, matching the previous `color(mcast ?? -1)`.
+        const maxOf = (values: (number | undefined)[], start: number, end: number): number | undefined => {
+            let max: number | undefined;
+            for (let i = start; i < end; i++) {
+                const value = values[i];
+                if (value !== undefined && (max === undefined || value > max)) {
+                    max = value;
+                }
+            }
+            return max;
+        };
+
+        const reduce = (values: (number | undefined)[]): string[] => {
+            const columns: string[] = [];
+            for (let col = 0; col < columnCount; col++) {
+                const start = Math.floor((col * dataSize) / columnCount);
+                // Always cover at least one step so a column can't come out empty
+                // when columnCount and dataSize are close.
+                const end = Math.max(start + 1, Math.floor(((col + 1) * dataSize) / columnCount));
+                columns.push(color(maxOf(values, start, Math.min(end, dataSize)) ?? -1));
+            }
+            return columns;
+        };
+
+        return [
+            reduce(metricValues.worst),
+            reduce(metricValues.utilization),
+            reduce(metricValues.demand),
+            reduce(metricValues.mcast),
+        ];
+    }, [metricValues, columnCount, dataSize, altCongestionColors]);
 
     useEffect(() => {
         const canvas = heatmapCanvasRef.current;
@@ -167,28 +188,33 @@ const NPETimelineComponent = ({
         }
 
         ctx.clearRect(0, 0, canvas.width, HEATMAP_HEIGHT + canvasZoneHeight);
-        const dataSize = congestionMapPerTimestamp.worst.length;
 
-        const metricDataArray = [
-            congestionMapPerTimestamp.worst,
-            congestionMapPerTimestamp.utilization,
-            congestionMapPerTimestamp.demand,
-            congestionMapPerTimestamp.mcast,
-        ];
-        const numLines = metricDataArray.length;
+        const numLines = heatColumns.length;
+        const rowHeight = HEATMAP_HEIGHT / numLines;
+        const columnWidth = canvas.width / columnCount;
+
+        // A report with no timesteps has no heat rows to draw — zones below still do.
+        for (let row = 0; dataSize > 0 && row < numLines; row++) {
+            const y = row * rowHeight;
+            const columns = heatColumns[row];
+            let runStart = 0;
+
+            // Coalesce neighbouring columns that resolved to the same colour into
+            // one rect. Long idle stretches collapse to a handful of fills, and it
+            // avoids per-column `fillStyle` churn.
+            for (let col = 0; col < columnCount; col++) {
+                const isLast = col === columnCount - 1;
+                if (isLast || columns[col + 1] !== columns[runStart]) {
+                    ctx.fillStyle = columns[runStart];
+                    const x = runStart * columnWidth;
+                    // Ceil the span so sub-pixel column widths can't leave seams.
+                    ctx.fillRect(x, y, Math.ceil((col + 1) * columnWidth - x), rowHeight);
+                    runStart = col + 1;
+                }
+            }
+        }
 
         const chunkWidth = canvas.width / dataSize;
-        const rowHeight = HEATMAP_HEIGHT / numLines;
-
-        for (let row = 0; row < numLines; row++) {
-            const y = row * rowHeight;
-            const pointList = metricDataArray[row];
-
-            pointList.forEach((point, index) => {
-                ctx.fillStyle = point.color;
-                ctx.fillRect(index * chunkWidth, y, chunkWidth, rowHeight);
-            });
-        }
 
         const groupBaseY = new Map<number, number>();
         {
@@ -237,50 +263,39 @@ const NPETimelineComponent = ({
         setHoverMap(hovermap);
     }, [
         //
-        congestionMapPerTimestamp,
+        heatColumns,
+        columnCount,
+        dataSize,
         canvasWidth,
         canvasZoneHeight,
         selectedZoneList,
         zoneRanges,
     ]);
 
-    // Playhead overlay: the only per-scrub paint. Clears its own canvas and draws
-    // a single 2px line, so scrubbing cost is O(1) instead of O(n_timesteps).
-    useEffect(() => {
-        const canvas = playheadCanvasRef.current;
-        const ctx = canvas?.getContext('2d');
-        if (!canvas || !ctx) {
-            return;
-        }
+    // The playhead is a positioned div rather than a canvas layer: a scrub then
+    // changes one style value the compositor can act on, instead of clearing and
+    // repainting a full-width canvas every tick. Percent-based so it needs no
+    // measurement and stays correct as the timeline is resized.
+    const playheadPercent = dataSize ? ((currentTimestep ?? 0) / dataSize) * 100 : 0;
 
-        ctx.clearRect(0, 0, canvas.width, HEATMAP_HEIGHT + canvasZoneHeight);
-        const dataSize = congestionMapPerTimestamp.worst.length;
-        if (!dataSize) {
-            return;
-        }
-
-        const chunkWidth = canvas.width / dataSize;
-        const x = (currentTimestep ?? 0) * chunkWidth;
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.75)';
-        ctx.fillRect(x, 0, 2, HEATMAP_HEIGHT + canvasZoneHeight);
-    }, [currentTimestep, canvasWidth, canvasZoneHeight, congestionMapPerTimestamp.worst.length]);
-
-    const handleTimelineClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-        const canvas = playheadCanvasRef.current;
-        if (canvas) {
-            const rect = canvas.getBoundingClientRect();
-            const chunkWidth = rect.width / congestionMapPerTimestamp.worst.length;
+    const handleTimelineClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        const stack = stackRef.current;
+        if (stack && dataSize) {
+            const rect = stack.getBoundingClientRect();
+            const chunkWidth = rect.width / dataSize;
             const index = Math.floor((event.clientX - rect.left) / chunkWidth);
             navigationCallback(index);
         }
     };
-    const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
-        const canvas = playheadCanvasRef.current;
-        if (canvas) {
-            const rect = canvas.getBoundingClientRect();
-            const scaleX = canvas.width / rect.width;
+    const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+        const stack = stackRef.current;
+        if (stack && dataSize) {
+            const rect = stack.getBoundingClientRect();
+            // `hoverMap` rects are in canvas-pixel space, so scale the pointer into
+            // it for zone hit-testing while the index stays in CSS space.
+            const scaleX = canvasWidth / rect.width;
             const mouseX = (event.clientX - rect.left) * scaleX;
-            const chunkWidth = rect.width / congestionMapPerTimestamp.worst.length;
+            const chunkWidth = rect.width / dataSize;
             const hoveredIndex = Math.floor((event.clientX - rect.left) / chunkWidth);
             const y = event.clientY - rect.top;
             const x = mouseX;
@@ -300,6 +315,15 @@ const NPETimelineComponent = ({
                     return;
                 }
 
+                // Colours for the hovered step only — four calls, versus
+                // colourising every step up front.
+                const swatch = (value: number | undefined) =>
+                    calculateLinkCongestionColor(value ?? -1, 0, altCongestionColors);
+                const worstValue = metricValues.worst[hoveredIndex];
+                const utilizationValue = metricValues.utilization[hoveredIndex];
+                const demandValue = metricValues.demand[hoveredIndex];
+                const mcastValue = metricValues.mcast[hoveredIndex];
+
                 setTooltip({
                     x,
                     y: 0,
@@ -314,46 +338,32 @@ const NPETimelineComponent = ({
                                     <div>
                                         <span
                                             className='color-square'
-                                            style={{
-                                                backgroundColor: congestionMapPerTimestamp.worst[hoveredIndex].color,
-                                            }}
+                                            style={{ backgroundColor: swatch(worstValue) }}
                                         />{' '}
-                                        Max Demand:{' '}
-                                        {congestionMapPerTimestamp.worst[hoveredIndex].value > -1
-                                            ? `${formatPercentage(congestionMapPerTimestamp.worst[hoveredIndex].value, 3)}`
-                                            : 'N/A'}
+                                        Max Demand: {worstValue > -1 ? `${formatPercentage(worstValue, 3)}` : 'N/A'}
                                     </div>
                                     <div>
                                         <span
                                             className='color-square'
-                                            style={{
-                                                backgroundColor:
-                                                    congestionMapPerTimestamp.utilization[hoveredIndex].color,
-                                            }}
+                                            style={{ backgroundColor: swatch(utilizationValue) }}
                                         />
-                                        {` Avg Utilization: ${formatPercentage(congestionMapPerTimestamp.utilization[hoveredIndex].value, 3)}`}
+                                        {` Avg Utilization: ${formatPercentage(utilizationValue, 3)}`}
                                     </div>
                                     <div>
                                         <span
                                             className='color-square'
-                                            style={{
-                                                backgroundColor: congestionMapPerTimestamp.demand[hoveredIndex].color,
-                                            }}
+                                            style={{ backgroundColor: swatch(demandValue) }}
                                         />
-                                        {` Avg Demand: ${formatPercentage(congestionMapPerTimestamp.demand[hoveredIndex].value, 3)}`}
+                                        {` Avg Demand: ${formatPercentage(demandValue, 3)}`}
                                     </div>
 
                                     <div>
                                         <span
                                             className='color-square'
-                                            style={{
-                                                backgroundColor: congestionMapPerTimestamp.mcast[hoveredIndex].color,
-                                            }}
+                                            style={{ backgroundColor: swatch(mcastValue) }}
                                         />
                                         {` Multicast Utilization:`}{' '}
-                                        {congestionMapPerTimestamp.mcast[hoveredIndex].value !== undefined
-                                            ? `${formatPercentage(congestionMapPerTimestamp.mcast[hoveredIndex].value, 3)}`
-                                            : 'N/A'}
+                                        {mcastValue !== undefined ? `${formatPercentage(mcastValue, 3)}` : 'N/A'}
                                     </div>
                                 </>
                             )}
@@ -381,9 +391,14 @@ const NPETimelineComponent = ({
         // line box above the block canvas stack and shove the timeline down when it
         // mounts on hover. Contained here (canvases are absolute), it can't reflow
         // anything, and the absolute anchor is positioned relative to the timeline.
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
         <div
             className='npe-timeline-canvas-stack'
+            ref={stackRef}
             style={{ position: 'relative', width: '100%', height: `${HEATMAP_HEIGHT + canvasZoneHeight}px` }}
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+            onClick={handleTimelineClick}
         >
             <canvas
                 style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
@@ -391,14 +406,9 @@ const NPETimelineComponent = ({
                 width={canvasWidth}
                 height={HEATMAP_HEIGHT + canvasZoneHeight}
             />
-            <canvas
-                style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
-                ref={playheadCanvasRef}
-                width={canvasWidth}
-                height={HEATMAP_HEIGHT + canvasZoneHeight}
-                onMouseMove={handleMouseMove}
-                onMouseLeave={handleMouseLeave}
-                onClick={handleTimelineClick}
+            <div
+                className='npe-timeline-playhead'
+                style={{ left: `${playheadPercent}%` }}
             />
             {tooltip && (
                 <Tooltip

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -6,7 +6,7 @@
 import 'highlight.js/styles/a11y-dark.css';
 import 'styles/components/NPEComponent.scss';
 import 'styles/components/NPEZoneFilterComponent.scss';
-import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, ButtonGroup, ButtonVariant, Classes, Intent, Size, Slider, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
@@ -17,6 +17,7 @@ import {
     FABRIC_EVENT_SCOPE_OPTIONS,
     FabricEventScopeColors,
     KERNEL_PROCESS,
+    LinkUtilization,
     NPEData,
     NPERootZone,
     NPERootZoneUXInfo,
@@ -31,14 +32,8 @@ import {
     TimestepData,
 } from '../../model/NPEModel';
 import TensixTransferRenderer from './TensixTransferRenderer';
-import {
-    NODE_SIZE,
-    calculateFabricColor,
-    calculateLinkCongestionColor,
-    getLines,
-    getLinkPoints,
-    resetRouteColors,
-} from './drawingApi';
+import ChipCongestionCanvas from './ChipCongestionCanvas';
+import { NODE_SIZE, getLines, resetRouteColors } from './drawingApi';
 import NPETimelineComponent from './NPETimelineComponent';
 import ActiveTransferDetails from './ActiveTransferDetails';
 import { useNodeType } from '../../hooks/useAPI';
@@ -218,6 +213,44 @@ const NPEView = ({
             });
     }, [npeData.noc_transfers, links?.active_transfers, fabricEventsFilter]);
 
+    // Pre-bucket per chip so each chip renders only its own entries instead of the
+    // render walking all D link_demand rows / A transfers 8 times (once per chip)
+    // and discarding the misses. #1803. A transfer lands in every chip its src or
+    // any dst touches, matching what RouteOriginsRenderer draws.
+    const linkDemandByChip = useMemo(() => {
+        const byChip = new Map<number, { linkUtilization: LinkUtilization; index: number }[]>();
+        links?.link_demand.forEach((linkUtilization, index) => {
+            const chipId = linkUtilization[NPE_LINK.CHIP_ID];
+            const bucket = byChip.get(chipId);
+            if (bucket) {
+                bucket.push({ linkUtilization, index });
+            } else {
+                byChip.set(chipId, [{ linkUtilization, index }]);
+            }
+        });
+        return byChip;
+    }, [links]);
+
+    const transfersByChip = useMemo(() => {
+        const byChip = new Map<number, { transfer: NoCTransfer; index: number }[]>();
+        transfers.forEach((transfer, index) => {
+            const chipIds = new Set<number>();
+            if (transfer.src) {
+                chipIds.add(transfer.src[NPE_LINK.CHIP_ID]);
+            }
+            transfer.dst.forEach((dst) => chipIds.add(dst[NPE_LINK.CHIP_ID]));
+            chipIds.forEach((chipId) => {
+                const bucket = byChip.get(chipId);
+                if (bucket) {
+                    bucket.push({ transfer, index });
+                } else {
+                    byChip.set(chipId, [{ transfer, index }]);
+                }
+            });
+        });
+        return byChip;
+    }, [transfers]);
+
     const showNOCType = (value: NoCType) => {
         if (nocFilter === null) {
             setNocFilter(value === NoCType.NOC0 ? NoCType.NOC1 : NoCType.NOC0);
@@ -349,6 +382,22 @@ const NPEView = ({
         setSelectedTransferList,
     });
 
+    // showActiveTransfers re-creates on every scrub/selection (its deps include
+    // selectedTimestep + selectedNode); route it through a ref so the click
+    // handlers handed to the congestion canvas stay referentially stable. #1803.
+    const showActiveTransfersRef = useRef(showActiveTransfers);
+    useEffect(() => {
+        showActiveTransfersRef.current = showActiveTransfers;
+    }, [showActiveTransfers]);
+    const handleSelectLink = useCallback((linkUtilization: LinkUtilization, index: number) => {
+        showActiveTransfersRef.current(linkUtilization, index);
+    }, []);
+    // Canvas misses (clicking a cell with no link) mirror the old empty-tile
+    // click, which deselected via showActiveTransfers(null).
+    const handleClearSelection = useCallback(() => {
+        showActiveTransfersRef.current(null);
+    }, []);
+
     const showAllTransfers = () => {
         setIsShowingAllTransfers(true);
         setSelectedNode(null);
@@ -382,6 +431,13 @@ const NPEView = ({
 
         return 0.5;
     };
+
+    // The base origin squares are driven entirely by `getOriginOpacity`, which
+    // returns 0 for every id-bearing transfer unless one is selected or
+    // highlighted. In the common scrub state (nothing selected/highlighted) the
+    // whole layer is fully transparent, so rendering it just churns thousands of
+    // invisible src/dst divs per scrub. Skip it unless it can actually be seen. #1803.
+    const hasVisibleTransferOrigins = selectedTransferList.length > 0 || highlightedTransfer !== null;
 
     const switchWidth = canvasWidth - canvasWidth / npeData.timestep_data.length - RIGHT_MARGIN_OFFSET_PX;
     const isTimelinePlaying = playbackSpeed > 0;
@@ -633,7 +689,7 @@ const NPEView = ({
                                     dram={dram}
                                     eth={eth}
                                     pcie={pcie}
-                                    showActiveTransfers={showActiveTransfers}
+                                    showActiveTransfers={handleClearSelection}
                                     selectedZoneAddress={selectedZoneAddress}
                                     isAnnotatingCores={isAnnotatingCores}
                                     TENSIX_SIZE={TENSIX_SIZE}
@@ -647,15 +703,16 @@ const NPEView = ({
                                         gridTemplateRows: `repeat(${height || 0}, ${TENSIX_SIZE}px)`,
                                     }}
                                 >
-                                    {transfers.map((transfer, index) => (
-                                        <RouteOriginsRenderer
-                                            key={`${transfer.id}-${index}`}
-                                            transfer={transfer}
-                                            clusterChip={clusterChip}
-                                            index={index}
-                                            getOriginOpacity={getOriginOpacity}
-                                        />
-                                    ))}
+                                    {hasVisibleTransferOrigins &&
+                                        (transfersByChip.get(clusterChip.id) ?? []).map(({ transfer, index }) => (
+                                            <RouteOriginsRenderer
+                                                key={`${transfer.id}-${index}`}
+                                                transfer={transfer}
+                                                clusterChip={clusterChip}
+                                                index={index}
+                                                getOriginOpacity={getOriginOpacity}
+                                            />
+                                        ))}
                                     {highlightedTransfer !== null &&
                                         highlightedRoute !== null &&
                                         highlightedTransfer.route[highlightedRoute].device_id === clusterChip.id && (
@@ -668,82 +725,19 @@ const NPEView = ({
                                             />
                                         )}
 
-                                    {links?.link_demand.map((linkUtilization, index) => {
-                                        let fabricCondition = true;
-                                        if (fabricEventsFilter === EVENT_TYPE_FILTER.FABRIC_EVENTS) {
-                                            fabricCondition =
-                                                linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE] ===
-                                                    FABRIC_EVENT_SCOPE_OPTIONS.FABRIC ||
-                                                linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE] ===
-                                                    FABRIC_EVENT_SCOPE_OPTIONS.BOTH;
-                                        } else if (fabricEventsFilter === EVENT_TYPE_FILTER.LOCAL_EVENTS) {
-                                            fabricCondition =
-                                                linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE] ===
-                                                    FABRIC_EVENT_SCOPE_OPTIONS.LOCAL ||
-                                                linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE] ===
-                                                    FABRIC_EVENT_SCOPE_OPTIONS.BOTH;
-                                        }
-                                        if (
-                                            linkUtilization[NPE_LINK.CHIP_ID] === clusterChip.id &&
-                                            (nocFilter === null ||
-                                                linkUtilization[NPE_LINK.NOC_ID].indexOf(nocFilter) === 0) &&
-                                            fabricCondition
-                                        ) {
-                                            return (
-                                                <button
-                                                    type='button'
-                                                    key={`${index}-${linkUtilization[NPE_LINK.Y]}-${linkUtilization[NPE_LINK.X]}-${linkUtilization[NPE_LINK.NOC_ID]}`}
-                                                    className={`tensix ${linkUtilization[NPE_LINK.Y]}-${linkUtilization[NPE_LINK.X]}`}
-                                                    style={{
-                                                        position: 'relative',
-                                                        gridColumn: linkUtilization[NPE_LINK.X] + 1,
-                                                        gridRow: linkUtilization[NPE_LINK.Y] + 1,
-                                                    }}
-                                                    onClick={() => showActiveTransfers(linkUtilization, index)}
-                                                >
-                                                    {/* // TENSIX CONGESTION */}
-                                                    <TensixTransferRenderer
-                                                        key={`${index}-${linkUtilization[NPE_LINK.Y]}-${linkUtilization[NPE_LINK.X]}-${linkUtilization[NPE_LINK.NOC_ID]}-transfers`}
-                                                        style={{
-                                                            opacity:
-                                                                highlightedTransfer !== null ||
-                                                                selectedTransferList.length !== 0
-                                                                    ? 0.15
-                                                                    : 1,
-                                                        }}
-                                                        width={SVG_SIZE}
-                                                        height={SVG_SIZE}
-                                                        data={[
-                                                            getLinkPoints(
-                                                                linkUtilization[NPE_LINK.NOC_ID],
-                                                                visualizationMode === VISUALIZATION_MODE.CONGESTION
-                                                                    ? calculateLinkCongestionColor(
-                                                                          linkUtilization[NPE_LINK.DEMAND],
-                                                                          0,
-                                                                          altCongestionColors,
-                                                                      )
-                                                                    : calculateFabricColor(
-                                                                          linkUtilization[NPE_LINK.FABRIC_EVENT_SCOPE],
-                                                                      ),
-                                                            ),
-                                                        ]}
-                                                        isMulticolor={false}
-                                                    />
-                                                    <div
-                                                        style={{
-                                                            fontSize: '9px',
-                                                            position: 'absolute',
-                                                            top: 0,
-                                                            opacity: 1,
-                                                        }}
-                                                    >
-                                                        {linkUtilization[NPE_LINK.Y]}-{linkUtilization[NPE_LINK.X]}
-                                                    </div>
-                                                </button>
-                                            );
-                                        }
-                                        return null;
-                                    })}
+                                    <ChipCongestionCanvas
+                                        links={linkDemandByChip.get(clusterChip.id) ?? []}
+                                        gridWidth={width}
+                                        gridHeight={height}
+                                        isFabricMode={visualizationMode === VISUALIZATION_MODE.TRANSFERS}
+                                        altCongestionColors={altCongestionColors}
+                                        nocFilter={nocFilter}
+                                        fabricEventsFilter={fabricEventsFilter}
+                                        dimmed={highlightedTransfer !== null || selectedTransferList.length !== 0}
+                                        zoom={zoom}
+                                        onSelectLink={handleSelectLink}
+                                        onClearSelection={handleClearSelection}
+                                    />
                                 </div>
 
                                 <div

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -32,7 +32,7 @@ import {
     TimestepData,
 } from '../../model/NPEModel';
 import TensixTransferRenderer from './TensixTransferRenderer';
-import ChipCongestionCanvas from './ChipCongestionCanvas';
+import ChipCongestionCanvas, { ChipLink } from './ChipCongestionCanvas';
 import { NODE_SIZE, getLines, resetRouteColors } from './drawingApi';
 import NPETimelineComponent from './NPETimelineComponent';
 import ActiveTransferDetails from './ActiveTransferDetails';
@@ -67,17 +67,33 @@ interface NPEViewProps {
 
 const LABEL_STEP_THRESHOLD = 25;
 const RIGHT_MARGIN_OFFSET_PX = 25;
+
+interface ChipTransfer {
+    transfer: NoCTransfer;
+    index: number;
+}
+
+// Every seek ultimately indexes `timestep_data`, and an out-of-range index throws
+// during render straight past to the router's root error page. Clamp at the source
+// instead of relying on each caller's arithmetic. #1803
+const clampTimestep = (timestep: number, length: number): number => {
+    if (!Number.isFinite(timestep) || length === 0) {
+        return 0;
+    }
+    return Math.min(Math.max(0, Math.trunc(timestep)), length - 1);
+};
+
 // Shared fallbacks for chips with nothing to draw. A fresh `[]` per render would
 // give every idle chip a new prop identity on every scrub, re-running the
 // congestion canvas's draw effect across the whole cluster for no visual change —
 // the bulk of the cost of stepping between two empty timesteps. #1803.
-const NO_LINKS: { linkUtilization: LinkUtilization; index: number }[] = [];
-const NO_TRANSFERS: { transfer: NoCTransfer; index: number }[] = [];
+const NO_LINKS: readonly ChipLink[] = Object.freeze([]);
+const NO_TRANSFERS: readonly ChipTransfer[] = Object.freeze([]);
 // Same hazard on the zone path: `npeData` is a new object per scrub, so a fresh `[]`
 // here would churn `zones` → `selectedZoneList` → the timeline's `zoneRanges`, whose
 // effect repaints 4 × n_timesteps heat cells. On a 196k-timestep report that is
 // ~780k fillRects per scrub — for a report that simply has no zones.
-const NO_ZONES: NPERootZone[] = [];
+const NO_ZONES: readonly NPERootZone[] = Object.freeze([]);
 const TENSIX_SIZE: number = NODE_SIZE; // * 0.75;
 const SVG_SIZE = TENSIX_SIZE;
 const PLAYBACK_SPEED = 1;
@@ -135,7 +151,7 @@ const NPEView = ({
         };
     });
 
-    const zones: NPERootZone[] = useMemo(() => {
+    const zones: readonly NPERootZone[] = useMemo(() => {
         return npeData.zones || NO_ZONES;
     }, [npeData]);
 
@@ -171,7 +187,14 @@ const NPEView = ({
     }, [expandedZoneMap, selectedZoneAddress, zones]);
 
     const links = useMemo(() => {
-        const timestepData = npeData.timestep_data[selectedTimestep];
+        // An out-of-range index would throw here during render, and the nearest
+        // boundary is the router's root `errorElement` — it replaces the whole app
+        // shell, so the user cannot recover in place. Callers are clamped too; this
+        // is the backstop that keeps a bad index from being fatal. #1803
+        const timestepData = npeData.timestep_data[selectedTimestep] ?? npeData.timestep_data.at(-1);
+        if (!timestepData) {
+            return undefined;
+        }
         timestepData.active_transfers.forEach((id) => {
             const transfer = npeData.noc_transfers.find((tr) => tr.id === id);
             // TODO: this functionality should MAYBE move to BE. https://github.com/orgs/tenstorrent/projects/178/views/1?pane=issue&itemId=124188622&issue=tenstorrent%7Cttnn-visualizer%7C745
@@ -229,7 +252,7 @@ const NPEView = ({
     // and discarding the misses. #1803. A transfer lands in every chip its src or
     // any dst touches, matching what RouteOriginsRenderer draws.
     const linkDemandByChip = useMemo(() => {
-        const byChip = new Map<number, { linkUtilization: LinkUtilization; index: number }[]>();
+        const byChip = new Map<number, ChipLink[]>();
         links?.link_demand.forEach((linkUtilization, index) => {
             const chipId = linkUtilization[NPE_LINK.CHIP_ID];
             const bucket = byChip.get(chipId);
@@ -243,7 +266,7 @@ const NPEView = ({
     }, [links]);
 
     const transfersByChip = useMemo(() => {
-        const byChip = new Map<number, { transfer: NoCTransfer; index: number }[]>();
+        const byChip = new Map<number, ChipTransfer[]>();
         transfers.forEach((transfer, index) => {
             const chipIds = new Set<number>();
             if (transfer.src) {
@@ -366,8 +389,11 @@ const NPEView = ({
     };
 
     const onHandleZoneNavigation = (zone: NPEZone) => {
+        // `cycles_per_timestep` defaulting to 1 turns a raw cycle count into a
+        // timestep index, so a report missing it can seek far past the end. Clamp
+        // rather than trust the arithmetic. #1803
         const timestep = Math.floor(zone.start / (npeData.common_info.cycles_per_timestep ?? 1));
-        setSelectedTimestep(timestep);
+        setSelectedTimestep(clampTimestep(timestep, npeData.timestep_data.length));
     };
 
     const handleScrubberChange = (value: number) => {
@@ -412,7 +438,7 @@ const NPEView = ({
     const showAllTransfers = () => {
         setIsShowingAllTransfers(true);
         setSelectedNode(null);
-        const activeTransfers = npeData.timestep_data[selectedTimestep].active_transfers
+        const activeTransfers = (npeData.timestep_data[selectedTimestep]?.active_transfers ?? [])
             .map((transferId) => npeData.noc_transfers.find((tr) => tr.id === transferId))
             .filter((transfer): transfer is NoCTransfer => transfer !== undefined);
         setSelectedTransferList(activeTransfers as NoCTransfer[]);
@@ -700,7 +726,7 @@ const NPEView = ({
                                     dram={dram}
                                     eth={eth}
                                     pcie={pcie}
-                                    showActiveTransfers={handleClearSelection}
+                                    onEmptyCellClick={handleClearSelection}
                                     selectedZoneAddress={selectedZoneAddress}
                                     isAnnotatingCores={isAnnotatingCores}
                                     TENSIX_SIZE={TENSIX_SIZE}
@@ -747,7 +773,6 @@ const NPEView = ({
                                         nocFilter={nocFilter}
                                         fabricEventsFilter={fabricEventsFilter}
                                         dimmed={highlightedTransfer !== null || selectedTransferList.length !== 0}
-                                        zoom={zoom}
                                         onSelectLink={handleSelectLink}
                                         onClearSelection={handleClearSelection}
                                     />
@@ -858,11 +883,13 @@ const NPEView = ({
                 isOpen={isActiveTransferDetailsOpen}
                 groupedTransfersByNoCID={groupedTransfersByNoCID}
                 selectedNode={selectedNode}
-                congestionData={links?.link_demand.filter(
-                    (route) =>
-                        route[NPE_LINK.Y] === selectedNode?.coords[NPE_LINK.Y] &&
-                        route[NPE_LINK.X] === selectedNode?.coords[NPE_LINK.X],
-                )}
+                congestionData={
+                    links?.link_demand.filter(
+                        (route) =>
+                            route[NPE_LINK.Y] === selectedNode?.coords[NPE_LINK.Y] &&
+                            route[NPE_LINK.X] === selectedNode?.coords[NPE_LINK.X],
+                    ) ?? []
+                }
                 showActiveTransfers={showActiveTransfers}
                 highlightedTransfer={highlightedTransfer}
                 setHighlightedTransfer={setHighlightedTransfer}

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -67,6 +67,17 @@ interface NPEViewProps {
 
 const LABEL_STEP_THRESHOLD = 25;
 const RIGHT_MARGIN_OFFSET_PX = 25;
+// Shared fallbacks for chips with nothing to draw. A fresh `[]` per render would
+// give every idle chip a new prop identity on every scrub, re-running the
+// congestion canvas's draw effect across the whole cluster for no visual change —
+// the bulk of the cost of stepping between two empty timesteps. #1803.
+const NO_LINKS: { linkUtilization: LinkUtilization; index: number }[] = [];
+const NO_TRANSFERS: { transfer: NoCTransfer; index: number }[] = [];
+// Same hazard on the zone path: `npeData` is a new object per scrub, so a fresh `[]`
+// here would churn `zones` → `selectedZoneList` → the timeline's `zoneRanges`, whose
+// effect repaints 4 × n_timesteps heat cells. On a 196k-timestep report that is
+// ~780k fillRects per scrub — for a report that simply has no zones.
+const NO_ZONES: NPERootZone[] = [];
 const TENSIX_SIZE: number = NODE_SIZE; // * 0.75;
 const SVG_SIZE = TENSIX_SIZE;
 const PLAYBACK_SPEED = 1;
@@ -125,7 +136,7 @@ const NPEView = ({
     });
 
     const zones: NPERootZone[] = useMemo(() => {
-        return npeData.zones || [];
+        return npeData.zones || NO_ZONES;
     }, [npeData]);
 
     const isFabricTransfersFilteringEnabled = useMemo(() => {
@@ -704,15 +715,17 @@ const NPEView = ({
                                     }}
                                 >
                                     {hasVisibleTransferOrigins &&
-                                        (transfersByChip.get(clusterChip.id) ?? []).map(({ transfer, index }) => (
-                                            <RouteOriginsRenderer
-                                                key={`${transfer.id}-${index}`}
-                                                transfer={transfer}
-                                                clusterChip={clusterChip}
-                                                index={index}
-                                                getOriginOpacity={getOriginOpacity}
-                                            />
-                                        ))}
+                                        (transfersByChip.get(clusterChip.id) ?? NO_TRANSFERS).map(
+                                            ({ transfer, index }) => (
+                                                <RouteOriginsRenderer
+                                                    key={`${transfer.id}-${index}`}
+                                                    transfer={transfer}
+                                                    clusterChip={clusterChip}
+                                                    index={index}
+                                                    getOriginOpacity={getOriginOpacity}
+                                                />
+                                            ),
+                                        )}
                                     {highlightedTransfer !== null &&
                                         highlightedRoute !== null &&
                                         highlightedTransfer.route[highlightedRoute].device_id === clusterChip.id && (
@@ -726,7 +739,7 @@ const NPEView = ({
                                         )}
 
                                     <ChipCongestionCanvas
-                                        links={linkDemandByChip.get(clusterChip.id) ?? []}
+                                        links={linkDemandByChip.get(clusterChip.id) ?? NO_LINKS}
                                         gridWidth={width}
                                         gridHeight={height}
                                         isFabricMode={visualizationMode === VISUALIZATION_MODE.TRANSFERS}

--- a/src/components/npe/NPEZoneFilterComponent.tsx
+++ b/src/components/npe/NPEZoneFilterComponent.tsx
@@ -214,11 +214,18 @@ const NPEZoneFilterComponent = ({
                                 </div>
                             }
                             isOpen={false}
+                            // A large report can carry ~100k zones across these
+                            // collapsibles. `Collapsible` keeps children mounted by
+                            // default, so every one of them stayed in the DOM while
+                            // collapsed — ~218k nodes that React then re-diffed on
+                            // every NPEView render, costing ~1.4 s per scrub, click
+                            // or hover regardless of the data. Mount on expand. #1803
+                            keepChildrenMounted={false}
                             onExpandToggle={(state) => {
                                 onExpandStateChange(state, rootZone.proc, rootZone.core);
                             }}
                         >
-                            <div>{getZoneElements(rootZone.zones, rootZone.core, 1)}</div>
+                            {() => <div>{getZoneElements(rootZone.zones, rootZone.core, 1)}</div>}
                         </Collapsible>
                     );
                 })}

--- a/src/components/npe/NPEZoneFilterComponent.tsx
+++ b/src/components/npe/NPEZoneFilterComponent.tsx
@@ -199,36 +199,37 @@ const NPEZoneFilterComponent = ({
                 </ButtonGroup>
             </div>
             <div className='zones-container'>
-                {sortedFilteredZones.map((rootZone) => {
-                    return (
-                        <Collapsible
-                            collapseClassName='root-zone-collapsible'
-                            key={`${rootZone.proc}-${rootZone.core.join('-')}`}
-                            label={
-                                <div className='root-zone-label'>
-                                    <span
-                                        className='color-square'
-                                        style={{ backgroundColor: getKernelColor(rootZone.proc) }}
-                                    />
-                                    {rootZone.proc} {rootZone.core.join('-')}
-                                </div>
-                            }
-                            isOpen={false}
-                            // A large report can carry ~100k zones across these
-                            // collapsibles. `Collapsible` keeps children mounted by
-                            // default, so every one of them stayed in the DOM while
-                            // collapsed — ~218k nodes that React then re-diffed on
-                            // every NPEView render, costing ~1.4 s per scrub, click
-                            // or hover regardless of the data. Mount on expand. #1803
-                            keepChildrenMounted={false}
-                            onExpandToggle={(state) => {
-                                onExpandStateChange(state, rootZone.proc, rootZone.core);
-                            }}
-                        >
-                            {() => <div>{getZoneElements(rootZone.zones, rootZone.core, 1)}</div>}
-                        </Collapsible>
-                    );
-                })}
+                {/* The panel is hidden by CSS rather than unmounted, so without this
+                    gate a zone-heavy report still reconciled one `Collapsible` per
+                    root zone (~5k of them, each with two state hooks, a Button and a
+                    Collapse) on every NPEView render while shut. #1803 */}
+                {open &&
+                    sortedFilteredZones.map((rootZone) => {
+                        return (
+                            <Collapsible
+                                collapseClassName='root-zone-collapsible'
+                                key={`${rootZone.proc}-${rootZone.core.join('-')}`}
+                                label={
+                                    <div className='root-zone-label'>
+                                        <span
+                                            className='color-square'
+                                            style={{ backgroundColor: getKernelColor(rootZone.proc) }}
+                                        />
+                                        {rootZone.proc} {rootZone.core.join('-')}
+                                    </div>
+                                }
+                                isOpen={false}
+                                // A large report can carry ~100k zones across these
+                                // collapsibles, and mounting them all made every NPEView
+                                // render re-diff that whole hidden host tree. Build each
+                                // section's rows only while it is open. #1803
+                                renderContent={() => <div>{getZoneElements(rootZone.zones, rootZone.core, 1)}</div>}
+                                onExpandToggle={(state) => {
+                                    onExpandStateChange(state, rootZone.proc, rootZone.core);
+                                }}
+                            />
+                        );
+                    })}
             </div>
         </div>
     );

--- a/src/components/npe/TensixTransferRenderer.tsx
+++ b/src/components/npe/TensixTransferRenderer.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import React, { Fragment } from 'react';
-import { LinkPoints } from './drawingApi';
+import { LinkPoints, formatArrowPoints, formatRotation } from './drawingApi';
 import { NoCID } from '../../model/NPEModel';
 
 interface SVGTensixRendererProps {
@@ -69,18 +69,11 @@ const TensixTransferRenderer = ({ width, height, data, isMulticolor = false, sty
                                     ? { strokeDashoffset: multiplier * dashArray.get(line.nocId)![0] }
                                     : {})}
                             />
-                            {line.arrow && !isMulticolor && (
+                            {line.arrow && (
                                 <polygon
-                                    transform={line.transform}
-                                    points={`${line.arrow.p1} ${line.arrow.p2} ${line.arrow.p3}`}
-                                    fill={line.color || 'white'}
-                                />
-                            )}
-                            {line.arrow && isMulticolor && (
-                                <polygon
-                                    transform={line.transform}
-                                    points={`${line.arrow.p1} ${line.arrow.p2} ${line.arrow.p3}`}
-                                    fill='#999'
+                                    transform={formatRotation(line.rotation)}
+                                    points={formatArrowPoints(line.arrow)}
+                                    fill={isMulticolor ? '#999' : line.color || 'white'}
                                 />
                             )}
                         </Fragment>

--- a/src/components/npe/drawingApi.ts
+++ b/src/components/npe/drawingApi.ts
@@ -21,17 +21,65 @@ export const NOC_CONFIGURATION = {
     core: { x: CORE_CENTER.x, y: CORE_CENTER.y },
 };
 
+export interface Point {
+    x: number;
+    y: number;
+}
+
+// Geometry is numeric so both renderers can consume it directly: the SVG path
+// stringifies at the edge (`TensixTransferRenderer`), the canvas path uses the
+// numbers as-is. It used to be stored pre-formatted for SVG, which forced the
+// canvas to `split(',')` the points and regex-parse `rotate(a cx cy)` back into
+// numbers on every link of every repaint — a string contract between two modules
+// that no type or test could hold. #1803
 export interface LinkPoints {
     x1: number;
     y1: number;
     x2: number;
     y2: number;
-    arrow: { p1: string; p2: string; p3: string };
-    transform: string;
+    arrow: { p1: Point; p2: Point; p3: Point };
+    rotation: { angle: number; cx: number; cy: number } | null;
     color?: string;
     colors?: string[];
     nocId: NoCID;
 }
+
+// `points="x,y x,y x,y"` for an SVG <polygon>.
+export const formatArrowPoints = ({ p1, p2, p3 }: LinkPoints['arrow']): string =>
+    `${p1.x},${p1.y} ${p2.x},${p2.y} ${p3.x},${p3.y}`;
+
+// `transform="rotate(angle cx cy)"` for an SVG element, or undefined when the
+// link needs no rotation.
+export const formatRotation = (rotation: LinkPoints['rotation']): string | undefined =>
+    rotation ? `rotate(${rotation.angle} ${rotation.cx} ${rotation.cy})` : undefined;
+
+// Canvas twin of the SVG <line> + <polygon> pair `TensixTransferRenderer` emits.
+// Lives here so both renderers of the same geometry sit side by side. #1803
+export const drawLinkToCanvas = (ctx: CanvasRenderingContext2D, points: LinkPoints, color: string): void => {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(points.x1, points.y1);
+    ctx.lineTo(points.x2, points.y2);
+    ctx.stroke();
+
+    const { p1, p2, p3 } = points.arrow;
+    ctx.save();
+    if (points.rotation) {
+        const { angle, cx, cy } = points.rotation;
+        ctx.translate(cx, cy);
+        ctx.rotate((angle * Math.PI) / 180);
+        ctx.translate(-cx, -cy);
+    }
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.moveTo(p1.x, p1.y);
+    ctx.lineTo(p2.x, p2.y);
+    ctx.lineTo(p3.x, p3.y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+};
 
 const colorList: string[] = [
     '#FFFFFF',
@@ -84,11 +132,11 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
     let arrowHeadHeight = 9;
     let arrowHeadWidth = 9;
 
-    let transform = '';
+    let rotation: LinkPoints['rotation'] = null;
     let angle: number;
 
     let arrowOffset: number;
-    let arrow = { p1: '', p2: '', p3: '' };
+    let arrow = { p1: { x: 0, y: 0 }, p2: { x: 0, y: 0 }, p3: { x: 0, y: 0 } };
     // const arrowSecondary = { p1: '', p2: '', p3: '' };
 
     switch (nocId) {
@@ -100,9 +148,9 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             x2 = NOC_CENTER.x + NOC_1_X_OFFSET;
             y2 = 0;
             arrow = {
-                p1: `${x2 - arrowHeadWidth / 2},${y2 + arrowHeadHeight + arrowOffset}`,
-                p2: `${x2 + arrowHeadWidth / 2},${y2 + arrowHeadHeight + arrowOffset}`,
-                p3: `${x2},${y2 + arrowOffset}`,
+                p1: { x: x2 - arrowHeadWidth / 2, y: y2 + arrowHeadHeight + arrowOffset },
+                p2: { x: x2 + arrowHeadWidth / 2, y: y2 + arrowHeadHeight + arrowOffset },
+                p3: { x: x2, y: y2 + arrowOffset },
             };
             break;
 
@@ -115,9 +163,9 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y1 = NOC_CENTER.y + NOC_1_Y_OFFSET;
             y2 = NOC_CENTER.y + NOC_1_Y_OFFSET;
             arrow = {
-                p1: `${x2 + arrowHeadHeight + arrowOffset},${y2 - arrowHeadWidth / 2}`,
-                p2: `${x2 + arrowHeadHeight + arrowOffset},${y2 + arrowHeadWidth / 2}`,
-                p3: `${x2 + arrowOffset},${y2}`,
+                p1: { x: x2 + arrowHeadHeight + arrowOffset, y: y2 - arrowHeadWidth / 2 },
+                p2: { x: x2 + arrowHeadHeight + arrowOffset, y: y2 + arrowHeadWidth / 2 },
+                p3: { x: x2 + arrowOffset, y: y2 },
             };
 
             break;
@@ -130,9 +178,9 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y1 = NOC_CENTER.y + NOC_0_Y_OFFSET;
             y2 = NODE_SIZE;
             arrow = {
-                p1: `${x2 - arrowHeadWidth / 2},${y2 - arrowHeadHeight - arrowOffset}`,
-                p2: `${x2 + arrowHeadWidth / 2},${y2 - arrowHeadHeight - arrowOffset}`,
-                p3: `${x2},${y2 - arrowOffset}`,
+                p1: { x: x2 - arrowHeadWidth / 2, y: y2 - arrowHeadHeight - arrowOffset },
+                p2: { x: x2 + arrowHeadWidth / 2, y: y2 - arrowHeadHeight - arrowOffset },
+                p3: { x: x2, y: y2 - arrowOffset },
             };
 
             break;
@@ -145,9 +193,9 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y1 = NOC_CENTER.y + NOC_0_Y_OFFSET;
             y2 = NOC_CENTER.y + NOC_0_Y_OFFSET;
             arrow = {
-                p1: `${x2 - arrowHeadHeight - arrowOffset},${y2 - arrowHeadWidth / 2}`,
-                p2: `${x2 - arrowHeadHeight - arrowOffset},${y2 + arrowHeadWidth / 2}`,
-                p3: `${x2 - arrowOffset},${y2}`,
+                p1: { x: x2 - arrowHeadHeight - arrowOffset, y: y2 - arrowHeadWidth / 2 },
+                p2: { x: x2 - arrowHeadHeight - arrowOffset, y: y2 + arrowHeadWidth / 2 },
+                p3: { x: x2 - arrowOffset, y: y2 },
             };
             break;
         case NoCID.NOC0_OUT:
@@ -159,12 +207,12 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y1 = NOC_CENTER.y + NOC_0_Y_OFFSET - CORE_DISPERSION;
             y2 = CORE_CENTER.y + NOC_0_Y_OFFSET - CORE_DISPERSION;
             arrow = {
-                p1: `${x2 - arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p2: `${x2 + arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p3: `${x2},${y2 - arrowOffset}`,
+                p1: { x: x2 - arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p2: { x: x2 + arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p3: { x: x2, y: y2 - arrowOffset },
             };
             angle = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI + 90;
-            transform = `rotate(${angle} ${x2} ${y2})`;
+            rotation = { angle, cx: x2, cy: y2 };
 
             break;
         case NoCID.NOC0_IN:
@@ -176,12 +224,12 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y2 = NOC_CENTER.y + NOC_0_Y_OFFSET + CORE_DISPERSION;
             y1 = CORE_CENTER.y + NOC_0_Y_OFFSET + CORE_DISPERSION;
             arrow = {
-                p1: `${x2 - arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p2: `${x2 + arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p3: `${x2},${y2 - arrowOffset}`,
+                p1: { x: x2 - arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p2: { x: x2 + arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p3: { x: x2, y: y2 - arrowOffset },
             };
             angle = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI + 90;
-            transform = `rotate(${angle} ${x2} ${y2})`;
+            rotation = { angle, cx: x2, cy: y2 };
             break;
         case NoCID.NOC1_OUT:
             arrowHeadWidth = 7;
@@ -192,13 +240,13 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y1 = NOC_CENTER.y + NOC_1_Y_OFFSET - CORE_DISPERSION;
             y2 = CORE_CENTER.y + NOC_1_Y_OFFSET - CORE_DISPERSION;
             arrow = {
-                p1: `${x2 - arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p2: `${x2 + arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p3: `${x2},${y2 - arrowOffset}`,
+                p1: { x: x2 - arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p2: { x: x2 + arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p3: { x: x2, y: y2 - arrowOffset },
             };
             angle = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI + 90;
 
-            transform = `rotate(${angle} ${x2} ${y2})`;
+            rotation = { angle, cx: x2, cy: y2 };
 
             break;
         case NoCID.NOC1_IN:
@@ -210,20 +258,20 @@ export const getLinkPoints = (nocId: NoCID, color?: string): LinkPoints => {
             y2 = NOC_CENTER.y + NOC_1_Y_OFFSET + CORE_DISPERSION;
             y1 = CORE_CENTER.y + NOC_1_Y_OFFSET + CORE_DISPERSION;
             arrow = {
-                p1: `${x2 - arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p2: `${x2 + arrowHeadWidth / 2},${y2 + arrowHeadHeight - arrowOffset}`,
-                p3: `${x2},${y2 - arrowOffset}`,
+                p1: { x: x2 - arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p2: { x: x2 + arrowHeadWidth / 2, y: y2 + arrowHeadHeight - arrowOffset },
+                p3: { x: x2, y: y2 - arrowOffset },
             };
             angle = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI + 90;
 
-            transform = `rotate(${angle} ${x2} ${y2})`;
+            rotation = { angle, cx: x2, cy: y2 };
 
             break;
         default:
             // console.warn('Unknown link type', nocId);
             break;
     }
-    return { x2, y2, x1, y1, arrow, transform, color, nocId } as LinkPoints;
+    return { x2, y2, x1, y1, arrow, rotation, color, nocId } as LinkPoints;
 };
 export const calculateLinkCongestionColor = (value: number, min: number = 0, isHC: boolean = false): string => {
     if (value === -1) {

--- a/src/functions/reduceToColumns.ts
+++ b/src/functions/reduceToColumns.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Summarises a per-timestep series down to one value per drawn column for the NPE
+// timeline heat bar. Each column takes the MAX of the steps it covers so an
+// isolated congestion spike survives being summarised — a mean or a last-wins
+// reduction averages spikes into invisibility, which is the opposite of what a
+// congestion bar is for. Drawing one rect per timestep instead was both far slower
+// and lossy: at 196k steps the rects were ~0.008px wide, so every screen pixel was
+// written hundreds of times and only the blended result survived. #1803
+//
+// Pure and colour-free on purpose: the palette is applied per column by the
+// caller, so switching colour schemes doesn't rescan the whole series.
+export default function reduceToColumns(
+    values: readonly (number | undefined)[],
+    columnCount: number,
+): (number | undefined)[] {
+    const dataSize = values.length;
+    if (columnCount <= 0 || dataSize === 0) {
+        return [];
+    }
+
+    const columns: (number | undefined)[] = [];
+    for (let col = 0; col < columnCount; col++) {
+        const start = Math.floor((col * dataSize) / columnCount);
+        // Always cover at least one step so a column can't come out empty when
+        // columnCount and dataSize are close.
+        const end = Math.min(dataSize, Math.max(start + 1, Math.floor(((col + 1) * dataSize) / columnCount)));
+
+        let max: number | undefined;
+        for (let i = start; i < end; i++) {
+            const value = values[i];
+            if (value !== undefined && (max === undefined || value > max)) {
+                max = value;
+            }
+        }
+        columns.push(max);
+    }
+    return columns;
+}

--- a/src/scss/components/NPEComponent.scss
+++ b/src/scss/components/NPEComponent.scss
@@ -355,6 +355,20 @@
     z-index: variables.$z-index-2-interactive;
 }
 
+// Scrub playhead. A positioned div rather than a canvas layer so moving it is a
+// style update the compositor handles, not a full-width canvas clear + repaint on
+// every tick (#1803). `pointer-events: none` keeps the stack's click/hover
+// handling — which used to live on the playhead canvas — reaching the wrapper.
+.npe-timeline-playhead {
+    position: absolute;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    background-color: rgba($tt-white, 0.75);
+    pointer-events: none;
+    z-index: variables.$z-index-2-interactive;
+}
+
 .congestion-heatmap-tooltip {
     h3 {
         margin: 0;

--- a/src/scss/components/NPEComponent.scss
+++ b/src/scss/components/NPEComponent.scss
@@ -154,18 +154,33 @@
         // Above the src/dst origin markers (`.tensix` = $z-index-2-interactive)
         // so the link arrows paint over them, matching the old tile order.
         z-index: variables.$z-index-2-interactive;
+    }
 
-        // Hover feedback gets its own layer so following the pointer repaints one
-        // 1px rect instead of the chip's whole congestion layer. It must not
-        // swallow the events the base canvas below it is listening for.
-        &--hover {
-            pointer-events: none;
-        }
+    // Hover feedback for the canvas cells, replacing the `.tensix:hover` border the
+    // DOM tiles used to carry. A positioned element rather than a second canvas: it
+    // is one 1px border, so a full-grid backing store bought nothing. Moved with a
+    // transform (compositor-only) and must not swallow the base canvas's events.
+    .congestion-hover {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: none;
+        box-sizing: border-box;
+        border: 1px solid $tt-yellow-tint-2;
+        pointer-events: none;
+        z-index: variables.$z-index-2-interactive;
     }
 
     .tensix-grid {
         display: grid;
         gap: 1px;
+
+        // The congestion canvas and its hover marker are absolutely positioned
+        // against this grid, so it has to be their containing block — otherwise
+        // they resolve against `.chip` and only line up by coincidence.
+        &.congestion {
+            position: relative;
+        }
 
         &.empty {
             position: absolute;
@@ -355,10 +370,16 @@
     z-index: variables.$z-index-2-interactive;
 }
 
-// Scrub playhead. A positioned div rather than a canvas layer so moving it is a
-// style update the compositor handles, not a full-width canvas clear + repaint on
-// every tick (#1803). `pointer-events: none` keeps the stack's click/hover
-// handling — which used to live on the playhead canvas — reaching the wrapper.
+// The timeline's canvas layers and playhead are positioned against this box.
+.npe-timeline-canvas-stack {
+    position: relative;
+    width: 100%;
+}
+
+// Scrub playhead. A positioned div rather than a canvas layer, so moving it costs
+// one element's layout + paint instead of clearing and repainting a full-width
+// canvas on every tick (#1803). `pointer-events: none` so the stack wrapper keeps
+// receiving the click/hover the timeline needs.
 .npe-timeline-playhead {
     position: absolute;
     top: 0;

--- a/src/scss/components/NPEComponent.scss
+++ b/src/scss/components/NPEComponent.scss
@@ -145,6 +145,17 @@
         position: relative;
     }
 
+    .congestion-canvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+        cursor: pointer;
+
+        // Above the src/dst origin markers (`.tensix` = $z-index-2-interactive)
+        // so the link arrows paint over them, matching the old tile order.
+        z-index: variables.$z-index-2-interactive;
+    }
+
     .tensix-grid {
         display: grid;
         gap: 1px;

--- a/src/scss/components/NPEComponent.scss
+++ b/src/scss/components/NPEComponent.scss
@@ -154,6 +154,13 @@
         // Above the src/dst origin markers (`.tensix` = $z-index-2-interactive)
         // so the link arrows paint over them, matching the old tile order.
         z-index: variables.$z-index-2-interactive;
+
+        // Hover feedback gets its own layer so following the pointer repaints one
+        // 1px rect instead of the chip's whole congestion layer. It must not
+        // swallow the events the base canvas below it is listening for.
+        &--hover {
+            pointer-events: none;
+        }
     }
 
     .tensix-grid {

--- a/tests/ChipCongestionCanvas.spec.tsx
+++ b/tests/ChipCongestionCanvas.spec.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ChipCongestionCanvas from '../src/components/npe/ChipCongestionCanvas';
+import { EVENT_TYPE_FILTER, LinkUtilization, NoCType } from '../src/model/NPEModel';
+import { NODE_SIZE } from '../src/components/npe/drawingApi';
+
+// The per-chip congestion layer is a canvas, so clicks are resolved by hit-testing
+// rather than by DOM targets. #1803
+const GAP = 1;
+const CELL_STRIDE = NODE_SIZE + GAP;
+const GRID = 4;
+
+// [chip, y, x, nocId, demand, fabricScope]
+const makeLink = (y: number, x: number, nocId: string, demand = 0.5): LinkUtilization =>
+    [0, y, x, nocId, demand, undefined] as unknown as LinkUtilization;
+
+type SelectLink = (linkUtilization: LinkUtilization, index: number) => void;
+type ClearSelection = () => void;
+
+const renderCanvas = (
+    links: LinkUtilization[],
+    handlers: { onSelectLink: SelectLink; onClearSelection: ClearSelection },
+    nocFilter: NoCType | null = null,
+) => {
+    const result = render(
+        <ChipCongestionCanvas
+            links={links.map((linkUtilization, index) => ({ linkUtilization, index }))}
+            gridWidth={GRID}
+            gridHeight={GRID}
+            isFabricMode={false}
+            altCongestionColors={false}
+            nocFilter={nocFilter}
+            fabricEventsFilter={EVENT_TYPE_FILTER.ALL_EVENTS}
+            dimmed={false}
+            zoom={1}
+            onSelectLink={handlers.onSelectLink}
+            onClearSelection={handlers.onClearSelection}
+        />,
+    );
+    // The base canvas carries the pointer handlers; the hover overlay is inert.
+    const canvas = document.querySelector('.congestion-canvas') as HTMLCanvasElement;
+    const cssWidth = GRID * CELL_STRIDE - GAP;
+    const cssHeight = GRID * CELL_STRIDE - GAP;
+    // Hit-testing scales the pointer offset by the element's on-screen box, which
+    // jsdom reports as zero — stub it to the canvas's own CSS size.
+    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+        left: 0,
+        top: 0,
+        width: cssWidth,
+        height: cssHeight,
+        right: cssWidth,
+        bottom: cssHeight,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    } as DOMRect);
+    return { ...result, canvas };
+};
+
+// Centre of the given grid cell, in the canvas's CSS pixel space.
+const cellCentre = (x: number, y: number) => ({
+    clientX: x * CELL_STRIDE + NODE_SIZE / 2,
+    clientY: y * CELL_STRIDE + NODE_SIZE / 2,
+});
+
+let onSelectLink: Mock<SelectLink>;
+let onClearSelection: Mock<ClearSelection>;
+
+beforeEach(() => {
+    onSelectLink = vi.fn<SelectLink>();
+    onClearSelection = vi.fn<ClearSelection>();
+});
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+});
+
+describe('ChipCongestionCanvas hit-testing', () => {
+    it('selects the link occupying the clicked cell', () => {
+        const link = makeLink(2, 1, 'NOC0');
+        const { canvas } = renderCanvas([link], { onSelectLink, onClearSelection });
+
+        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(1, 2) }));
+
+        expect(onSelectLink).toHaveBeenCalledWith(link, 0);
+        expect(onClearSelection).not.toHaveBeenCalled();
+    });
+
+    it('clears the selection when a cell with no link is clicked', () => {
+        const { canvas } = renderCanvas([makeLink(2, 1, 'NOC0')], { onSelectLink, onClearSelection });
+
+        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(3, 3) }));
+
+        expect(onClearSelection).toHaveBeenCalled();
+        expect(onSelectLink).not.toHaveBeenCalled();
+    });
+
+    it('resolves the topmost link when several stack on one cell', () => {
+        // Last drawn wins, matching the old grid where the last-mounted tile caught
+        // the click.
+        const under = makeLink(0, 0, 'NOC0');
+        const over = makeLink(0, 0, 'NOC1');
+        const { canvas } = renderCanvas([under, over], { onSelectLink, onClearSelection });
+
+        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(0, 0) }));
+
+        expect(onSelectLink).toHaveBeenCalledWith(over, 1);
+    });
+
+    it('ignores a link filtered out by the active NOC filter', () => {
+        const { canvas } = renderCanvas([makeLink(1, 1, 'NOC0')], { onSelectLink, onClearSelection }, NoCType.NOC1);
+
+        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(1, 1) }));
+
+        expect(onSelectLink).not.toHaveBeenCalled();
+        expect(onClearSelection).toHaveBeenCalled();
+    });
+});
+
+describe('ChipCongestionCanvas backing store', () => {
+    it('does not resize the backing store when a redraw keeps the same geometry', () => {
+        // Assigning width/height reallocates and zeroes the buffer (~2.8 MB per chip
+        // at dpr 2) and forces a GPU re-upload, so a same-size redraw must not.
+        const { canvas, rerender } = renderCanvas([makeLink(1, 1, 'NOC0')], { onSelectLink, onClearSelection });
+        const widthSpy = vi.fn();
+        Object.defineProperty(canvas, 'width', {
+            get: () => GRID * CELL_STRIDE - GAP,
+            set: widthSpy,
+            configurable: true,
+        });
+
+        rerender(
+            <ChipCongestionCanvas
+                links={[{ linkUtilization: makeLink(1, 1, 'NOC0'), index: 0 }]}
+                gridWidth={GRID}
+                gridHeight={GRID}
+                isFabricMode={false}
+                altCongestionColors={false}
+                nocFilter={null}
+                fabricEventsFilter={EVENT_TYPE_FILTER.ALL_EVENTS}
+                dimmed
+                zoom={1}
+                onSelectLink={onSelectLink}
+                onClearSelection={onClearSelection}
+            />,
+        );
+
+        expect(widthSpy).not.toHaveBeenCalled();
+    });
+});

--- a/tests/ChipCongestionCanvas.spec.tsx
+++ b/tests/ChipCongestionCanvas.spec.tsx
@@ -2,73 +2,77 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ChipCongestionCanvas from '../src/components/npe/ChipCongestionCanvas';
-import { EVENT_TYPE_FILTER, LinkUtilization, NoCType } from '../src/model/NPEModel';
+import { EVENT_TYPE_FILTER, LinkUtilization, NoCID, NoCType } from '../src/model/NPEModel';
 import { NODE_SIZE } from '../src/components/npe/drawingApi';
 
-// The per-chip congestion layer is a canvas, so clicks are resolved by hit-testing
-// rather than by DOM targets. #1803
+// The per-chip congestion layer is a canvas, so clicks and hover are resolved by
+// hit-testing rather than by DOM targets. #1803
 const GAP = 1;
 const CELL_STRIDE = NODE_SIZE + GAP;
 const GRID = 4;
+const CSS_WIDTH = GRID * CELL_STRIDE - GAP;
+const CSS_HEIGHT = GRID * CELL_STRIDE - GAP;
 
+// Real NoCID values so the arrow geometry and rotation actually get exercised —
+// a bare 'NOC0' falls through `getLinkPoints`' default branch to all-zero points.
 // [chip, y, x, nocId, demand, fabricScope]
-const makeLink = (y: number, x: number, nocId: string, demand = 0.5): LinkUtilization =>
+const makeLink = (y: number, x: number, nocId: NoCID = NoCID.NOC0_EAST, demand = 50): LinkUtilization =>
     [0, y, x, nocId, demand, undefined] as unknown as LinkUtilization;
 
 type SelectLink = (linkUtilization: LinkUtilization, index: number) => void;
 type ClearSelection = () => void;
 
-const renderCanvas = (
-    links: LinkUtilization[],
-    handlers: { onSelectLink: SelectLink; onClearSelection: ClearSelection },
-    nocFilter: NoCType | null = null,
-) => {
-    const result = render(
-        <ChipCongestionCanvas
-            links={links.map((linkUtilization, index) => ({ linkUtilization, index }))}
-            gridWidth={GRID}
-            gridHeight={GRID}
-            isFabricMode={false}
-            altCongestionColors={false}
-            nocFilter={nocFilter}
-            fabricEventsFilter={EVENT_TYPE_FILTER.ALL_EVENTS}
-            dimmed={false}
-            zoom={1}
-            onSelectLink={handlers.onSelectLink}
-            onClearSelection={handlers.onClearSelection}
-        />,
-    );
-    // The base canvas carries the pointer handlers; the hover overlay is inert.
-    const canvas = document.querySelector('.congestion-canvas') as HTMLCanvasElement;
-    const cssWidth = GRID * CELL_STRIDE - GAP;
-    const cssHeight = GRID * CELL_STRIDE - GAP;
-    // Hit-testing scales the pointer offset by the element's on-screen box, which
-    // jsdom reports as zero — stub it to the canvas's own CSS size.
-    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+let onSelectLink: Mock<SelectLink>;
+let onClearSelection: Mock<ClearSelection>;
+
+// The component derives its raster scale by measuring itself, so the on-screen box
+// is what drives both the backing store and hit-testing. jsdom reports a zero-sized
+// rect, so stub the prototype before render.
+const stubOnScreenScale = (onScreenScale: number) => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
         left: 0,
         top: 0,
-        width: cssWidth,
-        height: cssHeight,
-        right: cssWidth,
-        bottom: cssHeight,
+        width: CSS_WIDTH * onScreenScale,
+        height: CSS_HEIGHT * onScreenScale,
+        right: CSS_WIDTH * onScreenScale,
+        bottom: CSS_HEIGHT * onScreenScale,
         x: 0,
         y: 0,
         toJSON: () => ({}),
     } as DOMRect);
-    return { ...result, canvas };
 };
 
-// Centre of the given grid cell, in the canvas's CSS pixel space.
-const cellCentre = (x: number, y: number) => ({
-    clientX: x * CELL_STRIDE + NODE_SIZE / 2,
-    clientY: y * CELL_STRIDE + NODE_SIZE / 2,
+const props = (links: LinkUtilization[], nocFilter: NoCType | null = null) => ({
+    links: links.map((linkUtilization, index) => ({ linkUtilization, index })),
+    gridWidth: GRID,
+    gridHeight: GRID,
+    isFabricMode: false,
+    altCongestionColors: false,
+    nocFilter,
+    fabricEventsFilter: EVENT_TYPE_FILTER.ALL_EVENTS,
+    dimmed: false,
+    onSelectLink,
+    onClearSelection,
 });
 
-let onSelectLink: Mock<SelectLink>;
-let onClearSelection: Mock<ClearSelection>;
+const renderCanvas = (links: LinkUtilization[], nocFilter: NoCType | null = null, onScreenScale = 1) => {
+    stubOnScreenScale(onScreenScale);
+    const result = render(<ChipCongestionCanvas {...props(links, nocFilter)} />);
+    return {
+        ...result,
+        canvas: document.querySelector('.congestion-canvas') as HTMLCanvasElement,
+        hover: document.querySelector('.congestion-hover') as HTMLDivElement,
+    };
+};
+
+// Centre of the given grid cell, in the canvas's on-screen pixel space.
+const cellCentre = (x: number, y: number, onScreenScale = 1) => ({
+    clientX: (x * CELL_STRIDE + NODE_SIZE / 2) * onScreenScale,
+    clientY: (y * CELL_STRIDE + NODE_SIZE / 2) * onScreenScale,
+});
 
 beforeEach(() => {
     onSelectLink = vi.fn<SelectLink>();
@@ -82,74 +86,132 @@ afterEach(() => {
 
 describe('ChipCongestionCanvas hit-testing', () => {
     it('selects the link occupying the clicked cell', () => {
-        const link = makeLink(2, 1, 'NOC0');
-        const { canvas } = renderCanvas([link], { onSelectLink, onClearSelection });
+        const link = makeLink(2, 1);
+        const { canvas } = renderCanvas([link]);
 
-        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(1, 2) }));
+        fireEvent.click(canvas, cellCentre(1, 2));
 
         expect(onSelectLink).toHaveBeenCalledWith(link, 0);
         expect(onClearSelection).not.toHaveBeenCalled();
     });
 
     it('clears the selection when a cell with no link is clicked', () => {
-        const { canvas } = renderCanvas([makeLink(2, 1, 'NOC0')], { onSelectLink, onClearSelection });
+        const { canvas } = renderCanvas([makeLink(2, 1)]);
 
-        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(3, 3) }));
+        fireEvent.click(canvas, cellCentre(3, 3));
 
         expect(onClearSelection).toHaveBeenCalled();
         expect(onSelectLink).not.toHaveBeenCalled();
     });
 
     it('resolves the topmost link when several stack on one cell', () => {
-        // Last drawn wins, matching the old grid where the last-mounted tile caught
-        // the click.
-        const under = makeLink(0, 0, 'NOC0');
-        const over = makeLink(0, 0, 'NOC1');
-        const { canvas } = renderCanvas([under, over], { onSelectLink, onClearSelection });
+        // Last painted wins, matching the old grid where the last-mounted tile
+        // caught the click.
+        const under = makeLink(0, 0, NoCID.NOC0_EAST);
+        const over = makeLink(0, 0, NoCID.NOC1_NORTH);
+        const { canvas } = renderCanvas([under, over]);
 
-        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(0, 0) }));
+        fireEvent.click(canvas, cellCentre(0, 0));
 
         expect(onSelectLink).toHaveBeenCalledWith(over, 1);
     });
 
     it('ignores a link filtered out by the active NOC filter', () => {
-        const { canvas } = renderCanvas([makeLink(1, 1, 'NOC0')], { onSelectLink, onClearSelection }, NoCType.NOC1);
+        const { canvas } = renderCanvas([makeLink(1, 1, NoCID.NOC0_EAST)], NoCType.NOC1);
 
-        canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, ...cellCentre(1, 1) }));
+        fireEvent.click(canvas, cellCentre(1, 1));
 
         expect(onSelectLink).not.toHaveBeenCalled();
         expect(onClearSelection).toHaveBeenCalled();
     });
+
+    it('maps the pointer back into tile space when the cluster is scaled', () => {
+        // The cluster is scaled with CSS zoom, so a click at cell (1,2) arrives at
+        // twice the coordinates. Getting this wrong selects the wrong link.
+        const link = makeLink(2, 1);
+        const { canvas } = renderCanvas([link], null, 2);
+
+        fireEvent.click(canvas, cellCentre(1, 2, 2));
+
+        expect(onSelectLink).toHaveBeenCalledWith(link, 0);
+    });
+});
+
+describe('ChipCongestionCanvas hover marker', () => {
+    it('is hidden until the pointer is over a cell carrying a link', () => {
+        const { canvas, hover } = renderCanvas([makeLink(1, 1)]);
+        expect(hover.style.display).toBe('none');
+
+        fireEvent.mouseMove(canvas, cellCentre(3, 3));
+        expect(hover.style.display).toBe('none');
+    });
+
+    it('moves to the hovered link cell', () => {
+        const { canvas, hover } = renderCanvas([makeLink(1, 2)]);
+
+        fireEvent.mouseMove(canvas, cellCentre(2, 1));
+
+        expect(hover.style.display).toBe('block');
+        expect(hover.style.transform).toBe(`translate(${2 * CELL_STRIDE}px, ${1 * CELL_STRIDE}px)`);
+    });
+
+    it('hides again when the pointer leaves the canvas', () => {
+        const { canvas, hover } = renderCanvas([makeLink(0, 0)]);
+        fireEvent.mouseMove(canvas, cellCentre(0, 0));
+        expect(hover.style.display).toBe('block');
+
+        fireEvent.mouseLeave(canvas);
+
+        expect(hover.style.display).toBe('none');
+    });
+
+    it('drops the marker when a scrub takes the link out from under a still pointer', () => {
+        const { canvas, hover, rerender } = renderCanvas([makeLink(0, 0)]);
+        fireEvent.mouseMove(canvas, cellCentre(0, 0));
+        expect(hover.style.display).toBe('block');
+
+        // Same pointer position, new timestep in which that cell has no link.
+        rerender(<ChipCongestionCanvas {...props([makeLink(3, 3)])} />);
+
+        expect(hover.style.display).toBe('none');
+    });
+
+    it('shows the marker when a scrub brings a link under a still pointer', () => {
+        const { canvas, hover, rerender } = renderCanvas([makeLink(3, 3)]);
+        fireEvent.mouseMove(canvas, cellCentre(0, 0));
+        expect(hover.style.display).toBe('none');
+
+        rerender(<ChipCongestionCanvas {...props([makeLink(0, 0)])} />);
+
+        expect(hover.style.display).toBe('block');
+    });
 });
 
 describe('ChipCongestionCanvas backing store', () => {
-    it('does not resize the backing store when a redraw keeps the same geometry', () => {
-        // Assigning width/height reallocates and zeroes the buffer (~2.8 MB per chip
-        // at dpr 2) and forces a GPU re-upload, so a same-size redraw must not.
-        const { canvas, rerender } = renderCanvas([makeLink(1, 1, 'NOC0')], { onSelectLink, onClearSelection });
-        const widthSpy = vi.fn();
-        Object.defineProperty(canvas, 'width', {
-            get: () => GRID * CELL_STRIDE - GAP,
-            set: widthSpy,
-            configurable: true,
-        });
+    it('rasterises at device-pixel resolution', () => {
+        Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+        const { canvas } = renderCanvas([makeLink(1, 1)]);
 
-        rerender(
-            <ChipCongestionCanvas
-                links={[{ linkUtilization: makeLink(1, 1, 'NOC0'), index: 0 }]}
-                gridWidth={GRID}
-                gridHeight={GRID}
-                isFabricMode={false}
-                altCongestionColors={false}
-                nocFilter={null}
-                fabricEventsFilter={EVENT_TYPE_FILTER.ALL_EVENTS}
-                dimmed
-                zoom={1}
-                onSelectLink={onSelectLink}
-                onClearSelection={onClearSelection}
-            />,
-        );
+        expect(canvas.width).toBe(CSS_WIDTH * 2);
+        expect(canvas.height).toBe(CSS_HEIGHT * 2);
+    });
 
-        expect(widthSpy).not.toHaveBeenCalled();
+    it('caps the scale so zooming cannot grow the buffer without bound', () => {
+        // dpr 2 × zoom 2 would ask for a 4× linear (16× area) buffer — hundreds of
+        // MB across an 8-chip cluster, past where the browser discards buffers and
+        // chips render blank. The cap also means zooming past it stops reallocating.
+        Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+        const { canvas } = renderCanvas([makeLink(1, 1)], null, 2);
+
+        expect(canvas.width).toBe(CSS_WIDTH * 2);
+        expect(canvas.height).toBe(CSS_HEIGHT * 2);
+    });
+
+    it('keeps the CSS box in pre-scale tile units', () => {
+        Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+        const { canvas } = renderCanvas([makeLink(1, 1)]);
+
+        expect(canvas.style.width).toBe(`${CSS_WIDTH}px`);
+        expect(canvas.style.height).toBe(`${CSS_HEIGHT}px`);
     });
 });

--- a/tests/CollapsibleLazyChildren.spec.tsx
+++ b/tests/CollapsibleLazyChildren.spec.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Collapsible from '../src/components/Collapsible';
+
+// Function children exist so a caller whose collapsed content is enormous (the NPE
+// zone filter can hold ~100k rows) never builds that element tree while shut. #1803
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('Collapsible function children', () => {
+    it('does not invoke the child builder while collapsed', () => {
+        const build = vi.fn(() => <div data-testid='content'>body</div>);
+
+        render(
+            <Collapsible
+                label='Section'
+                isOpen={false}
+                keepChildrenMounted={false}
+            >
+                {build}
+            </Collapsible>,
+        );
+
+        expect(build).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('content')).toBeNull();
+    });
+
+    it('still offers the expand toggle when collapsed children are lazy', () => {
+        // The toggle only renders when `children` is truthy — a function has to
+        // count, or a lazy section could never be opened.
+        render(
+            <Collapsible
+                label='Section'
+                isOpen={false}
+                keepChildrenMounted={false}
+            >
+                {() => <div data-testid='content'>body</div>}
+            </Collapsible>,
+        );
+
+        expect(screen.getByRole('button', { name: /Section/ })).toBeTruthy();
+    });
+
+    it('builds and mounts the children once expanded', () => {
+        const build = vi.fn(() => <div data-testid='content'>body</div>);
+
+        render(
+            <Collapsible
+                label='Section'
+                isOpen={false}
+                keepChildrenMounted={false}
+            >
+                {build}
+            </Collapsible>,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /Section/ }));
+
+        expect(build).toHaveBeenCalled();
+        expect(screen.getByTestId('content')).toBeTruthy();
+    });
+
+    it('renders plain element children unchanged', () => {
+        // Backwards compatibility: the other call sites pass elements, not builders.
+        render(
+            <Collapsible
+                label='Section'
+                isOpen
+            >
+                <div data-testid='content'>body</div>
+            </Collapsible>,
+        );
+
+        expect(screen.getByTestId('content')).toBeTruthy();
+    });
+});

--- a/tests/CollapsibleLazyChildren.spec.tsx
+++ b/tests/CollapsibleLazyChildren.spec.tsx
@@ -6,14 +6,14 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Collapsible from '../src/components/Collapsible';
 
-// Function children exist so a caller whose collapsed content is enormous (the NPE
+// `renderContent` exists so a caller whose collapsed content is enormous (the NPE
 // zone filter can hold ~100k rows) never builds that element tree while shut. #1803
 afterEach(() => {
     cleanup();
     vi.clearAllMocks();
 });
 
-describe('Collapsible function children', () => {
+describe('Collapsible lazy renderContent', () => {
     it('does not invoke the child builder while collapsed', () => {
         const build = vi.fn(() => <div data-testid='content'>body</div>);
 
@@ -21,10 +21,8 @@ describe('Collapsible function children', () => {
             <Collapsible
                 label='Section'
                 isOpen={false}
-                keepChildrenMounted={false}
-            >
-                {build}
-            </Collapsible>,
+                renderContent={build}
+            />,
         );
 
         expect(build).not.toHaveBeenCalled();
@@ -38,10 +36,8 @@ describe('Collapsible function children', () => {
             <Collapsible
                 label='Section'
                 isOpen={false}
-                keepChildrenMounted={false}
-            >
-                {() => <div data-testid='content'>body</div>}
-            </Collapsible>,
+                renderContent={() => <div data-testid='content'>body</div>}
+            />,
         );
 
         expect(screen.getByRole('button', { name: /Section/ })).toBeTruthy();
@@ -54,10 +50,8 @@ describe('Collapsible function children', () => {
             <Collapsible
                 label='Section'
                 isOpen={false}
-                keepChildrenMounted={false}
-            >
-                {build}
-            </Collapsible>,
+                renderContent={build}
+            />,
         );
         fireEvent.click(screen.getByRole('button', { name: /Section/ }));
 

--- a/tests/NPETimelineHeatmap.spec.tsx
+++ b/tests/NPETimelineHeatmap.spec.tsx
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import NPETimelineComponent from '../src/components/npe/NPETimelineComponent';
+import { TimestepData } from '../src/model/NPEModel';
+import { calculateLinkCongestionColor } from '../src/components/npe/drawingApi';
+
+// The heat bar summarises n_timesteps into one column per device pixel. Emitting a
+// rect per timestep instead meant ~0.008px rects at 196k steps: each screen pixel
+// was written hundreds of times and the blended result could hide a spike. #1803
+
+const HEATMAP_HEIGHT = 30;
+
+// Non-visited windowed steps carry only the per-step scalar, which is the path the
+// heat bar reduces over.
+const makeStep = (maxLinkDemand: number): TimestepData =>
+    ({
+        start_cycle: 0,
+        end_cycle: 1,
+        active_transfers: [],
+        link_demand: [],
+        max_link_demand: maxLinkDemand,
+        avg_link_demand: 0,
+        avg_link_util: 0,
+        mcast_write_link_util: 0,
+        noc: {},
+    }) as unknown as TimestepData;
+
+// Colours go through the canvas, which normalises them; push the expected value
+// through the same conversion so the comparison is apples to apples.
+const normalise = (color: string): string => {
+    const ctx = document.createElement('canvas').getContext('2d')!;
+    ctx.fillStyle = color;
+    return String(ctx.fillStyle);
+};
+
+let fills: { style: string; args: number[] }[];
+
+const renderTimeline = (steps: TimestepData[], canvasWidth: number) =>
+    render(
+        <NPETimelineComponent
+            timestepList={steps}
+            canvasWidth={canvasWidth}
+            useTimesteps
+            currentTimestep={0}
+            cyclesPerTimestep={1}
+            selectedZoneList={[]}
+            nocType={null}
+            navigationCallback={vi.fn()}
+        />,
+    );
+
+beforeEach(() => {
+    fills = [];
+    // Recorded as a named function so `this` is the calling context and the current
+    // `fillStyle` can be captured alongside the geometry.
+    vi.spyOn(CanvasRenderingContext2D.prototype, 'fillRect').mockImplementation(function recordFill(
+        this: CanvasRenderingContext2D,
+        ...args: number[]
+    ) {
+        fills.push({ style: String(this.fillStyle), args });
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+});
+
+describe('NPE timeline heat bar downsampling', () => {
+    it('reduces each column to the worst demand it covers so spikes survive', () => {
+        // Two columns over four steps. The spike is deliberately NOT the last step in
+        // its bucket: with a last-wins (or blended) reduction the column would take
+        // 0.05 and the spike would vanish, which is the bug this guards.
+        renderTimeline([makeStep(0.9), makeStep(0.05), makeStep(0.1), makeStep(0.1)], 2);
+
+        const firstColumn = fills[0];
+        expect(firstColumn.style).toBe(normalise(calculateLinkCongestionColor(0.9, 0, false)));
+        expect(firstColumn.style).not.toBe(normalise(calculateLinkCongestionColor(0.05, 0, false)));
+    });
+
+    it('keeps a spike that sits in the middle of a column’s range', () => {
+        // Six steps over two columns = three per column, so the spike is neither the
+        // first nor the last value in its bucket.
+        renderTimeline([makeStep(0.1), makeStep(0.8), makeStep(0.1), makeStep(0.1), makeStep(0.1), makeStep(0.1)], 2);
+
+        expect(fills[0].style).toBe(normalise(calculateLinkCongestionColor(0.8, 0, false)));
+    });
+
+    it('emits at most one rect per column per metric row, not one per timestep', () => {
+        const steps = Array.from({ length: 500 }, (_, i) => makeStep((i % 10) / 10));
+        renderTimeline(steps, 50);
+
+        // 4 metric rows × 50 columns is the ceiling; run-coalescing only lowers it.
+        expect(fills.length).toBeLessThanOrEqual(4 * 50);
+        expect(fills.length).toBeLessThan(steps.length);
+    });
+
+    it('coalesces neighbouring columns that resolve to the same colour', () => {
+        const steps = Array.from({ length: 200 }, () => makeStep(0.5));
+        renderTimeline(steps, 100);
+
+        // Every column is identical, so each of the 4 rows collapses to one rect.
+        expect(fills).toHaveLength(4);
+    });
+
+    it('spans the full canvas width across the drawn columns', () => {
+        const steps = Array.from({ length: 200 }, () => makeStep(0.5));
+        const canvasWidth = 100;
+        renderTimeline(steps, canvasWidth);
+
+        const row = fills[0];
+        expect(row.args[0]).toBe(0);
+        expect(row.args[2]).toBeCloseTo(canvasWidth, 5);
+    });
+
+    it('draws nothing for the heat rows when the report has no timesteps', () => {
+        renderTimeline([], 100);
+
+        expect(fills).toHaveLength(0);
+    });
+});
+
+describe('NPE timeline heat bar resolution', () => {
+    it('sizes the backing store to device pixels so the bar is not upscaled', () => {
+        const original = window.devicePixelRatio;
+        Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+
+        try {
+            renderTimeline(
+                Array.from({ length: 100 }, () => makeStep(0.5)),
+                100,
+            );
+            const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+            expect(canvas.width).toBe(200);
+            expect(canvas.height).toBe(HEATMAP_HEIGHT * 2);
+        } finally {
+            Object.defineProperty(window, 'devicePixelRatio', { value: original, configurable: true });
+        }
+    });
+
+    it('never uses more columns than there are timesteps', () => {
+        // A short report must not be stretched into more columns than it has data.
+        renderTimeline([makeStep(0.1), makeStep(0.9)], 400);
+
+        expect(fills.length).toBeLessThanOrEqual(4 * 2);
+    });
+});

--- a/tests/NPETimelineHeatmap.spec.tsx
+++ b/tests/NPETimelineHeatmap.spec.tsx
@@ -4,15 +4,13 @@
 
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import NPETimelineComponent from '../src/components/npe/NPETimelineComponent';
+import NPETimelineComponent, { HEATMAP_HEIGHT } from '../src/components/npe/NPETimelineComponent';
 import { TimestepData } from '../src/model/NPEModel';
 import { calculateLinkCongestionColor } from '../src/components/npe/drawingApi';
 
 // The heat bar summarises n_timesteps into one column per device pixel. Emitting a
 // rect per timestep instead meant ~0.008px rects at 196k steps: each screen pixel
 // was written hundreds of times and the blended result could hide a spike. #1803
-
-const HEATMAP_HEIGHT = 30;
 
 // Non-visited windowed steps carry only the per-step scalar, which is the path the
 // heat bar reduces over.
@@ -74,24 +72,24 @@ describe('NPE timeline heat bar downsampling', () => {
     it('reduces each column to the worst demand it covers so spikes survive', () => {
         // Two columns over four steps. The spike is deliberately NOT the last step in
         // its bucket: with a last-wins (or blended) reduction the column would take
-        // 0.05 and the spike would vanish, which is the bug this guards.
-        renderTimeline([makeStep(0.9), makeStep(0.05), makeStep(0.1), makeStep(0.1)], 2);
+        // the low value and the spike would vanish, which is the bug this guards.
+        renderTimeline([makeStep(90), makeStep(5), makeStep(10), makeStep(10)], 2);
 
         const firstColumn = fills[0];
-        expect(firstColumn.style).toBe(normalise(calculateLinkCongestionColor(0.9, 0, false)));
-        expect(firstColumn.style).not.toBe(normalise(calculateLinkCongestionColor(0.05, 0, false)));
+        expect(firstColumn.style).toBe(normalise(calculateLinkCongestionColor(90, 0, false)));
+        expect(firstColumn.style).not.toBe(normalise(calculateLinkCongestionColor(5, 0, false)));
     });
 
     it('keeps a spike that sits in the middle of a column’s range', () => {
         // Six steps over two columns = three per column, so the spike is neither the
         // first nor the last value in its bucket.
-        renderTimeline([makeStep(0.1), makeStep(0.8), makeStep(0.1), makeStep(0.1), makeStep(0.1), makeStep(0.1)], 2);
+        renderTimeline([makeStep(10), makeStep(80), makeStep(10), makeStep(10), makeStep(10), makeStep(10)], 2);
 
-        expect(fills[0].style).toBe(normalise(calculateLinkCongestionColor(0.8, 0, false)));
+        expect(fills[0].style).toBe(normalise(calculateLinkCongestionColor(80, 0, false)));
     });
 
     it('emits at most one rect per column per metric row, not one per timestep', () => {
-        const steps = Array.from({ length: 500 }, (_, i) => makeStep((i % 10) / 10));
+        const steps = Array.from({ length: 500 }, (_, i) => makeStep((i % 10) * 15));
         renderTimeline(steps, 50);
 
         // 4 metric rows × 50 columns is the ceiling; run-coalescing only lowers it.
@@ -100,7 +98,7 @@ describe('NPE timeline heat bar downsampling', () => {
     });
 
     it('coalesces neighbouring columns that resolve to the same colour', () => {
-        const steps = Array.from({ length: 200 }, () => makeStep(0.5));
+        const steps = Array.from({ length: 200 }, () => makeStep(50));
         renderTimeline(steps, 100);
 
         // Every column is identical, so each of the 4 rows collapses to one rect.
@@ -108,7 +106,7 @@ describe('NPE timeline heat bar downsampling', () => {
     });
 
     it('spans the full canvas width across the drawn columns', () => {
-        const steps = Array.from({ length: 200 }, () => makeStep(0.5));
+        const steps = Array.from({ length: 200 }, () => makeStep(50));
         const canvasWidth = 100;
         renderTimeline(steps, canvasWidth);
 
@@ -131,7 +129,7 @@ describe('NPE timeline heat bar resolution', () => {
 
         try {
             renderTimeline(
-                Array.from({ length: 100 }, () => makeStep(0.5)),
+                Array.from({ length: 100 }, () => makeStep(50)),
                 100,
             );
             const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -142,10 +140,10 @@ describe('NPE timeline heat bar resolution', () => {
         }
     });
 
-    it('never uses more columns than there are timesteps', () => {
-        // A short report must not be stretched into more columns than it has data.
-        renderTimeline([makeStep(0.1), makeStep(0.9)], 400);
-
-        expect(fills.length).toBeLessThanOrEqual(4 * 2);
-    });
+    // Note: the `columnCount` clamp to `dataSize` is deliberately NOT asserted here.
+    // Run-coalescing merges equal-coloured neighbours and colour boundaries always
+    // fall on step boundaries, so the drawn rects are identical whether or not the
+    // clamp is applied — it bounds the work done, not the output, and no rendering
+    // assertion can distinguish it. The reduction contract it relies on is covered
+    // directly in `reduceToColumns.spec.ts`.
 });

--- a/tests/NPEViewTransferOriginsGate.spec.tsx
+++ b/tests/NPEViewTransferOriginsGate.spec.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import NPEView from '../src/components/npe/NPEViewComponent';
+import { NPEData } from '../src/model/NPEModel';
+
+// `getOriginOpacity` returns 0 for every id-bearing transfer unless one is selected
+// or highlighted, so in the ordinary scrub state the whole base origins layer is
+// invisible. It used to be rendered anyway — thousands of `opacity: 0` divs rebuilt
+// per scrub. These tests pin the gate that skips it. #1803
+
+let originRenders = 0;
+
+vi.mock('../src/components/npe/RouteOriginsRenderer', () => ({
+    RouteOriginsRenderer: () => {
+        originRenders += 1;
+        return <div data-testid='route-origin' />;
+    },
+}));
+
+vi.mock('../src/components/npe/NPETimelineComponent', () => ({ default: () => <div data-testid='timeline' /> }));
+vi.mock('../src/components/npe/ChipCongestionCanvas', () => ({ default: () => null }));
+vi.mock('../src/components/npe/TensixTransferRenderer', () => ({ default: () => null }));
+vi.mock('../src/components/npe/ActiveTransferDetails', () => ({ default: () => null }));
+vi.mock('../src/components/npe/NPEMetadata', () => ({ default: () => null }));
+vi.mock('../src/components/npe/EmptyChipRenderer', () => ({ EmptyChipRenderer: () => null }));
+vi.mock('../src/components/npe/NPEZoneFilterComponent', () => ({ default: () => null }));
+vi.mock('../src/components/GlobalSwitch', () => ({ default: () => null }));
+vi.mock('../src/functions/createToastNotification', () => ({ default: vi.fn() }));
+vi.mock('../src/components/npe/useNPEHandlers', () => ({
+    useSelectedTransferGrouping: () => ({ transferListSelectionRendering: new Map(), groupedTransfersByNoCID: {} }),
+    useShowActiveTransfers: () => vi.fn(),
+}));
+vi.mock('../src/hooks/useAPI', () => ({
+    useNodeType: () => ({
+        architecture: { arch_name: 'wormhole_b0', grid: { x_size: 2, y_size: 2 } },
+        cores: [],
+        dram: [],
+        eth: [],
+        pcie: [],
+    }),
+}));
+
+// One chip with a transfer routed through it, active on the rendered timestep — so
+// the layer has something it *could* draw.
+const makeNpeData = (): NPEData =>
+    ({
+        common_info: { arch: 'wormhole_b0', version: '1.0.0', cycles_per_timestep: 1 },
+        chips: { '0': [0, 0, 0, 0] },
+        noc_transfers: [
+            {
+                id: 1,
+                src: [0, 0, 0],
+                dst: [[0, 1, 1]],
+                route: [{ device_id: 0, links: [[0, 0, 0, 'NOC0', 0.5, undefined]] }],
+            },
+        ],
+        timestep_data: [
+            {
+                start_cycle: 0,
+                end_cycle: 9,
+                active_transfers: [1],
+                link_demand: [[0, 0, 0, 'NOC0', 0.5, undefined]],
+            },
+        ],
+        zones: [],
+    }) as unknown as NPEData;
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    originRenders = 0;
+});
+
+describe('NPEView transfer origins gate', () => {
+    it('skips the base origins layer while nothing is selected or highlighted', () => {
+        render(<NPEView npeData={makeNpeData()} />);
+
+        expect(screen.queryAllByTestId('route-origin')).toHaveLength(0);
+        expect(originRenders).toBe(0);
+    });
+
+    it('still renders the rest of the view', () => {
+        // Guards against the gate being satisfied by the view failing to render.
+        render(<NPEView npeData={makeNpeData()} />);
+
+        expect(screen.getByTestId('timeline')).toBeTruthy();
+    });
+});

--- a/tests/NPEViewTransferOriginsGate.spec.tsx
+++ b/tests/NPEViewTransferOriginsGate.spec.tsx
@@ -2,10 +2,11 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import { act } from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import NPEView from '../src/components/npe/NPEViewComponent';
-import { NPEData } from '../src/model/NPEModel';
+import { LinkUtilization, NPEData } from '../src/model/NPEModel';
 
 // `getOriginOpacity` returns 0 for every id-bearing transfer unless one is selected
 // or highlighted, so in the ordinary scrub state the whole base origins layer is
@@ -13,6 +14,10 @@ import { NPEData } from '../src/model/NPEModel';
 // per scrub. These tests pin the gate that skips it. #1803
 
 let originRenders = 0;
+const emptyChipHandlers: (() => void)[] = [];
+// The link the fixture's transfer routes through, so selecting it matches a route.
+const ROUTED_LINK = [0, 0, 0, 'NOC0_EAST', 50, undefined] as unknown as LinkUtilization;
+let selectLink: (() => void) | undefined;
 
 vi.mock('../src/components/npe/RouteOriginsRenderer', () => ({
     RouteOriginsRenderer: () => {
@@ -22,17 +27,30 @@ vi.mock('../src/components/npe/RouteOriginsRenderer', () => ({
 }));
 
 vi.mock('../src/components/npe/NPETimelineComponent', () => ({ default: () => <div data-testid='timeline' /> }));
-vi.mock('../src/components/npe/ChipCongestionCanvas', () => ({ default: () => null }));
+vi.mock('../src/components/npe/ChipCongestionCanvas', () => ({
+    default: ({ onSelectLink }: { onSelectLink: (link: LinkUtilization, index: number) => void }) => {
+        selectLink = () => onSelectLink(ROUTED_LINK, 0);
+        return null;
+    },
+}));
 vi.mock('../src/components/npe/TensixTransferRenderer', () => ({ default: () => null }));
 vi.mock('../src/components/npe/ActiveTransferDetails', () => ({ default: () => null }));
 vi.mock('../src/components/npe/NPEMetadata', () => ({ default: () => null }));
-vi.mock('../src/components/npe/EmptyChipRenderer', () => ({ EmptyChipRenderer: () => null }));
+vi.mock('../src/components/npe/EmptyChipRenderer', () => ({
+    EmptyChipRenderer: (props: { onEmptyCellClick: () => void }) => {
+        emptyChipHandlers.push(props.onEmptyCellClick);
+        return null;
+    },
+}));
 vi.mock('../src/components/npe/NPEZoneFilterComponent', () => ({ default: () => null }));
 vi.mock('../src/components/GlobalSwitch', () => ({ default: () => null }));
 vi.mock('../src/functions/createToastNotification', () => ({ default: vi.fn() }));
-vi.mock('../src/components/npe/useNPEHandlers', () => ({
+// `useShowActiveTransfers` is deliberately NOT mocked away: it returns a new
+// callback on every scrub, and the whole point of the `showActiveTransfersRef`
+// indirection is to absorb that so the memoized children keep stable props.
+vi.mock('../src/components/npe/useNPEHandlers', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../src/components/npe/useNPEHandlers')>()),
     useSelectedTransferGrouping: () => ({ transferListSelectionRendering: new Map(), groupedTransfersByNoCID: {} }),
-    useShowActiveTransfers: () => vi.fn(),
 }));
 vi.mock('../src/hooks/useAPI', () => ({
     useNodeType: () => ({
@@ -55,7 +73,7 @@ const makeNpeData = (): NPEData =>
                 id: 1,
                 src: [0, 0, 0],
                 dst: [[0, 1, 1]],
-                route: [{ device_id: 0, links: [[0, 0, 0, 'NOC0', 0.5, undefined]] }],
+                route: [{ device_id: 0, links: [ROUTED_LINK] }],
             },
         ],
         timestep_data: [
@@ -63,7 +81,13 @@ const makeNpeData = (): NPEData =>
                 start_cycle: 0,
                 end_cycle: 9,
                 active_transfers: [1],
-                link_demand: [[0, 0, 0, 'NOC0', 0.5, undefined]],
+                link_demand: [ROUTED_LINK],
+            },
+            {
+                start_cycle: 10,
+                end_cycle: 19,
+                active_transfers: [1],
+                link_demand: [ROUTED_LINK],
             },
         ],
         zones: [],
@@ -73,6 +97,8 @@ afterEach(() => {
     cleanup();
     vi.clearAllMocks();
     originRenders = 0;
+    emptyChipHandlers.length = 0;
+    selectLink = undefined;
 });
 
 describe('NPEView transfer origins gate', () => {
@@ -88,5 +114,47 @@ describe('NPEView transfer origins gate', () => {
         render(<NPEView npeData={makeNpeData()} />);
 
         expect(screen.getByTestId('timeline')).toBeTruthy();
+    });
+
+    it('renders the origins layer once a transfer is selected', () => {
+        // The direction that actually matters: a gate that is too aggressive drops
+        // visible UI silently. Selecting a link is what makes the layer visible, and
+        // the canvas resolves that click through `onSelectLink`.
+        render(<NPEView npeData={makeNpeData()} />);
+        expect(originRenders).toBe(0);
+
+        act(() => selectLink?.());
+
+        expect(screen.queryAllByTestId('route-origin').length).toBeGreaterThan(0);
+    });
+});
+
+describe('NPEView memoized child stability', () => {
+    it('hands the chip backdrop the same handler across a scrub', () => {
+        // `useShowActiveTransfers` returns a fresh callback per scrub; the ref
+        // indirection exists so `memo(EmptyChipRenderer)` still holds. Passing the
+        // raw handler instead would silently un-memoize every backdrop — the exact
+        // regression #1803 fixes, and one no other assertion would catch.
+        const { rerender } = render(
+            <NPEView
+                npeData={makeNpeData()}
+                selectedTimestep={0}
+                onSelectedTimestepChange={vi.fn()}
+                reportKey='report'
+            />,
+        );
+        const first = emptyChipHandlers.at(-1);
+
+        rerender(
+            <NPEView
+                npeData={makeNpeData()}
+                selectedTimestep={1}
+                onSelectedTimestepChange={vi.fn()}
+                reportKey='report'
+            />,
+        );
+
+        expect(emptyChipHandlers.length).toBeGreaterThan(1);
+        expect(emptyChipHandlers.at(-1)).toBe(first);
     });
 });

--- a/tests/NPEZoneFilterCollapsedZones.spec.tsx
+++ b/tests/NPEZoneFilterCollapsedZones.spec.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import NPEZoneFilterComponent from '../src/components/npe/NPEZoneFilterComponent';
+import { KERNEL_PROCESS, NPEData, NPERootZone, NPEZone } from '../src/model/NPEModel';
+
+// Collapsed zone rows used to stay mounted: a large report held ~218k of them, and
+// React re-diffed that whole host tree on every NPEView render (~1.4 s per scrub,
+// click or hover). These tests pin the fix at the feature level. #1803
+
+const makeZone = (id: string, children: NPEZone[] = []): NPEZone => ({
+    id,
+    zones: children,
+    start: 0,
+    end: 10,
+    depth: 0,
+});
+
+const makeRootZone = (proc: KERNEL_PROCESS, core: [number, number, number], zoneCount: number): NPERootZone => ({
+    proc,
+    core,
+    zones: Array.from({ length: zoneCount }, (_, i) => makeZone(`${proc}-KERNEL[${i}]`)),
+});
+
+const makeNpeData = (zones: NPERootZone[]): NPEData =>
+    ({
+        common_info: { arch: 'wormhole_b0', version: '1.0.0', cycles_per_timestep: 1 },
+        chips: { '0': [0, 0, 0, 0] },
+        noc_transfers: [],
+        timestep_data: [],
+        zones,
+    }) as unknown as NPEData;
+
+const renderPanel = (zones: NPERootZone[]) =>
+    render(
+        <NPEZoneFilterComponent
+            npeData={makeNpeData(zones)}
+            open
+            onClose={vi.fn()}
+            onSelect={vi.fn()}
+            onExpand={vi.fn()}
+            onZoneClick={vi.fn()}
+        />,
+    );
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('NPE zone filter collapsed zones', () => {
+    it('mounts no zone rows while every root zone is collapsed', () => {
+        renderPanel([
+            makeRootZone(KERNEL_PROCESS.BRISC, [0, 2, 1], 25),
+            makeRootZone(KERNEL_PROCESS.NCRISC, [0, 2, 2], 25),
+        ]);
+
+        expect(document.querySelectorAll('.zone-interactive')).toHaveLength(0);
+    });
+
+    it('still lists every root zone so they remain expandable', () => {
+        renderPanel([
+            makeRootZone(KERNEL_PROCESS.BRISC, [0, 2, 1], 25),
+            makeRootZone(KERNEL_PROCESS.NCRISC, [0, 2, 2], 25),
+        ]);
+
+        expect(document.querySelectorAll('.root-zone-collapsible')).toHaveLength(2);
+        expect(screen.getByRole('button', { name: /BRISC 0-2-1/ })).toBeTruthy();
+    });
+
+    it('mounts only the expanded root zone’s rows when one is opened', () => {
+        renderPanel([
+            makeRootZone(KERNEL_PROCESS.BRISC, [0, 2, 1], 3),
+            makeRootZone(KERNEL_PROCESS.NCRISC, [0, 2, 2], 25),
+        ]);
+
+        fireEvent.click(screen.getByRole('button', { name: /BRISC 0-2-1/ }));
+
+        // Only the opened root zone contributes rows — the other stays unmounted.
+        expect(document.querySelectorAll('.zone-interactive')).toHaveLength(3);
+        expect(screen.getByText(/BRISC-KERNEL\[0\]/)).toBeTruthy();
+    });
+
+    it('does not mount rows for zones nested inside a collapsed root zone', () => {
+        const nested = makeZone('BRISC-KERNEL[0]', [makeZone('BRISC-INNER[0]')]);
+        renderPanel([{ proc: KERNEL_PROCESS.BRISC, core: [0, 2, 1], zones: [nested] }]);
+
+        expect(document.querySelectorAll('.zone-interactive')).toHaveLength(0);
+    });
+});

--- a/tests/reduceToColumns.spec.ts
+++ b/tests/reduceToColumns.spec.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import reduceToColumns from '../src/functions/reduceToColumns';
+
+describe('reduceToColumns', () => {
+    it('takes the max of each column’s range, wherever the peak sits', () => {
+        // Peak first, peak middle, peak last — a last-wins or first-wins reduction
+        // fails at least one of these.
+        expect(reduceToColumns([9, 1, 1, 1, 1, 1], 2)).toEqual([9, 1]);
+        expect(reduceToColumns([1, 9, 1, 1, 1, 1], 2)).toEqual([9, 1]);
+        expect(reduceToColumns([1, 1, 9, 1, 1, 1], 2)).toEqual([9, 1]);
+        expect(reduceToColumns([1, 1, 1, 1, 1, 9], 2)).toEqual([1, 9]);
+    });
+
+    it('partitions the series with no gap, overlap or dropped step', () => {
+        // Every input value must land in exactly one column, so summing the maxima
+        // of a strictly-increasing series per column is a full-coverage check.
+        const values = [0, 1, 2, 3, 4, 5, 6, 7];
+        expect(reduceToColumns(values, 4)).toEqual([1, 3, 5, 7]);
+        expect(reduceToColumns(values, 8)).toEqual(values);
+    });
+
+    it('emits one column per step when asked for more columns than steps', () => {
+        // Callers clamp columnCount to the data size; if one doesn't, no column may
+        // come out empty.
+        expect(reduceToColumns([5, 7], 5)).toEqual([5, 5, 5, 7, 7]);
+    });
+
+    it('ignores undefined values but keeps a column undefined when it has none', () => {
+        expect(reduceToColumns([undefined, 4, 2, undefined], 2)).toEqual([4, 2]);
+        expect(reduceToColumns([undefined, undefined, 3, 3], 2)).toEqual([undefined, 3]);
+    });
+
+    it('preserves negative sentinels rather than treating them as absent', () => {
+        // -1 means "no data" for max-link-demand and must reach the palette as -1.
+        expect(reduceToColumns([-1, -1, -1, 5], 2)).toEqual([-1, 5]);
+    });
+
+    it('returns nothing for an empty series or a non-positive column count', () => {
+        expect(reduceToColumns([], 10)).toEqual([]);
+        expect(reduceToColumns([1, 2], 0)).toEqual([]);
+        expect(reduceToColumns([1, 2], -1)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Scrubbing, clicking and hovering the NPE view were all sluggish on large reports, and the cost was **data-independent** — stepping between two idle timesteps was as slow as two busy ones. Profiling found the dominant cost was not the paint layer but React reconciling a hidden DOM tree: the zone-filter panel kept every collapsed zone row mounted, so a zone-bearing report carried ~218k nodes that were re-diffed on *every* render. This PR fixes that, plus the paint-layer costs originally identified in the ticket.

Closes #1803

<img width="1512" height="835" alt="image" src="https://github.com/user-attachments/assets/3598d2fc-9b61-48e1-8ad4-9e5c7dd82480" />

Measured in the app on a 196,146-timestep, 8-chip report (`UnknownOP_ID2.npeviz.zst`):

| | Before | After |
|---|---|---|
| Main-thread blocking per timeline click | 1543 ms + 1437 ms | **0 ms** |
| Document elements | 222,174 | **2,382** |

The backend was ruled out by measurement, not assumption — `read_window` is 0.1 ms idle / 0.6 ms busy, so per-seek fetch was never a factor.

### Frontend

- **`src/components/Collapsible.tsx`** — new `renderContent` prop that builds content only while the section is open, and `keepChildrenMounted` is derived from it so the wiring matches the documented semantics. This is the mechanism behind the fix below; the existing `children` callers are unaffected.
- **`src/components/npe/NPEZoneFilterComponent.tsx`** — build a root zone's rows only when it is expanded, and skip the list entirely while the panel is closed. Previously every nested zone was materialised eagerly and `Collapsible` kept collapsed children mounted, so ~109k rows (218k nodes) sat in the DOM behind a CSS-hidden panel. This is the dominant win, and it explains why filtering by zone used to make the app feel fast — filtering shrank that tree.
- **`src/components/npe/ChipCongestionCanvas.tsx`** (new) — draws a chip's whole congestion layer to one canvas instead of a `<button>` + SVG tile per link_demand row (hundreds per busy step), with cell hit-testing for click and a positioned hover marker. The backing-store scale is capped: it is inflated by `devicePixelRatio` × the cluster's on-screen scale, and uncapped an 8-chip cluster under the zoom slider wants hundreds of MB, at which point the browser discards buffers and chips render blank. The on-screen scale is measured from the element rather than passed down as the ancestor's zoom, so hit-testing and rasterisation share one source of truth.
- **`src/components/npe/NPETimelineComponent.tsx`** — the heat bar no longer repaints on scrub (`currentTimestep` is out of the draw effect's dependencies); the playhead is a positioned div. The bar is downsampled to one column per **device** pixel with a max-preserving reduction, so an isolated congestion spike still shows: emitting one rect per timestep meant ~0.008px rects at 196k steps, where each screen pixel was overwritten hundreds of times and the blended result could hide a spike. Colours are computed per drawn column instead of per timestep, removing ~780k palette calls per report.
- **`src/functions/reduceToColumns.ts`** (new) — the column reduction as a pure, colour-free helper, so changing colour scheme no longer rescans the series.
- **`src/components/npe/drawingApi.ts` / `TensixTransferRenderer.tsx`** — `LinkPoints` carries numeric geometry; the SVG renderer stringifies at the edge and a new `drawLinkToCanvas` sits beside it. The canvas path had been splitting `"x,y"` strings and regex-parsing `rotate(a cx cy)` per link per repaint to recover numbers it had one call earlier.
- **`src/components/npe/NPEViewComponent.tsx`** — per-chip bucketing of link demand and transfers (the render previously walked all rows once per chip); the base transfer-origins layer is skipped while nothing is selected or highlighted, since `getOriginOpacity` makes it fully transparent in that state; and every timestep seek is clamped. An out-of-range index threw during render and escaped to the router's root error page, replacing the whole app shell — reachable from zone navigation on a report missing `cycles_per_timestep`.
- **`src/components/npe/EmptyChipRenderer.tsx`** — memoized with an O(1) node-type lookup, keeping first-match-wins precedence across the arch location lists.

### Docs

- **`CONVENTIONS.md`** — new canvas/rendering-performance section recording the patterns this work established: downsample to device pixels with a max-preserving reduction, cap the raster scale, put high-frequency feedback on its own layer rather than through state, and treat prop stability as a contract once a component is `memo()`-wrapped.

## Known limitations (out of scope)

- `TensixTransferRenderer` is still unmemoized. Its two remaining consumers (the selected- and highlighted-transfer layers) are bounded by selection size rather than by link count, so they are not on the scrub path.
- The per-cell `:hover` border is now a single marker element rather than CSS on each tile, and the canvas has no keyboard path where the old tiles were focusable `<button>`s.
- The timeline's "worst" heat row saturates above 150% demand while real traces reach ~438%, so that row loses discrimination at the top end. Pre-existing, and independent of this change.

## Test plan

- [x] `pnpm vitest run` — 135 files / 1131 passed, 1 skipped
- [x] `tsc --noEmit`, `eslint`, `prettier`, `stylelint` clean
- [x] Manual: scrub across idle and busy regions of a 196k-timestep 8-chip report; click a congestion cell to open transfer details; hover to highlight; open the zones panel, expand a root zone and confirm its rows appear; scrub with a zone expanded
- [x] Manual: hover mapping verified correct under cluster zoom, including after a layout shift moves the canvas

## Follow-ups

- #1802 — NPE index disk quota / cleanup, sidecar compression, file-management UI
