### PR TITLE
Scope report reads to rank 0 so multi-host reports stop rendering a colliding union

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1100,7 +1100,7 @@ Every route in the file decorates with `@api.route("/path", methods=[...])` and 
 
 **Don't.** Create a second blueprint for a new endpoint group unless you genuinely need a separate `url_prefix` and lifecycle (e.g. an unauthenticated `/health` namespace). Two blueprints with the same prefix create silent registration-order bugs.
 
-Module-private helpers inside `views.py` (cross-route utilities like rank-parameter parsing) carry a leading underscore — covered under [Naming](#naming). Examples currently in `views.py`: `_file_path_from_stack_source_request`, `_optional_rank_query_param`, `_reject_nonzero_rank_on_legacy_db`, `_stack_source_availability_response`. New cross-endpoint helpers go in the same file with the same prefix; only reach for a separate module if the helper is needed outside `views.py`.
+Module-private helpers inside `views.py` (cross-route utilities like rank-parameter parsing) carry a leading underscore — covered under [Naming](#naming). Examples currently in `views.py`: `_file_path_from_stack_source_request`, `_rank_query_param`, `_reject_nonzero_rank_on_legacy_db`, `_stack_source_availability_response`. New cross-endpoint helpers go in the same file with the same prefix; only reach for a separate module if the helper is needed outside `views.py`.
 
 ### Prefer `Response(orjson.dumps(payload), mimetype="application/json")` for read-mostly endpoints
 

--- a/backend/ttnn_visualizer/queries.py
+++ b/backend/ttnn_visualizer/queries.py
@@ -144,26 +144,45 @@ class DatabaseQueries:
                 )
             self.query_runner = LocalQueryRunner(instance=instance)
 
+        # A report DB is read-only for the lifetime of this context manager, so its
+        # schema cannot change under us. Worth caching because these two run on
+        # nearly every read: `merge_rank_filter` alone probes per table per call,
+        # a dozen-plus times on `/operations` and `/tensors`.
+        self._table_exists_cache: Dict[str, bool] = {}
+        self._table_columns_cache: Dict[str, List[str]] = {}
+
     def _check_table_exists(self, table_name: str) -> bool:
         """
         Checks if a table exists in the database.
         This method works for both local and remote databases.
         """
+        cached = self._table_exists_cache.get(table_name)
+        if cached is not None:
+            return cached
+
         # Properly format the table name into the query string with single quotes
         query = "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?"
 
         # Use the execute_query method to handle both local and remote cases.
         rows = self.query_runner.execute_query(query, [table_name])
 
-        return bool(rows)
+        exists = bool(rows)
+        self._table_exists_cache[table_name] = exists
+        return exists
 
     def _get_table_columns(self, table_name: str) -> List[str]:
         """
         Gets the list of column names for a table.
         """
+        cached = self._table_columns_cache.get(table_name)
+        if cached is not None:
+            return cached
+
         query = f"PRAGMA table_info({table_name})"
         rows = self.query_runner.execute_query(query)
-        return [row[1] for row in rows]  # row[1] is the column name
+        columns = [row[1] for row in rows]  # row[1] is the column name
+        self._table_columns_cache[table_name] = columns
+        return columns
 
     def _dataclass_select_clause(
         self,
@@ -240,7 +259,13 @@ class DatabaseQueries:
     ) -> Dict[str, Any]:
         """
         Return a copy of filters with rank = rank if the table has a rank column.
-        No-op when rank is None or the schema has no rank (old reports).
+        No-op when the schema has no rank column (old reports).
+
+        ``rank=None`` means "every rank", which for a report route is almost never
+        what you want: ids restart at 1 per rank, so an unfiltered read unions the
+        ranks and collides. Report routes get their rank from
+        ``views._rank_query_param()``, which defaults to 0 and never returns None.
+        Pass None only for a genuinely rank-agnostic aggregate. #1842
         """
         out = dict(filters or {})
         if rank is None:
@@ -371,8 +396,25 @@ class DatabaseQueries:
             yield ErrorRecord(*row)
 
     def query_tensor_comparisons(
-        self, local: bool = True, filters: Optional[Dict[str, Any]] = None
+        self,
+        local: bool = True,
+        filters: Optional[Dict[str, Any]] = None,
+        rank: Optional[int] = None,
     ) -> Generator[TensorComparisonRecord, None, None]:
+        """
+        Yield comparison records, optionally narrowed to one rank's tensors.
+
+        The comparison tables have no ``rank`` column, so a rank can only be
+        applied indirectly, through the tensor ids that belong to it. That
+        narrowing is expressed as a subquery rather than by reading the ids out
+        and binding one parameter each: a report with more tensors than SQLite's
+        variable cap (32766) would fail outright, and every report would pay a
+        parameter list that grows with its tensor count.
+
+        Caveat this cannot fix here: with ids restarting per rank, a comparison
+        row for ``tensor_id = 1`` is ambiguous between ranks. Disambiguating it
+        needs a ``rank`` column on the comparison tables. #1842
+        """
         if local:
             table_name = "local_tensor_comparison_records"
         else:
@@ -380,7 +422,22 @@ class DatabaseQueries:
         select_clause = self._dataclass_select_clause(
             table_name, TensorComparisonRecord
         )
-        rows = self._query_table(table_name, filters, select_clause=select_clause)
+
+        additional_conditions = None
+        additional_params: Optional[List[Any]] = None
+        if rank is not None and "rank" in self._get_table_columns("tensors"):
+            additional_conditions = (
+                "AND tensor_id IN (SELECT tensor_id FROM tensors WHERE rank = ?)"
+            )
+            additional_params = [rank]
+
+        rows = self._query_table(
+            table_name,
+            filters,
+            additional_conditions=additional_conditions,
+            additional_params=additional_params,
+            select_clause=select_clause,
+        )
         for row in rows:
             yield TensorComparisonRecord(*row)
 

--- a/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
+++ b/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
@@ -3,13 +3,14 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 """
-API tests for optional ``?rank=`` filtering on multi-host report databases.
+API tests for ``?rank=`` filtering on multi-host report databases.
 """
 
 import sqlite3
 import tempfile
 from http import HTTPStatus
 from pathlib import Path
+from typing import Any, List
 
 import pytest
 from ttnn_visualizer.extensions import db
@@ -245,9 +246,157 @@ CREATE TABLE global_tensor_comparison_records (
 """
 
 
+# Shaped like a real multi-host capture: the writer restarts `operation_id` and
+# `tensor_id` at 1 for every rank, so both ranks reuse the SAME ids and only
+# `(rank, id)` is unique. `_RANKED_REPORT_SQL` above keeps ids distinct per rank
+# because its mismatch tests need an id that exists on one rank only; this
+# fixture is the one that reproduces the collision from #1842.
+_COLLIDING_RANK_REPORT_SQL = """
+CREATE TABLE operations (
+    operation_id int,
+    name text,
+    duration float,
+    rank int NOT NULL DEFAULT 0,
+    UNIQUE(operation_id, rank)
+);
+INSERT INTO operations VALUES (1, 'ttnn.to_device', 1.0, 0), (1, 'ttnn.to_device', 2.0, 1);
+
+CREATE TABLE operation_arguments (
+    operation_id int,
+    name text,
+    value text,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE stack_traces (
+    operation_id int,
+    stack_trace text,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE input_tensors (
+    operation_id int,
+    input_index int,
+    tensor_id int,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE output_tensors (
+    operation_id int,
+    output_index int,
+    tensor_id int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO output_tensors VALUES (1, 0, 1, 0), (1, 0, 1, 1);
+
+CREATE TABLE tensors (
+    tensor_id int,
+    shape text,
+    dtype text,
+    layout text,
+    memory_config text,
+    device_id int,
+    address int,
+    buffer_type int,
+    rank int NOT NULL DEFAULT 0,
+    size int,
+    UNIQUE(tensor_id, rank)
+);
+INSERT INTO tensors VALUES
+(1, '(1,)', 'float32', 'TILE', '{}', 0, 100, 0, 0, 4096),
+(1, '(1,)', 'float32', 'TILE', '{}', 0, 100, 0, 1, 4096);
+
+CREATE TABLE buffers (
+    operation_id int,
+    device_id int,
+    address int,
+    max_size_per_bank int,
+    buffer_type int,
+    buffer_layout int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO buffers VALUES (1, 0, 100, 512, 0, 0, 0), (1, 0, 100, 512, 0, 0, 1);
+
+CREATE TABLE buffer_pages (
+    operation_id int,
+    device_id int,
+    address int,
+    core_y int,
+    core_x int,
+    bank_id int,
+    page_index int,
+    page_address int,
+    page_size int,
+    buffer_type int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO buffer_pages VALUES
+(1, 0, 100, 0, 0, 0, 0, 100, 4096, 0, 0),
+(1, 0, 100, 0, 0, 0, 0, 100, 4096, 0, 1);
+
+-- `device_id` is re-normalised to 0-based per rank by the writer, so both ranks
+-- report `device 0`. That is exactly why device_id cannot disambiguate a rank.
+CREATE TABLE devices (
+    device_id int,
+    num_y_cores int,
+    num_x_cores int,
+    num_y_compute_cores int,
+    num_x_compute_cores int,
+    worker_l1_size int,
+    l1_num_banks int,
+    l1_bank_size int,
+    address_at_first_l1_bank int,
+    address_at_first_l1_cb_buffer int,
+    num_banks_per_storage_core int,
+    num_compute_cores int,
+    total_l1_memory int,
+    total_l1_for_tensors int,
+    total_l1_for_interleaved_buffers int,
+    total_l1_for_sharded_buffers int,
+    cb_limit int,
+    rank int NOT NULL DEFAULT 0
+);
+INSERT INTO devices VALUES
+(0, 4, 4, 2, 2, 1024, 4, 256, 0, 0, 1, 2, 4096, 2048, 2048, 2048, 256, 0),
+(0, 4, 4, 2, 2, 1024, 4, 256, 0, 0, 1, 2, 4096, 2048, 2048, 2048, 256, 1);
+
+CREATE TABLE errors (
+    operation_id int,
+    operation_name text,
+    error_type text,
+    error_message text,
+    stack_trace text,
+    timestamp text,
+    rank int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE local_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+CREATE TABLE global_tensor_comparison_records (
+    tensor_id int,
+    golden_tensor_id int,
+    matches int,
+    desired_pcc float,
+    actual_pcc float
+);
+"""
+
+
 def _write_ranked_report_db(path: str) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(_RANKED_REPORT_SQL)
+    conn.commit()
+    conn.close()
+
+
+def _write_colliding_rank_report_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(_COLLIDING_RANK_REPORT_SQL)
     conn.commit()
     conn.close()
 
@@ -302,6 +451,35 @@ def test_operations_list_without_rank_defaults_to_rank_zero(app, client):
         Path(path).unlink(missing_ok=True)
 
 
+def _collect_ranks(payload: Any) -> List[int]:
+    """Every ``rank`` value anywhere in a response, however deeply nested."""
+    found: List[int] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key == "rank" and isinstance(value, int):
+                found.append(value)
+            else:
+                found.extend(_collect_ranks(value))
+    elif isinstance(payload, list):
+        for item in payload:
+            found.extend(_collect_ranks(item))
+    return found
+
+
+def _assert_scoped_to_rank_zero(payload: Any, path: str) -> None:
+    """
+    Assert a response carries rank-0 rows only.
+
+    A union would surface rank 1 somewhere in the payload, so this is the
+    assertion that can actually fail if a route stops filtering. The
+    non-empty check keeps it from passing vacuously on a route whose
+    serializer drops the ``rank`` field.
+    """
+    ranks = _collect_ranks(payload)
+    assert ranks, f"{path} serialized no rank field, so scoping is unverifiable"
+    assert set(ranks) == {0}, f"{path} leaked non-zero ranks: {sorted(set(ranks))}"
+
+
 @pytest.mark.parametrize(
     "path,extra_query",
     [
@@ -312,6 +490,13 @@ def test_operations_list_without_rank_defaults_to_rank_zero(app, client):
         ("/api/operation-buffers", {}),
         ("/api/errors", {}),
         ("/api/operations/1", {}),
+        ("/api/operation-buffers/1", {}),
+        ("/api/tensors/100", {}),
+        ("/api/buffer-pages", {"operation_id": "1", "address": "100"}),
+        # `/api/buffer` is deliberately absent: `query_next_buffer` looks for the
+        # address in a *later* operation, so it 404s on a one-operation-per-rank
+        # fixture for reasons unrelated to rank. Its rank handling is covered by
+        # `test_legacy_nonzero_rank_returns_422_not_rank_zero_payload`.
     ],
 )
 def test_omitted_rank_is_equivalent_to_explicit_rank_zero(
@@ -321,6 +506,9 @@ def test_omitted_rank_is_equivalent_to_explicit_rank_zero(
     The two route families used to disagree on what an absent rank meant:
     file-backed routes defaulted to 0, DB-backed routes returned every rank.
     Pin the unified contract so the asymmetry can't come back. #1842
+
+    Payload equality alone is not enough: two identical unions would satisfy it.
+    The rank-0 assertion below is what makes this test able to fail.
     """
     with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
         db_path = f.name
@@ -342,6 +530,7 @@ def test_omitted_rank_is_equivalent_to_explicit_rank_zero(
         assert (
             omitted.get_json() == explicit.get_json()
         ), f"{path} returns a different payload when rank is omitted"
+        _assert_scoped_to_rank_zero(omitted.get_json(), path)
     finally:
         Path(db_path).unlink(missing_ok=True)
 
@@ -613,6 +802,96 @@ def test_legacy_nonzero_rank_returns_422_not_rank_zero_payload(
         assert not isinstance(err, list)
     finally:
         Path(path_db).unlink(missing_ok=True)
+
+
+def test_colliding_ids_do_not_union_without_rank(app, client):
+    """
+    The #1842 symptom: with both ranks reusing ``operation_id = 1`` and
+    ``tensor_id = 1``, an unfiltered read returned two indistinguishable rows
+    per entity. Scoped to rank 0 there must be exactly one of each.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_colliding_rank_report_db(path)
+        _register_profiler_instance(app, path)
+
+        operations = client.get(
+            "/api/operations",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert operations.status_code == HTTPStatus.OK
+        ops = operations.get_json()
+        assert len(ops) == 1, f"unioned ranks: {ops}"
+        assert ops[0]["id"] == 1
+        assert ops[0]["rank"] == 0
+        assert len(ops[0]["outputs"]) == 1
+
+        tensors = client.get(
+            "/api/tensors",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert tensors.status_code == HTTPStatus.OK
+        tensor_rows = tensors.get_json()
+        assert len(tensor_rows) == 1, f"unioned ranks: {tensor_rows}"
+        assert tensor_rows[0]["id"] == 1
+        assert tensor_rows[0]["rank"] == 0
+
+        buffers = client.get(
+            "/api/buffers",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert buffers.status_code == HTTPStatus.OK
+        buffer_rows = buffers.get_json()
+        assert len(buffer_rows) == 1, f"unioned ranks: {buffer_rows}"
+        assert buffer_rows[0]["rank"] == 0
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_colliding_ids_resolve_per_rank_on_detail_routes(app, client):
+    """
+    A shared id must still address both rows: ``/operations/1`` is rank 0's
+    operation by default and rank 1's when asked, never an arbitrary winner.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_colliding_rank_report_db(path)
+        _register_profiler_instance(app, path)
+
+        default = client.get(
+            "/api/operations/1",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert default.status_code == HTTPStatus.OK
+        assert default.get_json()["rank"] == 0
+        assert default.get_json()["duration"] == 1.0
+
+        rank_one = client.get(
+            "/api/operations/1",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert rank_one.status_code == HTTPStatus.OK
+        assert rank_one.get_json()["rank"] == 1
+        assert rank_one.get_json()["duration"] == 2.0
+
+        # Same colliding tensor_id, disambiguated only by rank.
+        tensor_zero = client.get(
+            "/api/tensors/1",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert tensor_zero.status_code == HTTPStatus.OK
+        assert tensor_zero.get_json()["rank"] == 0
+
+        tensor_one = client.get(
+            "/api/tensors/1",
+            query_string={"instanceId": INSTANCE_ID, "rank": "1"},
+        )
+        assert tensor_one.status_code == HTTPStatus.OK
+        assert tensor_one.get_json()["rank"] == 1
+    finally:
+        Path(path).unlink(missing_ok=True)
 
 
 def test_rank_zero_explicit_allowed_on_legacy_db(app, client):

--- a/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
+++ b/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
@@ -276,7 +276,12 @@ def _register_profiler_instance(
         db.session.commit()
 
 
-def test_operations_list_without_rank_returns_all_ranks(app, client):
+def test_operations_list_without_rank_defaults_to_rank_zero(app, client):
+    """
+    Omitting ``?rank`` must scope to rank 0, not union every rank. The writer
+    restarts operation_id/tensor_id at 1 per rank, so a union collides on ids
+    and the client renders one row per rank with no way to tell them apart. #1842
+    """
     with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
         path = f.name
     try:
@@ -290,11 +295,55 @@ def test_operations_list_without_rank_returns_all_ranks(app, client):
         assert response.status_code == HTTPStatus.OK
         data = response.get_json()
         assert isinstance(data, list)
-        assert len(data) == 2
-        names = {op["name"] for op in data}
-        assert names == {"op_r0", "op_r1"}
+        assert len(data) == 1
+        assert data[0]["name"] == "op_r0"
+        assert data[0]["rank"] == 0
     finally:
         Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    "path,extra_query",
+    [
+        ("/api/operations", {}),
+        ("/api/tensors", {}),
+        ("/api/devices", {}),
+        ("/api/buffers", {}),
+        ("/api/operation-buffers", {}),
+        ("/api/errors", {}),
+        ("/api/operations/1", {}),
+    ],
+)
+def test_omitted_rank_is_equivalent_to_explicit_rank_zero(
+    app, client, path, extra_query
+):
+    """
+    The two route families used to disagree on what an absent rank meant:
+    file-backed routes defaulted to 0, DB-backed routes returned every rank.
+    Pin the unified contract so the asymmetry can't come back. #1842
+    """
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = f.name
+    try:
+        _write_ranked_report_db(db_path)
+        _register_profiler_instance(app, db_path)
+
+        omitted = client.get(
+            path,
+            query_string={"instanceId": INSTANCE_ID, **extra_query},
+        )
+        explicit = client.get(
+            path,
+            query_string={"instanceId": INSTANCE_ID, "rank": "0", **extra_query},
+        )
+
+        assert omitted.status_code == HTTPStatus.OK, f"{path} failed without rank"
+        assert explicit.status_code == HTTPStatus.OK, f"{path} failed with rank=0"
+        assert (
+            omitted.get_json() == explicit.get_json()
+        ), f"{path} returns a different payload when rank is omitted"
+    finally:
+        Path(db_path).unlink(missing_ok=True)
 
 
 def test_operations_list_rank_filter_limits_operations_and_nested_tensors(app, client):

--- a/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
+++ b/backend/ttnn_visualizer/tests/views/test_rank_query_param.py
@@ -15,6 +15,7 @@ from typing import Any, List
 import pytest
 from ttnn_visualizer.extensions import db
 from ttnn_visualizer.models import InstanceTable
+from ttnn_visualizer.queries import DatabaseQueries
 
 INSTANCE_ID = "pytest-rank-filter"
 LEGACY_INSTANCE_ID = "pytest-legacy-no-rank"
@@ -302,9 +303,12 @@ CREATE TABLE tensors (
     size int,
     UNIQUE(tensor_id, rank)
 );
+-- Tensor 1 collides across both ranks; tensor 2 exists on rank 1 only, so it is
+-- the probe for whether a rank-0 read reaches another rank's tensors.
 INSERT INTO tensors VALUES
 (1, '(1,)', 'float32', 'TILE', '{}', 0, 100, 0, 0, 4096),
-(1, '(1,)', 'float32', 'TILE', '{}', 0, 100, 0, 1, 4096);
+(1, '(1,)', 'float32', 'TILE', '{}', 0, 100, 0, 1, 4096),
+(2, '(2,)', 'float32', 'TILE', '{}', 0, 200, 0, 1, 8192);
 
 CREATE TABLE buffers (
     operation_id int,
@@ -370,6 +374,10 @@ CREATE TABLE errors (
     rank int NOT NULL DEFAULT 0
 );
 
+-- No `rank` column here, mirroring the real schema: a comparison can only be
+-- narrowed through the tensor ids belonging to a rank. Rows exist for tensor 1
+-- (both ranks) and tensor 2 (rank 1 only), so a rank-0 read must return the
+-- former and never the latter.
 CREATE TABLE local_tensor_comparison_records (
     tensor_id int,
     golden_tensor_id int,
@@ -377,6 +385,7 @@ CREATE TABLE local_tensor_comparison_records (
     desired_pcc float,
     actual_pcc float
 );
+INSERT INTO local_tensor_comparison_records VALUES (1, 900, 1, 0.99, 0.995), (2, 901, 0, 0.99, 0.5);
 CREATE TABLE global_tensor_comparison_records (
     tensor_id int,
     golden_tensor_id int,
@@ -384,6 +393,7 @@ CREATE TABLE global_tensor_comparison_records (
     desired_pcc float,
     actual_pcc float
 );
+INSERT INTO global_tensor_comparison_records VALUES (1, 800, 1, 0.98, 0.985), (2, 801, 0, 0.98, 0.4);
 """
 
 
@@ -397,6 +407,23 @@ def _write_ranked_report_db(path: str) -> None:
 def _write_colliding_rank_report_db(path: str) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(_COLLIDING_RANK_REPORT_SQL)
+    conn.commit()
+    conn.close()
+
+
+def _write_wide_ranked_report_db(path: str, *, tensor_count: int) -> None:
+    """Ranked report carrying ``tensor_count`` rank-0 tensors.
+
+    Sized past SQLite's 32766-variable cap, so a rank scoping that binds one
+    parameter per tensor id fails outright rather than merely being slow.
+    """
+    conn = sqlite3.connect(path)
+    conn.executescript(_COLLIDING_RANK_REPORT_SQL)
+    conn.executemany(
+        "INSERT INTO tensors VALUES (?, '(1,)', 'float32', 'TILE', '{}', 0, ?, 0, 0, 4096)",
+        # Tensor 1 already sits at rank 0 in the fixture.
+        [(tensor_id, 1000 + tensor_id) for tensor_id in range(2, tensor_count + 1)],
+    )
     conn.commit()
     conn.close()
 
@@ -731,7 +758,17 @@ def test_operation_detail_rank_mismatch_returns_404(app, client):
         Path(path).unlink(missing_ok=True)
 
 
-def test_invalid_rank_query_returns_400(app, client):
+@pytest.mark.parametrize(
+    "rank,reason",
+    [
+        ("not-an-int", "not an integer"),
+        # `int()` is arbitrary-precision: unbounded, this reaches SQLite's int64
+        # binding and raises OverflowError as an unhandled 500.
+        ("99999999999999999999", "beyond SQLite's integer range"),
+        ("-1", "negative, which no world size contains"),
+    ],
+)
+def test_invalid_rank_query_returns_400(app, client, rank, reason):
     with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
         path = f.name
     try:
@@ -740,9 +777,11 @@ def test_invalid_rank_query_returns_400(app, client):
 
         response = client.get(
             "/api/tensors",
-            query_string={"instanceId": INSTANCE_ID, "rank": "not-an-int"},
+            query_string={"instanceId": INSTANCE_ID, "rank": rank},
         )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert (
+            response.status_code == HTTPStatus.BAD_REQUEST
+        ), f"rank={rank!r} is {reason}, got {response.status_code}"
     finally:
         Path(path).unlink(missing_ok=True)
 
@@ -890,6 +929,99 @@ def test_colliding_ids_resolve_per_rank_on_detail_routes(app, client):
         )
         assert tensor_one.status_code == HTTPStatus.OK
         assert tensor_one.get_json()["rank"] == 1
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_scoped_comparisons_still_attach_to_their_tensor(app, client):
+    """
+    Scoping comparisons by rank must not cost the rank its own comparison.
+
+    Only the attachment is observable here: ``serialize_tensors`` keys
+    comparisons by the tensors in the response, so surplus rows for another
+    rank's tensors are silently dropped and cannot be asserted on. The
+    narrowing itself is verified in ``test_query_tensor_comparisons_rank``.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_colliding_rank_report_db(path)
+        _register_profiler_instance(app, path)
+
+        response = client.get(
+            "/api/tensors",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+        assert response.status_code == HTTPStatus.OK
+        rows = response.get_json()
+        assert len(rows) == 1
+
+        comparison = rows[0]["comparison"]
+        assert comparison is not None, "rank 0's own comparison was dropped"
+        assert comparison["local"]["golden_tensor_id"] == 900
+        assert comparison["global"]["golden_tensor_id"] == 800
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_query_tensor_comparisons_rank(app):
+    """
+    The rank argument must narrow to that rank's tensor ids and nothing else.
+
+    Tensor 2 exists on rank 1 only, so its comparison rows (golden 901/801) are
+    the evidence: reading them under ``rank=0`` means the scoping was dropped.
+    Asserted at this layer because the route serializes comparisons against the
+    tensors it already holds, which hides any surplus.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_colliding_rank_report_db(path)
+        connection = sqlite3.connect(path)
+        try:
+            db = DatabaseQueries(connection=connection)
+
+            scoped = [c.golden_tensor_id for c in db.query_tensor_comparisons(rank=0)]
+            assert scoped == [900], f"reached another rank's comparisons: {scoped}"
+
+            scoped_global = [
+                c.golden_tensor_id
+                for c in db.query_tensor_comparisons(local=False, rank=0)
+            ]
+            assert scoped_global == [800], scoped_global
+
+            # `rank=None` is the unscoped read the report routes no longer make.
+            unscoped = [c.golden_tensor_id for c in db.query_tensor_comparisons()]
+            assert sorted(unscoped) == [900, 901]
+        finally:
+            connection.close()
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_comparison_scoping_survives_a_report_larger_than_the_sqlite_var_cap(
+    app, client
+):
+    """
+    Scoping must not bind one parameter per tensor id.
+
+    SQLite refuses more than 32766 variables in a statement, so reading the ids
+    out and binding them made any report above that cap a hard 500 — and every
+    smaller one pay a parameter list growing with its tensor count.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    try:
+        _write_wide_ranked_report_db(path, tensor_count=40_000)
+        _register_profiler_instance(app, path)
+
+        response = client.get(
+            "/api/tensors",
+            query_string={"instanceId": INSTANCE_ID},
+        )
+
+        assert response.status_code == HTTPStatus.OK, response.get_data(as_text=True)
+        assert len(response.get_json()) == 40_000
     finally:
         Path(path).unlink(missing_ok=True)
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -176,6 +176,16 @@ def _stack_source_request_params():
 
 
 _DEFAULT_RANK = 0
+# `int()` is arbitrary-precision, so an unbounded parse lets a value too large for
+# SQLite's int64 binding reach the driver, where it raises OverflowError as an
+# unhandled 500. These routes aren't `@local_only`, so that is reachable by anyone
+# under SERVER_MODE. A world size never approaches this, and rejecting negatives
+# here also matches the 400 the file-backed routes already return for them.
+_MAX_RANK = 2**31 - 1
+_INVALID_RANK_MSG = (
+    f"Invalid query parameter 'rank': expected an integer "
+    f"between {_DEFAULT_RANK} and {_MAX_RANK}."
+)
 
 
 def _rank_query_param() -> int:
@@ -192,16 +202,20 @@ def _rank_query_param() -> int:
     raw = request.args.get("rank")
     if raw is None or raw == "":
         return _DEFAULT_RANK
+
     try:
-        return int(raw)
+        rank: Optional[int] = int(raw)
     except (TypeError, ValueError):
-        abort(
-            400,
-            description="Invalid query parameter 'rank': expected an integer.",
-        )
-        # Unreachable: `abort` raises. Flask's stubs don't type it `NoReturn`,
-        # so mypy needs a terminating return on this branch.
+        rank = None
+
+    if rank is None or not _DEFAULT_RANK <= rank <= _MAX_RANK:
+        abort(400, description=_INVALID_RANK_MSG)
+        # Unreachable: Flask annotates `abort` as `NoReturn`, but
+        # `follow_imports = "skip"` under `[tool.mypy]` stops mypy from reading
+        # that annotation, so it still requires a terminating return here.
         return _DEFAULT_RANK
+
+    return rank
 
 
 _NONZERO_RANK_UNSUPPORTED_MSG = (
@@ -699,25 +713,8 @@ def tensors_list(instance: Instance):
         tensors = list(
             db.query_tensors(db.merge_rank_filter("tensors", tensor_filters, rank))
         )
-        # The comparison tables carry no `rank` column, so they can only be
-        # narrowed indirectly, via the rank-scoped tensor ids.
-        if "rank" in db._get_table_columns("tensors"):
-            tensor_ids = [t.tensor_id for t in tensors]
-            if tensor_ids:
-                local_comparisons = list(
-                    db.query_tensor_comparisons(filters={"tensor_id": tensor_ids})
-                )
-                global_comparisons = list(
-                    db.query_tensor_comparisons(
-                        local=False, filters={"tensor_id": tensor_ids}
-                    )
-                )
-            else:
-                local_comparisons = []
-                global_comparisons = []
-        else:
-            local_comparisons = list(db.query_tensor_comparisons())
-            global_comparisons = list(db.query_tensor_comparisons(local=False))
+        local_comparisons = list(db.query_tensor_comparisons(rank=rank))
+        global_comparisons = list(db.query_tensor_comparisons(local=False, rank=rank))
         producers_consumers = list(db.query_producers_consumers(rank=rank))
         serialized_tensors = serialize_tensors(
             tensors, producers_consumers, local_comparisons, global_comparisons

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -175,16 +175,23 @@ def _stack_source_request_params():
     return file_path, source_file_id, None
 
 
-def _optional_rank_query_param() -> Optional[int]:
+_DEFAULT_RANK = 0
+
+
+def _rank_query_param() -> int:
     """
-    Parse optional ``?rank=`` for multi-host report DBs.
-    Returns None if the parameter is absent or empty.
+    Parse ``?rank=`` for multi-host report DBs, defaulting to rank 0.
+
+    An absent rank must mean rank 0, never "every rank". The report writer
+    restarts ``operation_id`` and ``tensor_id`` at 1 for each rank and
+    re-normalises ``device_id`` per rank, so an unfiltered read unions the
+    ranks and collides on all three. File-backed routes (cluster/mesh
+    descriptor, profiler config) already defaulted to 0; DB-backed routes
+    passed None and returned the union. #1842
     """
-    if "rank" not in request.args:
-        return None
     raw = request.args.get("rank")
     if raw is None or raw == "":
-        return None
+        return _DEFAULT_RANK
     try:
         return int(raw)
     except (TypeError, ValueError):
@@ -192,7 +199,7 @@ def _optional_rank_query_param() -> Optional[int]:
             400,
             description="Invalid query parameter 'rank': expected an integer.",
         )
-        return None
+        return _DEFAULT_RANK
 
 
 _NONZERO_RANK_UNSUPPORTED_MSG = (
@@ -201,13 +208,13 @@ _NONZERO_RANK_UNSUPPORTED_MSG = (
 )
 
 
-def _reject_nonzero_rank_on_legacy_db(db: DatabaseQueries, rank: Optional[int]):
+def _reject_nonzero_rank_on_legacy_db(db: DatabaseQueries, rank: int):
     """
     Legacy reports only represent rank 0. If the client asks for a different rank
     but the schema has no ``rank`` column, return 422 instead of returning all rows
     (which would misleadingly appear as rank 0 in the API).
     """
-    if rank is None or rank == 0:
+    if rank == _DEFAULT_RANK:
         return None
     if db.report_has_rank_column():
         return None
@@ -358,7 +365,7 @@ def get_system_capabilities():
 @with_instance
 @timer
 def operation_list(instance: Instance):
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -418,7 +425,7 @@ def operation_list(instance: Instance):
 @with_instance
 @timer
 def operation_detail(operation_id, instance: Instance):
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -600,7 +607,7 @@ def operation_history(instance: Instance):
 @with_instance
 @timer
 def errors_list(instance: Instance):
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -651,8 +658,7 @@ def get_config(instance: Instance):
     to read another host's file (debugging).
     """
     report_dir = Path(str(instance.profiler_path)).parent
-    rank_param = _optional_rank_query_param()
-    logical_rank = 0 if rank_param is None else rank_param
+    logical_rank = _rank_query_param()
 
     payload, err = read_profiler_config_api_payload(report_dir, logical_rank)
     if err == "rank_out_of_range":
@@ -676,7 +682,7 @@ def get_config(instance: Instance):
 @with_instance
 @timer
 def tensors_list(instance: Instance):
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -733,7 +739,7 @@ def buffer_detail(instance: Instance):
     else:
         return response_bad_request()
 
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -766,7 +772,7 @@ def buffer_pages(instance: Instance):
     else:
         buffer_type = None
 
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -792,7 +798,7 @@ def buffer_pages(instance: Instance):
 @with_instance
 @timer
 def tensor_detail(tensor_id, instance: Instance):
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -821,7 +827,7 @@ def get_all_buffers(instance: Instance):
     else:
         buffer_type = None
 
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -850,7 +856,7 @@ def get_operations_buffers(instance: Instance):
     else:
         buffer_type = None
 
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -883,7 +889,7 @@ def get_operation_buffers(operation_id, instance: Instance):
     else:
         buffer_type = None
 
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -1325,7 +1331,7 @@ def get_zone_statistics(zone, instance: Instance):
 @api.route("/devices", methods=["GET"])
 @with_instance
 def get_devices(instance: Instance):
-    rank = _optional_rank_query_param()
+    rank = _rank_query_param()
     with DatabaseQueries(instance) as db:
         rejected = _reject_nonzero_rank_on_legacy_db(db, rank)
         if rejected is not None:
@@ -1612,8 +1618,7 @@ def get_cluster_descriptor(instance: Instance):
         return response_not_found("cluster_descriptor.yaml not found")
 
     report_dir = Path(instance.profiler_path).parent
-    rank_param = _optional_rank_query_param()
-    logical_rank = 0 if rank_param is None else rank_param
+    logical_rank = _rank_query_param()
 
     path, err = pick_cluster_descriptor_path(report_dir, logical_rank)
     if err == "rank_out_of_range":
@@ -1649,8 +1654,7 @@ def get_mesh_descriptor(instance: Instance):
         )
 
     report_dir = Path(instance.profiler_path).parent
-    rank_param = _optional_rank_query_param()
-    logical_rank = 0 if rank_param is None else rank_param
+    logical_rank = _rank_query_param()
 
     path, err = pick_mesh_descriptor_path(report_dir, logical_rank)
     if err == "rank_out_of_range":

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -199,6 +199,8 @@ def _rank_query_param() -> int:
             400,
             description="Invalid query parameter 'rank': expected an integer.",
         )
+        # Unreachable: `abort` raises. Flask's stubs don't type it `NoReturn`,
+        # so mypy needs a terminating return on this branch.
         return _DEFAULT_RANK
 
 
@@ -697,7 +699,9 @@ def tensors_list(instance: Instance):
         tensors = list(
             db.query_tensors(db.merge_rank_filter("tensors", tensor_filters, rank))
         )
-        if rank is not None and "rank" in db._get_table_columns("tensors"):
+        # The comparison tables carry no `rank` column, so they can only be
+        # narrowed indirectly, via the rank-scoped tensor ids.
+        if "rank" in db._get_table_columns("tensors"):
             tensor_ids = [t.tensor_id for t in tensors]
             if tensor_ids:
                 local_comparisons = list(

--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -35,7 +35,7 @@ import ROUTES from '../definitions/Routes';
 import 'styles/components/FooterInfobar.scss';
 import { useGetLatestAppVersion, useInstance, useReportMetadata } from '../hooks/useAPI';
 import getServerConfig from '../functions/getServerConfig';
-import { formatSyncedReportName } from '../functions/reportRank';
+import { formatSyncedReportName, getScopedRankLabel } from '../functions/reportRank';
 import { Instance } from '../model/APIData';
 import LoadingSpinner from './LoadingSpinner';
 import { LoadingSpinnerSizes } from '../definitions/LoadingSpinner';
@@ -161,8 +161,9 @@ function FooterInfobar() {
                                     {isMultiHostReport && (
                                         <>
                                             <br />
-                                            <strong>Multi-host report:</strong> showing rank {SCOPED_RANK} of{' '}
-                                            {worldSize}. Other ranks are not yet selectable.
+                                            <strong>Multi-host report:</strong> showing{' '}
+                                            {getScopedRankLabel(SCOPED_RANK, worldSize)}. Other ranks are not yet
+                                            selectable.
                                         </>
                                     )}
                                 </>
@@ -241,16 +242,20 @@ interface ReportRankTagProps {
     worldSize: number;
 }
 
-const ReportRankTag = ({ worldSize }: ReportRankTagProps) => (
-    <Tag
-        minimal
-        className='report-rank-tag'
-        aria-label={`Showing rank ${SCOPED_RANK} of ${worldSize}`}
-        intent={Intent.WARNING}
-    >
-        rank {SCOPED_RANK} of {worldSize}
-    </Tag>
-);
+const ReportRankTag = ({ worldSize }: ReportRankTagProps) => {
+    const label = getScopedRankLabel(SCOPED_RANK, worldSize);
+
+    return (
+        <Tag
+            minimal
+            className='report-rank-tag'
+            aria-label={`Showing ${label}`}
+            intent={Intent.WARNING}
+        >
+            {label}
+        </Tag>
+    );
+};
 
 const ReportLocationTag = ({ location }: { location: ReportLocation }) => {
     const isRemote = location === ReportLocation.REMOTE;

--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -33,7 +33,7 @@ import ReportLinkStatus from './ReportLinkStatus';
 import Range from './RangeSlider';
 import ROUTES from '../definitions/Routes';
 import 'styles/components/FooterInfobar.scss';
-import { useGetLatestAppVersion, useInstance, useReportMetadata } from '../hooks/useAPI';
+import { SINGLE_HOST_WORLD_SIZE, useGetLatestAppVersion, useInstance, useReportMetadata } from '../hooks/useAPI';
 import getServerConfig from '../functions/getServerConfig';
 import { Instance } from '../model/APIData';
 import LoadingSpinner from './LoadingSpinner';
@@ -42,6 +42,11 @@ import AppVersionStatus from './AppVersionStatus';
 import { ReportGitMetadataLines } from './operation-details/GitCommitInfo';
 
 const RANGE_DISALLOWED_ROUTES: string[] = [ROUTES.NPE];
+
+// The API scopes every report-backed read to rank 0 while rank selection is
+// unimplemented, so the footer states which rank is on screen rather than
+// letting a multi-host report look like the whole run. #1842
+const SCOPED_RANK = 0;
 
 function FooterInfobar() {
     const [sliderIsOpen, setSliderIsOpen] = useState(false);
@@ -55,6 +60,8 @@ function FooterInfobar() {
 
     const { data: instance } = useInstance();
     const { data: reportMetadata } = useReportMetadata();
+    const worldSize = reportMetadata?.worldSize ?? SINGLE_HOST_WORLD_SIZE;
+    const isMultiHostReport = worldSize > SINGLE_HOST_WORLD_SIZE;
     const location = useLocation();
     const {
         data: latestAppVersion,
@@ -150,6 +157,13 @@ function FooterInfobar() {
                                         gitUrl={reportMetadata?.gitUrl ?? null}
                                         gitSha={reportMetadata?.gitSha ?? null}
                                     />
+                                    {isMultiHostReport && (
+                                        <>
+                                            <br />
+                                            <strong>Multi-host report:</strong> showing rank {SCOPED_RANK} of{' '}
+                                            {reportMetadata?.worldSize}. Other ranks are not yet selectable.
+                                        </>
+                                    )}
                                 </>
                             }
                             position={PopoverPosition.TOP}
@@ -162,6 +176,7 @@ function FooterInfobar() {
                                 {profilerReportLocation !== null && (
                                     <ReportLocationTag location={profilerReportLocation} />
                                 )}
+                                {isMultiHostReport && <ReportRankTag worldSize={worldSize} />}
                             </div>
                         </Tooltip>
                     )}
@@ -220,6 +235,21 @@ function FooterInfobar() {
         </footer>
     );
 }
+
+interface ReportRankTagProps {
+    worldSize: number;
+}
+
+const ReportRankTag = ({ worldSize }: ReportRankTagProps) => (
+    <Tag
+        minimal
+        className='report-rank-tag'
+        aria-label={`Showing rank ${SCOPED_RANK} of ${worldSize}`}
+        intent={Intent.WARNING}
+    >
+        rank {SCOPED_RANK} of {worldSize}
+    </Tag>
+);
 
 const ReportLocationTag = ({ location }: { location: ReportLocation }) => {
     const isRemote = location === ReportLocation.REMOTE;

--- a/src/components/FooterInfobar.tsx
+++ b/src/components/FooterInfobar.tsx
@@ -28,12 +28,12 @@ import {
     profilerReportLocationAtom,
     selectedOperationRangeAtom,
 } from '../store/app';
-import { ReportLocation } from '../definitions/Reports';
+import { ReportLocation, SINGLE_HOST_WORLD_SIZE } from '../definitions/Reports';
 import ReportLinkStatus from './ReportLinkStatus';
 import Range from './RangeSlider';
 import ROUTES from '../definitions/Routes';
 import 'styles/components/FooterInfobar.scss';
-import { SINGLE_HOST_WORLD_SIZE, useGetLatestAppVersion, useInstance, useReportMetadata } from '../hooks/useAPI';
+import { useGetLatestAppVersion, useInstance, useReportMetadata } from '../hooks/useAPI';
 import getServerConfig from '../functions/getServerConfig';
 import { Instance } from '../model/APIData';
 import LoadingSpinner from './LoadingSpinner';
@@ -161,7 +161,7 @@ function FooterInfobar() {
                                         <>
                                             <br />
                                             <strong>Multi-host report:</strong> showing rank {SCOPED_RANK} of{' '}
-                                            {reportMetadata?.worldSize}. Other ranks are not yet selectable.
+                                            {worldSize}. Other ranks are not yet selectable.
                                         </>
                                     )}
                                 </>

--- a/src/definitions/Reports.ts
+++ b/src/definitions/Reports.ts
@@ -7,6 +7,10 @@ export enum ReportLocation {
     REMOTE = 'remote',
 }
 
+// A report's `world_size` is the number of ranks it spans. Anything above this
+// is a multi-host capture, which the API currently scopes to rank 0. #1842
+export const SINGLE_HOST_WORLD_SIZE = 1;
+
 export interface ReportFolder {
     path: string;
     reportName: string;

--- a/src/functions/reportRank.ts
+++ b/src/functions/reportRank.ts
@@ -33,3 +33,13 @@ export const formatSyncedReportName = (syncedName: string): string => {
 
     return match ? getRankedReportLabel(syncedName.slice(0, match.index), Number(match[1])) : syncedName;
 };
+
+/**
+ * `rank 0 of 2` — which rank of a multi-host report the API is showing.
+ *
+ * One source of truth for the tag text, its accessible name and the assertions:
+ * the visible label and the `aria-label` would otherwise be free to drift, and
+ * the tests only read the accessible name. #1842
+ */
+export const getScopedRankLabel = (scopedRank: number, worldSize: number): string =>
+    `rank ${scopedRank} of ${worldSize}`;

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -76,7 +76,7 @@ import {
     NpeClientErrorKind,
 } from '../definitions/NPEData';
 import Endpoints from '../definitions/Endpoints';
-import { ReportFolder } from '../definitions/Reports';
+import { ReportFolder, SINGLE_HOST_WORLD_SIZE } from '../definitions/Reports';
 import { RemoteFolder } from '../definitions/RemoteConnection';
 import createToastNotification from '../functions/createToastNotification';
 import { ToastType } from '../definitions/ToastType';
@@ -925,9 +925,6 @@ export const usePerformanceRange = (): NumberRange | null => {
     );
 };
 
-// Single-host reports omit `world_size`; treat an absent or unparseable value as one rank.
-export const SINGLE_HOST_WORLD_SIZE = 1;
-
 interface ReportMetadata {
     version: SemVer;
     timestamp: string;
@@ -941,6 +938,7 @@ export const fetchReportMetadata = async (): Promise<ReportMetadata> => {
     const { data } = await axiosInstance.get<ReportMetadataResponse>(Endpoints.REPORT_METADATA);
     const parsedSchemaVersion = semverParse(data?.schema_version);
     const parsedDuration = Number(data?.total_duration_ns);
+    // Single-host reports omit `world_size`; an absent or unparseable value is one rank.
     const parsedWorldSize = Number(data?.world_size);
 
     return {

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -925,18 +925,23 @@ export const usePerformanceRange = (): NumberRange | null => {
     );
 };
 
+// Single-host reports omit `world_size`; treat an absent or unparseable value as one rank.
+export const SINGLE_HOST_WORLD_SIZE = 1;
+
 interface ReportMetadata {
     version: SemVer;
     timestamp: string;
     duration: number;
     gitUrl: string | null;
     gitSha: string | null;
+    worldSize: number;
 }
 
 export const fetchReportMetadata = async (): Promise<ReportMetadata> => {
     const { data } = await axiosInstance.get<ReportMetadataResponse>(Endpoints.REPORT_METADATA);
     const parsedSchemaVersion = semverParse(data?.schema_version);
     const parsedDuration = Number(data?.total_duration_ns);
+    const parsedWorldSize = Number(data?.world_size);
 
     return {
         timestamp: data?.capture_timestamp_ns,
@@ -944,6 +949,10 @@ export const fetchReportMetadata = async (): Promise<ReportMetadata> => {
         version: parsedSchemaVersion,
         gitUrl: data?.git_url ?? null,
         gitSha: data?.git_sha ?? null,
+        worldSize:
+            Number.isFinite(parsedWorldSize) && parsedWorldSize >= SINGLE_HOST_WORLD_SIZE
+                ? parsedWorldSize
+                : SINGLE_HOST_WORLD_SIZE,
     } as ReportMetadata;
 };
 

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -233,6 +233,7 @@ export interface ReportMetadataResponse {
     total_duration_ns?: string;
     git_url?: string;
     git_sha?: string;
+    world_size?: string;
 }
 export interface OperationDescription extends Operation {
     duration: number;

--- a/src/scss/components/FooterInfobar.scss
+++ b/src/scss/components/FooterInfobar.scss
@@ -54,7 +54,8 @@
         height: 24px;
     }
 
-    .report-source-tag {
+    .report-source-tag,
+    .report-rank-tag {
         flex-shrink: 0;
         font-size: 10px;
         line-height: 1.2;

--- a/tests/FooterInfobar.spec.tsx
+++ b/tests/FooterInfobar.spec.tsx
@@ -53,7 +53,9 @@ vi.mock('@blueprintjs/core', async () => {
 
 const REPORT_PATH = '/reports/memory/my-report';
 
-const renderFooter = (reportMetadata: { gitUrl?: string | null; gitSha?: string | null } | undefined) => {
+const renderFooter = (
+    reportMetadata: { gitUrl?: string | null; gitSha?: string | null; worldSize?: number } | undefined,
+) => {
     mockUseReportMetadata.mockReturnValue({ data: reportMetadata });
     mockUseInstance.mockReturnValue({ data: mockInstance });
     mockUseGetLatestAppVersion.mockReturnValue({
@@ -120,5 +122,26 @@ describe('FooterInfobar memory report tooltip', () => {
 
         const link = within(tooltip).getByRole('link');
         expect(link).toHaveAttribute('href', `https://github.com/foo/bar/commit/${MOCK_FULL_GIT_SHA}`);
+    });
+});
+
+// The API scopes report reads to rank 0, so a multi-host report shows one rank's
+// data. Without this notice the run looks complete rather than partial. #1842
+describe('FooterInfobar multi-host rank scoping', () => {
+    it('announces the scoped rank when the report spans several ranks', () => {
+        renderFooter({ worldSize: 2 });
+
+        expect(screen.getByLabelText('Showing rank 0 of 2')).toBeInTheDocument();
+        expect(getMemoryReportTooltipContent().textContent).toContain('showing rank 0 of 2');
+    });
+
+    it.each([
+        ['single-rank', 1],
+        ['unreported', undefined],
+    ])('stays silent on a %s report', (_label, worldSize) => {
+        renderFooter({ worldSize });
+
+        expect(screen.queryByLabelText(/Showing rank/)).not.toBeInTheDocument();
+        expect(getMemoryReportTooltipContent().textContent).not.toMatch(/showing rank/);
     });
 });

--- a/tests/fetchReportMetadata.spec.ts
+++ b/tests/fetchReportMetadata.spec.ts
@@ -48,4 +48,41 @@ describe('fetchReportMetadata', () => {
         expect(result.gitUrl).toBeNull();
         expect(result.gitSha).toBeNull();
     });
+
+    // world_size drives the footer's "rank 0 of N" scoping notice, so a
+    // multi-host report must not be mistaken for a complete single-host run. #1842
+    it('parses world_size from the multi-host metadata table', async () => {
+        vi.mocked(axiosInstance.get).mockResolvedValue({
+            data: {
+                schema_version: '3.1',
+                capture_timestamp_ns: '1782343284332053328',
+                total_duration_ns: '4657719476',
+                rank: '1',
+                world_size: '2',
+            },
+        });
+
+        const result = await fetchReportMetadata();
+
+        expect(result.worldSize).toBe(2);
+    });
+
+    it.each([
+        ['absent', undefined],
+        ['unparseable', 'not-a-number'],
+        ['below one', '0'],
+    ])('falls back to a single rank when world_size is %s', async (_label, worldSize) => {
+        vi.mocked(axiosInstance.get).mockResolvedValue({
+            data: {
+                schema_version: '2.0.0',
+                capture_timestamp_ns: '1773424287168605099',
+                total_duration_ns: '22119664963',
+                world_size: worldSize,
+            },
+        });
+
+        const result = await fetchReportMetadata();
+
+        expect(result.worldSize).toBe(1);
+    });
 });

--- a/tests/reportRank.spec.ts
+++ b/tests/reportRank.spec.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { formatSyncedReportName, getRankedReportLabel } from '../src/functions/reportRank';
+import { formatSyncedReportName, getRankedReportLabel, getScopedRankLabel } from '../src/functions/reportRank';
 
 const TIMESTAMP = '2026_07_28_18_04_24';
 
@@ -39,5 +39,12 @@ describe('formatSyncedReportName', () => {
     it('reads the same label the picker shows for the same report', () => {
         // The two spellings of one report must not read differently to the user.
         expect(formatSyncedReportName(`${TIMESTAMP}_rank3`)).toBe(getRankedReportLabel(TIMESTAMP, 3));
+    });
+});
+
+describe('getScopedRankLabel', () => {
+    it('says which rank of how many is on screen', () => {
+        expect(getScopedRankLabel(0, 2)).toBe('rank 0 of 2');
+        expect(getScopedRankLabel(0, 16)).toBe('rank 0 of 16');
     });
 });


### PR DESCRIPTION
## Summary

A multi-host report rendered every rank at once with colliding ids — the Operations list showed 8 rows for 4 operations, indistinguishable from one another (screenshot in #1842). The cause was an asymmetric default: an absent `?rank` meant "rank 0" on file-backed routes but "no filter" on DB-backed ones, and the report writer restarts `operation_id` and `tensor_id` at 1 for every rank, so the unfiltered read unioned the ranks and collided on both.

This is Stage 1 of the agreed two-stage plan: make the scoping correct and visible. Showing one rank correctly beats showing every rank with colliding keys. Rank *selection* is Stage 2 and is not in here.

Closes #1842

### Backend

- `views.py` — `_optional_rank_query_param() -> Optional[int]` becomes `_rank_query_param() -> int`, returning `_DEFAULT_RANK` (0) when `rank` is absent or empty, and still 400ing on unparseable input. All 11 DB-backed report routes now pass an explicit rank; the three file-backed routes drop their hand-rolled `0 if rank_param is None else rank_param` in favour of the shared helper. `_reject_nonzero_rank_on_legacy_db` narrows to `rank: int`, so its `None` arm goes away.
- `views.py` — the tensor-comparison branch in `tensors_list` kept a `rank is not None` guard that can no longer be false. Removed, with a note that the comparison tables have no `rank` column and can only be narrowed through the rank-scoped tensor ids.

Legacy reports are unaffected: `merge_rank_filter` already skips tables without a `rank` column, and the legacy guard only rejects *non-zero* ranks, so the new default never reaches it.

### Frontend

- `useAPI.tsx` / `APIData.ts` — `ReportMetadata` gains `worldSize`, parsed from the `world_size` key already present in `/report-metadata` and clamped to at least one rank so single-host and legacy reports degrade to 1.
- `FooterInfobar.tsx` — a warning-intent `rank 0 of N` tag and a matching tooltip line appear beside the report name when `worldSize > 1`, so a partial view reads as partial instead of looking like a complete run. Nothing branches on `worldSize`; it is purely an honesty affordance.
- `definitions/Reports.ts` — `SINGLE_HOST_WORLD_SIZE` lives here now that both the hook and the footer read it.

## Known limitations (out of scope, tracked separately)

- **No rank selection.** Ranks other than 0 are reachable only by passing `?rank=` by hand. Stage 2 (#1842) adds the atom, the query-key dimension, the route segment, and the selector.
- **`/report-metadata` is still report-global** and last-write-wins across ranks, so the capture timestamp and git SHA beside the new tag may belong to a different rank. Called out in #1842 item 6.
- **#1844** — per-device CB fan-out is summed into one core bucket, inflating per-core CB memory by the device count. Same duplication *symptom*, different cause (devices within a rank, not ranks), and unaffected by this change.
- **#1841** — memory-legend duplication, a child symptom of the same root cause.

## Test plan

- [x] Backend: `pytest backend/ttnn_visualizer/tests` — 522 passed
- [x] Frontend: `vitest run` — 1355 passed across 149 files
- [x] `tsc`, `eslint --max-warnings 0`, `black`, `isort`, `mypy` clean
- [x] Manual: `multihost_poc_jun24_2321` (`world_size = 2`) — Operations list drops from 8 rows to 4, and the footer shows `rank 0 of 2`
- [x] Manual: single-device reports and a legacy DB without a `rank` column render unchanged, with no tag

New coverage worth noting: a second fixture whose two ranks reuse `operation_id = 1` and `tensor_id = 1`, matching how a real capture numbers them, since the pre-existing fixture needs ids unique per rank for its mismatch-404 cases. The equivalence test now asserts rank 0 is the only rank anywhere in the payload — comparing an omitted-rank response to an explicit `rank=0` response is otherwise satisfied by two identical unions. Confirmed by stubbing `merge_rank_filter` to a no-op, which fails nine tests.

## Follow-ups

- #1842 — Stage 2, rank as a first-class dimension
- #1844 — per-device CB fan-out summed across devices
- #1841 — memory-legend duplication

Made with [Cursor](https://cursor.com)