### PR TITLE
Render Cluster without a baked SoC descriptor

### DIFF
--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -127,6 +127,18 @@ interface EthPort {
     chan: EthChannel;
 }
 
+// Endpoint uids are built once, when connections are recorded, and carried to the segment
+// pass. Rebuilding them there instead would let the two constructions drift, which renders
+// no links at all rather than failing loudly. #1772
+interface ResolvedLink {
+    a: RenderChip;
+    b: RenderChip;
+    uidA: string;
+    uidB: string;
+    interHost: boolean;
+    index: number;
+}
+
 // Cheap deterministic non-negative hash for distributing ports across a small
 // candidate edge list. Quality only needs to be uniform over 2-3 buckets. #1510
 const hashLinkKey = (key: string): number => {
@@ -270,21 +282,27 @@ function buildClusterRenderModel(
         canonicalLinkKeyByUid.set(uidB, key);
     };
 
-    for (const link of intraHostLinks) {
+    const resolvedLinks: ResolvedLink[] = [];
+
+    intraHostLinks.forEach((link, index) => {
         const a = chipsByKey.get(chipKey(link.rank, link.a.chip));
         const b = chipsByKey.get(chipKey(link.rank, link.b.chip));
         if (a && b) {
-            rememberLinkKey(...recordConnection(a, link.a.chan, b, link.b.chan));
+            const [uidA, uidB] = recordConnection(a, link.a.chan, b, link.b.chan);
+            rememberLinkKey(uidA, uidB);
+            resolvedLinks.push({ a, b, uidA, uidB, interHost: false, index });
         }
-    }
+    });
 
-    for (const link of interHostLinks) {
+    interHostLinks.forEach((link, index) => {
         const a = chipsByKey.get(chipKey(link.a.rank, link.a.chip));
         const b = chipsByKey.get(chipKey(link.b.rank, link.b.chip));
         if (a && b) {
-            rememberLinkKey(...recordConnection(a, link.a.chan, b, link.b.chan));
+            const [uidA, uidB] = recordConnection(a, link.a.chan, b, link.b.chan);
+            rememberLinkKey(uidA, uidB);
+            resolvedLinks.push({ a, b, uidA, uidB, interHost: true, index });
         }
-    }
+    });
 
     // Ascending to match the previous arch-list order, which was channel order; dedup
     // guards a channel appearing on two links.
@@ -529,19 +547,20 @@ function buildClusterRenderModel(
     const pushSegment = (
         a: RenderChip,
         b: RenderChip,
-        uidA: string | undefined,
-        uidB: string | undefined,
+        uidA: string,
+        uidB: string,
         interHost: boolean,
         prefix: string,
         index: number,
     ) => {
-        const portA = uidA ? portPixelByUid.get(uidA) : undefined;
-        const portB = uidB ? portPixelByUid.get(uidB) : undefined;
+        const portA = portPixelByUid.get(uidA);
+        const portB = portPixelByUid.get(uidB);
+        // A uid can exist without a placed port when its chord direction is degenerate.
         if (!portA || !portB) {
             return;
         }
         // Inter-host always curves; intra-host curves only when long-haul.
-        const longHaul = !interHost && (longHaulUids.has(uidA ?? '') || longHaulUids.has(uidB ?? ''));
+        const longHaul = !interHost && (longHaulUids.has(uidA) || longHaulUids.has(uidB));
         const useCurve = interHost || longHaul;
         linkSegments.push({
             key: `${prefix}__${uidA}__${uidB}__${index}`,
@@ -556,36 +575,8 @@ function buildClusterRenderModel(
         });
     };
 
-    intraHostLinks.forEach((link, index) => {
-        const a = chipsByKey.get(chipKey(link.rank, link.a.chip));
-        const b = chipsByKey.get(chipKey(link.rank, link.b.chip));
-        if (a && b) {
-            pushSegment(
-                a,
-                b,
-                ethUid(a.rank, a.id, link.a.chan),
-                ethUid(b.rank, b.id, link.b.chan),
-                false,
-                'intra',
-                index,
-            );
-        }
-    });
-
-    interHostLinks.forEach((link, index) => {
-        const a = chipsByKey.get(chipKey(link.a.rank, link.a.chip));
-        const b = chipsByKey.get(chipKey(link.b.rank, link.b.chip));
-        if (a && b) {
-            pushSegment(
-                a,
-                b,
-                ethUid(a.rank, a.id, link.a.chan),
-                ethUid(b.rank, b.id, link.b.chan),
-                true,
-                'inter',
-                index,
-            );
-        }
+    resolvedLinks.forEach(({ a, b, uidA, uidB, interHost, index }) => {
+        pushSegment(a, b, uidA, uidB, interHost, interHost ? 'inter' : 'intra', index);
     });
 
     const neighboursByChip = new Map<string, Set<string>>();

--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -23,6 +23,7 @@ import {
     ClusterCoordinates,
     ClusterTopology,
     DEFAULT_ARCHITECTURE,
+    EthChannel,
 } from '../../model/ClusterModel';
 import {
     CHIP_GAP,
@@ -95,7 +96,7 @@ interface ClusterRenderModel {
     totalRows: number;
     contentWidth: number;
     contentHeight: number;
-    ethPositionsByChip: Map<string, Map<CLUSTER_ETH_POSITION, string[]>>;
+    ethPositionsByChip: Map<string, Map<CLUSTER_ETH_POSITION, EthPort[]>>;
     linkSegments: LinkSegment[];
     idFontSize: number;
     isMultiHost: boolean;
@@ -112,7 +113,20 @@ interface ClusterRenderModel {
 type ClusterRenderResult = { status: 'ready'; model: ClusterRenderModel } | { status: 'unsupported' };
 
 const chipKey = (rank: number, id: number) => `${rank}-${id}`;
-const ethUid = (rank: number, chipId: number, coreId: string) => `${rank}-${chipId}-${coreId}`;
+// Keyed by channel, not arch core-id, so links resolve from the cluster descriptor alone. #1772
+const ethUid = (rank: number, chipId: number, chan: EthChannel) => `${rank}-${chipId}-ch${chan}`;
+
+// `chipDesign.eth` is channel-indexed; undefined when no descriptor is baked for the arch.
+const ethCoordLabel = (chip: ClusterChip, chan: EthChannel): string | undefined => {
+    const coreId = chip.design?.eth?.[chan];
+    return coreId === undefined ? undefined : `${chip.rank ?? 0}-${chip.id}-${coreId}`;
+};
+
+// Channel travels with the uid so the render needn't parse it back out for the label.
+interface EthPort {
+    uid: string;
+    chan: EthChannel;
+}
 
 // Cheap deterministic non-negative hash for distributing ports across a small
 // candidate edge list. Quality only needs to be uniform over 2-3 buckets. #1510
@@ -156,14 +170,14 @@ function buildClusterRenderModel(
     chipDesign: ChipDesign,
     requestedLayoutMode: ClusterLayoutMode = 'mesh',
 ): ClusterRenderResult {
-    if (!chipDesign?.eth) {
-        return { status: 'unsupported' };
-    }
-
+    // A missing cluster descriptor is unrenderable; a missing *arch* one only costs the
+    // optional enrichment, since placement and links come from the cluster descriptor. #1772
     const { hosts, isMultiHost, worldSize, intraHostLinks, interHostLinks } = topology;
     if (hosts.length === 0) {
         return { status: 'unsupported' };
     }
+
+    const hasArchDescriptor = Boolean(chipDesign?.eth?.length);
 
     // Step 1: place every chip on a global virtual grid. `mesh` honours the
     // report's mesh coords (1D or 2D); `condensed` tiles each host into a
@@ -216,9 +230,9 @@ function buildClusterRenderModel(
                 chipUniqueId: host.descriptor.chip_unique_ids?.[chipId],
                 coords: [x, y, 0, 0] satisfies ClusterCoordinates,
                 mmio: mmioChipIds.has(chipId),
-                eth: chipDesign.eth.map((coreId) => ethUid(host.rank, chipId, coreId)),
+                ethChannels: [],
                 connectedChipsByEthId: new Map(),
-                design: chipDesign,
+                design: hasArchDescriptor ? chipDesign : undefined,
             });
         }
 
@@ -233,26 +247,21 @@ function buildClusterRenderModel(
     // Step 2: wire intra-host and inter-host eth connections into each chip's
     // `connectedChipsByEthId` map so the port-positioning step below can compute
     // edges relative to neighbours.
-    const recordConnection = (
-        chipA: RenderChip,
-        chipB: RenderChip,
-        uidA: string | undefined,
-        uidB: string | undefined,
-    ) => {
-        if (uidA === undefined || uidB === undefined) {
-            return;
-        }
+    // Also collects live channels, which replace the arch eth list as the ports to draw.
+    const recordConnection = (chipA: RenderChip, chanA: EthChannel, chipB: RenderChip, chanB: EthChannel) => {
+        const uidA = ethUid(chipA.rank, chipA.id, chanA);
+        const uidB = ethUid(chipB.rank, chipB.id, chanB);
         chipA.connectedChipsByEthId.set(uidA, chipB);
         chipB.connectedChipsByEthId.set(uidB, chipA);
+        chipA.ethChannels.push(chanA);
+        chipB.ethChannels.push(chanB);
+        return [uidA, uidB] as const;
     };
 
     // Canonical link key (lex-min of endpoint uids) shared by both ends, so
     // ordering ports by it on each edge keeps facing edges in sync.
     const canonicalLinkKeyByUid = new Map<string, string>();
-    const rememberLinkKey = (uidA: string | undefined, uidB: string | undefined) => {
-        if (uidA === undefined || uidB === undefined) {
-            return;
-        }
+    const rememberLinkKey = (uidA: string, uidB: string) => {
         const key = uidA < uidB ? uidA : uidB;
         canonicalLinkKeyByUid.set(uidA, key);
         canonicalLinkKeyByUid.set(uidB, key);
@@ -262,8 +271,7 @@ function buildClusterRenderModel(
         const a = chipsByKey.get(chipKey(link.rank, link.a.chip));
         const b = chipsByKey.get(chipKey(link.rank, link.b.chip));
         if (a && b) {
-            recordConnection(a, b, a.eth[link.a.chan], b.eth[link.b.chan]);
-            rememberLinkKey(a.eth[link.a.chan], b.eth[link.b.chan]);
+            rememberLinkKey(...recordConnection(a, link.a.chan, b, link.b.chan));
         }
     }
 
@@ -271,9 +279,14 @@ function buildClusterRenderModel(
         const a = chipsByKey.get(chipKey(link.a.rank, link.a.chip));
         const b = chipsByKey.get(chipKey(link.b.rank, link.b.chip));
         if (a && b) {
-            recordConnection(a, b, a.eth[link.a.chan], b.eth[link.b.chan]);
-            rememberLinkKey(a.eth[link.a.chan], b.eth[link.b.chan]);
+            rememberLinkKey(...recordConnection(a, link.a.chan, b, link.b.chan));
         }
+    }
+
+    // Ascending to match the previous arch-list order, which was channel order; dedup
+    // guards a channel appearing on two links.
+    for (const chip of renderChips) {
+        chip.ethChannels = [...new Set(chip.ethChannels)].sort((x, y) => x - y);
     }
 
     // Step 3: pick which edge of each chip an ETH port sits on, based on the
@@ -312,7 +325,7 @@ function buildClusterRenderModel(
         return { x: px, y: py, edge };
     };
 
-    const ethPositionsByChip = new Map<string, Map<CLUSTER_ETH_POSITION, string[]>>();
+    const ethPositionsByChip = new Map<string, Map<CLUSTER_ETH_POSITION, EthPort[]>>();
     const portPixelByUid = new Map<string, PortPixel>();
     // UIDs whose link skips ≥1 chip. Tagged here, rendered as curves in step 4
     // so they fly past the intermediates instead of overlapping them.
@@ -374,15 +387,15 @@ function buildClusterRenderModel(
     };
 
     renderChips.forEach((clusterChip) => {
-        const ethPosition = new Map<CLUSTER_ETH_POSITION, string[]>();
+        const ethPosition = new Map<CLUSTER_ETH_POSITION, EthPort[]>();
         // Edges already claimed by direct neighbours — pass 2 avoids these.
         const directNeighbourEdges = new Set<CLUSTER_ETH_POSITION>();
         // Long-haul/inter-host placements deferred until pass 2.
-        const deferred: { uid: string; chord: CLUSTER_ETH_POSITION }[] = [];
+        const deferred: (EthPort & { chord: CLUSTER_ETH_POSITION })[] = [];
 
         // Pass 1: direct cardinal neighbours go on their chord edge.
-        clusterChip.design?.eth.forEach((coreId) => {
-            const uid = ethUid(clusterChip.rank, clusterChip.id, coreId);
+        clusterChip.ethChannels.forEach((chan) => {
+            const uid = ethUid(clusterChip.rank, clusterChip.id, chan);
             const connectedChip = clusterChip.connectedChipsByEthId.get(uid);
             if (!connectedChip) {
                 return;
@@ -403,10 +416,10 @@ function buildClusterRenderModel(
                 if (!ethPosition.has(chord)) {
                     ethPosition.set(chord, []);
                 }
-                ethPosition.get(chord)!.push(uid);
+                ethPosition.get(chord)!.push({ uid, chan });
                 directNeighbourEdges.add(chord);
             } else {
-                deferred.push({ uid, chord });
+                deferred.push({ uid, chan, chord });
                 if (sameRank) {
                     longHaulUids.add(uid);
                 }
@@ -420,7 +433,7 @@ function buildClusterRenderModel(
         // canonical link key so both endpoints pick the same side and the
         // bezier bows in one direction instead of arcing across. #1510
         const outwardForChip = ALL_EDGES.filter((edge) => isOutwardEdge(clusterChip, edge));
-        for (const { uid, chord } of deferred) {
+        for (const { uid, chan, chord } of deferred) {
             const perp = perpendicularEdges(chord);
             let chosen: CLUSTER_ETH_POSITION;
             if (outwardForChip.length === 0) {
@@ -442,29 +455,29 @@ function buildClusterRenderModel(
             if (!ethPosition.has(chosen)) {
                 ethPosition.set(chosen, []);
             }
-            ethPosition.get(chosen)!.push(uid);
+            ethPosition.get(chosen)!.push({ uid, chan });
         }
 
         // Order ports along each edge by partner perpendicular-axis coord
         // (X for horizontal edges, Y for vertical), tiebroken by canonical
         // link key so both facing edges produce matching orderings.
-        ethPosition.forEach((uids, position) => {
+        ethPosition.forEach((ports, position) => {
             const isVerticalEdge = position === CLUSTER_ETH_POSITION.LEFT || position === CLUSTER_ETH_POSITION.RIGHT;
             const partnerAxis = isVerticalEdge ? CLUSTER_COORDS.Y : CLUSTER_COORDS.X;
-            const sorted = [...uids].sort((uidA, uidB) => {
-                const partnerA = clusterChip.connectedChipsByEthId.get(uidA);
-                const partnerB = clusterChip.connectedChipsByEthId.get(uidB);
+            const sorted = [...ports].sort((portA, portB) => {
+                const partnerA = clusterChip.connectedChipsByEthId.get(portA.uid);
+                const partnerB = clusterChip.connectedChipsByEthId.get(portB.uid);
                 if (partnerA && partnerB) {
                     const delta = partnerA.coords[partnerAxis] - partnerB.coords[partnerAxis];
                     if (delta !== 0) {
                         return delta;
                     }
                 }
-                const keyA = canonicalLinkKeyByUid.get(uidA) ?? uidA;
-                const keyB = canonicalLinkKeyByUid.get(uidB) ?? uidB;
+                const keyA = canonicalLinkKeyByUid.get(portA.uid) ?? portA.uid;
+                const keyB = canonicalLinkKeyByUid.get(portB.uid) ?? portB.uid;
                 return keyA.localeCompare(keyB);
             });
-            sorted.forEach((uid, index) => {
+            sorted.forEach(({ uid }, index) => {
                 const { x, y } = getEthGridPosition(position, index);
                 portPixelByUid.set(uid, portPixel(clusterChip.coords, x, y, position));
             });
@@ -544,7 +557,15 @@ function buildClusterRenderModel(
         const a = chipsByKey.get(chipKey(link.rank, link.a.chip));
         const b = chipsByKey.get(chipKey(link.rank, link.b.chip));
         if (a && b) {
-            pushSegment(a, b, a.eth[link.a.chan], b.eth[link.b.chan], false, 'intra', index);
+            pushSegment(
+                a,
+                b,
+                ethUid(a.rank, a.id, link.a.chan),
+                ethUid(b.rank, b.id, link.b.chan),
+                false,
+                'intra',
+                index,
+            );
         }
     });
 
@@ -552,7 +573,15 @@ function buildClusterRenderModel(
         const a = chipsByKey.get(chipKey(link.a.rank, link.a.chip));
         const b = chipsByKey.get(chipKey(link.b.rank, link.b.chip));
         if (a && b) {
-            pushSegment(a, b, a.eth[link.a.chan], b.eth[link.b.chan], true, 'inter', index);
+            pushSegment(
+                a,
+                b,
+                ethUid(a.rank, a.id, link.a.chan),
+                ethUid(b.rank, b.id, link.b.chan),
+                true,
+                'inter',
+                index,
+            );
         }
     });
 
@@ -942,7 +971,7 @@ function ClusterRenderer() {
 
                         {chips.map((clusterChip) => {
                             const ethPosition =
-                                ethPositionsByChip.get(clusterChip.key) ?? new Map<CLUSTER_ETH_POSITION, string[]>();
+                                ethPositionsByChip.get(clusterChip.key) ?? new Map<CLUSTER_ETH_POSITION, EthPort[]>();
                             const active = isChipActive(clusterChip.key);
                             const titleParts = [`Device ${clusterChip.id}`];
                             if (isMultiHost) {
@@ -994,15 +1023,15 @@ function ClusterRenderer() {
                                         </span>
                                     )}
 
-                                    {[...ethPosition.entries()].map(([position, value]) => {
-                                        return value.map((uid: string, index: number) => {
+                                    {[...ethPosition.entries()].map(([position, ports]) => {
+                                        return ports.map(({ uid, chan }, index) => {
                                             const { x, y } = getEthGridPosition(position, index);
                                             const size = clusterChipSize / CLUSTER_NODE_GRID_SIZE - CHIP_GAP;
                                             // scale the label with the port so it doesn't overflow on dense meshes
                                             const ethFontSize = Math.max(4, Math.round(size / 4));
                                             return (
                                                 <div
-                                                    title={`${uid}`}
+                                                    title={ethCoordLabel(clusterChip, chan) ?? uid}
                                                     key={uid}
                                                     className={`eth eth-position-${position}`}
                                                     style={{
@@ -1013,17 +1042,18 @@ function ClusterRenderer() {
                                                         fontSize: `${ethFontSize}px`,
                                                     }}
                                                 >
-                                                    <span>{uid}</span>
+                                                    <span>{ethCoordLabel(clusterChip, chan)}</span>
                                                 </div>
                                             );
                                         });
                                     })}
 
                                     {clusterChip.mmio &&
-                                        chipDesign.pcie?.map((coord, pcieIndex) => {
+                                        clusterChip.design?.grid &&
+                                        clusterChip.design.pcie?.map((coord, pcieIndex) => {
                                             const { left, top, size } = calculatePciePixelPosition(
                                                 coord,
-                                                chipDesign.grid,
+                                                clusterChip.design!.grid,
                                                 clusterChipSize,
                                             );
                                             return (

--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -9,7 +9,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import 'styles/components/ClusterView.scss';
 import { stringToArchitecture } from '../../functions/stringToArchitecture';
-import { getChipDesign, useGetClusterTopology } from '../../hooks/useAPI';
+import { useGetClusterTopology } from '../../hooks/useAPI';
+import { getChipDesign } from '../../functions/getChipDesign';
 import {
     FALLBACK_PER_HOST_COLS,
     hostHasMeshCoords,
@@ -23,6 +24,7 @@ import {
     ClusterCoordinates,
     ClusterTopology,
     EthChannel,
+    EthPort,
 } from '../../model/ClusterModel';
 import {
     CHIP_GAP,
@@ -115,17 +117,13 @@ const chipKey = (rank: number, id: number) => `${rank}-${id}`;
 // Keyed by channel, not arch core-id, so links resolve from the cluster descriptor alone. #1772
 const ethUid = (rank: number, chipId: number, chan: EthChannel) => `${rank}-${chipId}-ch${chan}`;
 
-// `chipDesign.eth` is channel-indexed; undefined when no descriptor is baked for the arch.
-const ethCoordLabel = (chip: ClusterChip, chan: EthChannel): string | undefined => {
+// `chipDesign.eth` is channel-indexed. Absent for an unknown arch, and also for a channel the
+// cluster descriptor reports live but the baked list is too short to cover, since the two are
+// now sourced independently. #1772
+const ethCoordLabel = (chip: ClusterChip, chan: EthChannel): string | null => {
     const coreId = chip.design?.eth?.[chan];
-    return coreId === undefined ? undefined : `${chip.rank ?? 0}-${chip.id}-${coreId}`;
+    return coreId === undefined ? null : `${chip.rank ?? 0}-${chip.id}-${coreId}`;
 };
-
-// Channel travels with the uid so the render needn't parse it back out for the label.
-interface EthPort {
-    uid: string;
-    chan: EthChannel;
-}
 
 // Endpoint uids are built once, when connections are recorded, and carried to the segment
 // pass. Rebuilding them there instead would let the two constructions drift, which renders
@@ -214,11 +212,10 @@ function buildClusterRenderModel(
         );
 
         // Per chip, not per cluster: a heterogeneous report labels each chip from its own
-        // arch entry, and an unrecognised one just loses its enrichment.
-        const designForChip = (chipId: number): ChipDesign | undefined => {
-            const design = getChipDesign(stringToArchitecture(host.descriptor.arch?.[chipId] ?? ''));
-            return design.eth?.length ? design : undefined;
-        };
+        // arch entry, and an unrecognised one just loses its enrichment. `stringToArchitecture`
+        // absorbs a missing or non-string entry, so no coercion is needed here.
+        const designForChip = (chipId: number): ChipDesign | null =>
+            getChipDesign(stringToArchitecture(host.descriptor.arch?.[chipId]));
 
         let usedFallback = false;
 
@@ -245,7 +242,7 @@ function buildClusterRenderModel(
                 chipUniqueId: host.descriptor.chip_unique_ids?.[chipId],
                 coords: [x, y, 0, 0] satisfies ClusterCoordinates,
                 mmio: mmioChipIds.has(chipId),
-                ethChannels: [],
+                ethPorts: [],
                 connectedChipsByEthId: new Map(),
                 design: designForChip(chipId),
             });
@@ -262,14 +259,16 @@ function buildClusterRenderModel(
     // Step 2: wire intra-host and inter-host eth connections into each chip's
     // `connectedChipsByEthId` map so the port-positioning step below can compute
     // edges relative to neighbours.
-    // Also collects live channels, which replace the arch eth list as the ports to draw.
+    // Also collects the live ports, which replace the arch eth list as the ports to draw.
+    // Sole construction site for both the uid and the coordinate label: every later pass reads
+    // them off the `EthPort` rather than rebuilding, so the two cannot disagree. #1772
     const recordConnection = (chipA: RenderChip, chanA: EthChannel, chipB: RenderChip, chanB: EthChannel) => {
         const uidA = ethUid(chipA.rank, chipA.id, chanA);
         const uidB = ethUid(chipB.rank, chipB.id, chanB);
         chipA.connectedChipsByEthId.set(uidA, chipB);
         chipB.connectedChipsByEthId.set(uidB, chipA);
-        chipA.ethChannels.push(chanA);
-        chipB.ethChannels.push(chanB);
+        chipA.ethPorts.push({ uid: uidA, chan: chanA, coordLabel: ethCoordLabel(chipA, chanA) });
+        chipB.ethPorts.push({ uid: uidB, chan: chanB, coordLabel: ethCoordLabel(chipB, chanB) });
         return [uidA, uidB] as const;
     };
 
@@ -304,10 +303,12 @@ function buildClusterRenderModel(
         }
     });
 
-    // Ascending to match the previous arch-list order, which was channel order; dedup
-    // guards a channel appearing on two links.
+    // Ascending by channel to match the previous arch-list order; dedup on uid guards a
+    // channel the descriptor reports on two links, which would otherwise draw two ports at
+    // the same coordinates and place only whichever won the last write.
     for (const chip of renderChips) {
-        chip.ethChannels = [...new Set(chip.ethChannels)].sort((x, y) => x - y);
+        const portsByUid = new Map<string, EthPort>(chip.ethPorts.map((port) => [port.uid, port]));
+        chip.ethPorts = [...portsByUid.values()].sort((portA, portB) => portA.chan - portB.chan);
     }
 
     // Step 3: pick which edge of each chip an ETH port sits on, based on the
@@ -412,12 +413,11 @@ function buildClusterRenderModel(
         // Edges already claimed by direct neighbours — pass 2 avoids these.
         const directNeighbourEdges = new Set<CLUSTER_ETH_POSITION>();
         // Long-haul/inter-host placements deferred until pass 2.
-        const deferred: (EthPort & { chord: CLUSTER_ETH_POSITION })[] = [];
+        const deferred: { port: EthPort; chord: CLUSTER_ETH_POSITION }[] = [];
 
         // Pass 1: direct cardinal neighbours go on their chord edge.
-        clusterChip.ethChannels.forEach((chan) => {
-            const uid = ethUid(clusterChip.rank, clusterChip.id, chan);
-            const connectedChip = clusterChip.connectedChipsByEthId.get(uid);
+        clusterChip.ethPorts.forEach((port) => {
+            const connectedChip = clusterChip.connectedChipsByEthId.get(port.uid);
             if (!connectedChip) {
                 return;
             }
@@ -437,12 +437,12 @@ function buildClusterRenderModel(
                 if (!ethPosition.has(chord)) {
                     ethPosition.set(chord, []);
                 }
-                ethPosition.get(chord)!.push({ uid, chan });
+                ethPosition.get(chord)!.push(port);
                 directNeighbourEdges.add(chord);
             } else {
-                deferred.push({ uid, chan, chord });
+                deferred.push({ port, chord });
                 if (sameRank) {
-                    longHaulUids.add(uid);
+                    longHaulUids.add(port.uid);
                 }
             }
         });
@@ -454,7 +454,7 @@ function buildClusterRenderModel(
         // canonical link key so both endpoints pick the same side and the
         // bezier bows in one direction instead of arcing across. #1510
         const outwardForChip = ALL_EDGES.filter((edge) => isOutwardEdge(clusterChip, edge));
-        for (const { uid, chan, chord } of deferred) {
+        for (const { port, chord } of deferred) {
             const perp = perpendicularEdges(chord);
             let chosen: CLUSTER_ETH_POSITION;
             if (outwardForChip.length === 0) {
@@ -469,14 +469,14 @@ function buildClusterRenderModel(
                 if (candidates.length === 1) {
                     [chosen] = candidates;
                 } else {
-                    const linkKey = canonicalLinkKeyByUid.get(uid) ?? uid;
+                    const linkKey = canonicalLinkKeyByUid.get(port.uid) ?? port.uid;
                     chosen = candidates[hashLinkKey(linkKey) % candidates.length];
                 }
             }
             if (!ethPosition.has(chosen)) {
                 ethPosition.set(chosen, []);
             }
-            ethPosition.get(chosen)!.push({ uid, chan });
+            ethPosition.get(chosen)!.push(port);
         }
 
         // Order ports along each edge by partner perpendicular-axis coord
@@ -1013,14 +1013,17 @@ function ClusterRenderer() {
                                     )}
 
                                     {[...ethPosition.entries()].map(([position, ports]) => {
-                                        return ports.map(({ uid, chan }, index) => {
+                                        return ports.map(({ uid, coordLabel }, index) => {
                                             const { x, y } = getEthGridPosition(position, index);
                                             const size = clusterChipSize / CLUSTER_NODE_GRID_SIZE - CHIP_GAP;
                                             // scale the label with the port so it doesn't overflow on dense meshes
                                             const ethFontSize = Math.max(4, Math.round(size / 4));
                                             return (
                                                 <div
-                                                    title={ethCoordLabel(clusterChip, chan) ?? uid}
+                                                    // Tooltip falls back to the uid so an unlabelled port stays
+                                                    // identifiable; the inline text deliberately does not, since at
+                                                    // this size (4px on dense meshes) a uid is unreadable. #1772
+                                                    title={coordLabel ?? uid}
                                                     key={uid}
                                                     className={`eth eth-position-${position}`}
                                                     style={{
@@ -1031,7 +1034,7 @@ function ClusterRenderer() {
                                                         fontSize: `${ethFontSize}px`,
                                                     }}
                                                 >
-                                                    <span>{ethCoordLabel(clusterChip, chan)}</span>
+                                                    <span>{coordLabel}</span>
                                                 </div>
                                             );
                                         });

--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import 'styles/components/ClusterView.scss';
 import { stringToArchitecture } from '../../functions/stringToArchitecture';
-import { useArchitecture, useGetClusterTopology } from '../../hooks/useAPI';
+import { getChipDesign, useGetClusterTopology } from '../../hooks/useAPI';
 import {
     FALLBACK_PER_HOST_COLS,
     hostHasMeshCoords,
@@ -22,7 +22,6 @@ import {
     ClusterChip,
     ClusterCoordinates,
     ClusterTopology,
-    DEFAULT_ARCHITECTURE,
     EthChannel,
 } from '../../model/ClusterModel';
 import {
@@ -167,7 +166,6 @@ const getEthGridPosition = (ethPosition: CLUSTER_ETH_POSITION, index: number) =>
 
 function buildClusterRenderModel(
     topology: ClusterTopology,
-    chipDesign: ChipDesign,
     requestedLayoutMode: ClusterLayoutMode = 'mesh',
 ): ClusterRenderResult {
     // A missing cluster descriptor is unrenderable; a missing *arch* one only costs the
@@ -176,8 +174,6 @@ function buildClusterRenderModel(
     if (hosts.length === 0) {
         return { status: 'unsupported' };
     }
-
-    const hasArchDescriptor = Boolean(chipDesign?.eth?.length);
 
     // Step 1: place every chip on a global virtual grid. `mesh` honours the
     // report's mesh coords (1D or 2D); `condensed` tiles each host into a
@@ -204,6 +200,13 @@ function buildClusterRenderModel(
         const mmioChipIds = new Set(
             (host.descriptor.chips_with_mmio ?? []).map((obj) => Object.values(obj)[0] as number),
         );
+
+        // Per chip, not per cluster: a heterogeneous report labels each chip from its own
+        // arch entry, and an unrecognised one just loses its enrichment.
+        const designForChip = (chipId: number): ChipDesign | undefined => {
+            const design = getChipDesign(stringToArchitecture(host.descriptor.arch?.[chipId] ?? ''));
+            return design.eth?.length ? design : undefined;
+        };
 
         let usedFallback = false;
 
@@ -232,7 +235,7 @@ function buildClusterRenderModel(
                 mmio: mmioChipIds.has(chipId),
                 ethChannels: [],
                 connectedChipsByEthId: new Map(),
-                design: hasArchDescriptor ? chipDesign : undefined,
+                design: designForChip(chipId),
             });
         }
 
@@ -637,11 +640,6 @@ function ClusterRenderer() {
         topology: ClusterTopology;
     } | null>(null);
 
-    // Heterogeneous clusters aren't supported yet; assume the first host's arch.
-    const firstHostArch = topology?.hosts[0]?.descriptor.arch ?? [];
-    const arch = stringToArchitecture((firstHostArch.length && firstHostArch[0]) || DEFAULT_ARCHITECTURE);
-    const chipDesign = useArchitecture(arch);
-
     // Honour the report's mesh coords (1D or 2D) when present; otherwise pick
     // `condensed` upfront rather than silently falling back inside the builder. #1510
     const defaultLayoutMode: ClusterLayoutMode = useMemo(() => {
@@ -666,8 +664,8 @@ function ClusterRenderer() {
         if (!topology) {
             return null;
         }
-        return buildClusterRenderModel(topology, chipDesign, requestedLayoutMode);
-    }, [topology, chipDesign, requestedLayoutMode]);
+        return buildClusterRenderModel(topology, requestedLayoutMode);
+    }, [topology, requestedLayoutMode]);
 
     // close the topology overlay when Escape is pressed
     useEffect(() => {

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -303,14 +303,17 @@ const NPEView = ({
     }, []);
 
     const { architecture, cores, dram, eth, pcie } = useNodeType(npeData.common_info.arch as DeviceArchitecture);
-    const width = architecture.grid?.x_size || 10;
-    const height = architecture.grid?.y_size || 12;
+    const width = architecture?.grid?.x_size || 10;
+    const height = architecture?.grid?.y_size || 12;
 
     useEffect(() => {
-        if (architecture.arch_name === undefined) {
+        // `architecture === null` rather than probing a field: `arch_name` is declared required
+        // on `ChipDesign` and only read as absent because the unresolved case used to return an
+        // empty stand-in. Now the same predicate holds here as everywhere else. #1772
+        if (architecture === null) {
             createToastNotification(`Unsupported architecture`, npeData.common_info.arch, ToastType.WARNING);
         }
-    }, [architecture.arch_name, npeData.common_info.arch]);
+    }, [architecture, npeData.common_info.arch]);
 
     useEffect(() => {
         resetRouteColors();

--- a/src/functions/getChipDesign.ts
+++ b/src/functions/getChipDesign.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import archBlackhole from '../assets/data/arch-blackhole.json';
+import archWormhole from '../assets/data/arch-wormhole.json';
+import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
+import { ChipDesign } from '../model/ClusterModel';
+
+// `null` rather than an empty-object stand-in: `ChipDesign` declares `arch_name`, `grid`,
+// `eth` and `pcie` as required, so a stand-in claims fields it doesn't have and pushes every
+// reader into optional chaining against a non-optional type. `design === null` is now the one
+// predicate for "did the arch resolve?", and it is as stable an identity across renders as a
+// frozen object, which consumers memoising on the descriptor rely on. #1772
+export const getChipDesign = (arch: DeviceArchitecture): ChipDesign | null => {
+    switch (arch) {
+        case DeviceArchitecture.WORMHOLE:
+            return archWormhole as ChipDesign;
+        case DeviceArchitecture.BLACKHOLE:
+            return archBlackhole as ChipDesign;
+        default:
+            return null;
+    }
+};

--- a/src/functions/stringToArchitecture.ts
+++ b/src/functions/stringToArchitecture.ts
@@ -4,11 +4,15 @@
 
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
 
+// Prefixed, not substring: descriptors carry a revision suffix (`wormhole_b0`) that has to
+// resolve, but a name merely *containing* an arch must not. Cluster now enriches per chip
+// from this result, so a licensee arch silently resolving to Wormhole would mislabel it. #1772
 export const stringToArchitecture = (arch: string): DeviceArchitecture => {
-    if (arch.toLowerCase().includes('wormhole')) {
+    const name = arch.toLowerCase();
+    if (name.startsWith('wormhole')) {
         return DeviceArchitecture.WORMHOLE;
     }
-    if (arch.toLowerCase().includes('blackhole')) {
+    if (name.startsWith('blackhole')) {
         return DeviceArchitecture.BLACKHOLE;
     }
     return DeviceArchitecture.UNKNOWN;

--- a/src/functions/stringToArchitecture.ts
+++ b/src/functions/stringToArchitecture.ts
@@ -4,10 +4,16 @@
 
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
 
-// Prefixed, not substring: descriptors carry a revision suffix (`wormhole_b0`) that has to
-// resolve, but a name merely *containing* an arch must not. Cluster now enriches per chip
-// from this result, so a licensee arch silently resolving to Wormhole would mislabel it. #1772
-export const stringToArchitecture = (arch: string): DeviceArchitecture => {
+// Takes `unknown`, not `string`: the only caller reads an uploaded cluster descriptor that
+// reaches us via `yaml.safe_load` with no schema validation, and YAML readily yields an int
+// or a nested map for `arch`. A non-string reaching `.toLowerCase()` throws, and the nearest
+// boundary is the router's root `errorElement`, which replaces the whole app shell. Treating
+// it as unresolved matches how an unrecognised arch already degrades — enrichment is lost,
+// placement and links are not. #1772
+export const stringToArchitecture = (arch: unknown): DeviceArchitecture => {
+    if (typeof arch !== 'string') {
+        return DeviceArchitecture.UNKNOWN;
+    }
     const name = arch.toLowerCase();
     if (name.startsWith('wormhole')) {
         return DeviceArchitecture.WORMHOLE;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1261,6 +1261,10 @@ export const useInstance = () => {
     });
 };
 
+// Stable identity across renders: a fresh `{}` made consumers memoizing on the
+// descriptor recompute every render, which now matters on the unknown-arch path. #1772
+const NO_CHIP_DESIGN = Object.freeze({}) as ChipDesign;
+
 export const useArchitecture = (arch: DeviceArchitecture): ChipDesign => {
     switch (arch) {
         case DeviceArchitecture.WORMHOLE:
@@ -1270,7 +1274,7 @@ export const useArchitecture = (arch: DeviceArchitecture): ChipDesign => {
         default: {
             // eslint-disable-next-line no-console
             console.error(`Unsupported arch: ${arch}`);
-            return {} as ChipDesign;
+            return NO_CHIP_DESIGN;
         }
     }
 };

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -1265,18 +1265,27 @@ export const useInstance = () => {
 // descriptor recompute every render, which now matters on the unknown-arch path. #1772
 const NO_CHIP_DESIGN = Object.freeze({}) as ChipDesign;
 
-export const useArchitecture = (arch: DeviceArchitecture): ChipDesign => {
+// Pure so callers that need a descriptor per chip (Cluster, for heterogeneous reports)
+// can resolve one outside a hook. Returns `NO_CHIP_DESIGN` rather than logging, leaving
+// the caller to decide whether an unresolved arch is degraded-but-fine or an error.
+export const getChipDesign = (arch: DeviceArchitecture): ChipDesign => {
     switch (arch) {
         case DeviceArchitecture.WORMHOLE:
             return archWormhole as ChipDesign;
         case DeviceArchitecture.BLACKHOLE:
             return archBlackhole as ChipDesign;
-        default: {
-            // eslint-disable-next-line no-console
-            console.error(`Unsupported arch: ${arch}`);
+        default:
             return NO_CHIP_DESIGN;
-        }
     }
+};
+
+export const useArchitecture = (arch: DeviceArchitecture): ChipDesign => {
+    const design = getChipDesign(arch);
+    if (design === NO_CHIP_DESIGN) {
+        // eslint-disable-next-line no-console
+        console.error(`Unsupported arch: ${arch}`);
+    }
+    return design;
 };
 
 export const useGetTensorSizesById = (tensorIdList: number[]): { id: number; size: number }[] => {

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -4,7 +4,7 @@
 
 import { AxiosError, AxiosRequestConfig } from 'axios';
 import { keepPreviousData, useQueries, useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { NumberRange } from '@blueprintjs/core';
 import Ajv from 'ajv';
@@ -51,9 +51,8 @@ import {
     stackedGroupByAtom,
     tracingModeAtom,
 } from '../store/app';
-import archWormhole from '../assets/data/arch-wormhole.json';
-import archBlackhole from '../assets/data/arch-blackhole.json';
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
+import { getChipDesign } from '../functions/getChipDesign';
 import { NPEData, NPEManifestEntry, NpeSummary, NpeWindow } from '../model/NPEModel';
 import { GraphBundle } from '../model/MLIRJsonModel';
 import { ChipDesign, ClusterModel, ClusterTopology, MeshData, MeshDescriptorResponse } from '../model/ClusterModel';
@@ -1261,30 +1260,21 @@ export const useInstance = () => {
     });
 };
 
-// Stable identity across renders: a fresh `{}` made consumers memoizing on the
-// descriptor recompute every render, which now matters on the unknown-arch path. #1772
-const NO_CHIP_DESIGN = Object.freeze({}) as ChipDesign;
-
-// Pure so callers that need a descriptor per chip (Cluster, for heterogeneous reports)
-// can resolve one outside a hook. Returns `NO_CHIP_DESIGN` rather than logging, leaving
-// the caller to decide whether an unresolved arch is degraded-but-fine or an error.
-export const getChipDesign = (arch: DeviceArchitecture): ChipDesign => {
-    switch (arch) {
-        case DeviceArchitecture.WORMHOLE:
-            return archWormhole as ChipDesign;
-        case DeviceArchitecture.BLACKHOLE:
-            return archBlackhole as ChipDesign;
-        default:
-            return NO_CHIP_DESIGN;
-    }
-};
-
-export const useArchitecture = (arch: DeviceArchitecture): ChipDesign => {
+export const useArchitecture = (arch: DeviceArchitecture): ChipDesign | null => {
     const design = getChipDesign(arch);
-    if (design === NO_CHIP_DESIGN) {
-        // eslint-disable-next-line no-console
-        console.error(`Unsupported arch: ${arch}`);
-    }
+
+    // Reported from an effect rather than the hook body, which runs on every render:
+    // `useNodeType` is a consumer and NPE playback re-renders per interval tick, so an
+    // inline warn emits a line per frame for the length of the run. #1772
+    useEffect(() => {
+        if (design === null) {
+            // Still worth surfacing: unlike Cluster, these callers have no degraded mode and
+            // silently lose every core-type overlay when the arch doesn't resolve.
+            // eslint-disable-next-line no-console
+            console.error(`Unsupported arch: ${arch}`);
+        }
+    }, [arch, design]);
+
     return design;
 };
 
@@ -1307,7 +1297,7 @@ export const useGetTensorSizesById = (tensorIdList: number[]): { id: number; siz
 export const useNodeType = (arch: DeviceArchitecture) => {
     const architecture = useArchitecture(arch);
     const cores = useMemo(() => {
-        return architecture.functional_workers?.map((loc) => {
+        return architecture?.functional_workers?.map((loc) => {
             return loc
                 .split('-')
                 .reverse()
@@ -1316,7 +1306,7 @@ export const useNodeType = (arch: DeviceArchitecture) => {
     }, [architecture]);
 
     const dram = useMemo(() => {
-        return architecture.dram?.flat().map((loc) => {
+        return architecture?.dram?.flat().map((loc) => {
             return loc
                 .split('-')
                 .reverse()
@@ -1325,7 +1315,7 @@ export const useNodeType = (arch: DeviceArchitecture) => {
     }, [architecture]);
 
     const eth = useMemo(() => {
-        return architecture.eth?.flat().map((loc) => {
+        return architecture?.eth?.flat().map((loc) => {
             return loc
                 .split('-')
                 .reverse()
@@ -1334,7 +1324,7 @@ export const useNodeType = (arch: DeviceArchitecture) => {
     }, [architecture]);
 
     const pcie = useMemo(() => {
-        return architecture.pcie?.map((loc) => {
+        return architecture?.pcie?.map((loc) => {
             return loc
                 .split('-')
                 .reverse()

--- a/src/model/ClusterModel.ts
+++ b/src/model/ClusterModel.ts
@@ -60,9 +60,9 @@ export type RemoteEthernetConnectionRaw = [
 ];
 
 export interface ClusterModel {
-    // Keyed by chip id, as the YAML writes it. Typed as an array previously, which made
-    // `arch.length` undefined and silently routed every report to the Wormhole default.
-    arch: Record<ChipId, string>;
+    // Keyed by chip id, as the YAML writes it. Optional because a descriptor may omit it
+    // entirely, in which case chips render without arch enrichment.
+    arch?: Record<ChipId, string>;
     chips: {
         [key: ChipId]: ClusterCoordinates;
     };

--- a/src/model/ClusterModel.ts
+++ b/src/model/ClusterModel.ts
@@ -60,7 +60,9 @@ export type RemoteEthernetConnectionRaw = [
 ];
 
 export interface ClusterModel {
-    arch: string[];
+    // Keyed by chip id, as the YAML writes it. Typed as an array previously, which made
+    // `arch.length` undefined and silently routed every report to the Wormhole default.
+    arch: Record<ChipId, string>;
     chips: {
         [key: ChipId]: ClusterCoordinates;
     };
@@ -142,4 +144,5 @@ export interface ChipDesign {
 
     [unknownKey: string]: unknown;
 }
-export const DEFAULT_ARCHITECTURE = 'Wormhole';
+// No default architecture on purpose: guessing one renders another arch's coordinates as
+// if they were this report's. An unresolved arch omits the enrichment instead. #1772

--- a/src/model/ClusterModel.ts
+++ b/src/model/ClusterModel.ts
@@ -17,16 +17,27 @@ export enum CLUSTER_ETH_POSITION {
     RIGHT = 'right',
 }
 
+// A live ethernet port on a chip. Both the uid and the coordinate label are resolved once,
+// where the connection is recorded, and read back by the port-placement and render passes.
+// Reconstructing either downstream lets the two constructions drift, and a uid mismatch
+// renders no links at all rather than failing loudly. #1772
+export interface EthPort {
+    uid: string;
+    chan: EthChannel;
+    // Arch-derived `rank-chip-core` coordinate; null when no SoC descriptor is baked. #1772
+    coordLabel: string | null;
+}
+
 export interface ClusterChip {
     id: number;
     coords: ClusterCoordinates;
     mmio: boolean;
-    // Live channels from the cluster descriptor; port uids derive from these rather than
-    // the arch eth list, so a cluster renders with no baked SoC descriptor. #1772
-    ethChannels: EthChannel[];
+    // Live ports from the cluster descriptor; uids derive from its channels rather than the
+    // arch eth list, so a cluster renders with no baked SoC descriptor. #1772
+    ethPorts: EthPort[];
     connectedChipsByEthId: Map<string, ClusterChip>;
-    // Optional enrichment only (coordinate labels, PCIe markers); absent for an unknown arch.
-    design?: ChipDesign;
+    // Optional enrichment only (coordinate labels, PCIe markers); null for an unknown arch.
+    design: ChipDesign | null;
     // Rank of the host this chip lives on. Defaults to 0 for single-host reports.
     // For multi-host topologies the unique key is `(rank, id)`; local `id`s can collide across ranks.
     rank?: number;

--- a/src/model/ClusterModel.ts
+++ b/src/model/ClusterModel.ts
@@ -5,7 +5,7 @@
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
 
 type ChipId = number;
-type EthChannel = number;
+export type EthChannel = number;
 type CoreId = string;
 
 export type ClusterCoordinates = [x: number, y: number, r: number, s: number];
@@ -21,8 +21,11 @@ export interface ClusterChip {
     id: number;
     coords: ClusterCoordinates;
     mmio: boolean;
-    eth: string[];
+    // Live channels from the cluster descriptor; port uids derive from these rather than
+    // the arch eth list, so a cluster renders with no baked SoC descriptor. #1772
+    ethChannels: EthChannel[];
     connectedChipsByEthId: Map<string, ClusterChip>;
+    // Optional enrichment only (coordinate labels, PCIe markers); absent for an unknown arch.
     design?: ChipDesign;
     // Rank of the host this chip lives on. Defaults to 0 for single-host reports.
     // For multi-host topologies the unique key is `(rank, id)`; local `id`s can collide across ranks.

--- a/tests/ClusterUnknownArch.spec.tsx
+++ b/tests/ClusterUnknownArch.spec.tsx
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ClusterRenderer from '../src/components/cluster/ClusterRenderer';
+import { ChipDesign, ClusterTopology } from '../src/model/ClusterModel';
+
+// Cluster placement and links come from the cluster descriptor; the arch descriptor is
+// only enrichment. An unrecognised arch used to blank the whole view because port uids
+// were keyed off the arch eth list. #1772
+
+// Two chips side by side, linked on channels 4 and 6 — the channels are what the port
+// uids must key off, and channel 6 sits past the end of a 2-entry arch eth list so a
+// regression to arch-indexed lookup would drop that port.
+const topology = (): ClusterTopology =>
+    ({
+        isMultiHost: false,
+        worldSize: 1,
+        unresolvedRemoteCount: 0,
+        hosts: [
+            {
+                rank: 0,
+                descriptor: {
+                    arch: ['wormhole_b0'],
+                    chip_unique_ids: { 0: 100, 1: 101 },
+                    chips_with_mmio: [{ 0: 0 }],
+                    ethernet_connections: [],
+                },
+                meshChips: { 0: [0, 0, 0, 0], 1: [1, 0, 0, 0] },
+            },
+        ],
+        intraHostLinks: [{ rank: 0, a: { chip: 0, chan: 4 }, b: { chip: 1, chan: 6 } }],
+        interHostLinks: [],
+    }) as unknown as ClusterTopology;
+
+// Channel-indexed, mirroring the real arch json. Index 4 -> '9-0', index 6 -> '1-6'.
+const ARCH: ChipDesign = {
+    arch_name: 'wormhole_b0',
+    grid: { x_size: 10, y_size: 12 },
+    eth: ['0-0', '1-0', '2-0', '3-0', '9-0', '8-0', '1-6', '2-6'],
+    pcie: ['0-3'],
+    arc: [],
+    dram: [],
+    router_only: [],
+    functional_workers: [],
+} as unknown as ChipDesign;
+
+const NO_ARCH = Object.freeze({}) as ChipDesign;
+
+let chipDesign: ChipDesign = ARCH;
+
+vi.mock('react-router', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('../src/hooks/useAPI', () => ({
+    useGetClusterTopology: () => ({ data: topology(), isLoading: false, isError: false, error: null }),
+    useArchitecture: () => chipDesign,
+}));
+
+const ports = () => [...document.querySelectorAll('.eth')];
+const portLabels = () => ports().map((el) => el.querySelector('span')?.textContent ?? '');
+
+// The component observes its scroll container to fit the topology; jsdom has no
+// ResizeObserver and the fitted size is irrelevant to what these tests assert. Has to be
+// a class — vitest rejects an arrow function used as a constructor mock.
+/* eslint-disable class-methods-use-this -- no-op stub has nothing to hold */
+class ResizeObserverStub {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+}
+/* eslint-enable class-methods-use-this */
+
+beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    chipDesign = ARCH;
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('Cluster with a baked arch descriptor', () => {
+    it('labels each port with its rank-chip-core coordinate', () => {
+        render(<ClusterRenderer />);
+
+        // chip 0 on channel 4 -> eth[4] = '9-0'; chip 1 on channel 6 -> eth[6] = '1-6'.
+        expect(portLabels().sort()).toEqual(['0-0-9-0', '0-1-1-6']);
+    });
+
+    it('renders a PCIe marker on the mmio chip', () => {
+        render(<ClusterRenderer />);
+
+        expect(document.querySelectorAll('.mmio').length).toBeGreaterThan(0);
+    });
+});
+
+describe('Cluster with no baked arch descriptor', () => {
+    beforeEach(() => {
+        chipDesign = NO_ARCH;
+    });
+
+    it('still renders a port per linked channel', () => {
+        render(<ClusterRenderer />);
+
+        // The link is the only source of channels, so both endpoints must still appear.
+        expect(ports()).toHaveLength(2);
+    });
+
+    it('does not fall back to the unsupported-setup panel', () => {
+        render(<ClusterRenderer />);
+
+        // Matching the panel's actual copy — it reads "not supported", so asserting on
+        // the word "unsupported" would pass no matter what the component rendered.
+        expect(document.body.textContent).not.toContain('not supported for your current setup');
+    });
+
+    it('omits the coordinate labels rather than inventing them', () => {
+        render(<ClusterRenderer />);
+
+        expect(portLabels()).toEqual(['', '']);
+    });
+
+    it('omits PCIe markers', () => {
+        render(<ClusterRenderer />);
+
+        expect(document.querySelectorAll('.mmio')).toHaveLength(0);
+    });
+
+    it('keys ports by channel so the uid survives without the arch list', () => {
+        render(<ClusterRenderer />);
+
+        // Titles fall back to the uid when there is no coordinate to show.
+        expect(
+            ports()
+                .map((el) => el.getAttribute('title'))
+                .sort(),
+        ).toEqual(['0-0-ch4', '0-1-ch6']);
+    });
+});

--- a/tests/ClusterUnknownArch.spec.tsx
+++ b/tests/ClusterUnknownArch.spec.tsx
@@ -5,16 +5,19 @@
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ClusterRenderer from '../src/components/cluster/ClusterRenderer';
-import { ChipDesign, ClusterTopology } from '../src/model/ClusterModel';
+import { ClusterTopology } from '../src/model/ClusterModel';
 
 // Cluster placement and links come from the cluster descriptor; the arch descriptor is
 // only enrichment. An unrecognised arch used to blank the whole view because port uids
 // were keyed off the arch eth list. #1772
+//
+// The real `getChipDesign` is used deliberately — these assert against the baked
+// wormhole json, so a change to its channel ordering surfaces here.
 
-// Two chips side by side, linked on channels 4 and 6 — the channels are what the port
-// uids must key off, and channel 6 sits past the end of a 2-entry arch eth list so a
-// regression to arch-indexed lookup would drop that port.
-const topology = (): ClusterTopology =>
+// Two chips side by side, linked on channels 4 and 6. Channel 6 sits past the end of a
+// short eth list, so a regression to arch-indexed lookup drops that port rather than
+// mislabelling it. `arch` is keyed by chip id, matching the YAML.
+const topology = (arch: Record<number, string>): ClusterTopology =>
     ({
         isMultiHost: false,
         worldSize: 1,
@@ -23,7 +26,7 @@ const topology = (): ClusterTopology =>
             {
                 rank: 0,
                 descriptor: {
-                    arch: ['wormhole_b0'],
+                    arch,
                     chip_unique_ids: { 0: 100, 1: 101 },
                     chips_with_mmio: [{ 0: 0 }],
                     ethernet_connections: [],
@@ -35,26 +38,16 @@ const topology = (): ClusterTopology =>
         interHostLinks: [],
     }) as unknown as ClusterTopology;
 
-// Channel-indexed, mirroring the real arch json. Index 4 -> '9-0', index 6 -> '1-6'.
-const ARCH: ChipDesign = {
-    arch_name: 'wormhole_b0',
-    grid: { x_size: 10, y_size: 12 },
-    eth: ['0-0', '1-0', '2-0', '3-0', '9-0', '8-0', '1-6', '2-6'],
-    pcie: ['0-3'],
-    arc: [],
-    dram: [],
-    router_only: [],
-    functional_workers: [],
-} as unknown as ChipDesign;
+const WORMHOLE = { 0: 'wormhole_b0', 1: 'wormhole_b0' };
+// Neither substring-matches a baked descriptor, so it resolves to no design.
+const UNKNOWN_ARCH = { 0: 'quasar', 1: 'quasar' };
 
-const NO_ARCH = Object.freeze({}) as ChipDesign;
-
-let chipDesign: ChipDesign = ARCH;
+let clusterArch: Record<number, string> = WORMHOLE;
 
 vi.mock('react-router', () => ({ useNavigate: () => vi.fn() }));
-vi.mock('../src/hooks/useAPI', () => ({
-    useGetClusterTopology: () => ({ data: topology(), isLoading: false, isError: false, error: null }),
-    useArchitecture: () => chipDesign,
+vi.mock('../src/hooks/useAPI', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../src/hooks/useAPI')>()),
+    useGetClusterTopology: () => ({ data: topology(clusterArch), isLoading: false, isError: false, error: null }),
 }));
 
 const ports = () => [...document.querySelectorAll('.eth')];
@@ -75,7 +68,7 @@ class ResizeObserverStub {
 
 beforeEach(() => {
     vi.stubGlobal('ResizeObserver', ResizeObserverStub);
-    chipDesign = ARCH;
+    clusterArch = WORMHOLE;
 });
 
 afterEach(() => {
@@ -83,12 +76,12 @@ afterEach(() => {
     vi.clearAllMocks();
 });
 
-describe('Cluster with a baked arch descriptor', () => {
+describe('Cluster with a recognised arch', () => {
     it('labels each port with its rank-chip-core coordinate', () => {
         render(<ClusterRenderer />);
 
-        // chip 0 on channel 4 -> eth[4] = '9-0'; chip 1 on channel 6 -> eth[6] = '1-6'.
-        expect(portLabels().sort()).toEqual(['0-0-9-0', '0-1-1-6']);
+        // Wormhole eth is channel-indexed: [4] = '7-0', [6] = '6-0'.
+        expect(portLabels().sort()).toEqual(['0-0-7-0', '0-1-6-0']);
     });
 
     it('renders a PCIe marker on the mmio chip', () => {
@@ -98,9 +91,9 @@ describe('Cluster with a baked arch descriptor', () => {
     });
 });
 
-describe('Cluster with no baked arch descriptor', () => {
+describe('Cluster with an unrecognised arch', () => {
     beforeEach(() => {
-        chipDesign = NO_ARCH;
+        clusterArch = UNKNOWN_ARCH;
     });
 
     it('still renders a port per linked channel', () => {
@@ -118,7 +111,7 @@ describe('Cluster with no baked arch descriptor', () => {
         expect(document.body.textContent).not.toContain('not supported for your current setup');
     });
 
-    it('omits the coordinate labels rather than inventing them', () => {
+    it('omits the coordinate labels rather than borrowing another arch’s', () => {
         render(<ClusterRenderer />);
 
         expect(portLabels()).toEqual(['', '']);
@@ -130,14 +123,30 @@ describe('Cluster with no baked arch descriptor', () => {
         expect(document.querySelectorAll('.mmio')).toHaveLength(0);
     });
 
-    it('keys ports by channel so the uid survives without the arch list', () => {
+    it('keys ports by channel so the uid survives without an eth list', () => {
         render(<ClusterRenderer />);
 
-        // Titles fall back to the uid when there is no coordinate to show.
         expect(
             ports()
                 .map((el) => el.getAttribute('title'))
                 .sort(),
         ).toEqual(['0-0-ch4', '0-1-ch6']);
+    });
+});
+
+describe('Cluster with a heterogeneous arch', () => {
+    it('enriches each chip from its own arch entry', () => {
+        clusterArch = { 0: 'wormhole_b0', 1: 'quasar' };
+        render(<ClusterRenderer />);
+
+        // Chip 0 resolves, chip 1 does not — one label, not a cluster-wide guess.
+        expect(portLabels().sort()).toEqual(['', '0-0-7-0']);
+    });
+
+    it('does not let an unresolved first chip suppress the rest', () => {
+        clusterArch = { 0: 'quasar', 1: 'wormhole_b0' };
+        render(<ClusterRenderer />);
+
+        expect(portLabels().sort()).toEqual(['', '0-1-6-0']);
     });
 });

--- a/tests/ClusterUnknownArch.spec.tsx
+++ b/tests/ClusterUnknownArch.spec.tsx
@@ -39,6 +39,7 @@ const topology = (arch: Record<number, string>): ClusterTopology =>
     }) as unknown as ClusterTopology;
 
 const WORMHOLE = { 0: 'wormhole_b0', 1: 'wormhole_b0' };
+const BLACKHOLE = { 0: 'blackhole', 1: 'blackhole' };
 // Neither substring-matches a baked descriptor, so it resolves to no design.
 const UNKNOWN_ARCH = { 0: 'quasar', 1: 'quasar' };
 
@@ -52,6 +53,7 @@ vi.mock('../src/hooks/useAPI', async (importOriginal) => ({
 
 const ports = () => [...document.querySelectorAll('.eth')];
 const portLabels = () => ports().map((el) => el.querySelector('span')?.textContent ?? '');
+const links = () => [...document.querySelectorAll('.cluster-link')];
 
 // The component observes its scroll container to fit the topology; jsdom has no
 // ResizeObserver and the fitted size is irrelevant to what these tests assert. Has to be
@@ -89,6 +91,37 @@ describe('Cluster with a recognised arch', () => {
 
         expect(document.querySelectorAll('.mmio').length).toBeGreaterThan(0);
     });
+
+    // A segment only draws when the uid built at the link pass matches the one the port
+    // pass registered. Those are separate constructions of the same key, so a drift
+    // between them silently drops every link while ports, labels and markers all survive.
+    it('draws a segment for the link', () => {
+        render(<ClusterRenderer />);
+
+        expect(links()).toHaveLength(1);
+    });
+});
+
+describe('Cluster with a Blackhole arch', () => {
+    beforeEach(() => {
+        clusterArch = BLACKHOLE;
+    });
+
+    // Blackhole's eth channel map is disjoint from Wormhole's, so these labels are what
+    // separates "resolved per chip" from "resolved to Wormhole regardless" — the defect
+    // this ticket uncovered, where every report was enriched from the wormhole list.
+    it('labels ports from the Blackhole eth list, not Wormhole’s', () => {
+        render(<ClusterRenderer />);
+
+        // Blackhole eth: [4] = '5-1', [6] = '7-1'. Wormhole would give '7-0' / '6-0'.
+        expect(portLabels().sort()).toEqual(['0-0-5-1', '0-1-7-1']);
+    });
+
+    it('renders a PCIe marker on the mmio chip', () => {
+        render(<ClusterRenderer />);
+
+        expect(document.querySelectorAll('.mmio').length).toBeGreaterThan(0);
+    });
 });
 
 describe('Cluster with an unrecognised arch', () => {
@@ -101,6 +134,13 @@ describe('Cluster with an unrecognised arch', () => {
 
         // The link is the only source of channels, so both endpoints must still appear.
         expect(ports()).toHaveLength(2);
+    });
+
+    // The point of the ticket: links resolve from the cluster descriptor alone.
+    it('still draws a segment for the link', () => {
+        render(<ClusterRenderer />);
+
+        expect(links()).toHaveLength(1);
     });
 
     it('does not fall back to the unsupported-setup panel', () => {

--- a/tests/ClusterUnknownArch.spec.tsx
+++ b/tests/ClusterUnknownArch.spec.tsx
@@ -5,7 +5,7 @@
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ClusterRenderer from '../src/components/cluster/ClusterRenderer';
-import { ClusterTopology } from '../src/model/ClusterModel';
+import { ClusterTopology, IntraHostEthernetLink } from '../src/model/ClusterModel';
 
 // Cluster placement and links come from the cluster descriptor; the arch descriptor is
 // only enrichment. An unrecognised arch used to blank the whole view because port uids
@@ -14,10 +14,16 @@ import { ClusterTopology } from '../src/model/ClusterModel';
 // The real `getChipDesign` is used deliberately — these assert against the baked
 // wormhole json, so a change to its channel ordering surfaces here.
 
-// Two chips side by side, linked on channels 4 and 6. Channel 6 sits past the end of a
-// short eth list, so a regression to arch-indexed lookup drops that port rather than
-// mislabelling it. `arch` is keyed by chip id, matching the YAML.
-const topology = (arch: Record<number, string>): ClusterTopology =>
+const DEFAULT_LINKS: IntraHostEthernetLink[] = [{ rank: 0, a: { chip: 0, chan: 4 }, b: { chip: 1, chan: 6 } }];
+
+// Two chips side by side. Channels 4 and 6 are both in range for the wormhole (16 entries)
+// and blackhole (14) eth lists, so the label assertions compare two real arch lookups rather
+// than one lookup and one miss — the out-of-range case is covered separately below.
+// `arch` is keyed by chip id, matching the YAML.
+const twoChipTopology = (
+    arch: Record<number, string>,
+    intraHostLinks: IntraHostEthernetLink[] = DEFAULT_LINKS,
+): ClusterTopology =>
     ({
         isMultiHost: false,
         worldSize: 1,
@@ -34,25 +40,60 @@ const topology = (arch: Record<number, string>): ClusterTopology =>
                 meshChips: { 0: [0, 0, 0, 0], 1: [1, 0, 0, 0] },
             },
         ],
-        intraHostLinks: [{ rank: 0, a: { chip: 0, chan: 4 }, b: { chip: 1, chan: 6 } }],
+        intraHostLinks,
         interHostLinks: [],
+    }) as unknown as ClusterTopology;
+
+// One chip per host, both with local id 0, linked across the hosts. Local chip ids collide
+// across ranks, so this is the fixture that distinguishes a rank-qualified uid from a
+// chip-id-only one — the latter would collapse both endpoints onto a single port.
+const twoHostTopology = (arch: Record<number, string>): ClusterTopology =>
+    ({
+        isMultiHost: true,
+        worldSize: 2,
+        unresolvedRemoteCount: 0,
+        hosts: [0, 1].map((rank) => ({
+            rank,
+            descriptor: {
+                arch,
+                chip_unique_ids: { 0: 100 + rank },
+                chips_with_mmio: [{ 0: 0 }],
+                ethernet_connections: [],
+            },
+            meshChips: { 0: [rank, 0, 0, 0] },
+        })),
+        intraHostLinks: [],
+        interHostLinks: [
+            {
+                a: { rank: 0, chip: 0, chan: 4, chipUniqueId: 100 },
+                b: { rank: 1, chip: 0, chan: 4, chipUniqueId: 101 },
+            },
+        ],
     }) as unknown as ClusterTopology;
 
 const WORMHOLE = { 0: 'wormhole_b0', 1: 'wormhole_b0' };
 const BLACKHOLE = { 0: 'blackhole', 1: 'blackhole' };
-// Neither substring-matches a baked descriptor, so it resolves to no design.
+// Neither prefix-matches a baked descriptor, so it resolves to no design.
 const UNKNOWN_ARCH = { 0: 'quasar', 1: 'quasar' };
 
 let clusterArch: Record<number, string> = WORMHOLE;
+// Set by tests that need a shape the arch knob can't express (extra links, multi-host, no hosts).
+let topologyOverride: ClusterTopology | null = null;
 
 vi.mock('react-router', () => ({ useNavigate: () => vi.fn() }));
 vi.mock('../src/hooks/useAPI', async (importOriginal) => ({
     ...(await importOriginal<typeof import('../src/hooks/useAPI')>()),
-    useGetClusterTopology: () => ({ data: topology(clusterArch), isLoading: false, isError: false, error: null }),
+    useGetClusterTopology: () => ({
+        data: topologyOverride ?? twoChipTopology(clusterArch),
+        isLoading: false,
+        isError: false,
+        error: null,
+    }),
 }));
 
 const ports = () => [...document.querySelectorAll('.eth')];
 const portLabels = () => ports().map((el) => el.querySelector('span')?.textContent ?? '');
+const portTitles = () => ports().map((el) => el.getAttribute('title') ?? '');
 const links = () => [...document.querySelectorAll('.cluster-link')];
 
 // The component observes its scroll container to fit the topology; jsdom has no
@@ -71,6 +112,7 @@ class ResizeObserverStub {
 beforeEach(() => {
     vi.stubGlobal('ResizeObserver', ResizeObserverStub);
     clusterArch = WORMHOLE;
+    topologyOverride = null;
 });
 
 afterEach(() => {
@@ -166,11 +208,7 @@ describe('Cluster with an unrecognised arch', () => {
     it('keys ports by channel so the uid survives without an eth list', () => {
         render(<ClusterRenderer />);
 
-        expect(
-            ports()
-                .map((el) => el.getAttribute('title'))
-                .sort(),
-        ).toEqual(['0-0-ch4', '0-1-ch6']);
+        expect(portTitles().sort()).toEqual(['0-0-ch4', '0-1-ch6']);
     });
 });
 
@@ -188,5 +226,119 @@ describe('Cluster with a heterogeneous arch', () => {
         render(<ClusterRenderer />);
 
         expect(portLabels().sort()).toEqual(['', '0-1-6-0']);
+    });
+});
+
+// Distinct from an unrecognised arch: the arch resolves, but the descriptor reports a channel
+// the baked list is too short to cover. Since #1772 sources ports from the cluster descriptor
+// and labels from the arch one independently, the two can disagree per channel.
+describe('Cluster with a channel past the end of the baked eth list', () => {
+    beforeEach(() => {
+        // Wormhole's eth list covers channels 0-15.
+        topologyOverride = twoChipTopology(WORMHOLE, [{ rank: 0, a: { chip: 0, chan: 4 }, b: { chip: 1, chan: 20 } }]);
+    });
+
+    it('still renders both ports', () => {
+        render(<ClusterRenderer />);
+
+        expect(ports()).toHaveLength(2);
+    });
+
+    it('still draws the link', () => {
+        render(<ClusterRenderer />);
+
+        expect(links()).toHaveLength(1);
+    });
+
+    it('labels the in-range channel and leaves the out-of-range one blank', () => {
+        render(<ClusterRenderer />);
+
+        // Wormhole eth[4] = '7-0'; channel 20 has no entry.
+        expect(portLabels().sort()).toEqual(['', '0-0-7-0']);
+    });
+
+    // Pins the deliberate split between the two: the tooltip falls back to the uid so the port
+    // stays identifiable, while the inline label stays empty rather than showing a raw uid.
+    it('keeps the unlabelled port identifiable by uid in its tooltip', () => {
+        render(<ClusterRenderer />);
+
+        expect(portTitles().sort()).toEqual(['0-0-7-0', '0-1-ch20']);
+    });
+});
+
+describe('Cluster spanning two hosts', () => {
+    beforeEach(() => {
+        topologyOverride = twoHostTopology(WORMHOLE);
+    });
+
+    it('draws the inter-host link', () => {
+        render(<ClusterRenderer />);
+
+        expect(links()).toHaveLength(1);
+    });
+
+    // Both endpoints are chip 0 on channel 4; only the rank separates them. An unqualified
+    // uid would collapse them into one port and lose the link.
+    it('qualifies ports by rank so same-id chips on different hosts do not collide', () => {
+        render(<ClusterRenderer />);
+
+        expect(ports()).toHaveLength(2);
+        expect(portLabels().sort()).toEqual(['0-0-7-0', '1-0-7-0']);
+    });
+
+    it('badges each chip with its host rank', () => {
+        render(<ClusterRenderer />);
+
+        // Sorted: condensed layout orders hosts by connection proximity, not by rank.
+        expect([...document.querySelectorAll('.chip-rank-badge')].map((el) => el.textContent ?? '').sort()).toEqual([
+            'R0',
+            'R1',
+        ]);
+    });
+});
+
+describe('Cluster where a channel appears on two links', () => {
+    beforeEach(() => {
+        // Chip 0 channel 4 is reported twice. Without the dedupe both would place a port at
+        // the same coordinates, and only the last write would survive into `portPixelByUid`.
+        topologyOverride = twoChipTopology(WORMHOLE, [
+            { rank: 0, a: { chip: 0, chan: 4 }, b: { chip: 1, chan: 6 } },
+            { rank: 0, a: { chip: 0, chan: 4 }, b: { chip: 1, chan: 7 } },
+        ]);
+    });
+
+    it('draws one port per channel, not one per link', () => {
+        render(<ClusterRenderer />);
+
+        // Chip 0 contributes channel 4 once; chip 1 contributes channels 6 and 7.
+        expect(portTitles().sort()).toEqual(['0-0-7-0', '0-1-4-0', '0-1-6-0']);
+    });
+});
+
+// Counterpart to the negative assertion above: without this, that test would pass even if the
+// panel were unreachable, since it only checks the copy is *absent*.
+describe('Cluster with no hosts', () => {
+    beforeEach(() => {
+        topologyOverride = {
+            isMultiHost: false,
+            worldSize: 0,
+            unresolvedRemoteCount: 0,
+            hosts: [],
+            intraHostLinks: [],
+            interHostLinks: [],
+        } as unknown as ClusterTopology;
+    });
+
+    it('falls back to the unsupported-setup panel', () => {
+        render(<ClusterRenderer />);
+
+        expect(document.body.textContent).toContain('not supported for your current setup');
+    });
+
+    it('renders no chips or ports', () => {
+        render(<ClusterRenderer />);
+
+        expect(ports()).toHaveLength(0);
+        expect(document.querySelectorAll('.chip')).toHaveLength(0);
     });
 });

--- a/tests/clusterTopology.spec.ts
+++ b/tests/clusterTopology.spec.ts
@@ -16,7 +16,7 @@ import { ClusterHost, ClusterModel, InterHostEthernetLink, MeshData, MeshDataDoc
 
 // Minimal ClusterModel factory; fills in defaults so tests can override only what they care about.
 const makeDescriptor = (overrides: Partial<ClusterModel>): ClusterModel => ({
-    arch: ['blackhole'],
+    arch: { 0: 'blackhole' },
     chips: {},
     ethernet_connections: [],
     chips_with_mmio: [],
@@ -340,7 +340,7 @@ describe('pickMeshDocForRank', () => {
 
 describe('looksLikeRankedDescriptor', () => {
     const baseDescriptor = {
-        arch: [],
+        arch: {},
         chips: {},
         ethernet_connections: [],
         chips_with_mmio: [],
@@ -412,7 +412,7 @@ describe('sortHostsByConnectionProximity', () => {
     const makeHost = (rank: number, chipUniqueIds: Record<number, number>): ClusterHost => ({
         rank,
         descriptor: {
-            arch: [],
+            arch: {},
             chips: {},
             ethernet_connections: [],
             chips_with_mmio: [],
@@ -462,7 +462,7 @@ describe('mesh-availability helpers', () => {
     const makeHost = (meshChips: ClusterHost['meshChips']): ClusterHost => ({
         rank: 0,
         descriptor: {
-            arch: [],
+            arch: {},
             chips: {},
             ethernet_connections: [],
             chips_with_mmio: [],

--- a/tests/getChipDesign.spec.ts
+++ b/tests/getChipDesign.spec.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { DeviceArchitecture } from '../src/definitions/DeviceArchitecture';
+import { getChipDesign } from '../src/functions/getChipDesign';
+
+// `null`, not an empty stand-in: the stand-in claimed the required fields of `ChipDesign`
+// without having them, so callers each invented their own "did this resolve?" probe
+// (`design === NO_CHIP_DESIGN`, `design.eth?.length`, `design.arch_name === undefined`).
+// One of those probes only agreed with the others because every baked descriptor happens
+// to carry a non-empty eth list. #1772
+
+describe('getChipDesign', () => {
+    it('returns the baked descriptor for a supported arch', () => {
+        expect(getChipDesign(DeviceArchitecture.WORMHOLE)?.arch_name).toBe('WORMHOLE');
+        expect(getChipDesign(DeviceArchitecture.BLACKHOLE)?.arch_name).toBe('BLACKHOLE');
+    });
+
+    it('returns null for an arch with no baked descriptor', () => {
+        expect(getChipDesign(DeviceArchitecture.UNKNOWN)).toBeNull();
+    });
+
+    // Consumers memoise on the descriptor identity, so a fresh object per call would
+    // invalidate those memos on every render.
+    it('returns a stable identity across calls', () => {
+        expect(getChipDesign(DeviceArchitecture.WORMHOLE)).toBe(getChipDesign(DeviceArchitecture.WORMHOLE));
+    });
+
+    // The eth list is what Cluster indexes by channel for coordinate labels, and a design
+    // whose list were empty would be indistinguishable from an unresolved arch under the
+    // predicate this change removed.
+    it('carries a non-empty channel-indexed eth list for every supported arch', () => {
+        expect(getChipDesign(DeviceArchitecture.WORMHOLE)?.eth?.length).toBeGreaterThan(0);
+        expect(getChipDesign(DeviceArchitecture.BLACKHOLE)?.eth?.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/stringToArchitecture.spec.ts
+++ b/tests/stringToArchitecture.spec.ts
@@ -32,4 +32,16 @@ describe('stringToArchitecture', () => {
         expect(stringToArchitecture('quasar')).toBe(DeviceArchitecture.UNKNOWN);
         expect(stringToArchitecture('')).toBe(DeviceArchitecture.UNKNOWN);
     });
+
+    // The descriptor is uploaded and reaches us through `yaml.safe_load`, which does no schema
+    // validation: a bare `arch: 1` or a nested map both parse. Calling `.toLowerCase()` on one
+    // throws, and the nearest boundary is the router's root `errorElement`, which replaces the
+    // whole app shell rather than degrading the cluster view.
+    it('treats a non-string arch as unknown instead of throwing', () => {
+        expect(stringToArchitecture(undefined)).toBe(DeviceArchitecture.UNKNOWN);
+        expect(stringToArchitecture(null)).toBe(DeviceArchitecture.UNKNOWN);
+        expect(stringToArchitecture(1)).toBe(DeviceArchitecture.UNKNOWN);
+        expect(stringToArchitecture({ name: 'wormhole_b0' })).toBe(DeviceArchitecture.UNKNOWN);
+        expect(stringToArchitecture(['wormhole_b0'])).toBe(DeviceArchitecture.UNKNOWN);
+    });
 });

--- a/tests/stringToArchitecture.spec.ts
+++ b/tests/stringToArchitecture.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { DeviceArchitecture } from '../src/definitions/DeviceArchitecture';
+import { stringToArchitecture } from '../src/functions/stringToArchitecture';
+
+// Cluster resolves a baked descriptor per chip from this result, so an arch that resolves
+// to the wrong family mislabels eth coordinates and PCIe markers rather than omitting
+// them. The values here are the ones cluster_descriptor.yaml actually carries. #1772
+
+describe('stringToArchitecture', () => {
+    it('resolves the revision-suffixed names descriptors carry', () => {
+        expect(stringToArchitecture('wormhole_b0')).toBe(DeviceArchitecture.WORMHOLE);
+        expect(stringToArchitecture('blackhole')).toBe(DeviceArchitecture.BLACKHOLE);
+    });
+
+    it('is case insensitive', () => {
+        expect(stringToArchitecture('WORMHOLE_B0')).toBe(DeviceArchitecture.WORMHOLE);
+        expect(stringToArchitecture('Blackhole')).toBe(DeviceArchitecture.BLACKHOLE);
+    });
+
+    it('does not resolve a name that merely contains an arch', () => {
+        // Substring matching used to resolve these, so an unknown arch borrowed Wormhole's
+        // eth list instead of dropping its enrichment.
+        expect(stringToArchitecture('nonwormhole_b0')).toBe(DeviceArchitecture.UNKNOWN);
+        expect(stringToArchitecture('notblackhole')).toBe(DeviceArchitecture.UNKNOWN);
+    });
+
+    it('reports an unrecognised or absent arch as unknown', () => {
+        expect(stringToArchitecture('quasar')).toBe(DeviceArchitecture.UNKNOWN);
+        expect(stringToArchitecture('')).toBe(DeviceArchitecture.UNKNOWN);
+    });
+});


### PR DESCRIPTION
Closes #1772

## Summary

Cluster's chip placement and link graph already come entirely from the **cluster descriptor**. The baked SoC/arch descriptor was only ever used for *enrichment* — translating an eth channel index to a NoC core-id for coordinate labels, and placing PCIe marker dots — yet it was load-bearing: an unrecognised arch blanked the entire view behind the "not supported" panel. This decouples them, so a cluster renders from its own descriptor alone and we don't need to bake an arch JSON per licensee just to draw its topology.

- Eth ports are keyed by **channel** (`ethUid(rank, chipId, chan)`), so links resolve from `ethernet_connections` without an arch core-id lookup.
- Coordinate labels and PCIe markers became optional enrichment, resolved **per chip** from that chip's own `arch` entry — a heterogeneous cluster no longer labels every chip from chip 0 of host 0, and an unresolved chip doesn't suppress its neighbour's label.
- The `!chipDesign?.eth → unsupported` guard is gone. An unknown arch now degrades to a fully drawn topology without labels or PCIe dots.

A cluster report with an arch of `quasar`, `grendel` or any licensee name renders its placement and links normally.

## Fixed along the way

**Every cluster report was rendering Wormhole eth coordinates and PCIe positions regardless of its actual architecture.** `arch` in `cluster_descriptor.yaml` is a map keyed by chip id, but the model typed it `string[]` and the component gated on `firstHostArch.length` — `undefined` on an object — so `|| DEFAULT_ARCHITECTURE` won unconditionally and the arch string was never read at all. Wormhole's eth list has 16 entries against Blackhole's 14, so every Blackhole channel indexed successfully into the wrong list: coordinate labels were wrong, but no links were dropped, which is why it went unnoticed.

This **deliberately deviates from the ticket's "Wormhole/Blackhole cluster reports are visually unchanged" criterion**. Blackhole labels do change, because they were previously wrong. Wormhole is unchanged, and placement and links are unchanged for both.

Arch matching is also now prefix-based rather than substring. Descriptors carry a revision suffix (`wormhole_b0`) that has to resolve, but a name merely *containing* an arch must not — now that the resolved arch drives per-chip enrichment, a licensee name containing "wormhole" would mislabel that chip instead of cleanly omitting its labels.

## Test plan

Covered by tests (`tests/ClusterUnknownArch.spec.tsx`, `tests/stringToArchitecture.spec.ts`):

- [x] Recognised Wormhole arch labels ports, draws a PCIe marker, draws the link segment
- [x] Blackhole arch labels from Blackhole's channel map, not Wormhole's — the two are disjoint at the linked channels, so this pins the per-chip resolution
- [x] Unrecognised arch still draws ports and link segments, omits labels and PCIe markers, and does not fall back to the unsupported panel
- [x] Heterogeneous arch enriches each chip independently, in either ordering
- [x] Arch resolver handles the revision suffix and case, and rejects a name that merely contains an arch

Worth checking when reviewing:

- [ ] A Wormhole cluster report looks identical to `dev`
- [ ] A Blackhole cluster report now shows Blackhole eth coordinates (this is the fix above — labels change)
- [ ] A multi-host report still stitches and draws inter-host links

## Notes for the reviewer

The port uid is now built in one place. Previously the segment pass rebuilt it independently, and a drift between the two constructions rendered **zero links while the whole suite passed** — ports, labels and PCIe markers never touch `portPixelByUid`. The uids are now carried from `recordConnection` to the segment pass, and both remaining constructions are immediately validated by a map lookup the tests exercise.

## Follow-ups (not in scope here)

- The `unsupported` panel is now unreachable on the real fetch path — `fetchClusterTopology` always yields at least one host. A genuinely missing cluster descriptor leaves the view on "Loading…" indefinitely, because there's no error branch. Pre-existing; this change makes it the only remaining path.
- Inter-host link rendering has no test coverage; the fixture here is single-host.
- `getChipDesign` signals "no descriptor" via a frozen sentinel compared by identity. Returning `ChipDesign | null` would put that in the type system.
- A channel beyond a known arch's eth list renders one blank label among labelled siblings. Currently unspecified behaviour.