### PR TITLE
Memory tag style and formatting

### DIFF
--- a/src/components/MemoryTag.tsx
+++ b/src/components/MemoryTag.tsx
@@ -13,9 +13,12 @@ const MemoryTag = ({ memory }: MemoryTagProps) => {
     if (memory === undefined) {
         return null;
     }
-    const memoryLabel = stripEnum(memory).replace(' ', '-');
-    const memoryType = memoryLabel?.toLowerCase();
 
-    return <Tag className={`memory-tag tag-${memoryType}`}>{memoryLabel}</Tag>;
+    const memoryLabel = stripEnum(memory);
+    const memoryType = memoryLabel?.toLowerCase();
+    const memoryClass = `memory-tag tag-${memoryType.replace(/ /g, '-')}`;
+
+    return <Tag className={memoryClass}>{memoryLabel}</Tag>;
 };
+
 export default MemoryTag;

--- a/src/components/MemoryTag.tsx
+++ b/src/components/MemoryTag.tsx
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { Tag } from '@blueprintjs/core';
-import { stripEnum } from '../functions/formatting';
 
 interface MemoryTagProps {
+    /** A display label from `BufferTypeLabel` / `StringBufferTypeLabel`, not a raw enum key. */
     memory: string | undefined;
 }
 
@@ -14,11 +14,9 @@ const MemoryTag = ({ memory }: MemoryTagProps) => {
         return null;
     }
 
-    const memoryLabel = stripEnum(memory);
-    const memoryType = memoryLabel?.toLowerCase();
-    const memoryClass = `memory-tag tag-${memoryType.replace(/ /g, '-')}`;
+    const memoryClass = `memory-tag tag-${memory.toLowerCase().replaceAll(' ', '-')}`;
 
-    return <Tag className={memoryClass}>{memoryLabel}</Tag>;
+    return <Tag className={memoryClass}>{memory}</Tag>;
 };
 
 export default MemoryTag;

--- a/src/components/OperationGraphComponent.tsx
+++ b/src/components/OperationGraphComponent.tsx
@@ -21,7 +21,7 @@ import { extractOperationSourceData } from '../functions/stackTraceSource';
 import { StackTraceLanguage } from '../definitions/StackTrace';
 import MemoryConfigRow from './MemoryConfigRow';
 import { ShardSpec } from '../model/MemoryConfig';
-import { BufferType } from '../model/BufferType';
+import { BufferTypeLabel } from '../model/BufferType';
 import { formatDuration, toReadableShape, toReadableType } from '../functions/formatting';
 import SearchField from './SearchField';
 import MemoryTag from './MemoryTag';
