### PR TITLE
Fix version check flagging updates when the local app is ahead

### DIFF
--- a/src/components/AppVersionStatus.tsx
+++ b/src/components/AppVersionStatus.tsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 import { Icon, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useMemo } from 'react';
-import { semverParse } from '../functions/semverParse';
+import { getVersionOutdatedLevel } from '../functions/getVersionOutdatedLevel';
+import { OutdatedLevel } from '../definitions/Versions';
 import { VERSION_ICON_SIZE } from '../definitions/UiConfig';
 import 'styles/components/AppVersionStatus.scss';
 
@@ -15,13 +16,6 @@ interface AppVersionStatusProps {
     latestAppVersion?: string;
     isServerMode?: boolean;
     latestVersionCheckFailed?: boolean;
-}
-
-enum OutdatedLevel {
-    NONE = 0,
-    ONE = 1,
-    TWO = 2,
-    THREE = 3,
 }
 
 const OUTDATED_CLASS_MAP: Record<OutdatedLevel, string> = {
@@ -110,38 +104,5 @@ function AppVersionStatus({
         </Tooltip>
     );
 }
-
-const getVersionOutdatedLevel = (appVersion: string, latestAppVersion: string): OutdatedLevel => {
-    if (!latestAppVersion || !appVersion) {
-        return OutdatedLevel.NONE;
-    }
-
-    const current = semverParse(appVersion);
-    const latest = semverParse(latestAppVersion);
-
-    if (!current || !latest) {
-        return OutdatedLevel.NONE;
-    }
-
-    const majorDiff = latest.major - current.major;
-    const minorDiff = latest.minor - current.minor;
-    const patchDiff = latest.patch - current.patch;
-
-    if (majorDiff > 0) {
-        return OutdatedLevel.THREE;
-    }
-
-    if (minorDiff === 1) {
-        return OutdatedLevel.ONE;
-    }
-    if (minorDiff === 2) {
-        return OutdatedLevel.TWO;
-    }
-    if (minorDiff > 2) {
-        return OutdatedLevel.THREE;
-    }
-
-    return patchDiff > 0 ? OutdatedLevel.ONE : OutdatedLevel.NONE;
-};
 
 export default AppVersionStatus;

--- a/src/components/AppVersionStatus.tsx
+++ b/src/components/AppVersionStatus.tsx
@@ -34,10 +34,7 @@ function AppVersionStatus({
     latestVersionCheckFailed,
 }: AppVersionStatusProps) {
     const versionOutdatedLevel: OutdatedLevel = useMemo(
-        () =>
-            isServerMode || !latestAppVersion
-                ? OutdatedLevel.NONE
-                : getVersionOutdatedLevel(appVersion, latestAppVersion),
+        () => (isServerMode ? OutdatedLevel.NONE : getVersionOutdatedLevel(appVersion, latestAppVersion)),
         [isServerMode, latestAppVersion, appVersion],
     );
     const isAppOutdated = versionOutdatedLevel > OutdatedLevel.NONE;

--- a/src/definitions/Versions.ts
+++ b/src/definitions/Versions.ts
@@ -10,3 +10,11 @@ export enum DBVersionValidation {
     DB_OLD,
     DB_NEW,
 }
+
+/** Severity of how far the running app trails the latest published release. Ordered, so `> NONE` means an update is available. */
+export enum OutdatedLevel {
+    NONE = 0,
+    ONE = 1,
+    TWO = 2,
+    THREE = 3,
+}

--- a/src/functions/getVersionOutdatedLevel.ts
+++ b/src/functions/getVersionOutdatedLevel.ts
@@ -5,37 +5,42 @@
 import { OutdatedLevel } from '../definitions/Versions';
 import { semverParse } from './semverParse';
 
-const MINOR_DIFF_LEVEL_ONE = 1;
-const MINOR_DIFF_LEVEL_TWO = 2;
-
 /**
  * Compares (major, minor, patch) as an ordered triple. PyPI's release feed lags a freshly tagged
  * release, so a local build ahead of the published one is routine and must report NONE.
+ *
+ * Prereleases compare equal to their release: a local 1.0.0-rc1 is not prompted towards 1.0.0,
+ * because prompting every dev build to "update" to the version it already contains is worse noise
+ * than the missed prompt.
  */
-export const getVersionOutdatedLevel = (appVersion: string, latestAppVersion: string): OutdatedLevel => {
+export const getVersionOutdatedLevel = (
+    appVersion: string | undefined,
+    latestAppVersion: string | undefined,
+): OutdatedLevel => {
     if (!appVersion || !latestAppVersion) {
         return OutdatedLevel.NONE;
     }
 
     const current = semverParse(appVersion);
     const latest = semverParse(latestAppVersion);
+    const majorDiff = latest.major - current.major;
 
-    if (latest.major !== current.major) {
-        return latest.major > current.major ? OutdatedLevel.THREE : OutdatedLevel.NONE;
+    if (majorDiff !== 0) {
+        return majorDiff > 0 ? OutdatedLevel.THREE : OutdatedLevel.NONE;
     }
 
-    if (latest.minor !== current.minor) {
-        if (latest.minor < current.minor) {
+    const minorDiff = latest.minor - current.minor;
+
+    if (minorDiff !== 0) {
+        if (minorDiff < 0) {
             return OutdatedLevel.NONE;
         }
 
-        const minorDiff = latest.minor - current.minor;
-
-        if (minorDiff === MINOR_DIFF_LEVEL_ONE) {
+        if (minorDiff === 1) {
             return OutdatedLevel.ONE;
         }
 
-        return minorDiff === MINOR_DIFF_LEVEL_TWO ? OutdatedLevel.TWO : OutdatedLevel.THREE;
+        return minorDiff === 2 ? OutdatedLevel.TWO : OutdatedLevel.THREE;
     }
 
     return latest.patch > current.patch ? OutdatedLevel.ONE : OutdatedLevel.NONE;

--- a/src/functions/getVersionOutdatedLevel.ts
+++ b/src/functions/getVersionOutdatedLevel.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { OutdatedLevel } from '../definitions/Versions';
+import { semverParse } from './semverParse';
+
+const MINOR_DIFF_LEVEL_ONE = 1;
+const MINOR_DIFF_LEVEL_TWO = 2;
+
+/**
+ * Compares (major, minor, patch) as an ordered triple. PyPI's release feed lags a freshly tagged
+ * release, so a local build ahead of the published one is routine and must report NONE.
+ */
+export const getVersionOutdatedLevel = (appVersion: string, latestAppVersion: string): OutdatedLevel => {
+    if (!appVersion || !latestAppVersion) {
+        return OutdatedLevel.NONE;
+    }
+
+    const current = semverParse(appVersion);
+    const latest = semverParse(latestAppVersion);
+
+    if (latest.major !== current.major) {
+        return latest.major > current.major ? OutdatedLevel.THREE : OutdatedLevel.NONE;
+    }
+
+    if (latest.minor !== current.minor) {
+        if (latest.minor < current.minor) {
+            return OutdatedLevel.NONE;
+        }
+
+        const minorDiff = latest.minor - current.minor;
+
+        if (minorDiff === MINOR_DIFF_LEVEL_ONE) {
+            return OutdatedLevel.ONE;
+        }
+
+        return minorDiff === MINOR_DIFF_LEVEL_TWO ? OutdatedLevel.TWO : OutdatedLevel.THREE;
+    }
+
+    return latest.patch > current.patch ? OutdatedLevel.ONE : OutdatedLevel.NONE;
+};

--- a/src/functions/getVersionOutdatedLevel.ts
+++ b/src/functions/getVersionOutdatedLevel.ts
@@ -9,9 +9,13 @@ import { semverParse } from './semverParse';
  * Compares (major, minor, patch) as an ordered triple. PyPI's release feed lags a freshly tagged
  * release, so a local build ahead of the published one is routine and must report NONE.
  *
- * Prereleases compare equal to their release: a local 1.0.0-rc1 is not prompted towards 1.0.0,
- * because prompting every dev build to "update" to the version it already contains is worse noise
- * than the missed prompt.
+ * Hyphenated prereleases compare equal to their release: a local 1.0.0-rc1 is not prompted towards
+ * 1.0.0, because prompting every dev build to "update" to the version it already contains is worse
+ * noise than the missed prompt. Only the local side can carry a prerelease — the published version
+ * is regex-constrained to \d+\.\d+\.\d+ in views.get_latest_version — which is where suppressing
+ * the prompt is the right policy. Non-hyphenated PEP 440 spellings (1.0.0rc1, 1.0.0.dev0) miss
+ * semverParse's regex and degrade to 0.0.0, so they would invert this; unreachable while the local
+ * version comes from package.json via import.meta.env.APP_VERSION.
  */
 export const getVersionOutdatedLevel = (
     appVersion: string | undefined,

--- a/tests/AppVersionStatus.spec.tsx
+++ b/tests/AppVersionStatus.spec.tsx
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AppVersionStatus from '../src/components/AppVersionStatus';
+
+vi.mock('@blueprintjs/core', async () => {
+    const original = await vi.importActual<typeof import('@blueprintjs/core')>('@blueprintjs/core');
+    return {
+        ...original,
+        Tooltip: ({ children, content }: { children: React.ReactNode; content: React.ReactNode }) => (
+            <div data-testid='tooltip-host'>
+                <div data-testid='tooltip-content'>{content}</div>
+                {children}
+            </div>
+        ),
+    };
+});
+
+const CURRENT_VERSION = '0.96.0';
+
+afterEach(cleanup);
+
+describe('AppVersionStatus', () => {
+    it('does not offer an update when the published version matches', () => {
+        render(
+            <AppVersionStatus
+                appVersion={CURRENT_VERSION}
+                latestAppVersion={CURRENT_VERSION}
+            />,
+        );
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        expect(screen.getByText(`v${CURRENT_VERSION}`)).toBeInTheDocument();
+        expect(screen.getByTestId('tooltip-content')).toHaveTextContent('TT-NN Visualizer is up to date');
+    });
+
+    it.each([
+        ['0.96.0', '0.95.1'],
+        ['1.0.0', '0.99.5'],
+    ])('does not offer an update when local %s is ahead of published %s', (appVersion, latestAppVersion) => {
+        render(
+            <AppVersionStatus
+                appVersion={appVersion}
+                latestAppVersion={latestAppVersion}
+            />,
+        );
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('links to the published release on PyPI when an update is available', () => {
+        render(
+            <AppVersionStatus
+                appVersion={CURRENT_VERSION}
+                latestAppVersion='0.97.0'
+            />,
+        );
+
+        const link = screen.getByRole('link');
+
+        expect(link).toHaveAttribute('href', 'https://pypi.org/project/ttnn-visualizer/0.97.0');
+        expect(link).toHaveClass('is-outdated-one');
+        expect(screen.getByTestId('tooltip-content')).toHaveTextContent('App update available: v0.97.0');
+    });
+
+    it('escalates the outdated level for a major version gap', () => {
+        render(
+            <AppVersionStatus
+                appVersion={CURRENT_VERSION}
+                latestAppVersion='1.0.0'
+            />,
+        );
+
+        expect(screen.getByRole('link')).toHaveClass('is-outdated-three');
+    });
+
+    it('does not offer an update when the published version is unknown', () => {
+        render(<AppVersionStatus appVersion={CURRENT_VERSION} />);
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('shows the version alone in server mode', () => {
+        render(
+            <AppVersionStatus
+                appVersion={CURRENT_VERSION}
+                latestAppVersion='1.0.0'
+                isServerMode
+            />,
+        );
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('tooltip-host')).not.toBeInTheDocument();
+        expect(screen.getByText(`v${CURRENT_VERSION}`)).toBeInTheDocument();
+    });
+
+    it('reports an unsuccessful version check without offering an update', () => {
+        render(
+            <AppVersionStatus
+                appVersion={CURRENT_VERSION}
+                latestVersionCheckFailed
+            />,
+        );
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Could not check for the latest version');
+    });
+});

--- a/tests/getVersionOutdatedLevel.spec.ts
+++ b/tests/getVersionOutdatedLevel.spec.ts
@@ -15,7 +15,7 @@ describe('getVersionOutdatedLevel', () => {
         ['0.96.0', '0.99.0', OutdatedLevel.THREE],
         ['0.96.0', '1.0.0', OutdatedLevel.THREE],
         ['0.96.5', '0.97.0', OutdatedLevel.ONE],
-    ])('reports level %#: local %s against published %s', (current, latest, expected) => {
+    ])('local %s against published %s reports level %i', (current, latest, expected) => {
         expect(getVersionOutdatedLevel(current, latest)).toBe(expected);
     });
 
@@ -30,15 +30,22 @@ describe('getVersionOutdatedLevel', () => {
     });
 
     test.each([
-        ['', '0.96.0'],
-        ['0.96.0', ''],
-        ['', ''],
-    ])('reports NONE when a version is missing (%s, %s)', (current, latest) => {
+        ['missing local version', undefined, '0.96.0'],
+        ['missing published version', '0.96.0', undefined],
+        ['empty local version', '', '0.96.0'],
+        ['empty published version', '0.96.0', ''],
+        ['both versions missing', undefined, undefined],
+    ])('reports NONE with a %s', (_case, current, latest) => {
         expect(getVersionOutdatedLevel(current, latest)).toBe(OutdatedLevel.NONE);
     });
 
     test('treats omitted minor and patch components as zero', () => {
         expect(getVersionOutdatedLevel('1', '1.0.0')).toBe(OutdatedLevel.NONE);
         expect(getVersionOutdatedLevel('1.0', '1.0.1')).toBe(OutdatedLevel.ONE);
+    });
+
+    test('ignores prerelease identifiers, so a local rc reports as its release', () => {
+        expect(getVersionOutdatedLevel('1.0.0-rc1', '1.0.0')).toBe(OutdatedLevel.NONE);
+        expect(getVersionOutdatedLevel('1.0.0-rc1', '1.0.1')).toBe(OutdatedLevel.ONE);
     });
 });

--- a/tests/getVersionOutdatedLevel.spec.ts
+++ b/tests/getVersionOutdatedLevel.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, test } from 'vitest';
+import { getVersionOutdatedLevel } from '../src/functions/getVersionOutdatedLevel';
+import { OutdatedLevel } from '../src/definitions/Versions';
+
+describe('getVersionOutdatedLevel', () => {
+    test.each([
+        ['0.96.0', '0.96.0', OutdatedLevel.NONE],
+        ['0.96.0', '0.96.1', OutdatedLevel.ONE],
+        ['0.96.0', '0.97.0', OutdatedLevel.ONE],
+        ['0.96.0', '0.98.0', OutdatedLevel.TWO],
+        ['0.96.0', '0.99.0', OutdatedLevel.THREE],
+        ['0.96.0', '1.0.0', OutdatedLevel.THREE],
+        ['0.96.5', '0.97.0', OutdatedLevel.ONE],
+    ])('reports level %#: local %s against published %s', (current, latest, expected) => {
+        expect(getVersionOutdatedLevel(current, latest)).toBe(expected);
+    });
+
+    test.each([
+        ['0.96.0', '0.95.1'],
+        ['0.96.1', '0.96.0'],
+        ['1.0.0', '0.99.5'],
+        ['2.5.0', '1.6.0'],
+        ['0.97.0', '0.96.5'],
+    ])('reports NONE for local %s ahead of published %s', (current, latest) => {
+        expect(getVersionOutdatedLevel(current, latest)).toBe(OutdatedLevel.NONE);
+    });
+
+    test.each([
+        ['', '0.96.0'],
+        ['0.96.0', ''],
+        ['', ''],
+    ])('reports NONE when a version is missing (%s, %s)', (current, latest) => {
+        expect(getVersionOutdatedLevel(current, latest)).toBe(OutdatedLevel.NONE);
+    });
+
+    test('treats omitted minor and patch components as zero', () => {
+        expect(getVersionOutdatedLevel('1', '1.0.0')).toBe(OutdatedLevel.NONE);
+        expect(getVersionOutdatedLevel('1.0', '1.0.1')).toBe(OutdatedLevel.ONE);
+    });
+});

--- a/tests/semverParse.spec.ts
+++ b/tests/semverParse.spec.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, test } from 'vitest';
+import { semverParse } from '../src/functions/semverParse';
+
+const VERSION_0 = { major: 0, minor: 0, patch: 0 };
+
+describe('semverParse', () => {
+    test.each([
+        ['undefined', undefined],
+        ['an empty string', ''],
+        ['unparseable input', 'garbage'],
+        ['a v-prefixed tag', 'v1.2.3'],
+        ['a PEP 440 dev release', '1.0.0.dev0'],
+        ['a PEP 440 prerelease', '1.0.0rc1'],
+        ['a PEP 440 post release', '1.0.0.post1'],
+    ])('falls back to 0.0.0 for %s', (_case, version) => {
+        expect(semverParse(version)).toEqual(VERSION_0);
+    });
+
+    test('never returns nullish, so callers may read components unguarded', () => {
+        // getVersionOutdatedLevel and useAPI's schema_version check both dereference the result
+        // without a null check; loosening the return type to SemVer | null would break them silently.
+        expect(semverParse('garbage')).not.toBeNull();
+        expect(semverParse(undefined)).not.toBeUndefined();
+    });
+
+    test('parses a full version', () => {
+        expect(semverParse('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+    });
+
+    test('defaults omitted minor and patch components to zero', () => {
+        expect(semverParse('1')).toEqual({ major: 1, minor: 0, patch: 0 });
+        expect(semverParse('1.2')).toEqual({ major: 1, minor: 2, patch: 0 });
+    });
+
+    test('captures a hyphenated prerelease identifier', () => {
+        expect(semverParse('1.2.3-rc1')).toEqual({ major: 1, minor: 2, patch: 3, prerelease: 'rc1' });
+    });
+
+    test('omits the prerelease key when there is no prerelease', () => {
+        expect(semverParse('1.2.3')).not.toHaveProperty('prerelease');
+    });
+});


### PR DESCRIPTION
## Summary

`getVersionOutdatedLevel` compared major, minor and patch as three independent deltas, so a lower-precedence component could fire even when a higher-precedence one already proved the local build was newer than the published release. Running `v0.96.0` against a published `v0.95.1` fell through to `patchDiff > 0` and reported "App update available". Because PyPI's release feed legitimately lags a fresh tag, "local is ahead of published" is a routine state rather than an edge case.

- Compare `(major, minor, patch)` as an ordered triple, returning `NONE` unless the published version sorts strictly after the local one, and only then deriving the severity level.
- Extract the comparison into the pure `src/functions/getVersionOutdatedLevel.ts`, with the `OutdatedLevel` enum moved to the existing `src/definitions/Versions.ts` alongside `DBVersionValidation`. The enum stays numeric because its ordering is load-bearing (`> OutdatedLevel.NONE`) and it keys `OUTDATED_CLASS_MAP`.
- Drop the dead `if (!current || !latest)` guard: `semverParse` always returns a `SemVer`, falling back to `0.0.0`.

No other version comparison in the frontend shares the bug — `evaluateDbVersion`, `validateNpeData` and the `schema_version` check all compare `major` only.

Prerelease ordering is deliberately unchanged: `semverParse` captures `prerelease` but the comparison ignores it, so a local `0.97.0-dev` against a published `0.97.0` still reports up to date. Flagging every dev build seems worse than the status quo, but happy to revisit.

## Test plan

- [x] New `tests/getVersionOutdatedLevel.spec.ts` covers the table from the issue, including every local-ahead row (`0.96.0`/`0.95.1`, `1.0.0`/`0.99.5`, `2.5.0`/`1.6.0`, `0.96.1`/`0.96.0`), the level one/two/three ladder, missing versions, and omitted minor/patch components.
- [x] `pnpm test` — 139 files, 1192 tests passing.
- [x] `pnpm lint`, `pnpm lint:ts`, `pnpm lint:spdx`, Prettier check on touched files.
- [ ] `/styleguide` still shows up to date plus levels one to three (samples are `0.80.0`/`0.79.0`/`0.78.0`/`0.77.0` against `0.80.0`, all local-behind-or-equal, so unaffected by the fix).

Fixes #1818