@@ -939,7 +939,7 @@ const TensorDetailsComponent = ({ tensor }: OperationGraphTensorDetailsProps) =>
     return (
         <div className='tensor-details'>
             <h3 className='tensor-header'>
-                <span>{tensor.buffer_type !== null && <MemoryTag memory={BufferType[tensor.buffer_type]} />}</span>{' '}
+                <span>{tensor.buffer_type !== null && <MemoryTag memory={BufferTypeLabel[tensor.buffer_type]} />}</span>{' '}
                 {toReadableShape(tensor.shape)} Tensor {tensor.id}{' '}
             </h3>
 

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -34,7 +34,7 @@ import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../../definitions/L1Memory
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import MemoryTag from '../MemoryTag';
 import { toReadableLayout, toReadableShape, toReadableType } from '../../functions/formatting';
-import { BufferTypeToStringBufferType, StringBufferType } from '../../model/BufferType';
+import { BufferTypeToStringBufferType, StringBufferType, StringBufferTypeLabel } from '../../model/BufferType';
 import {
     DEVICE_OPERATION_ANALYSIS_RESULT_LABEL,
     DeviceOperationAnalysisResult,
@@ -101,7 +101,7 @@ const renderBufferDetails = ({ bufferOrTensorNode, optionalOutput, details }: Bu
             <span> {formatMemorySize(size, 2)}</span>
             <span>{dtype && `${toReadableType(dtype)}`}</span>
             <span>
-                <MemoryTag memory={type} />
+                <MemoryTag memory={StringBufferTypeLabel[type]} />
             </span>
             {layout && <span className='layout'>{layout}</span>}
 

--- a/src/model/BufferType.ts
+++ b/src/model/BufferType.ts
@@ -13,14 +13,6 @@ export enum BufferType {
     TRACE,
 }
 
-export const BufferTypeLabel: Record<BufferType, string> = {
-    [BufferType.DRAM]: 'DRAM',
-    [BufferType.L1]: 'L1',
-    [BufferType.SYSTEM_MEMORY]: 'System Memory',
-    [BufferType.L1_SMALL]: 'L1 Small',
-    [BufferType.TRACE]: 'Trace',
-};
-
 export enum StringBufferType {
     DRAM = 'DRAM',
     L1 = 'L1',
@@ -29,6 +21,18 @@ export enum StringBufferType {
     TRACE = 'TRACE',
 }
 
+export const BufferTypeToStringBufferType: Record<BufferType, StringBufferType> = {
+    [BufferType.DRAM]: StringBufferType.DRAM,
+    [BufferType.L1]: StringBufferType.L1,
+    [BufferType.SYSTEM_MEMORY]: StringBufferType.SYSTEM_MEMORY,
+    [BufferType.L1_SMALL]: StringBufferType.L1_SMALL,
+    [BufferType.TRACE]: StringBufferType.TRACE,
+};
+
+/**
+ * The only place display labels are spelled out. `MemoryTag` slugs these into its
+ * `tag-*` class, so renaming one requires a matching rule in `_common.scss`.
+ */
 export const StringBufferTypeLabel: Record<StringBufferType, string> = {
     [StringBufferType.DRAM]: 'DRAM',
     [StringBufferType.L1]: 'L1',
@@ -37,10 +41,10 @@ export const StringBufferTypeLabel: Record<StringBufferType, string> = {
     [StringBufferType.TRACE]: 'Trace',
 };
 
-export const BufferTypeToStringBufferType: Record<BufferType, StringBufferType> = {
-    [BufferType.DRAM]: StringBufferType.DRAM,
-    [BufferType.L1]: StringBufferType.L1,
-    [BufferType.SYSTEM_MEMORY]: StringBufferType.SYSTEM_MEMORY,
-    [BufferType.L1_SMALL]: StringBufferType.L1_SMALL,
-    [BufferType.TRACE]: StringBufferType.TRACE,
+export const BufferTypeLabel: Record<BufferType, string> = {
+    [BufferType.DRAM]: StringBufferTypeLabel[StringBufferType.DRAM],
+    [BufferType.L1]: StringBufferTypeLabel[StringBufferType.L1],
+    [BufferType.SYSTEM_MEMORY]: StringBufferTypeLabel[StringBufferType.SYSTEM_MEMORY],
+    [BufferType.L1_SMALL]: StringBufferTypeLabel[StringBufferType.L1_SMALL],
+    [BufferType.TRACE]: StringBufferTypeLabel[StringBufferType.TRACE],
 };

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -744,6 +744,8 @@ export default function Styleguide() {
                 <MemoryTag memory={BufferTypeLabel[BufferType.DRAM]} />
                 <MemoryTag memory={BufferTypeLabel[BufferType.L1]} />
                 <MemoryTag memory={BufferTypeLabel[BufferType.L1_SMALL]} />
+                <MemoryTag memory={BufferTypeLabel[BufferType.SYSTEM_MEMORY]} />
+                <MemoryTag memory={BufferTypeLabel[BufferType.TRACE]} />
             </div>
 
             <h3>Progress bar</h3>

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -32,6 +32,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import GlobalSwitch from '../components/GlobalSwitch';
 import useClearSelectedBuffer from '../hooks/useClearSelectedBuffer';
 import MemoryTag from '../components/MemoryTag';
+import { BufferType, BufferTypeLabel } from '../model/BufferType';
 import { fileTransferProgressAtom } from '../store/app';
 import { FileProgress, FileStatus } from '../model/APIData';
 import NPEProcessingStatus from '../components/NPEProcessingStatus';
@@ -740,9 +741,9 @@ export default function Styleguide() {
                     Danger
                 </Tag>
 
-                <MemoryTag memory='DRAM' />
-                <MemoryTag memory='L1' />
-                <MemoryTag memory='L1 Small' />
+                <MemoryTag memory={BufferTypeLabel[BufferType.DRAM]} />
+                <MemoryTag memory={BufferTypeLabel[BufferType.L1]} />
+                <MemoryTag memory={BufferTypeLabel[BufferType.L1_SMALL]} />
             </div>
 
             <h3>Progress bar</h3>

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -740,9 +740,9 @@ export default function Styleguide() {
                     Danger
                 </Tag>
 
-                <MemoryTag memory='L1' />
-
                 <MemoryTag memory='DRAM' />
+                <MemoryTag memory='L1' />
+                <MemoryTag memory='L1 Small' />
             </div>
 
             <h3>Progress bar</h3>

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -185,6 +185,9 @@ $row-background: $tt-grey-2;
 
 .bp6-tag {
     &.memory-tag {
+        // Blueprint tags default to white text, which is unreadable on the light fills
+        // below, so dark text is the default here and only the dark DRAM fill opts out.
+        color: $tt-grey-2;
         background-color: $tt-grey-6;
 
         &.tag-l1 {
@@ -192,11 +195,11 @@ $row-background: $tt-grey-2;
         }
 
         &.tag-dram {
+            color: $tt-white;
             background-color: $tt-teal-shade;
         }
 
         &.tag-l1-small {
-            color: $tt-grey-2;
             background-color: $tt-yellow-tint-1;
         }
     }

--- a/tests/MemoryTag.spec.tsx
+++ b/tests/MemoryTag.spec.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import MemoryTag from '../src/components/MemoryTag';
+import { BufferType, BufferTypeLabel, StringBufferType, StringBufferTypeLabel } from '../src/model/BufferType';
+
+// Blueprint wraps the label in an inner span, so the node `getByText` returns is a
+// child of the element carrying the classes.
+function getTagFor(label: string) {
+    return screen.getByText(label).closest('.memory-tag');
+}
+
+afterEach(cleanup);
+
+describe('MemoryTag', () => {
+    it.each([
+        [BufferType.DRAM, 'DRAM', 'tag-dram'],
+        [BufferType.L1, 'L1', 'tag-l1'],
+        [BufferType.SYSTEM_MEMORY, 'System Memory', 'tag-system-memory'],
+        [BufferType.L1_SMALL, 'L1 Small', 'tag-l1-small'],
+        [BufferType.TRACE, 'Trace', 'tag-trace'],
+    ])('renders %s as "%s" with class %s', (bufferType, expectedLabel, expectedClass) => {
+        render(<MemoryTag memory={BufferTypeLabel[bufferType]} />);
+
+        expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+        expect(getTagFor(expectedLabel)).toHaveClass('memory-tag', expectedClass);
+    });
+
+    it('derives the same class from the string-keyed label map', () => {
+        render(<MemoryTag memory={StringBufferTypeLabel[StringBufferType.L1_SMALL]} />);
+
+        expect(getTagFor('L1 Small')).toHaveClass('tag-l1-small');
+    });
+
+    it('keeps spaces in the label while hyphenating only the class (#1824)', () => {
+        render(<MemoryTag memory='L1 Small' />);
+
+        expect(screen.getByText('L1 Small')).toBeInTheDocument();
+        expect(screen.queryByText('L1-Small')).not.toBeInTheDocument();
+    });
+
+    it('slugs a multi-word label into one class rather than several', () => {
+        render(<MemoryTag memory='L1 Small' />);
+
+        // Dropping the replacement leaves `tag-l1 small`, which the DOM reads as two
+        // classes — `tag-l1` would then apply the wrong colour.
+        expect(getTagFor('L1 Small')).toHaveClass('tag-l1-small');
+        expect(getTagFor('L1 Small')).not.toHaveClass('tag-l1');
+        expect(getTagFor('L1 Small')).not.toHaveClass('small');
+    });
+
+    it('renders the label verbatim without stripping enum-style prefixes', () => {
+        render(<MemoryTag memory='BufferType::L1' />);
+
+        expect(screen.getByText('BufferType::L1')).toBeInTheDocument();
+        expect(screen.queryByText('L1')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when no memory type is supplied', () => {
+        const { container } = render(<MemoryTag memory={undefined} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});


### PR DESCRIPTION
Fixes the copy for the L1 Small memory tag: `MemoryTag` no longer hyphenates the display label, so it reads `L1 Small` rather than `L1-Small`, while still producing the `tag-l1-small` class the styles already target.

Also corrects two call sites that passed a raw enum *key* instead of a display label, so they rendered `L1_SMALL` with a `tag-l1_small` class that matched no style rule:

- `OperationGraphComponent.tsx` now passes `BufferTypeLabel[tensor.buffer_type]`
- `DeviceOperationsFullRender.tsx` now passes `StringBufferTypeLabel[type]`

<img width="729" height="104" alt="Screenshot 2026-08-04 at 11 07 38" src="https://github.com/user-attachments/assets/1b0892b6-94b3-4645-b80e-bedd1376664a" />
