### PR TITLE
 Improvemen validation and handling of remote report paths

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -53,7 +53,9 @@
 # ---------------------------------------------------------------------------
 # SSH — remote / MLIR connection dialog defaults + remote-op timeouts
 # ---------------------------------------------------------------------------
-# Dialog prefills (code default port is 22; TT boxes often use 45985):
+# Dialog prefills (code default port is 22; TT boxes often use 45985).
+# Report paths must be absolute — a `~`-relative path is not expanded on the remote host and
+# the connection dialog refuses it:
 # SSH_DEFAULT_PORT=22
 # SSH_DEFAULT_PROFILER_PATH=/home/username/tt-metal/generated/ttnn/reports/
 # SSH_DEFAULT_PERFORMANCE_PATH=/home/username/tt-metal/generated/profiler/reports/

--- a/backend/ttnn_visualizer/app.py
+++ b/backend/ttnn_visualizer/app.py
@@ -29,6 +29,7 @@ from ttnn_visualizer.exceptions import (
     DatabaseFileNotFoundException,
     InvalidProfilerPath,
     InvalidReportPath,
+    InvalidRequestPayload,
     ReportNotLoadedException,
 )
 from ttnn_visualizer.instances import create_instance_from_local_paths
@@ -226,6 +227,10 @@ def middleware(app: flask.Flask):
         response = jsonify({"error": str(error)})
         response.status_code = HTTPStatus.NOT_FOUND
         return response
+
+    @app.errorhandler(InvalidRequestPayload)
+    def handle_invalid_request_payload(error: InvalidRequestPayload):
+        return jsonify({"error": str(error)}), HTTPStatus.BAD_REQUEST
 
     @app.errorhandler(HTTPException)
     def handle_http_error(error: HTTPException):

--- a/backend/ttnn_visualizer/exceptions.py
+++ b/backend/ttnn_visualizer/exceptions.py
@@ -119,6 +119,16 @@ class NoReportsException(RemoteConnectionException):
     pass
 
 
+class InvalidRequestPayload(Exception):
+    """A request body failed model validation.
+
+    Raised so a rejected payload renders as a 400 the client can display. Model
+    validators tighten over time, and a value a previous release stored is still
+    user input on the way back in — a stored connection whose report path is no
+    longer accepted must not surface as a 500 the user cannot act on.
+    """
+
+
 class DatabaseFileNotFoundException(Exception):
     pass
 

--- a/backend/ttnn_visualizer/mlir.py
+++ b/backend/ttnn_visualizer/mlir.py
@@ -26,7 +26,6 @@ import json
 import logging
 import os
 import re
-import shlex
 import tempfile
 import time
 import uuid
@@ -41,7 +40,7 @@ from ttnn_visualizer.exceptions import (
     SSHException,
 )
 from ttnn_visualizer.models import MlirServerConnection, RemoteConnection, StatusMessage
-from ttnn_visualizer.remote_command import RemoteCommand
+from ttnn_visualizer.remote_command import RemoteCommand, remote_arg
 from ttnn_visualizer.ssh_client import SSHClient
 
 logger = logging.getLogger(__name__)
@@ -148,7 +147,8 @@ def test_mlir_server_connection(
 
     curl_cmd = (
         "curl -s -o /dev/null -w '%{http_code}' "
-        f"--connect-timeout {_CURL_CONNECT_TIMEOUT_SECONDS} {shlex.quote(_remote_upload_url(http_port))}"
+        f"--connect-timeout {_CURL_CONNECT_TIMEOUT_SECONDS} "
+        f"{remote_arg(_remote_upload_url(http_port))}"
     )
 
     try:
@@ -214,13 +214,13 @@ def _upload_file_to_server(
         f"/tmp/{_TEMP_UPLOAD_BASENAME_PREFIX}"
         f"{os.getpid()}_{uuid.uuid4().hex}{Path(safe_filename).suffix}"
     )
-    upload_form_arg = shlex.quote(f"{MLIR_UPLOAD_FIELD}=@{remote_path}")
+    upload_form_arg = remote_arg(f"{MLIR_UPLOAD_FIELD}=@{remote_path}")
     curl_cmd = (
         "curl -sS -H 'Expect:' -w '\\n%{http_code}' "
         f"--connect-timeout {_CURL_CONNECT_TIMEOUT_SECONDS} "
         f"--max-time {_UPLOAD_TIMEOUT_SECONDS} "
         f"-F {upload_form_arg} "
-        f"{shlex.quote(upload_url)}"
+        f"{remote_arg(upload_url)}"
     )
 
     started = time.perf_counter()
@@ -391,7 +391,7 @@ def _convert_with_extension(
         "curl -sS -X POST -H 'Content-Type: application/json' "
         f"--connect-timeout {_CURL_CONNECT_TIMEOUT_SECONDS} "
         f"--max-time {_CONVERT_TIMEOUT_SECONDS} "
-        f"-d {shlex.quote(payload)} {shlex.quote(convert_url)}"
+        f"-d {remote_arg(payload)} {remote_arg(convert_url)}"
     )
 
     logger.info(

--- a/backend/ttnn_visualizer/mlir.py
+++ b/backend/ttnn_visualizer/mlir.py
@@ -41,6 +41,7 @@ from ttnn_visualizer.exceptions import (
     SSHException,
 )
 from ttnn_visualizer.models import MlirServerConnection, RemoteConnection, StatusMessage
+from ttnn_visualizer.remote_command import RemoteCommand
 from ttnn_visualizer.ssh_client import SSHClient
 
 logger = logging.getLogger(__name__)
@@ -152,7 +153,8 @@ def test_mlir_server_connection(
 
     try:
         output = client.execute_command(
-            curl_cmd, timeout=_ENDPOINT_TEST_TIMEOUT_SECONDS
+            RemoteCommand.from_shell_fragment(curl_cmd),
+            timeout=_ENDPOINT_TEST_TIMEOUT_SECONDS,
         )
     except SSHException as e:
         # curl exits non-zero (e.g. connection refused) when the server is down.
@@ -225,7 +227,8 @@ def _upload_file_to_server(
     try:
         client.upload_file(local_path, remote_path, timeout=_UPLOAD_TIMEOUT_SECONDS)
         stdout = client.execute_command(
-            curl_cmd, timeout=_UPLOAD_TIMEOUT_SECONDS + _CURL_TIMEOUT_GRACE_SECONDS
+            RemoteCommand.from_shell_fragment(curl_cmd),
+            timeout=_UPLOAD_TIMEOUT_SECONDS + _CURL_TIMEOUT_GRACE_SECONDS,
         )
     except SSHException as e:
         elapsed = time.perf_counter() - started
@@ -238,7 +241,7 @@ def _upload_file_to_server(
         Path(local_path).unlink(missing_ok=True)
         try:
             client.execute_command(
-                f"rm -f {shlex.quote(remote_path)}",
+                RemoteCommand.of("rm", "-f", remote_path),
                 timeout=_CURL_CONNECT_TIMEOUT_SECONDS,
             )
         except SSHException:
@@ -398,7 +401,8 @@ def _convert_with_extension(
     started = time.perf_counter()
     try:
         stdout = client.execute_command(
-            curl_cmd, timeout=_CONVERT_TIMEOUT_SECONDS + _CURL_TIMEOUT_GRACE_SECONDS
+            RemoteCommand.from_shell_fragment(curl_cmd),
+            timeout=_CONVERT_TIMEOUT_SECONDS + _CURL_TIMEOUT_GRACE_SECONDS,
         )
     except SSHException as e:
         return None, str(e)

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -368,6 +368,56 @@ def sanitise_ssh_username(value: object) -> str:
     return reject_ssh_option_like(stripped)
 
 
+# Linux PATH_MAX. A report path is typed into a form field, so anything approaching
+# this is a payload rather than a path, and a remote command line has its own limits.
+MAX_REMOTE_PATH_LENGTH = 4096
+
+
+def sanitise_remote_report_path(value: object) -> str:
+    """Validate a remote report root, which is interpolated into remote shell commands.
+
+    Quoting at the call site is what makes these paths safe; this is the second half,
+    so that a value which could not be a legitimate report root is refused before it
+    reaches a command at all and a future unquoted call site has less to work with.
+
+    Relative paths are refused even though ``find`` would resolve them against the SSH
+    login home: accepting them means the same connection means different directories
+    depending on the account, and ``~`` has never worked (it is quoted, so no shell
+    expands it) while looking like it should. Absolute-only makes both cases say so.
+    """
+    if not isinstance(value, str):
+        # Pydantic's lax mode coerces bytes and bytearray to str *after* "before"
+        # validators run, which would otherwise smuggle a payload past these checks.
+        raise ValueError("must be a string")
+
+    stripped = value.strip()
+    if not stripped:
+        # An unconfigured path is a supported state: MlirServerConnection builds a
+        # RemoteConnection with no profiler path, and report discovery skips a path
+        # it was not given.
+        return ""
+
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in stripped):
+        # NUL reaches subprocess as ValueError("embedded null byte") — a 500 — and a
+        # newline would split one remote command into two.
+        raise ValueError("must not contain control characters")
+
+    if not stripped.startswith("/"):
+        raise ValueError("must be an absolute path starting with '/'")
+
+    if len(stripped) > MAX_REMOTE_PATH_LENGTH:
+        raise ValueError(f"must be at most {MAX_REMOTE_PATH_LENGTH} characters")
+
+    return stripped
+
+
+def sanitise_optional_remote_report_path(value: object) -> Optional[str]:
+    """As ``sanitise_remote_report_path``, but leaves an absent path absent."""
+    if value is None:
+        return None
+    return sanitise_remote_report_path(value)
+
+
 class RemoteConnection(SerializeableModel):
     name: str
     username: str
@@ -389,6 +439,16 @@ class RemoteConnection(SerializeableModel):
     @classmethod
     def _sanitise_username(cls, value: object) -> str:
         return sanitise_ssh_username(value)
+
+    @field_validator("profilerPath", mode="before")
+    @classmethod
+    def _sanitise_profiler_path(cls, value: object) -> str:
+        return sanitise_remote_report_path(value)
+
+    @field_validator("performancePath", mode="before")
+    @classmethod
+    def _sanitise_performance_path(cls, value: object) -> Optional[str]:
+        return sanitise_optional_remote_report_path(value)
 
 
 class MlirServerConnection(SerializeableModel):

--- a/backend/ttnn_visualizer/models.py
+++ b/backend/ttnn_visualizer/models.py
@@ -372,6 +372,10 @@ def sanitise_ssh_username(value: object) -> str:
 # this is a payload rather than a path, and a remote command line has its own limits.
 MAX_REMOTE_PATH_LENGTH = 4096
 
+# C0 controls and DEL. Compiled rather than iterated per character because the
+# validator runs on every instance-scoped request through to_pydantic().
+_CONTROL_CHARACTERS = re.compile("[\x00-\x1f\x7f]")
+
 
 def sanitise_remote_report_path(value: object) -> str:
     """Validate a remote report root, which is interpolated into remote shell commands.
@@ -397,16 +401,19 @@ def sanitise_remote_report_path(value: object) -> str:
         # it was not given.
         return ""
 
-    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in stripped):
+    if len(stripped) > MAX_REMOTE_PATH_LENGTH:
+        # Checked first so an oversized value is rejected on its length rather than
+        # scanned character by character to reach the same answer. This validator also
+        # runs on the read path, via InstanceTable.to_pydantic().
+        raise ValueError(f"must be at most {MAX_REMOTE_PATH_LENGTH} characters")
+
+    if _CONTROL_CHARACTERS.search(stripped):
         # NUL reaches subprocess as ValueError("embedded null byte") — a 500 — and a
         # newline would split one remote command into two.
         raise ValueError("must not contain control characters")
 
     if not stripped.startswith("/"):
         raise ValueError("must be an absolute path starting with '/'")
-
-    if len(stripped) > MAX_REMOTE_PATH_LENGTH:
-        raise ValueError(f"must be at most {MAX_REMOTE_PATH_LENGTH} characters")
 
     return stripped
 
@@ -521,6 +528,14 @@ class RemoteReportFolder(SerializeableModel):
     syncedName: Optional[str] = None
     rank: Optional[int] = None
 
+    @field_validator("remotePath", mode="before")
+    @classmethod
+    def _sanitise_remote_path(cls, value: object) -> str:
+        # This is the path that actually reaches remote commands — `find`, the scp
+        # target, the sftp batch script and the perf-CSV glob — so it earns the same
+        # guard as the configured roots it is discovered under, not less.
+        return sanitise_remote_report_path(value)
+
 
 def stored_remote_connection(value: Any) -> Optional[RemoteConnection]:
     """Deserialise a persisted connection, treating an unusable one as absent.
@@ -537,6 +552,23 @@ def stored_remote_connection(value: Any) -> Optional[RemoteConnection]:
         return RemoteConnection.model_validate(value, strict=False)
     except ValidationError as exc:
         logger.warning("Ignoring unusable stored remote connection: %s", exc)
+        return None
+
+
+def stored_remote_report_folder(value: Any) -> Optional[RemoteReportFolder]:
+    """Deserialise a persisted report folder, treating an unusable one as absent.
+
+    As ``stored_remote_connection``: a row whose ``remotePath`` predates the path
+    validator must not turn every instance-scoped request into a 500. The local
+    report paths are separate columns, so dropping this metadata costs the sync
+    badge rather than the loaded report.
+    """
+    if value is None:
+        return None
+    try:
+        return RemoteReportFolder.model_validate(value, strict=False)
+    except ValidationError as exc:
+        logger.warning("Ignoring unusable stored remote report folder: %s", exc)
         return None
 
 
@@ -621,18 +653,10 @@ class InstanceTable(db.Model):
                 else None
             ),
             remote_connection=stored_remote_connection(self.remote_connection),
-            remote_profiler_folder=(
-                RemoteReportFolder.model_validate(
-                    self.remote_profiler_folder, strict=False
-                )
-                if self.remote_profiler_folder is not None
-                else None
+            remote_profiler_folder=stored_remote_report_folder(
+                self.remote_profiler_folder
             ),
-            remote_performance_folder=(
-                RemoteReportFolder.model_validate(
-                    self.remote_performance_folder, strict=False
-                )
-                if self.remote_performance_folder is not None
-                else None
+            remote_performance_folder=stored_remote_report_folder(
+                self.remote_performance_folder
             ),
         )

--- a/backend/ttnn_visualizer/remote_command.py
+++ b/backend/ttnn_visualizer/remote_command.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Construction of remote shell commands, and the quoting they depend on.
+
+Every remote command this app runs is executed by a shell on the remote host:
+``ssh host cmd arg…`` concatenates the arguments after the target with spaces and
+hands the result to the login shell, and ``scp -O`` expands its remote path there
+too. So a report path typed into the connection form reaches a shell, and nothing
+but quoting stands between a crafted path and arbitrary remote execution.
+
+``RemoteCommand`` exists so that invariant is checked by the type checker rather
+than by reviewer attention: the runners take a ``RemoteCommand``, which is built here
+and nowhere else. A naive f-string at a call site is a type error.
+
+That check needs the whole package in one invocation, as ``pnpm flask:mypy`` does.
+``follow_imports = "skip"`` in ``pyproject.toml`` means a single-file mypy run
+resolves imported types to ``Any`` and reports nothing, so the type error only
+surfaces when every module is in the checked set.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+from ttnn_visualizer.models import RemoteConnection
+
+PathLike = Union[str, Path]
+
+
+def remote_arg(value: PathLike) -> str:
+    """Quote one value for use as a single argument in a remote shell command.
+
+    Deliberately does not route through ``Path``: that would normalise ``/a/`` to
+    ``/a`` and ``//a`` to ``/a``, and ``_report_search_find_expression`` manages
+    trailing slashes itself because GNU and BSD ``find`` disagree on whether the
+    root they echo keeps one.
+    """
+    return shlex.quote(str(value))
+
+
+def remote_glob_arg(pattern: str) -> str:
+    """Shell-quote a remote path while leaving ``*`` free to expand on the host.
+
+    ``shlex.quote`` on the whole pattern would quote the wildcard too, turning a
+    glob the caller depends on into a literal filename. Quoting each side of the
+    wildcards instead keeps the expansion while closing the quote-escape that a
+    hand-rolled ``'{path}'`` leaves open.
+    """
+    return "*".join(shlex.quote(segment) for segment in pattern.split("*"))
+
+
+def remote_scp_target(connection: RemoteConnection, remote_path: PathLike) -> str:
+    """Build the ``user@host:path`` argument for scp, quoting the path.
+
+    scp splits the argument at the first colon locally and sends the remainder to
+    a shell on the remote host, so the path half needs the same quoting as any
+    other remote argument even though the whole token is passed through argv.
+    """
+    return f"{connection.username}@{connection.host}:{remote_arg(remote_path)}"
+
+
+@dataclass(frozen=True)
+class RemoteCommand:
+    """A command line ready to be run by a shell on the remote host.
+
+    Build one with :meth:`of` or :meth:`from_shell_fragment`, so a value of this type
+    means someone decided how each argument was quoted. The field is private because
+    ``RemoteCommand(_command=…)`` would sidestep that decision — nothing in Python can
+    forbid it, but a call site reaching for a private name is visible in review.
+    """
+
+    _command: str
+
+    def __str__(self) -> str:
+        return self._command
+
+    @classmethod
+    def of(cls, program: str, *args: PathLike) -> "RemoteCommand":
+        """A command whose every argument is quoted as data.
+
+        The right choice whenever the command is a program plus arguments, which
+        is most of them. ``shlex.quote`` leaves already-safe tokens such as
+        ``-c`` and ``%Y`` untouched, so flags can be passed positionally.
+        """
+        quoted = " ".join(remote_arg(arg) for arg in args)
+        return cls(f"{program} {quoted}" if quoted else program)
+
+    @classmethod
+    def from_shell_fragment(cls, fragment: str) -> "RemoteCommand":
+        """A command that needs shell syntax the caller has assembled itself.
+
+        For redirections, ``||``, loops and ``find`` expressions, which :meth:`of`
+        cannot express because quoting them would strip their meaning. The caller
+        is asserting it has already passed every interpolated value through
+        :func:`remote_arg` or :func:`remote_glob_arg` — grep for this method to
+        review every place that claim is made.
+        """
+        return cls(fragment)

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import re
-import shlex
 import subprocess
 import time
 from http import HTTPStatus
@@ -32,6 +31,12 @@ from ttnn_visualizer.models import (
     RemoteReportFolder,
     folder_segment_from_remote_path,
     rank_from_remote_path,
+)
+from ttnn_visualizer.remote_command import (
+    RemoteCommand,
+    remote_arg,
+    remote_glob_arg,
+    remote_scp_target,
 )
 from ttnn_visualizer.sockets import FileProgress, FileStatus, emit_file_status
 from ttnn_visualizer.ssh_client import SSHClient, raise_for_ssh_subprocess_error
@@ -63,17 +68,6 @@ def _remote_transfer_key(remote_connection: RemoteConnection) -> tuple[str, str,
 
 def _is_sftp_subsystem_unavailable(stderr: str) -> bool:
     return "subsystem request failed" in (stderr or "").lower()
-
-
-def _quote_keeping_globs(pattern: str) -> str:
-    """Shell-quote a remote path while leaving ``*`` free to expand on the host.
-
-    ``shlex.quote`` on the whole pattern would quote the wildcard too, turning a
-    glob the caller depends on into a literal filename. Quoting each side of the
-    wildcards instead keeps the expansion while closing the quote-escape that a
-    hand-rolled ``'{path}'`` leaves open.
-    """
-    return "*".join(shlex.quote(segment) for segment in pattern.split("*"))
 
 
 def get_active_sync_method(remote_connection: RemoteConnection) -> SyncMethod:
@@ -137,6 +131,18 @@ def _ssh_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
         cmd.extend(["-p", str(remote_connection.port)])
     cmd.append(f"{remote_connection.username}@{remote_connection.host}")
     return cmd
+
+
+def _ssh_argv(remote_connection: RemoteConnection, command: RemoteCommand) -> List[str]:
+    """Full ``ssh`` argv for one remote command.
+
+    The only intended caller of ``_ssh_cmd_prefix``. Everything after ``user@host``
+    is a single element because OpenSSH joins multiple remote arguments with spaces
+    and hands the result to the remote login shell — passing a path as its own argv
+    element looks safe locally but is not quoted remotely. Taking a ``RemoteCommand``
+    rather than a ``str`` is what makes a naive f-string a type error here.
+    """
+    return _ssh_cmd_prefix(remote_connection) + [str(command)]
 
 
 def _sftp_cmd_prefix(remote_connection: RemoteConnection) -> List[str]:
@@ -215,9 +221,10 @@ def resolve_file_path(remote_connection, file_path: str) -> str:
     """
     if "*" in file_path:
         # Build SSH command to list files matching the pattern (never prompts for password)
-        ssh_cmd = _ssh_cmd_prefix(remote_connection) + [
-            f"ls -1 {_quote_keeping_globs(file_path)}"
-        ]
+        ssh_cmd = _ssh_argv(
+            remote_connection,
+            RemoteCommand.from_shell_fragment(f"ls -1 {remote_glob_arg(file_path)}"),
+        )
 
         try:
             result = subprocess.run(
@@ -564,10 +571,13 @@ def get_remote_file_list(
     # POSIX paths, so paths containing tabs/newlines round-trip safely; the
     # first '\t' in each record is the unambiguous separator between the
     # decimal size and the path. Falls back below if -printf is unsupported.
-    quoted_folder = shlex.quote(remote_folder)
-    ssh_cmd = _ssh_cmd_prefix(remote_connection) + [
-        f"find {quoted_folder} -type f -printf '%s\\t%p\\0'",
-    ]
+    quoted_folder = remote_arg(remote_folder)
+    ssh_cmd = _ssh_argv(
+        remote_connection,
+        RemoteCommand.from_shell_fragment(
+            f"find {quoted_folder} -type f -printf '%s\\t%p\\0'"
+        ),
+    )
 
     try:
         result = subprocess.run(
@@ -630,10 +640,10 @@ def _get_remote_file_list_without_sizes(
     exclude_patterns: List[str],
 ) -> List[tuple[str, int]]:
     """Fallback when GNU find -printf is unavailable. Sizes default to 0."""
-    quoted_folder = shlex.quote(remote_folder)
-    ssh_cmd = _ssh_cmd_prefix(remote_connection) + [
-        f"find {quoted_folder} -type f",
-    ]
+    ssh_cmd = _ssh_argv(
+        remote_connection,
+        RemoteCommand.of("find", remote_folder, "-type", "f"),
+    )
     try:
         result = subprocess.run(
             ssh_cmd,
@@ -666,10 +676,10 @@ def get_remote_directory_list(
     exclude_patterns = exclude_patterns or []
 
     # Build SSH command to find all directories recursively (never prompts for password)
-    quoted_folder = shlex.quote(remote_folder)
-    ssh_cmd = _ssh_cmd_prefix(remote_connection) + [
-        f"find {quoted_folder} -type d",
-    ]
+    ssh_cmd = _ssh_argv(
+        remote_connection,
+        RemoteCommand.of("find", remote_folder, "-type", "d"),
+    )
 
     try:
         result = subprocess.run(
@@ -704,8 +714,13 @@ def get_remote_directory_list(
 
 
 def _scp_remote_target(remote_connection: RemoteConnection, remote_file: str) -> str:
-    """Build scp remote target for argv (no shell quoting — subprocess passes it verbatim)."""
-    return f"{remote_connection.username}@{remote_connection.host}:{remote_file}"
+    """Build the ``user@host:path`` target for scp.
+
+    The path half needs quoting despite travelling in argv: ``-O`` selects the
+    legacy SCP protocol, under which the remote side expands the path through a
+    shell rather than treating it as a literal name.
+    """
+    return remote_scp_target(remote_connection, remote_file)
 
 
 def download_single_file_scp(
@@ -755,9 +770,7 @@ def download_single_file_sftp(
     local_file.parent.mkdir(parents=True, exist_ok=True)
     sftp_cmd = _sftp_cmd_prefix(remote_connection)
     # Batch script is parsed by sftp, not the shell — quote paths for spaces/special chars.
-    sftp_commands = (
-        f"get {shlex.quote(remote_file)} {shlex.quote(str(local_file))}\nquit\n"
-    )
+    sftp_commands = f"get {remote_arg(remote_file)} {remote_arg(local_file)}\nquit\n"
 
     try:
         subprocess.run(
@@ -825,22 +838,19 @@ def get_remote_profiler_folder_from_config_path(
         )
 
     def ssh_stat_mtime(path: str) -> int:
-        stat_cmd = _ssh_cmd_prefix(remote_connection) + [
-            "stat",
-            "-c",
-            "%Y",
-            path,
-        ]
+        stat_cmd = _ssh_argv(
+            remote_connection, RemoteCommand.of("stat", "-c", "%Y", path)
+        )
         stat_result = ssh_run_checked(stat_cmd)
         return int(float(stat_result.stdout.strip()))
 
     def ssh_cat(path: str) -> str:
-        cat_cmd = _ssh_cmd_prefix(remote_connection) + ["cat", path]
+        cat_cmd = _ssh_argv(remote_connection, RemoteCommand.of("cat", path))
         cat_result = ssh_run_checked(cat_cmd)
         return cat_result.stdout
 
     def ssh_test_file(path: str) -> bool:
-        test_cmd = _ssh_cmd_prefix(remote_connection) + ["test", "-f", path]
+        test_cmd = _ssh_argv(remote_connection, RemoteCommand.of("test", "-f", path))
         result = subprocess.run(
             test_cmd,
             capture_output=True,
@@ -855,11 +865,13 @@ def get_remote_profiler_folder_from_config_path(
         # `bash -lc '<script>'` string instead. Use find so the script has no
         # shell loop syntax.
         inner = (
-            f"find {shlex.quote(folder_str)} -maxdepth 1 "
+            f"find {remote_arg(folder_str)} -maxdepth 1 "
             "-name 'config_*_of_*.json' -print"
         )
-        remote_cmd = "bash -lc " + shlex.quote(inner)
-        list_cmd = _ssh_cmd_prefix(remote_connection) + [remote_cmd]
+        list_cmd = _ssh_argv(
+            remote_connection,
+            RemoteCommand.of("bash", "-lc", inner),
+        )
         result = subprocess.run(
             list_cmd,
             capture_output=True,
@@ -1124,19 +1136,22 @@ def _report_search_find_expression(
         # the same value is what stops the glob spanning segments and matching a
         # deeper accidental layout.
         depth = 1 + len(subdirectory_glob.split("/"))
-        path_filter = f" -path {shlex.quote(f'{root}/{subdirectory_glob}/*')}"
+        # Fully quoted, not `remote_glob_arg`: this `*` is part of a `-path` pattern
+        # that `find` itself matches, so the shell must not expand it.
+        path_filter = f" -path {remote_arg(f'{root}/{subdirectory_glob}/*')}"
 
     # The report-file test runs inside `find` rather than as a follow-up command
     # per candidate: the multihost layout multiplies candidates by the rank
     # count, and `_ssh_cmd_prefix` sets up no connection sharing, so a round trip
     # each meant a full TCP and auth handshake per rank per report.
+    # `{}` is find's own placeholder for the candidate directory, so this quotes a
+    # pattern find expands rather than a path the shell should resolve.
     tests = " -o ".join(
-        f"-exec test -f {shlex.quote('{}/' + file_name)} ';'"
-        for file_name in file_names
+        f"-exec test -f {remote_arg('{}/' + file_name)} ';'" for file_name in file_names
     )
 
     return (
-        f"find {shlex.quote(search_root)} "
+        f"find {remote_arg(search_root)} "
         f"-mindepth {depth} -maxdepth {depth} -type d{path_filter} "
         f"'(' {tests} ')' -print"
     )
@@ -1160,10 +1175,13 @@ def _remote_directory_mtimes(
 
     for index in range(0, len(directories), _MTIME_BATCH_SIZE):
         batch = directories[index : index + _MTIME_BATCH_SIZE]
-        quoted = " ".join(shlex.quote(directory) for directory in batch)
-        ssh_cmd = _ssh_cmd_prefix(remote_connection) + [
-            f'for p in {quoted}; do stat -c %Y "$p" 2>/dev/null || echo; done',
-        ]
+        quoted = " ".join(remote_arg(directory) for directory in batch)
+        ssh_cmd = _ssh_argv(
+            remote_connection,
+            RemoteCommand.from_shell_fragment(
+                f'for p in {quoted}; do stat -c %Y "$p" 2>/dev/null || echo; done'
+            ),
+        )
 
         try:
             result = subprocess.run(
@@ -1215,9 +1233,12 @@ def find_folders_by_files(
     if not root_folder or not file_names:
         return []
 
-    ssh_cmd = _ssh_cmd_prefix(remote_connection) + [
-        _report_search_find_expression(root_folder, subdirectory_glob, file_names),
-    ]
+    ssh_cmd = _ssh_argv(
+        remote_connection,
+        RemoteCommand.from_shell_fragment(
+            _report_search_find_expression(root_folder, subdirectory_glob, file_names)
+        ),
+    )
 
     try:
         result = subprocess.run(

--- a/backend/ttnn_visualizer/sftp_operations.py
+++ b/backend/ttnn_visualizer/sftp_operations.py
@@ -713,22 +713,12 @@ def get_remote_directory_list(
         return []
 
 
-def _scp_remote_target(remote_connection: RemoteConnection, remote_file: str) -> str:
-    """Build the ``user@host:path`` target for scp.
-
-    The path half needs quoting despite travelling in argv: ``-O`` selects the
-    legacy SCP protocol, under which the remote side expands the path through a
-    shell rather than treating it as a literal name.
-    """
-    return remote_scp_target(remote_connection, remote_file)
-
-
 def download_single_file_scp(
     remote_connection: RemoteConnection, remote_file: str, local_file: Path
 ) -> SyncMethod:
     """Download a single file using scp (when the remote SFTP subsystem is disabled)."""
     local_file.parent.mkdir(parents=True, exist_ok=True)
-    remote_spec = _scp_remote_target(remote_connection, remote_file)
+    remote_spec = remote_scp_target(remote_connection, remote_file)
     scp_cmd = _scp_cmd_prefix(remote_connection) + [remote_spec, str(local_file)]
     try:
         subprocess.run(

--- a/backend/ttnn_visualizer/ssh_client.py
+++ b/backend/ttnn_visualizer/ssh_client.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import shlex
 import subprocess
 from http import HTTPStatus
 from pathlib import Path
@@ -21,6 +20,11 @@ from ttnn_visualizer.exceptions import (
     SSHException,
 )
 from ttnn_visualizer.models import RemoteConnection
+from ttnn_visualizer.remote_command import (
+    RemoteCommand,
+    remote_arg,
+    remote_scp_target,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,16 +162,20 @@ class SSHClient:
 
         raise_for_ssh_subprocess_error(e, self.connection)
 
-    def execute_command(self, command: str, timeout: int = 30) -> str:
+    def execute_command(self, command: RemoteCommand, timeout: int = 30) -> str:
         """
         Execute a command on the remote server via SSH.
+
+        Takes a ``RemoteCommand`` rather than a ``str`` because the argument is run
+        by a shell on the remote host: only ``remote_command`` can build one, so a
+        path interpolated without quoting fails type checking instead of shipping.
 
         :param command: The command to execute
         :param timeout: Timeout in seconds
         :return: Command output (stdout)
         :raises: AuthenticationException, NoValidConnectionsError, SSHException
         """
-        ssh_cmd = self._base_ssh_cmd + [command]
+        ssh_cmd = self._base_ssh_cmd + [str(command)]
 
         logger.debug(f"Executing SSH command on {self.connection.host}: {command}")
 
@@ -200,7 +208,10 @@ class SSHClient:
                 log_message += f" on port {self.connection.port}"
             logger.info(log_message)
 
-            self.execute_command("echo 'SSH connection test'", timeout=10)
+            self.execute_command(
+                RemoteCommand.from_shell_fragment("echo 'SSH connection test'"),
+                timeout=10,
+            )
             return True
         except AuthenticationException as e:
             # Convert to AuthenticationFailedException for proper HTTP 422 response
@@ -270,7 +281,7 @@ class SSHClient:
 
         try:
             result = self.execute_command(
-                f"cat {shlex.quote(str(remote_path))}", timeout=timeout
+                RemoteCommand.of("cat", remote_path), timeout=timeout
             )
             return result.encode("utf-8")
         except SSHException as e:
@@ -309,7 +320,7 @@ class SSHClient:
 
         try:
             self.execute_command(
-                f"test -e {shlex.quote(str(remote_path))}", timeout=timeout
+                RemoteCommand.of("test", "-e", remote_path), timeout=timeout
             )
             return True
         except SSHException:
@@ -338,8 +349,7 @@ class SSHClient:
         # SFTP commands to execute
         # Batch script is parsed by sftp, not the shell — quote paths for spaces/special chars.
         sftp_commands = (
-            f"get {shlex.quote(str(remote_path))} {shlex.quote(str(local_path))}\n"
-            "quit\n"
+            f"get {remote_arg(remote_path)} {remote_arg(local_path)}\n" "quit\n"
         )
 
         logger.debug(f"Downloading: {remote_path} -> {local_path}")
@@ -393,7 +403,7 @@ class SSHClient:
         scp_cmd.extend(
             [
                 str(local_path),
-                f"{self.connection.username}@{self.connection.host}:{remote_path}",
+                remote_scp_target(self.connection, remote_path),
             ]
         )
 
@@ -439,8 +449,10 @@ class SSHClient:
         try:
             # Use stat command to get file information
             result = self.execute_command(
-                f"stat -c '%s %Y %F' {shlex.quote(str(path))} "
-                "2>/dev/null || echo 'NOT_FOUND'",
+                RemoteCommand.from_shell_fragment(
+                    f"stat -c '%s %Y %F' {remote_arg(path)} "
+                    "2>/dev/null || echo 'NOT_FOUND'"
+                ),
                 timeout=timeout,
             )
 
@@ -469,7 +481,10 @@ class SSHClient:
 
         try:
             result = self.execute_command(
-                f"ls -1 {shlex.quote(str(path))} 2>/dev/null", timeout=timeout
+                RemoteCommand.from_shell_fragment(
+                    f"ls -1 {remote_arg(path)} 2>/dev/null"
+                ),
+                timeout=timeout,
             )
             return [line.strip() for line in result.split("\n") if line.strip()]
         except SSHException:

--- a/backend/ttnn_visualizer/stack_trace_source.py
+++ b/backend/ttnn_visualizer/stack_trace_source.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 import logging
 import os
 import re
-import shlex
 from http import HTTPStatus
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from flask import Response, jsonify
 from ttnn_visualizer.exceptions import RemoteFileReadException
+from ttnn_visualizer.remote_command import RemoteCommand, remote_arg
 from ttnn_visualizer.ssh_client import SSHException
 
 if TYPE_CHECKING:
@@ -287,7 +287,7 @@ def read_stack_source_local(raw_path: str) -> Tuple[str, str, bool]:
 
 def _discover_tt_metal_roots_remote(ssh_client: "SSHClient") -> list[str]:
     """All existing remote tt-metal roots, same priority as local (deduped)."""
-    cmd = f"bash -lc {shlex.quote(_REMOTE_LIST_ROOTS_SCRIPT)}"
+    cmd = RemoteCommand.of("bash", "-lc", _REMOTE_LIST_ROOTS_SCRIPT)
     try:
         out = ssh_client.execute_command(cmd, timeout=30)
     except Exception as e:
@@ -392,10 +392,13 @@ def read_stack_source_remote(
 def _remote_regular_file_exists(ssh_client: "SSHClient", posix_path: str) -> bool:
     """True if remote path exists, is a regular file, and is readable (SSH test -f/-r)."""
 
-    quoted_path = shlex.quote(posix_path)
+    quoted_path = remote_arg(posix_path)
     try:
         ssh_client.execute_command(
-            f"test -f {quoted_path} && test -r {quoted_path}", timeout=15
+            RemoteCommand.from_shell_fragment(
+                f"test -f {quoted_path} && test -r {quoted_path}"
+            ),
+            timeout=15,
         )
         return True
     except SSHException:

--- a/backend/ttnn_visualizer/tests/test_models.py
+++ b/backend/ttnn_visualizer/tests/test_models.py
@@ -21,12 +21,19 @@ VALID_STORED_CONNECTION = {
     "profilerPath": "/reports",
 }
 
+VALID_STORED_PROFILER_FOLDER = {
+    "reportName": "resnet50",
+    "remotePath": "/reports/resnet50",
+    "lastModified": 1,
+}
 
-def _instance(remote_connection) -> InstanceTable:
+
+def _instance(remote_connection, remote_profiler_folder=None) -> InstanceTable:
     return InstanceTable(
         instance_id="test-instance-models",
         active_report={},
         remote_connection=remote_connection,
+        remote_profiler_folder=remote_profiler_folder,
     )
 
 
@@ -65,3 +72,29 @@ def test_to_pydantic_drops_a_connection_with_a_relative_report_path(caplog):
 
     assert pydantic_instance.remote_connection is None
     assert "unusable stored remote connection" in caplog.text
+
+
+def test_to_pydantic_keeps_a_valid_stored_report_folder():
+    instance = _instance(VALID_STORED_CONNECTION, VALID_STORED_PROFILER_FOLDER)
+
+    folder = instance.to_pydantic().remote_profiler_folder
+
+    assert folder is not None
+    assert folder.remotePath == "/reports/resnet50"
+
+
+# remotePath was discovered under a relative profilerPath, so it too could be stored
+# relative. The local report paths live in their own columns, so dropping this row costs
+# the sync badge rather than the loaded report.
+def test_to_pydantic_drops_a_report_folder_the_validators_now_reject(caplog):
+    instance = _instance(
+        VALID_STORED_CONNECTION,
+        {**VALID_STORED_PROFILER_FOLDER, "remotePath": "reports/resnet50"},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        pydantic_instance = instance.to_pydantic()
+
+    assert pydantic_instance.remote_profiler_folder is None
+    assert pydantic_instance.remote_connection is not None
+    assert "unusable stored remote report folder" in caplog.text

--- a/backend/ttnn_visualizer/tests/test_models.py
+++ b/backend/ttnn_visualizer/tests/test_models.py
@@ -50,3 +50,18 @@ def test_to_pydantic_drops_a_connection_the_validators_now_reject(caplog):
     assert pydantic_instance.remote_connection is None
     assert pydantic_instance.instance_id == "test-instance-models"
     assert "unusable stored remote connection" in caplog.text
+
+
+# Documents an accepted regression: a relative path resolved against the SSH login home
+# and worked, so requiring absolute paths costs these users their stored connection. It
+# is dropped rather than raised on so the instance stays loadable and can be re-entered.
+def test_to_pydantic_drops_a_connection_with_a_relative_report_path(caplog):
+    instance = _instance(
+        {**VALID_STORED_CONNECTION, "profilerPath": "tt-metal/generated/ttnn/reports"}
+    )
+
+    with caplog.at_level(logging.WARNING):
+        pydantic_instance = instance.to_pydantic()
+
+    assert pydantic_instance.remote_connection is None
+    assert "unusable stored remote connection" in caplog.text

--- a/backend/ttnn_visualizer/tests/test_remote_command.py
+++ b/backend/ttnn_visualizer/tests/test_remote_command.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Pins the quoting contract every remote command depends on.
+
+Each remote command is run by a shell on the remote host, so these are the checks
+that stand between a crafted report path and arbitrary remote execution.
+"""
+
+import shlex
+from pathlib import Path
+
+from ttnn_visualizer.models import RemoteConnection
+from ttnn_visualizer.remote_command import (
+    RemoteCommand,
+    remote_arg,
+    remote_glob_arg,
+    remote_scp_target,
+)
+
+_APOSTROPHE_PATH = "/remote/o'brien/reports"
+_INJECTION_PATH = "/remote/reports; touch /tmp/pwned"
+
+
+def _connection() -> RemoteConnection:
+    return RemoteConnection(
+        name="lab",
+        username="alice",
+        host="work-gpu",
+        port=22,
+        profilerPath="/reports",
+    )
+
+
+class TestRemoteArg:
+    def test_a_quoted_argument_round_trips_as_one_token(self):
+        for path in (_APOSTROPHE_PATH, _INJECTION_PATH, "/a path/with spaces"):
+            assert shlex.split(f"stat {remote_arg(path)}") == ["stat", path]
+
+    def test_command_substitution_does_not_survive_quoting(self):
+        quoted = remote_arg("/remote/$(touch /tmp/pwned)")
+
+        assert quoted.startswith("'")
+        assert shlex.split(f"stat {quoted}") == ["stat", "/remote/$(touch /tmp/pwned)"]
+
+    def test_a_trailing_slash_is_preserved(self):
+        # `_report_search_find_expression` strips trailing slashes itself because GNU
+        # and BSD `find` disagree on the root they echo; normalising here would take
+        # that decision away from it.
+        assert shlex.split(f"find {remote_arg('/reports/')}") == ["find", "/reports/"]
+        assert shlex.split(f"find {remote_arg('//reports')}") == ["find", "//reports"]
+
+    def test_a_path_is_accepted_and_not_normalised_further(self):
+        assert shlex.split(f"cat {remote_arg(Path('/a b/c'))}") == ["cat", "/a b/c"]
+
+
+class TestRemoteGlobArg:
+    def test_the_wildcard_stays_expandable_while_the_path_is_quoted(self):
+        pattern = "/remote/o'brien/*/config.json"
+        quoted = remote_glob_arg(pattern)
+
+        # Quote removal returns the pattern verbatim, so the apostrophe cannot close
+        # the quoting early, yet the wildcard is left outside quotes for the shell.
+        assert shlex.split(f"ls -1 {quoted}") == ["ls", "-1", pattern]
+        assert "'*'" not in quoted
+
+    def test_an_injection_attempt_around_a_wildcard_is_still_quoted(self):
+        quoted = remote_glob_arg("/remote/*/; touch /tmp/pwned")
+
+        assert shlex.split(f"ls -1 {quoted}") == [
+            "ls",
+            "-1",
+            "/remote/*/; touch /tmp/pwned",
+        ]
+
+
+class TestRemoteScpTarget:
+    def test_only_the_path_half_is_quoted(self):
+        target = remote_scp_target(_connection(), _APOSTROPHE_PATH)
+
+        # scp splits on the first colon locally, so user@host must stay bare while
+        # the path is quoted for the shell that expands it under `-O`.
+        assert target.startswith("alice@work-gpu:")
+        path_half = target.split(":", 1)[1]
+        assert shlex.split(path_half) == [_APOSTROPHE_PATH]
+
+    def test_an_injection_attempt_in_the_path_is_quoted(self):
+        target = remote_scp_target(_connection(), _INJECTION_PATH)
+
+        assert shlex.split(target.split(":", 1)[1]) == [_INJECTION_PATH]
+
+
+class TestRemoteCommand:
+    def test_of_quotes_every_argument(self):
+        command = RemoteCommand.of("stat", "-c", "%Y", _INJECTION_PATH)
+
+        assert shlex.split(str(command)) == ["stat", "-c", "%Y", _INJECTION_PATH]
+
+    def test_of_leaves_already_safe_tokens_unquoted(self):
+        # Keeps commands readable in debug logs, and lets flags be passed positionally.
+        assert str(RemoteCommand.of("stat", "-c", "%Y", "/reports")) == (
+            "stat -c %Y /reports"
+        )
+
+    def test_of_supports_a_program_with_no_arguments(self):
+        assert str(RemoteCommand.of("hostname")) == "hostname"
+
+    def test_a_nested_script_is_quoted_as_a_single_argument(self):
+        # `bash -lc <script>` is how multi-statement remote work is sent, and the
+        # script has to arrive as one argv element.
+        script = "find /reports -name 'config_*.json' -print"
+        command = RemoteCommand.of("bash", "-lc", script)
+
+        assert shlex.split(str(command)) == ["bash", "-lc", script]
+
+    def test_from_shell_fragment_is_passed_through_verbatim(self):
+        fragment = f"stat -c %Y {remote_arg(_INJECTION_PATH)} 2>/dev/null || echo"
+
+        assert str(RemoteCommand.from_shell_fragment(fragment)) == fragment

--- a/backend/ttnn_visualizer/tests/test_sftp_download_fallback.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_download_fallback.py
@@ -4,6 +4,7 @@
 
 """Tests for scp fallback when the remote SFTP subsystem is unavailable."""
 
+import shlex
 import subprocess
 from unittest.mock import patch
 
@@ -11,8 +12,8 @@ import pytest
 from ttnn_visualizer.enums import SyncMethod
 from ttnn_visualizer.models import RemoteConnection
 from ttnn_visualizer.sftp_operations import (
-    _scp_remote_target,
     _sftp_subsystem_unavailable,
+    download_single_file_scp,
     download_single_file_sftp,
     get_active_sync_method,
 )
@@ -38,12 +39,6 @@ def connection() -> RemoteConnection:
 
 def _scp_success() -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=["scp"], returncode=0, stdout="", stderr="")
-
-
-def test_scp_remote_target_has_no_shell_quotes(connection):
-    target = _scp_remote_target(connection, "/remote/report/config.json")
-    assert target == "user@example.test:/remote/report/config.json"
-    assert "'" not in target
 
 
 def test_sftp_subsystem_failure_falls_back_to_scp(connection, tmp_path):
@@ -94,6 +89,20 @@ def test_subsequent_downloads_skip_sftp_after_subsystem_failure(connection, tmp_
     # `-O` forces legacy SCP protocol so scp does not reuse the disabled SFTP subsystem.
     assert run.call_args_list[1][0][0][1] == "-O"
     assert run.call_args_list[2][0][0][1] == "-O"
+
+
+# The quoting contract itself lives in test_remote_command.py; this checks the download
+# path actually routes its target through it, since `-O` has the remote side expand the
+# path through a shell.
+def test_scp_download_quotes_the_remote_path_in_its_target(connection, tmp_path):
+    remote_file = "/remote/o'brien/reports/config.json"
+
+    with patch("subprocess.run", return_value=_scp_success()) as run:
+        download_single_file_scp(connection, remote_file, tmp_path / "config.json")
+
+    target = run.call_args[0][0][-2]
+    assert target.startswith(f"{connection.username}@{connection.host}:")
+    assert shlex.split(target.split(":", 1)[1]) == [remote_file]
 
 
 def test_active_sync_method_reflects_fallback_state(connection, tmp_path):

--- a/backend/ttnn_visualizer/tests/test_sftp_operations.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_operations.py
@@ -29,7 +29,6 @@ from ttnn_visualizer.sftp_operations import (
     _get_remote_file_list_without_sizes,
     _remote_directory_mtimes,
     _remote_transfer_key,
-    _scp_remote_target,
     _sftp_subsystem_unavailable,
     find_folders_by_files,
     get_remote_directory_list,
@@ -161,7 +160,18 @@ class TestRemoteFindShellQuoting:
 
     def test_no_config_path_command_leaks_the_payload_unquoted(self, connection):
         for command in self._config_path_commands(connection):
-            assert "; touch /tmp/pwned" not in shlex.split(command)
+            tokens = shlex.split(command)
+            # A leak splits the payload across argv — the path ends at `o'brien;`
+            # and `touch` becomes a word of its own. Asserted on the tokens rather
+            # than on the command text because some commands carry the config
+            # path's parent folder instead of the path itself, so what has to hold
+            # is that whichever of the two a token carries, it carries whole.
+            assert "touch" not in tokens
+            for token in tokens:
+                if "touch" in token:
+                    assert token.endswith("; touch /tmp/pwned/config.json") or (
+                        token.endswith("; touch /tmp/pwned")
+                    )
 
     def test_ranked_config_listing_wraps_the_folder_in_one_argument(self, connection):
         # The `bash -lc` script must reach the remote shell as a single argv element,
@@ -189,14 +199,6 @@ class TestRemoteFindShellQuoting:
         program, flag, script = shlex.split(listing[0])
         assert (program, flag) == ("bash", "-lc")
         assert shlex.split(script)[:2] == ["find", "/remote/o'brien/reports"]
-
-    def test_scp_remote_target_quotes_only_the_path(self, connection):
-        target = _scp_remote_target(connection, self._APOSTROPHE_FOLDER)
-
-        # `-O` selects the legacy SCP protocol, under which the remote side expands
-        # the path through a shell, so argv delivery alone is not protection.
-        assert target.startswith(f"{connection.username}@{connection.host}:")
-        assert shlex.split(target.split(":", 1)[1]) == [self._APOSTROPHE_FOLDER]
 
     def test_resolve_file_path_quotes_around_the_wildcard(self, connection):
         # The wildcard has to reach the remote shell unquoted for `ls` to expand it,

--- a/backend/ttnn_visualizer/tests/test_sftp_operations.py
+++ b/backend/ttnn_visualizer/tests/test_sftp_operations.py
@@ -29,10 +29,12 @@ from ttnn_visualizer.sftp_operations import (
     _get_remote_file_list_without_sizes,
     _remote_directory_mtimes,
     _remote_transfer_key,
+    _scp_remote_target,
     _sftp_subsystem_unavailable,
     find_folders_by_files,
     get_remote_directory_list,
     get_remote_file_list,
+    get_remote_profiler_folder_from_config_path,
     resolve_file_path,
     sync_files_and_directories,
 )
@@ -135,6 +137,66 @@ class TestRemoteFindShellQuoting:
         remote_cmd = _remote_shell_command_from_run(run)
         assert shlex.quote(self._APOSTROPHE_FOLDER) in remote_cmd
         assert f"stat -c %Y '{self._APOSTROPHE_FOLDER}'" not in remote_cmd
+
+    # These three ran the path as its own argv element after user@host, which looks
+    # safe but is not: ssh joins everything after the target with spaces and hands the
+    # result to the remote login shell. The paths come from `find` output rooted at the
+    # connection's configured path, so a crafted report path reached a shell unquoted.
+    _CONFIG_PATH = "/remote/reports/o'brien; touch /tmp/pwned/config.json"
+
+    def _config_path_commands(self, connection) -> list:
+        """Every remote command issued while describing one config path."""
+        with patch("subprocess.run", return_value=_completed("")) as run:
+            get_remote_profiler_folder_from_config_path(connection, self._CONFIG_PATH)
+
+        return [call[0][0][-1] for call in run.call_args_list]
+
+    def test_config_path_probe_passes_the_path_as_one_argument(self, connection):
+        commands = self._config_path_commands(connection)
+
+        assert commands, "expected at least one remote command"
+        # `test -f` runs first; the payload must arrive as a single token rather than
+        # as a command terminator followed by a second command.
+        assert shlex.split(commands[0]) == ["test", "-f", self._CONFIG_PATH]
+
+    def test_no_config_path_command_leaks_the_payload_unquoted(self, connection):
+        for command in self._config_path_commands(connection):
+            assert "; touch /tmp/pwned" not in shlex.split(command)
+
+    def test_ranked_config_listing_wraps_the_folder_in_one_argument(self, connection):
+        # The `bash -lc` script must reach the remote shell as a single argv element,
+        # or the find expression inside it is split across arguments.
+        def run_remote(cmd, *args, **kwargs):
+            # The ranked listing is only reached once `test -f` reports the single
+            # config absent, so that probe has to fail for this path to be exercised.
+            if "test -f" in cmd[-1]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout="", stderr=""
+                )
+            return _completed("")
+
+        with patch("subprocess.run", side_effect=run_remote) as run:
+            get_remote_profiler_folder_from_config_path(
+                connection, "/remote/o'brien/reports/config.json"
+            )
+
+        listing = [
+            command
+            for command in (call[0][0][-1] for call in run.call_args_list)
+            if command.startswith("bash")
+        ]
+        assert listing, "expected a ranked-config listing command"
+        program, flag, script = shlex.split(listing[0])
+        assert (program, flag) == ("bash", "-lc")
+        assert shlex.split(script)[:2] == ["find", "/remote/o'brien/reports"]
+
+    def test_scp_remote_target_quotes_only_the_path(self, connection):
+        target = _scp_remote_target(connection, self._APOSTROPHE_FOLDER)
+
+        # `-O` selects the legacy SCP protocol, under which the remote side expands
+        # the path through a shell, so argv delivery alone is not protection.
+        assert target.startswith(f"{connection.username}@{connection.host}:")
+        assert shlex.split(target.split(":", 1)[1]) == [self._APOSTROPHE_FOLDER]
 
     def test_resolve_file_path_quotes_around_the_wildcard(self, connection):
         # The wildcard has to reach the remote shell unquoted for `ls` to expand it,

--- a/backend/ttnn_visualizer/tests/test_ssh_client.py
+++ b/backend/ttnn_visualizer/tests/test_ssh_client.py
@@ -12,7 +12,11 @@ import os
 
 import pytest
 from pydantic import ValidationError
-from ttnn_visualizer.models import MlirServerConnection, RemoteConnection
+from ttnn_visualizer.models import (
+    MAX_REMOTE_PATH_LENGTH,
+    MlirServerConnection,
+    RemoteConnection,
+)
 from ttnn_visualizer.ssh_client import SSHClient
 
 
@@ -158,3 +162,89 @@ def test_connection_accepts_a_padded_username():
 
 def test_mlir_server_connection_accepts_a_padded_username():
     assert _mlir_connection(username="  alice  ").username == "alice"
+
+
+# Report paths are interpolated into remote shell commands, so they carry a validator
+# of their own rather than relying on call-site quoting as the only defence.
+@pytest.mark.parametrize("field", ["profilerPath", "performancePath"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "reports",
+        "tt-metal/generated/ttnn/reports",
+        "~/tt-metal/generated/ttnn/reports",
+        "./reports",
+    ],
+    ids=["bare", "relative", "tilde", "dot-relative"],
+)
+def test_connection_rejects_a_path_that_is_not_absolute(field, path):
+    with pytest.raises(ValidationError, match="must be an absolute path"):
+        _connection(**{field: path})
+
+
+@pytest.mark.parametrize("field", ["profilerPath", "performancePath"])
+@pytest.mark.parametrize(
+    "path",
+    ["/reports\nrm -rf /", "/reports\x00/etc", "/reports\treports", "/reports\x7f"],
+    ids=["newline", "nul", "tab", "delete"],
+)
+def test_connection_rejects_a_path_with_control_characters(field, path):
+    # A newline splits one remote command into two, and NUL reaches subprocess as
+    # ValueError("embedded null byte") — a 500 rather than a validation message.
+    with pytest.raises(ValidationError, match="must not contain control characters"):
+        _connection(**{field: path})
+
+
+@pytest.mark.parametrize("field", ["profilerPath", "performancePath"])
+def test_connection_rejects_an_over_long_path(field):
+    with pytest.raises(ValidationError, match="must be at most"):
+        _connection(**{field: "/" + "a" * MAX_REMOTE_PATH_LENGTH})
+
+
+@pytest.mark.parametrize("field", ["profilerPath", "performancePath"])
+def test_connection_rejects_a_non_string_path(field):
+    # Pydantic coerces bytes to str after "before" validators run, so a non-string has
+    # to be refused here rather than left to the field type.
+    with pytest.raises(ValidationError, match="must be a string"):
+        _connection(**{field: b"/reports"})
+
+
+@pytest.mark.parametrize("field", ["profilerPath", "performancePath"])
+def test_connection_strips_padding_from_a_path(field):
+    assert getattr(_connection(**{field: "  /reports  "}), field) == "/reports"
+
+
+# An unconfigured path is a supported state, so emptiness must not be mistaken for a
+# rejected value: report discovery skips a path it was not given.
+@pytest.mark.parametrize("path", ["", "   "], ids=["empty", "whitespace"])
+def test_connection_accepts_an_empty_profiler_path(path):
+    assert _connection(profilerPath=path).profilerPath == ""
+
+
+def test_connection_accepts_an_absent_performance_path():
+    assert _connection(performancePath=None).performancePath is None
+
+
+@pytest.mark.parametrize("path", ["", "   "], ids=["empty", "whitespace"])
+def test_connection_accepts_an_empty_performance_path(path):
+    assert _connection(performancePath=path).performancePath == ""
+
+
+# A path that survives validation can still contain shell metacharacters, which is why
+# quoting at the call site remains the primary defence.
+@pytest.mark.parametrize(
+    "path",
+    ["/reports; touch /tmp/pwned", "/reports/$(id)", "/remote/o'brien/reports"],
+    ids=["semicolon", "substitution", "apostrophe"],
+)
+def test_connection_accepts_an_absolute_path_containing_shell_metacharacters(path):
+    assert _connection(profilerPath=path).profilerPath == path
+
+
+# MlirServerConnection has no report paths of its own but builds a RemoteConnection
+# with an empty profiler path, so the validator must not break MLIR flows.
+def test_mlir_server_connection_still_converts_to_a_remote_connection():
+    remote = _mlir_connection().to_remote_connection()
+
+    assert remote.profilerPath == ""
+    assert remote.host == "work-gpu"

--- a/backend/ttnn_visualizer/tests/test_ssh_client.py
+++ b/backend/ttnn_visualizer/tests/test_ssh_client.py
@@ -9,6 +9,9 @@ its ProxyJump, IdentityFile and friends; a set identity file must isolate the ru
 """
 
 import os
+import shlex
+import subprocess
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -239,6 +242,25 @@ def test_connection_accepts_an_empty_performance_path(path):
 )
 def test_connection_accepts_an_absolute_path_containing_shell_metacharacters(path):
     assert _connection(profilerPath=path).profilerPath == path
+
+
+# `scp -O` expands its remote path through a shell on the far side, so delivering the
+# target as one argv element is not protection on its own — the path half needs quoting.
+def test_upload_file_quotes_the_remote_path_in_the_scp_target(tmp_path):
+    remote_path = "/remote/o'brien/reports/model.mlir"
+    local_file = tmp_path / "model.mlir"
+    local_file.write_text("x")
+    client = SSHClient(_connection())
+
+    with patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(args=["scp"], returncode=0),
+    ) as run:
+        client.upload_file(str(local_file), remote_path)
+
+    target = run.call_args[0][0][-1]
+    assert target.startswith("alice@work-gpu:")
+    assert shlex.split(target.split(":", 1)[1]) == [remote_path]
 
 
 # MlirServerConnection has no report paths of its own but builds a RemoteConnection

--- a/backend/ttnn_visualizer/tests/test_stack_trace_source.py
+++ b/backend/ttnn_visualizer/tests/test_stack_trace_source.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import shlex
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ from ttnn_visualizer.stack_trace_source import (
     _discover_tt_metal_roots_local,
     _extract_suffix_after_tt_metal,
     _preferred_remote_user_root_for_raw_path,
+    _remote_regular_file_exists,
     _remote_roots_for_raw_path,
     _resolve_local_stack_path,
     _safe_join_under_tt_metal_root,
@@ -120,6 +122,21 @@ def test_candidate_dirs_include_sudo_user_home_tt_metal(monkeypatch):
     """When sudo leaves HOME as root, /home/$SUDO_USER/tt-metal must still be tried."""
     monkeypatch.setenv("SUDO_USER", "someuser")
     assert Path("/home/someuser/tt-metal") in _candidate_tt_metal_dirs()
+
+
+# The existence probe interpolates a caller-supplied path into a `&&` fragment twice,
+# and every other test monkeypatches it out — so this is the only place its command
+# construction is checked. A stack-trace path arrives from report data, not a form.
+def test_remote_regular_file_exists_passes_the_path_as_one_argument():
+    raw_path = "/src/o'brien; touch /tmp/pwned/a.py"
+    ssh_client = MagicMock()
+
+    _remote_regular_file_exists(ssh_client, raw_path)
+
+    fragment = str(ssh_client.execute_command.call_args[0][0])
+    left, right = fragment.split("&&")
+    assert shlex.split(left) == ["test", "-f", raw_path]
+    assert shlex.split(right) == ["test", "-r", raw_path]
 
 
 def test_remote_root_script_matches_local_priority_order():

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -1112,6 +1112,31 @@ class TestConnectionTestReportStatuses:
     def _messages(response) -> list[str]:
         return [status["message"] for status in response.get_json()]
 
+    # The dialog calls this endpoint before saving, so a value the validators reject has
+    # to come back as a message the form can render rather than as a 500.
+    @pytest.mark.parametrize(
+        "payload_override",
+        [
+            {"profilerPath": "tt-metal/generated/ttnn/reports"},
+            {"performancePath": "reports"},
+            {"profilerPath": "/reports\nrm -rf /"},
+            {"host": ".."},
+        ],
+        ids=["relative-profiler", "relative-performance", "newline", "bad-host"],
+    )
+    def test_invalid_connection_data_is_a_bad_request(
+        self, app, client, payload_override
+    ):
+        app.config["SERVER_MODE"] = False
+
+        response = client.post(
+            "/api/remote/test",
+            json={**_remote_connection_payload(), **payload_override},
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.get_json()["error"] == "Invalid connection data"
+
     def _run_connection_test(self, client, payload, *, folders_per_path):
         with (
             patch("ttnn_visualizer.views.test_ssh_connection", return_value=True),

--- a/backend/ttnn_visualizer/tests/views/test_remote_reports.py
+++ b/backend/ttnn_visualizer/tests/views/test_remote_reports.py
@@ -1197,6 +1197,69 @@ class TestConnectionTestReportStatuses:
         )
 
 
+class TestRejectedPayloadsAreBadRequests:
+    """Every ``/api/remote`` route answers a rejected payload the same way.
+
+    The validators tightened after these values were storable, so the offending
+    connection can arrive from the client's own saved list rather than from a
+    hand-crafted request. A 500 gives the user nothing to act on.
+    """
+
+    _PROFILER_FOLDER = {
+        "reportName": "resnet50",
+        "remotePath": "/remote/profiler/reports/resnet50",
+        "lastModified": 1,
+    }
+
+    def _post(self, client, endpoint: str, *, connection: dict, profiler: dict):
+        if endpoint == "/api/remote/test":
+            return client.post(endpoint, json=connection)
+        return client.post(
+            endpoint, json={"connection": connection, "profiler": profiler}
+        )
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        ["/api/remote/test", "/api/remote/sync", "/api/remote/use"],
+        ids=["test", "sync", "use"],
+    )
+    def test_a_rejected_connection_path_is_a_bad_request(self, app, client, endpoint):
+        app.config["SERVER_MODE"] = False
+
+        response = self._post(
+            client,
+            endpoint,
+            connection={**_remote_connection_payload(), "profilerPath": "reports"},
+            profiler=self._PROFILER_FOLDER,
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.get_json()["error"] == "Invalid connection data"
+
+    @pytest.mark.parametrize(
+        "remote_path",
+        ["/remote/reports\nrm -rf /", "relative/reports"],
+        ids=["newline", "relative"],
+    )
+    @pytest.mark.parametrize(
+        "endpoint", ["/api/remote/sync", "/api/remote/use"], ids=["sync", "use"]
+    )
+    def test_a_rejected_report_path_is_a_bad_request(
+        self, app, client, endpoint, remote_path
+    ):
+        app.config["SERVER_MODE"] = False
+
+        response = self._post(
+            client,
+            endpoint,
+            connection=_remote_connection_payload(),
+            profiler={**self._PROFILER_FOLDER, "remotePath": remote_path},
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.get_json()["error"] == "Invalid report data"
+
+
 class TestReportSearchAgainstRealFind:
     """Run the emitted expression through a local ``find``.
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -1718,7 +1718,13 @@ def test_remote_folder():
     if not connection_data:
         return response_bad_request("Missing connection data")
 
-    connection = RemoteConnection.model_validate(connection_data, strict=False)
+    try:
+        connection = RemoteConnection.model_validate(connection_data, strict=False)
+    except ValidationError:
+        # A rejected host, username or report path is user input, not a server fault,
+        # and the dialog needs a message it can render rather than a 500.
+        return response_bad_request("Invalid connection data")
+
     logger.debug(
         "test_remote_folder request identityFile=%r, connection.identityFile=%r",
         connection_data.get("identityFile"),

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -13,7 +13,7 @@ import urllib
 import urllib.request
 from http import HTTPStatus
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import orjson
 import yaml
@@ -31,6 +31,7 @@ from ttnn_visualizer.enums import ConnectionTestStates, StackSourceOrigin
 from ttnn_visualizer.exceptions import (
     AuthenticationFailedException,
     DataFormatError,
+    InvalidRequestPayload,
     PerformanceReportNotLoadedException,
     RemoteConnectionException,
     RemoteFileReadException,
@@ -1562,16 +1563,34 @@ def _annotate_last_synced(
             logger.debug("%s not yet synced", directory_name)
 
 
+def _validated_remote_connection(connection_data: Any) -> RemoteConnection:
+    """Parse a request body's connection, refusing an unusable one as a 400.
+
+    A rejected host, username or report path is user input, not a server fault,
+    and the value can arrive from the client's own stored connections, so every
+    ``/api/remote`` route needs the same answer rather than a 500.
+    """
+    try:
+        return RemoteConnection.model_validate(connection_data, strict=False)
+    except ValidationError as validation_error:
+        raise InvalidRequestPayload("Invalid connection data") from validation_error
+
+
+def _validated_remote_report_folder(folder_data: Any) -> RemoteReportFolder:
+    """As ``_validated_remote_connection``, for a report folder in a request body."""
+    try:
+        return RemoteReportFolder.model_validate(folder_data, strict=False)
+    except ValidationError as validation_error:
+        raise InvalidRequestPayload("Invalid report data") from validation_error
+
+
 def _respond_remote_report_list(fetch_fn, directory_config_key: str):
     connection_data = request.get_json()
 
     if not connection_data:
         return response_bad_request("Missing connection data")
 
-    try:
-        connection = RemoteConnection.model_validate(connection_data, strict=False)
-    except ValidationError:
-        return response_bad_request("Invalid connection data")
+    connection = _validated_remote_connection(connection_data)
 
     try:
         remote_folders: List[RemoteReportFolder] = fetch_fn(connection)
@@ -1594,10 +1613,7 @@ def _respond_local_synced_folders(list_fn, directory_config_key: str):
     if not connection_data:
         return response_bad_request("Missing connection data")
 
-    try:
-        connection = RemoteConnection.model_validate(connection_data, strict=False)
-    except ValidationError:
-        return response_bad_request("Invalid connection data")
+    connection = _validated_remote_connection(connection_data)
 
     folders = list_fn(
         connection,
@@ -1718,12 +1734,7 @@ def test_remote_folder():
     if not connection_data:
         return response_bad_request("Missing connection data")
 
-    try:
-        connection = RemoteConnection.model_validate(connection_data, strict=False)
-    except ValidationError:
-        # A rejected host, username or report path is user input, not a server fault,
-        # and the dialog needs a message it can render rather than a 500.
-        return response_bad_request("Invalid connection data")
+    connection = _validated_remote_connection(connection_data)
 
     logger.debug(
         "test_remote_folder request identityFile=%r, connection.identityFile=%r",
@@ -2029,14 +2040,10 @@ def sync_remote_folder():
     profiler = request_body.get("profiler")
     performance = request_body.get("performance", None)
     instance_id = request.args.get("instanceId", None)
-    connection = RemoteConnection.model_validate(
-        request_body.get("connection"), strict=False
-    )
+    connection = _validated_remote_connection(request_body.get("connection"))
 
     if performance:
-        performance_folder = RemoteReportFolder.model_validate(
-            performance, strict=False
-        )
+        performance_folder = _validated_remote_report_folder(performance)
         try:
             sync_method = sync_remote_performance_folders(
                 connection,
@@ -2060,11 +2067,9 @@ def sync_remote_folder():
                 sync_method=e.sync_method or get_active_sync_method(connection).value,
             )
 
-    try:
-        remote_profiler_folder = RemoteReportFolder.model_validate(
-            profiler, strict=False
-        )
+    remote_profiler_folder = _validated_remote_report_folder(profiler)
 
+    try:
         sync_method = sync_remote_profiler_folders(
             connection,
             remote_profiler_folder.remotePath,
@@ -2134,7 +2139,7 @@ def use_remote_folder():
     if not connection_data or not (profiler or performance):
         return response_bad_request("Missing connection or report data")
 
-    connection = RemoteConnection.model_validate(connection_data, strict=False)
+    connection = _validated_remote_connection(connection_data)
 
     kwargs = {
         "instance_id": request.args.get("instanceId"),
@@ -2142,10 +2147,7 @@ def use_remote_folder():
     }
 
     if profiler:
-        remote_profiler_folder = RemoteReportFolder.model_validate(
-            profiler,
-            strict=False,
-        )
+        remote_profiler_folder = _validated_remote_report_folder(profiler)
         profiler_name = _safe_report_folder_name(
             report_name=remote_profiler_folder.reportName,
             remote_path=remote_profiler_folder.remotePath,
@@ -2160,10 +2162,7 @@ def use_remote_folder():
         kwargs["profiler_location"] = ReportLocation.REMOTE.value
 
     if performance:
-        remote_performance_folder = RemoteReportFolder.model_validate(
-            performance,
-            strict=False,
-        )
+        remote_performance_folder = _validated_remote_report_folder(performance)
         performance_name = _safe_report_folder_name(
             report_name=remote_performance_folder.reportName,
             remote_path=remote_performance_folder.remotePath,

--- a/docs/src/remote-sync.md
+++ b/docs/src/remote-sync.md
@@ -108,6 +108,15 @@ Make sure you have sufficient local storage space for the files you want to sync
 
 ### Report Paths
 
+Both report paths must be **absolute** — they have to start with `/`. The paths are sent to the
+remote host quoted, so nothing on the far side expands them: a home-relative path such as
+`~/tt-metal/generated/ttnn/reports/` is taken literally, matches nothing, and would otherwise
+report an empty folder list rather than an error. Write the full path instead
+(`/home/username/tt-metal/generated/ttnn/reports/`). Paths must also be free of line breaks and
+other control characters, and no longer than 4096 characters. The dialog flags a path it would
+refuse and withholds the connection test until you fix it; a connection saved before this was
+enforced stays in the list, marked with a warning, so you can edit it.
+
 When adding the SSH connection, you must specify a _Memory report folder path_. This is either a
 folder outside of tt-metal where you have stored reports, or you can point it directly to the
 `generated` directory in `tt-metal`. If syncing directly from the generated directory, point

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -19,6 +19,8 @@ import { useState } from 'react';
 import { ConnectionStatus, ConnectionTestStates } from '../../definitions/ConnectionStatus';
 import { MULTIHOST_CHECKBOX_LABEL, RemoteConnection } from '../../definitions/RemoteConnection';
 import {
+    REMOTE_MEMORY_PATH_ERROR_ID,
+    REMOTE_PERFORMANCE_PATH_ERROR_ID,
     SSH_HOST_SUBLABEL,
     SSH_IDENTITY_FILE_LABEL,
     SSH_IDENTITY_FILE_PLACEHOLDER,
@@ -290,11 +292,15 @@ const RemoteConnectionDialog = ({
                     subLabel='Path to a remote folder containing memory reports (e.g., "/<PATH TO TT METAL>/generated/ttnn/reports/")'
                     labelFor='remote-memory-path'
                     intent={profilerPathError ? Intent.DANGER : undefined}
-                    helperText={profilerPathError ?? undefined}
+                    helperText={profilerPathError && <span id={REMOTE_MEMORY_PATH_ERROR_ID}>{profilerPathError}</span>}
                 >
                     <InputGroup
                         id='remote-memory-path'
                         intent={profilerPathError ? Intent.DANGER : undefined}
+                        // Blueprint colours the field but tells assistive tech nothing, so the
+                        // error is announced only if the input points at it itself.
+                        aria-invalid={profilerPathError !== null}
+                        aria-describedby={profilerPathError ? REMOTE_MEMORY_PATH_ERROR_ID : undefined}
                         value={connection.profilerPath}
                         onChange={(e) => updateTarget({ profilerPath: e.target.value })}
                     />
@@ -305,11 +311,17 @@ const RemoteConnectionDialog = ({
                     subLabel='Path to a remote folder containing performance reports (e.g., "/<PATH TO TT METAL>/generated/profiler/reports/")'
                     labelFor='remote-performance-path'
                     intent={performancePathError ? Intent.DANGER : undefined}
-                    helperText={performancePathError ?? undefined}
+                    helperText={
+                        performancePathError && (
+                            <span id={REMOTE_PERFORMANCE_PATH_ERROR_ID}>{performancePathError}</span>
+                        )
+                    }
                 >
                     <InputGroup
                         id='remote-performance-path'
                         intent={performancePathError ? Intent.DANGER : undefined}
+                        aria-invalid={performancePathError !== null}
+                        aria-describedby={performancePathError ? REMOTE_PERFORMANCE_PATH_ERROR_ID : undefined}
                         value={connection.performancePath ?? ''}
                         onChange={(e) => updateTarget({ performancePath: e.target.value })}
                     />

--- a/src/components/report-selection/RemoteConnectionDialog.tsx
+++ b/src/components/report-selection/RemoteConnectionDialog.tsx
@@ -2,7 +2,17 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Button, Checkbox, Dialog, DialogBody, DialogFooter, FormGroup, InputGroup, Tooltip } from '@blueprintjs/core';
+import {
+    Button,
+    Checkbox,
+    Dialog,
+    DialogBody,
+    DialogFooter,
+    FormGroup,
+    InputGroup,
+    Intent,
+    Tooltip,
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { AxiosError } from 'axios';
 import { useState } from 'react';
@@ -16,8 +26,10 @@ import {
     SSH_USERNAME_SUBLABEL,
 } from '../../definitions/SshConnectionFields';
 import { SshConfigHost } from '../../model/SshConfigHost';
+import getResponseError from '../../functions/getResponseError';
 import getServerConfig from '../../functions/getServerConfig';
 import getSshConfigHostPrefill from '../../functions/getSshConfigHostPrefill';
+import { getRemotePathError } from '../../functions/remotePath';
 import useRemoteConnection from '../../hooks/useRemote';
 import useSshConfigHostSelection from '../../hooks/useSshConfigHostSelection';
 import ConnectionTestMessage from './ConnectionTestMessage';
@@ -93,8 +105,13 @@ const RemoteConnectionDialog = ({
     const { testConnection } = useRemoteConnection();
     const [isTestingConnection, setIsTestingconnection] = useState(false);
 
+    const profilerPathError = getRemotePathError(connection.profilerPath);
+    const performancePathError = getRemotePathError(connection.performancePath);
+    const hasPathError = profilerPathError !== null || performancePathError !== null;
+
     const isValidConnection =
         connectionTests.length > 0 &&
+        !hasPathError &&
         connectionTests.every(
             ({ status }) => status === ConnectionTestStates.OK || status === ConnectionTestStates.WARNING,
         );
@@ -102,6 +119,7 @@ const RemoteConnectionDialog = ({
         connection.username?.trim() &&
         connection.host?.trim() &&
         connection.port &&
+        !hasPathError &&
         (connection.profilerPath?.trim() || connection.performancePath?.trim());
 
     // Everything the test actually exercises — the SSH target, the credentials, and the paths it
@@ -136,12 +154,14 @@ const RemoteConnectionDialog = ({
         } catch (err) {
             // Check if this is an axios error with response data (e.g., HTTP 422 for auth failures)
             const axiosError = err as AxiosError;
-            if (axiosError.response && axiosError.response.data) {
+            // Only a status list can be rendered as one. A rejected field gives
+            // `{ error: … }` instead, which would otherwise reach `.map` as a non-array.
+            if (Array.isArray(axiosError.response?.data)) {
                 // Use the actual API response data which contains proper messages and details
                 setConnectionTests(axiosError.response.data as ConnectionStatus[]);
             } else {
-                // Fallback for other types of errors
-                setConnectionTests([FAILED_CONNECTION, FAILED_MEMORY_REPORT_PATH]);
+                const detail = getResponseError(err);
+                setConnectionTests([{ ...FAILED_CONNECTION, detail }, FAILED_MEMORY_REPORT_PATH]);
             }
         } finally {
             setIsTestingconnection(false);
@@ -269,9 +289,12 @@ const RemoteConnectionDialog = ({
                     label='Memory report folder path'
                     subLabel='Path to a remote folder containing memory reports (e.g., "/<PATH TO TT METAL>/generated/ttnn/reports/")'
                     labelFor='remote-memory-path'
+                    intent={profilerPathError ? Intent.DANGER : undefined}
+                    helperText={profilerPathError ?? undefined}
                 >
                     <InputGroup
                         id='remote-memory-path'
+                        intent={profilerPathError ? Intent.DANGER : undefined}
                         value={connection.profilerPath}
                         onChange={(e) => updateTarget({ profilerPath: e.target.value })}
                     />
@@ -281,9 +304,12 @@ const RemoteConnectionDialog = ({
                     label='Performance report folder path'
                     subLabel='Path to a remote folder containing performance reports (e.g., "/<PATH TO TT METAL>/generated/profiler/reports/")'
                     labelFor='remote-performance-path'
+                    intent={performancePathError ? Intent.DANGER : undefined}
+                    helperText={performancePathError ?? undefined}
                 >
                     <InputGroup
                         id='remote-performance-path'
+                        intent={performancePathError ? Intent.DANGER : undefined}
                         value={connection.performancePath ?? ''}
                         onChange={(e) => updateTarget({ performancePath: e.target.value })}
                     />
@@ -329,7 +355,7 @@ const RemoteConnectionDialog = ({
 
                     <Button
                         text='Run tests'
-                        disabled={isTestingConnection}
+                        disabled={isTestingConnection || hasPathError}
                         loading={isTestingConnection}
                         onClick={testConnectionStatus}
                     />

--- a/src/components/report-selection/RemoteConnectionSelector.tsx
+++ b/src/components/report-selection/RemoteConnectionSelector.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Button, MenuItem, PopoverPosition, Tooltip } from '@blueprintjs/core';
+import { Button, Icon, Intent, MenuItem, PopoverPosition, Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { useState } from 'react';
@@ -11,6 +11,7 @@ import { FETCH_REMOTE_FOLDERS_LABEL, RemoteConnection } from '../../definitions/
 import { ManagedEntity } from '../../definitions/ManagedEntity';
 import { TEST_IDS } from '../../definitions/TestIds';
 import { isSameConnection, remoteConnectionKey } from '../../functions/remoteConnection';
+import { getRemoteConnectionPathError } from '../../functions/remotePath';
 import ConfirmDeleteAlert from '../ConfirmDeleteAlert';
 import HighlightedText from '../HighlightedText';
 import SelectRowActions from './SelectRowActions';
@@ -40,11 +41,17 @@ const RemoteConnectionSelector = ({
     const [connectionToEdit, setConnectionToEdit] = useState<RemoteConnection | null>(null);
     const [connectionToDelete, setConnectionToDelete] = useState<RemoteConnection | null>(null);
     const selectedConnection = connection ?? connectionList[0];
+    // A connection saved before report paths were validated is kept in the list rather
+    // than hidden, so the only route back is editing it — which means the row has to say
+    // what is wrong and the fetch it would fail at has to be closed off.
+    const selectedConnectionPathError = selectedConnection ? getRemoteConnectionPathError(selectedConnection) : null;
 
     const renderRemoteConnection: ItemRenderer<RemoteConnection> = (item, { handleClick, modifiers, query }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
+
+        const pathError = getRemoteConnectionPathError(item);
 
         return (
             // Presentational for the same reason as the other selectors: MenuItem owns the
@@ -67,6 +74,20 @@ const RemoteConnectionSelector = ({
                         />
                     }
                 />
+
+                {pathError && (
+                    <Tooltip
+                        content={`${pathError} Edit this connection to fix it.`}
+                        position={PopoverPosition.TOP}
+                    >
+                        <Icon
+                            icon={IconNames.WARNING_SIGN}
+                            intent={Intent.WARNING}
+                            data-testid={TEST_IDS.REMOTE_CONNECTION_PATH_WARNING}
+                            aria-label={`${item.name} has an unusable report path`}
+                        />
+                    </Tooltip>
+                )}
 
                 <SelectRowActions
                     entity={ManagedEntity.REMOTE_CONNECTION}
@@ -108,13 +129,13 @@ const RemoteConnectionSelector = ({
             </div>
 
             <Tooltip
-                content='Fetching remote folders...'
+                content={selectedConnectionPathError ?? 'Fetching remote folders...'}
                 position={PopoverPosition.TOP}
-                disabled={!loading}
+                disabled={!loading && !selectedConnectionPathError}
             >
                 <Button
                     icon={IconNames.REFRESH}
-                    disabled={disabled || !selectedConnection}
+                    disabled={disabled || !selectedConnection || selectedConnectionPathError !== null}
                     loading={loading}
                     text={FETCH_REMOTE_FOLDERS_LABEL}
                     onClick={() => onSyncRemoteFolderList(selectedConnection)}

--- a/src/definitions/SshConnectionFields.ts
+++ b/src/definitions/SshConnectionFields.ts
@@ -32,3 +32,35 @@ export const SSH_IDENTITY_FILE_SUBLABEL =
     'Path to your private key. Leave empty to use SSH defaults / ~/.ssh/config for this host. Setting a path ignores SSH config for this connection.';
 
 export const SSH_IDENTITY_FILE_PLACEHOLDER = 'Leave empty for default / SSH config';
+
+/**
+ * The report-path rule, and the copy explaining each way of breaking it.
+ *
+ * Kept beside the limit the message quotes, and shared with the tests that assert it, so a
+ * reworded message cannot pass a spec matching the old wording. The rule itself is enforced
+ * by `getRemotePathError` and mirrored by `sanitise_remote_report_path` on the backend.
+ */
+
+/** Linux PATH_MAX, matching MAX_REMOTE_PATH_LENGTH on the backend. */
+export const MAX_REMOTE_PATH_LENGTH = 4096;
+
+export const REMOTE_PATH_NOT_TEXT_ERROR = 'Path must be text.';
+
+export const REMOTE_PATH_CONTROL_CHARACTERS_ERROR = 'Path must not contain line breaks or other control characters.';
+
+/**
+ * `~` is called out because it looks like it should work: it reaches the remote host quoted, so
+ * no shell expands it and discovery silently finds nothing.
+ */
+export const REMOTE_PATH_NOT_ABSOLUTE_ERROR =
+    'Path must be absolute, starting with "/". Home-relative paths such as "~/tt-metal" are not expanded.';
+
+export const REMOTE_PATH_TOO_LONG_ERROR = `Path must be at most ${MAX_REMOTE_PATH_LENGTH} characters.`;
+
+/**
+ * Ids for the elements carrying a path field's error, referenced by the inputs' `aria-describedby`.
+ * Blueprint renders `helperText` into an unlabelled div, so the association is ours to make.
+ */
+export const REMOTE_MEMORY_PATH_ERROR_ID = 'remote-memory-path-error';
+
+export const REMOTE_PERFORMANCE_PATH_ERROR_ID = 'remote-performance-path-error';

--- a/src/definitions/TestIds.ts
+++ b/src/definitions/TestIds.ts
@@ -23,6 +23,7 @@ export const TEST_IDS = Object.freeze({
     // Report-selection dropdown rows, each carrying its own edit/delete actions
     FOLDER_PICKER_ROW: 'folder-picker-row',
     REMOTE_CONNECTION_ROW: 'remote-connection-row',
+    REMOTE_CONNECTION_PATH_WARNING: 'remote-connection-path-warning',
     MLIR_SERVER_ROW: 'mlir-server-row',
 
     // Comparison components

--- a/src/functions/remotePath.ts
+++ b/src/functions/remotePath.ts
@@ -7,8 +7,13 @@
 // — but repeating the rule here turns a 400 from the connection test into a message
 // against the offending field while the user is still typing.
 
-// Linux PATH_MAX, matching MAX_REMOTE_PATH_LENGTH on the backend.
-export const MAX_REMOTE_PATH_LENGTH = 4096;
+import {
+    MAX_REMOTE_PATH_LENGTH,
+    REMOTE_PATH_CONTROL_CHARACTERS_ERROR,
+    REMOTE_PATH_NOT_ABSOLUTE_ERROR,
+    REMOTE_PATH_NOT_TEXT_ERROR,
+    REMOTE_PATH_TOO_LONG_ERROR,
+} from '../definitions/SshConnectionFields';
 
 const UNIT_SEPARATOR_CODE_POINT = 0x1f;
 const DELETE_CODE_POINT = 0x7f;
@@ -33,30 +38,55 @@ function hasControlCharacters(value: string): boolean {
  * An empty path is valid: it means the folder is not configured, and report discovery
  * skips a path it was not given.
  */
-export function getRemotePathError(path: string | undefined | null): string | null {
-    const trimmed = (path ?? '').trim();
+export function getRemotePathError(path: unknown): string | null {
+    // Callers include a getter over JSON.parse'd localStorage, so a non-string can
+    // arrive: typed as unknown rather than string so a `.trim()` on corrupted data
+    // can't throw out of a render.
+    if (path === undefined || path === null || path === '') {
+        return null;
+    }
+
+    if (typeof path !== 'string') {
+        return REMOTE_PATH_NOT_TEXT_ERROR;
+    }
+
+    const trimmed = path.trim();
 
     if (trimmed === '') {
         return null;
     }
 
+    if (trimmed.length > MAX_REMOTE_PATH_LENGTH) {
+        // Checked before scanning for control characters so an oversized paste is
+        // rejected on its length rather than walked in full first.
+        return REMOTE_PATH_TOO_LONG_ERROR;
+    }
+
     if (hasControlCharacters(trimmed)) {
-        return 'Path must not contain line breaks or other control characters.';
+        return REMOTE_PATH_CONTROL_CHARACTERS_ERROR;
     }
 
     if (!trimmed.startsWith('/')) {
-        // `~` is called out because it looks like it should work: it reaches the remote
-        // host quoted, so no shell expands it and discovery silently finds nothing.
-        return 'Path must be absolute, starting with "/". Home-relative paths such as "~/tt-metal" are not expanded.';
-    }
-
-    if (trimmed.length > MAX_REMOTE_PATH_LENGTH) {
-        return `Path must be at most ${MAX_REMOTE_PATH_LENGTH} characters.`;
+        return REMOTE_PATH_NOT_ABSOLUTE_ERROR;
     }
 
     return null;
 }
 
-export function isValidRemotePath(path: string | undefined | null): boolean {
+export function isValidRemotePath(path: unknown): boolean {
     return getRemotePathError(path) === null;
+}
+
+/**
+ * Why a saved connection's report paths would be refused by the server, or null.
+ *
+ * Such a connection is kept in the list rather than filtered out of it: it was
+ * storable before the paths were validated, and dropping it on read would erase
+ * it from storage on the next write with nothing telling the user why.
+ */
+export function getRemoteConnectionPathError(connection: {
+    profilerPath?: unknown;
+    performancePath?: unknown;
+}): string | null {
+    return getRemotePathError(connection.profilerPath) ?? getRemotePathError(connection.performancePath);
 }

--- a/src/functions/remotePath.ts
+++ b/src/functions/remotePath.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Mirrors sanitise_remote_report_path in backend/ttnn_visualizer/models.py. The backend
+// is the boundary that matters — these paths are interpolated into remote shell commands
+// — but repeating the rule here turns a 400 from the connection test into a message
+// against the offending field while the user is still typing.
+
+// Linux PATH_MAX, matching MAX_REMOTE_PATH_LENGTH on the backend.
+export const MAX_REMOTE_PATH_LENGTH = 4096;
+
+const UNIT_SEPARATOR_CODE_POINT = 0x1f;
+const DELETE_CODE_POINT = 0x7f;
+
+// Compared by code point rather than by regex: a character class covering C0 would trip
+// no-control-regex, and this mirrors how the backend validator iterates the string.
+function hasControlCharacters(value: string): boolean {
+    for (const character of value) {
+        const codePoint = character.codePointAt(0) ?? 0;
+
+        if (codePoint <= UNIT_SEPARATOR_CODE_POINT || codePoint === DELETE_CODE_POINT) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Why `path` is not a usable remote report folder, or null when it is.
+ *
+ * An empty path is valid: it means the folder is not configured, and report discovery
+ * skips a path it was not given.
+ */
+export function getRemotePathError(path: string | undefined | null): string | null {
+    const trimmed = (path ?? '').trim();
+
+    if (trimmed === '') {
+        return null;
+    }
+
+    if (hasControlCharacters(trimmed)) {
+        return 'Path must not contain line breaks or other control characters.';
+    }
+
+    if (!trimmed.startsWith('/')) {
+        // `~` is called out because it looks like it should work: it reaches the remote
+        // host quoted, so no shell expands it and discovery silently finds nothing.
+        return 'Path must be absolute, starting with "/". Home-relative paths such as "~/tt-metal" are not expanded.';
+    }
+
+    if (trimmed.length > MAX_REMOTE_PATH_LENGTH) {
+        return `Path must be at most ${MAX_REMOTE_PATH_LENGTH} characters.`;
+    }
+
+    return null;
+}
+
+export function isValidRemotePath(path: string | undefined | null): boolean {
+    return getRemotePathError(path) === null;
+}

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -12,7 +12,6 @@ import { REMOTE_SYNC_REQUEST_TIMEOUT_MS } from '../definitions/RemoteSync';
 import { StackSourceOrigin } from '../definitions/StackTrace';
 import { clearFileTransferProgressForSource } from '../store/fileTransferRegistry';
 import { isSameConnection, remoteConnectionKey } from '../functions/remoteConnection';
-import { isValidRemotePath } from '../functions/remotePath';
 import { beginRemoteSyncRequest, endRemoteSyncRequest } from '../functions/remoteSyncRequest';
 import { normaliseReportFolder } from '../functions/validateReportFolder';
 import axiosInstance from '../libs/axiosInstance';
@@ -417,21 +416,18 @@ const safeJsonStringify = <T,>(value: T, fallback: string = 'null'): string => {
     }
 };
 
-const isValidConnection = (connection?: Partial<RemoteConnection>) => {
-    if (
-        !connection?.name ||
-        !connection?.username ||
-        !connection?.host ||
-        !connection?.port ||
-        (!connection?.profilerPath && !connection?.performancePath)
-    ) {
-        return false;
-    }
-
-    // A relative path was storable before the backend required absolute ones, and the
-    // server now drops such a connection on read. Dropping it here too keeps the two
-    // sides agreeing, rather than listing a connection every request refuses to use.
-    return isValidRemotePath(connection.profilerPath) && isValidRemotePath(connection.performancePath);
-};
+// Deliberately does not check the report paths. A relative path was storable before the
+// backend required absolute ones, and filtering such a connection out here would erase it:
+// the list is read filtered but written whole, so the next add or edit would drop it from
+// storage silently. It stays listed and is flagged for repair instead — see
+// getRemoteConnectionPathError and RemoteConnectionSelector.
+const isValidConnection = (connection?: Partial<RemoteConnection>) =>
+    Boolean(
+        connection?.name &&
+        connection?.username &&
+        connection?.host &&
+        connection?.port &&
+        (connection?.profilerPath || connection?.performancePath),
+    );
 
 export default useRemoteConnection;

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -12,6 +12,7 @@ import { REMOTE_SYNC_REQUEST_TIMEOUT_MS } from '../definitions/RemoteSync';
 import { StackSourceOrigin } from '../definitions/StackTrace';
 import { clearFileTransferProgressForSource } from '../store/fileTransferRegistry';
 import { isSameConnection, remoteConnectionKey } from '../functions/remoteConnection';
+import { isValidRemotePath } from '../functions/remotePath';
 import { beginRemoteSyncRequest, endRemoteSyncRequest } from '../functions/remoteSyncRequest';
 import { normaliseReportFolder } from '../functions/validateReportFolder';
 import axiosInstance from '../libs/axiosInstance';
@@ -427,7 +428,10 @@ const isValidConnection = (connection?: Partial<RemoteConnection>) => {
         return false;
     }
 
-    return true;
+    // A relative path was storable before the backend required absolute ones, and the
+    // server now drops such a connection on read. Dropping it here too keeps the two
+    // sides agreeing, rather than listing a connection every request refuses to use.
+    return isValidRemotePath(connection.profilerPath) && isValidRemotePath(connection.performancePath);
 };
 
 export default useRemoteConnection;

--- a/tests/RemoteConnectionDialog.spec.tsx
+++ b/tests/RemoteConnectionDialog.spec.tsx
@@ -9,7 +9,7 @@ import RemoteConnectionDialog from '../src/components/report-selection/RemoteCon
 import { ConnectionStatus, ConnectionTestStates } from '../src/definitions/ConnectionStatus';
 import { MULTIHOST_CHECKBOX_LABEL, RemoteConnection } from '../src/definitions/RemoteConnection';
 import { SSH_CONFIG_HOST_LABEL } from '../src/definitions/SshConfigHostPicker';
-import { SSH_IDENTITY_FILE_LABEL } from '../src/definitions/SshConnectionFields';
+import { REMOTE_PATH_NOT_ABSOLUTE_ERROR, SSH_IDENTITY_FILE_LABEL } from '../src/definitions/SshConnectionFields';
 import getButtonWithText from './helpers/getButtonWithText';
 import { SshConfigHostsQueryResult, noSshConfigResult, sshConfigHostsResult } from './helpers/sshConfigFixtures';
 import { ExistingTarget, describeSshConfigPrefillContract } from './helpers/sshConfigPrefillContract';
@@ -273,9 +273,14 @@ describe('RemoteConnectionDialog remote path validation', () => {
             />,
         );
 
-        fireEvent.change(screen.getByLabelText(label), { target: { value } });
+        const input = screen.getByLabelText(label);
+        fireEvent.change(input, { target: { value } });
 
-        expect(screen.getByText(/must be absolute/)).toBeInTheDocument();
+        // Asserted as the input's description rather than as text on the page: Blueprint
+        // only colours the field, so the message reaches a screen reader solely through
+        // the aria-describedby the dialog wires up itself.
+        expect(input).toHaveAccessibleDescription(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
+        expect(input).toBeInvalid();
         expect(getButtonWithText('Run tests')).toBeDisabled();
     });
 
@@ -307,11 +312,12 @@ describe('RemoteConnectionDialog remote path validation', () => {
 
         const input = screen.getByLabelText('Memory report folder path');
         fireEvent.change(input, { target: { value: 'reports' } });
-        expect(screen.getByText(/must be absolute/)).toBeInTheDocument();
+        expect(input).toHaveAccessibleDescription(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
 
         fireEvent.change(input, { target: { value: '/reports' } });
 
-        expect(screen.queryByText(/must be absolute/)).not.toBeInTheDocument();
+        expect(input).not.toHaveAccessibleDescription(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
+        expect(input).toBeValid();
         expect(getButtonWithText('Run tests')).toBeEnabled();
     });
 
@@ -324,15 +330,19 @@ describe('RemoteConnectionDialog remote path validation', () => {
             />,
         );
 
-        fireEvent.change(screen.getByLabelText('Performance report folder path'), { target: { value: '' } });
+        const input = screen.getByLabelText('Performance report folder path');
+        fireEvent.change(input, { target: { value: '' } });
 
-        expect(screen.queryByText(/must be absolute/)).not.toBeInTheDocument();
+        expect(input).not.toHaveAccessibleDescription(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
+        expect(input).toBeValid();
         expect(getButtonWithText('Run tests')).toBeEnabled();
     });
 
-    it('blocks saving a stored connection whose path is no longer accepted', () => {
-        testConnectionMock.mockResolvedValue(PASSING_TESTS);
-
+    // The list keeps a connection stored before paths had to be absolute, so this is the
+    // repair route: opening it has to name the problem and leave the test — the only way to
+    // re-enable saving — closed until the path is fixed. Saving is already blocked by the
+    // absent test result, so `!hasPathError` in the save gate is defence in depth.
+    it('names the problem and withholds the test when a stored path is no longer accepted', () => {
         render(
             <RemoteConnectionDialog
                 open
@@ -348,8 +358,35 @@ describe('RemoteConnectionDialog remote path validation', () => {
             />,
         );
 
-        expect(screen.getByText(/must be absolute/)).toBeInTheDocument();
+        expect(screen.getByLabelText('Memory report folder path')).toHaveAccessibleDescription(
+            REMOTE_PATH_NOT_ABSOLUTE_ERROR,
+        );
+        expect(getButtonWithText('Run tests')).toBeDisabled();
         expect(getButtonWithText('Add connection')).toBeDisabled();
+    });
+
+    it('re-enables the test once the stored path is corrected', () => {
+        render(
+            <RemoteConnectionDialog
+                open
+                remoteConnection={{
+                    name: 'legacy',
+                    host: 'work-gpu',
+                    port: 22,
+                    username: 'bob',
+                    profilerPath: 'tt-metal/generated/ttnn/reports',
+                }}
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        const input = screen.getByLabelText('Memory report folder path');
+        fireEvent.change(input, { target: { value: '/tt-metal/generated/ttnn/reports' } });
+
+        expect(input).not.toHaveAccessibleDescription(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
+        expect(input).toBeValid();
+        expect(getButtonWithText('Run tests')).toBeEnabled();
     });
 });
 

--- a/tests/RemoteConnectionDialog.spec.tsx
+++ b/tests/RemoteConnectionDialog.spec.tsx
@@ -258,6 +258,148 @@ describe('RemoteConnectionDialog connection test invalidation', () => {
     });
 });
 
+describe('RemoteConnectionDialog remote path validation', () => {
+    // The backend refuses a relative path, so catching it here keeps the user in the
+    // form instead of sending a request that comes back as "Invalid connection data".
+    it.each([
+        ['Memory report folder path', 'tt-metal/generated/ttnn/reports'],
+        ['Performance report folder path', '~/tt-metal/generated/profiler/reports'],
+    ])('reports a path that is not absolute on %s', (label, value) => {
+        render(
+            <RemoteConnectionDialog
+                open
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText(label), { target: { value } });
+
+        expect(screen.getByText(/must be absolute/)).toBeInTheDocument();
+        expect(getButtonWithText('Run tests')).toBeDisabled();
+    });
+
+    it('does not run the connection test while a path is invalid', () => {
+        render(
+            <RemoteConnectionDialog
+                open
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText('Memory report folder path'), {
+            target: { value: 'reports' },
+        });
+        fireEvent.click(getButtonWithText('Run tests'));
+
+        expect(testConnectionMock).not.toHaveBeenCalled();
+    });
+
+    it('clears the error once the path is made absolute', () => {
+        render(
+            <RemoteConnectionDialog
+                open
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        const input = screen.getByLabelText('Memory report folder path');
+        fireEvent.change(input, { target: { value: 'reports' } });
+        expect(screen.getByText(/must be absolute/)).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: '/reports' } });
+
+        expect(screen.queryByText(/must be absolute/)).not.toBeInTheDocument();
+        expect(getButtonWithText('Run tests')).toBeEnabled();
+    });
+
+    it('leaves an unconfigured performance path unflagged', () => {
+        render(
+            <RemoteConnectionDialog
+                open
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText('Performance report folder path'), { target: { value: '' } });
+
+        expect(screen.queryByText(/must be absolute/)).not.toBeInTheDocument();
+        expect(getButtonWithText('Run tests')).toBeEnabled();
+    });
+
+    it('blocks saving a stored connection whose path is no longer accepted', () => {
+        testConnectionMock.mockResolvedValue(PASSING_TESTS);
+
+        render(
+            <RemoteConnectionDialog
+                open
+                remoteConnection={{
+                    name: 'legacy',
+                    host: 'work-gpu',
+                    port: 22,
+                    username: 'bob',
+                    profilerPath: 'tt-metal/generated/ttnn/reports',
+                }}
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/must be absolute/)).toBeInTheDocument();
+        expect(getButtonWithText('Add connection')).toBeDisabled();
+    });
+});
+
+describe('RemoteConnectionDialog connection test error handling', () => {
+    // A rejected field returns `{ error: … }`, not a status list. Casting that to an
+    // array reached `.map` as a non-array and took the dialog down with it.
+    it('falls back to a rendered failure when the error body is not a status list', async () => {
+        testConnectionMock.mockRejectedValue({
+            isAxiosError: true,
+            response: { status: 400, data: { error: 'Invalid connection data' } },
+        });
+
+        render(
+            <RemoteConnectionDialog
+                open
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        fireEvent.click(getButtonWithText('Run tests'));
+
+        await waitFor(() => expect(screen.getByText('Connection failed')).toBeInTheDocument());
+        expect(screen.getByText('Invalid connection data')).toBeInTheDocument();
+        expect(getButtonWithText('Add connection')).toBeDisabled();
+    });
+
+    it('renders a status list returned as an error body', async () => {
+        testConnectionMock.mockRejectedValue({
+            isAxiosError: true,
+            response: {
+                status: 422,
+                data: [{ status: ConnectionTestStates.FAILED, message: 'SSH authentication failed' }],
+            },
+        });
+
+        render(
+            <RemoteConnectionDialog
+                open
+                onClose={vi.fn()}
+                onAddConnection={vi.fn()}
+            />,
+        );
+
+        fireEvent.click(getButtonWithText('Run tests'));
+
+        await waitFor(() => expect(screen.getByText('SSH authentication failed')).toBeInTheDocument());
+    });
+});
+
 describe('RemoteConnectionDialog multihost performance flag', () => {
     it('defaults to unchecked for a new connection', () => {
         render(

--- a/tests/RemoteConnectionSelector.spec.tsx
+++ b/tests/RemoteConnectionSelector.spec.tsx
@@ -10,7 +10,8 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import RemoteConnectionSelector from '../src/components/report-selection/RemoteConnectionSelector';
 import { ConnectionStatus, ConnectionTestStates } from '../src/definitions/ConnectionStatus';
 import { CANCEL_DELETE_LABEL, CONFIRM_DELETE_LABEL } from '../src/definitions/ManagedEntity';
-import { RemoteConnection } from '../src/definitions/RemoteConnection';
+import { FETCH_REMOTE_FOLDERS_LABEL, RemoteConnection } from '../src/definitions/RemoteConnection';
+import { REMOTE_PATH_NOT_ABSOLUTE_ERROR } from '../src/definitions/SshConnectionFields';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import {
     getConnectionTrigger,
@@ -243,6 +244,61 @@ it('fetches folder lists when the edited connection is the selected one', async 
 
     expect(onSyncRemoteFolderList).toHaveBeenCalledTimes(1);
     expect(onSyncRemoteFolderList).toHaveBeenCalledWith(expect.objectContaining({ name: EDITED_NAME }));
+});
+
+// A connection saved before report paths had to be absolute stays in the list — dropping it
+// on read would erase it from storage on the next write. So the list has to say what is
+// wrong and refuse the fetch, leaving editing as the way out.
+const LEGACY_CONNECTION: RemoteConnection = {
+    name: 'Legacy',
+    username: 'tt',
+    host: 'worker-03',
+    port: 2222,
+    profilerPath: 'tt-metal/generated/ttnn/reports',
+};
+
+it('flags only the row whose report path the server would refuse', async () => {
+    renderSelector({ connectionList: [FIRST_CONNECTION, LEGACY_CONNECTION] });
+    await openConnectionDropdown();
+
+    const warnings = screen.getAllByTestId(TEST_IDS.REMOTE_CONNECTION_PATH_WARNING);
+
+    expect(warnings).toHaveLength(1);
+    expect(screen.getByLabelText(`${LEGACY_CONNECTION.name} has an unusable report path`)).toBeInTheDocument();
+});
+
+it('keeps the flagged connection editable so the path can be fixed', async () => {
+    renderSelector({ connectionList: [FIRST_CONNECTION, LEGACY_CONNECTION] });
+    await openConnectionDropdown();
+
+    fireEvent.click(screen.getByLabelText(getEditConnectionLabel(LEGACY_CONNECTION)));
+
+    const pathInput = screen.getByLabelText('Memory report folder path');
+
+    expect(pathInput).toHaveValue(LEGACY_CONNECTION.profilerPath);
+    expect(pathInput).toHaveAccessibleDescription(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
+});
+
+it('refuses the folder fetch while the selected connection has an unusable path', () => {
+    const { onSyncRemoteFolderList } = renderSelector({
+        connectionList: [LEGACY_CONNECTION],
+        connection: LEGACY_CONNECTION,
+    });
+
+    const fetchButton = screen.getByRole('button', { name: FETCH_REMOTE_FOLDERS_LABEL });
+
+    expect(fetchButton).toBeDisabled();
+
+    fireEvent.click(fetchButton);
+
+    expect(onSyncRemoteFolderList).not.toHaveBeenCalled();
+});
+
+it('allows the folder fetch for a connection whose paths are accepted', () => {
+    renderSelector();
+
+    expect(screen.getByRole('button', { name: FETCH_REMOTE_FOLDERS_LABEL })).toBeEnabled();
+    expect(screen.queryByTestId(TEST_IDS.REMOTE_CONNECTION_PATH_WARNING)).not.toBeInTheDocument();
 });
 
 it('leaves no reachable row action once the selector is disabled', async () => {

--- a/tests/remotePath.spec.ts
+++ b/tests/remotePath.spec.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { MAX_REMOTE_PATH_LENGTH, getRemotePathError, isValidRemotePath } from '../src/functions/remotePath';
+
+describe('getRemotePathError', () => {
+    it('accepts an absolute path', () => {
+        expect(getRemotePathError('/home/user/tt-metal/generated/ttnn/reports')).toBeNull();
+    });
+
+    it('accepts a trailing slash, which the backend preserves', () => {
+        expect(getRemotePathError('/reports/')).toBeNull();
+    });
+
+    // An unconfigured path is a supported state, not an error: report discovery skips a
+    // path it was not given, so the field must not go red merely for being empty.
+    it.each([
+        ['empty', ''],
+        ['whitespace', '   '],
+        ['undefined', undefined],
+        ['null', null],
+    ])('treats an unconfigured path (%s) as valid', (_label, path) => {
+        expect(getRemotePathError(path)).toBeNull();
+    });
+
+    it.each([
+        ['bare', 'reports'],
+        ['relative', 'tt-metal/generated/ttnn/reports'],
+        ['dot-relative', './reports'],
+    ])('rejects a path that is not absolute (%s)', (_label, path) => {
+        expect(getRemotePathError(path)).toMatch(/must be absolute/);
+    });
+
+    // Called out separately because a tilde path looks like it should work: it reaches
+    // the remote host quoted, so nothing expands it and discovery silently finds nothing.
+    it('names home-relative paths explicitly', () => {
+        expect(getRemotePathError('~/tt-metal/generated/ttnn/reports')).toMatch(/~\/tt-metal/);
+    });
+
+    it.each([
+        ['newline', '/reports\nrm -rf /'],
+        ['carriage return', '/reports\rls'],
+        ['nul', '/reports\u0000/etc'],
+        ['tab', '/reports\treports'],
+        ['delete', '/reports\u007f'],
+    ])('rejects control characters (%s)', (_label, path) => {
+        expect(getRemotePathError(path)).toMatch(/control characters/);
+    });
+
+    it('rejects a path longer than the backend limit', () => {
+        expect(getRemotePathError(`/${'a'.repeat(MAX_REMOTE_PATH_LENGTH)}`)).toMatch(/at most 4096/);
+    });
+
+    it('accepts a path at exactly the limit', () => {
+        expect(getRemotePathError(`/${'a'.repeat(MAX_REMOTE_PATH_LENGTH - 1)}`)).toBeNull();
+    });
+
+    // Quoting on the backend, not validation, is what makes these safe, so they must not
+    // be rejected here — a real report folder is allowed to contain odd characters.
+    it.each([
+        ['space', '/a path/reports'],
+        ['apostrophe', "/remote/o'brien/reports"],
+        ['semicolon', '/reports; touch /tmp/pwned'],
+    ])('accepts an absolute path containing shell metacharacters (%s)', (_label, path) => {
+        expect(getRemotePathError(path)).toBeNull();
+    });
+
+    it('trims before validating', () => {
+        expect(getRemotePathError('  /reports  ')).toBeNull();
+        expect(getRemotePathError('  reports  ')).toMatch(/must be absolute/);
+    });
+});
+
+describe('isValidRemotePath', () => {
+    it('mirrors getRemotePathError', () => {
+        expect(isValidRemotePath('/reports')).toBe(true);
+        expect(isValidRemotePath('reports')).toBe(false);
+        expect(isValidRemotePath(undefined)).toBe(true);
+    });
+});

--- a/tests/remotePath.spec.ts
+++ b/tests/remotePath.spec.ts
@@ -3,7 +3,14 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { MAX_REMOTE_PATH_LENGTH, getRemotePathError, isValidRemotePath } from '../src/functions/remotePath';
+import {
+    MAX_REMOTE_PATH_LENGTH,
+    REMOTE_PATH_CONTROL_CHARACTERS_ERROR,
+    REMOTE_PATH_NOT_ABSOLUTE_ERROR,
+    REMOTE_PATH_NOT_TEXT_ERROR,
+    REMOTE_PATH_TOO_LONG_ERROR,
+} from '../src/definitions/SshConnectionFields';
+import { getRemoteConnectionPathError, getRemotePathError, isValidRemotePath } from '../src/functions/remotePath';
 
 describe('getRemotePathError', () => {
     it('accepts an absolute path', () => {
@@ -30,7 +37,7 @@ describe('getRemotePathError', () => {
         ['relative', 'tt-metal/generated/ttnn/reports'],
         ['dot-relative', './reports'],
     ])('rejects a path that is not absolute (%s)', (_label, path) => {
-        expect(getRemotePathError(path)).toMatch(/must be absolute/);
+        expect(getRemotePathError(path)).toBe(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
     });
 
     // Called out separately because a tilde path looks like it should work: it reaches
@@ -46,11 +53,12 @@ describe('getRemotePathError', () => {
         ['tab', '/reports\treports'],
         ['delete', '/reports\u007f'],
     ])('rejects control characters (%s)', (_label, path) => {
-        expect(getRemotePathError(path)).toMatch(/control characters/);
+        expect(getRemotePathError(path)).toBe(REMOTE_PATH_CONTROL_CHARACTERS_ERROR);
     });
 
     it('rejects a path longer than the backend limit', () => {
-        expect(getRemotePathError(`/${'a'.repeat(MAX_REMOTE_PATH_LENGTH)}`)).toMatch(/at most 4096/);
+        expect(getRemotePathError(`/${'a'.repeat(MAX_REMOTE_PATH_LENGTH)}`)).toBe(REMOTE_PATH_TOO_LONG_ERROR);
+        expect(REMOTE_PATH_TOO_LONG_ERROR).toContain(String(MAX_REMOTE_PATH_LENGTH));
     });
 
     it('accepts a path at exactly the limit', () => {
@@ -69,7 +77,19 @@ describe('getRemotePathError', () => {
 
     it('trims before validating', () => {
         expect(getRemotePathError('  /reports  ')).toBeNull();
-        expect(getRemotePathError('  reports  ')).toMatch(/must be absolute/);
+        expect(getRemotePathError('  reports  ')).toBe(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
+    });
+
+    // Callers include a getter over JSON.parse'd localStorage, and the connection-list
+    // getter runs inside a useState initialiser — a throw there is a blank page, not a
+    // filtered-out row.
+    it.each([
+        ['number', 42],
+        ['object', { path: '/reports' }],
+        ['array', ['/reports']],
+        ['boolean', true],
+    ])('rejects a non-string path (%s) rather than throwing', (_label, path) => {
+        expect(getRemotePathError(path)).toBe(REMOTE_PATH_NOT_TEXT_ERROR);
     });
 });
 
@@ -78,5 +98,22 @@ describe('isValidRemotePath', () => {
         expect(isValidRemotePath('/reports')).toBe(true);
         expect(isValidRemotePath('reports')).toBe(false);
         expect(isValidRemotePath(undefined)).toBe(true);
+    });
+});
+
+describe('getRemoteConnectionPathError', () => {
+    it('accepts a connection whose configured paths are absolute', () => {
+        expect(getRemoteConnectionPathError({ profilerPath: '/mem', performancePath: '/perf' })).toBeNull();
+    });
+
+    it('accepts a connection with only one path configured', () => {
+        expect(getRemoteConnectionPathError({ profilerPath: '/mem' })).toBeNull();
+    });
+
+    it.each([
+        ['profiler', { profilerPath: 'reports', performancePath: '/perf' }],
+        ['performance', { profilerPath: '/mem', performancePath: 'reports' }],
+    ])('reports whichever path (%s) the server would refuse', (_label, connection) => {
+        expect(getRemoteConnectionPathError(connection)).toBe(REMOTE_PATH_NOT_ABSOLUTE_ERROR);
     });
 });

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -18,6 +18,8 @@ import {
 } from '../src/store/fileTransferRegistry';
 import { abortActiveRemoteSyncRequest } from '../src/functions/remoteSyncRequest';
 import useRemoteConnection, {
+    LOCAL_STORAGE_KEY_CONNECTIONS,
+    LOCAL_STORAGE_KEY_SELECTED,
     legacySavedPerformanceFoldersKey,
     legacySavedReportFoldersKey,
     savedPerformanceFoldersKey,
@@ -557,5 +559,64 @@ describe('useRemoteConnection - folder cache key migration', () => {
 
         expect(result.current.persistentState.getSavedReportFolders(connection)).toEqual([]);
         expect(window.localStorage.getItem(legacySavedReportFoldersKey(connection))).toBeNull();
+    });
+});
+
+// The list is read filtered but written whole, so anything the getter hides is erased from
+// storage by the next add or edit. Report paths are therefore not part of what makes a
+// stored connection listable — the selector flags those rows instead.
+describe('useRemoteConnection - savedConnectionList', () => {
+    const VALID_CONNECTION = {
+        name: 'lab',
+        host: 'work-gpu',
+        port: 22,
+        username: 'alice',
+        profilerPath: '/reports',
+    };
+    const LEGACY_RELATIVE_PATH_CONNECTION = {
+        ...VALID_CONNECTION,
+        name: 'legacy',
+        profilerPath: 'tt-metal/generated/ttnn/reports',
+    };
+
+    const seedConnections = (connections: unknown[]) =>
+        window.localStorage.setItem(LOCAL_STORAGE_KEY_CONNECTIONS, JSON.stringify(connections));
+
+    it('keeps a connection whose report path the server would now refuse', () => {
+        seedConnections([VALID_CONNECTION, LEGACY_RELATIVE_PATH_CONNECTION]);
+
+        const { result } = renderHook(() => useRemoteConnection());
+
+        expect(result.current.persistentState.savedConnectionList).toEqual([
+            VALID_CONNECTION,
+            LEGACY_RELATIVE_PATH_CONNECTION,
+        ]);
+    });
+
+    it('still drops an entry missing the fields needed to reach a host', () => {
+        seedConnections([VALID_CONNECTION, { name: 'broken', host: 'work-gpu', port: 22 }]);
+
+        const { result } = renderHook(() => useRemoteConnection());
+
+        expect(result.current.persistentState.savedConnectionList).toEqual([VALID_CONNECTION]);
+    });
+
+    it('leaves a stored selection with a refused path selected rather than reassigning it', () => {
+        seedConnections([VALID_CONNECTION, LEGACY_RELATIVE_PATH_CONNECTION]);
+        window.localStorage.setItem(LOCAL_STORAGE_KEY_SELECTED, JSON.stringify(LEGACY_RELATIVE_PATH_CONNECTION));
+
+        const { result } = renderHook(() => useRemoteConnection());
+
+        expect(result.current.persistentState.selectedConnection).toEqual(LEGACY_RELATIVE_PATH_CONNECTION);
+    });
+
+    // A non-string path can only arrive from hand-edited or corrupted storage, but the getter
+    // feeds a useState initialiser, so throwing there costs the whole page.
+    it('does not throw on a connection whose path is not a string', () => {
+        seedConnections([{ ...VALID_CONNECTION, profilerPath: 42 }]);
+
+        const { result } = renderHook(() => useRemoteConnection());
+
+        expect(() => result.current.persistentState.savedConnectionList).not.toThrow();
     });
 });


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the validation and handling of remote report paths, strengthens remote shell command construction to prevent injection vulnerabilities, and enhances error handling for invalid payloads. The changes ensure that user-supplied paths are strictly validated, all remote shell commands are safely constructed, and legacy or malformed data does not cause server errors.

**Remote path validation and sanitization:**

* Added `sanitise_remote_report_path` and `sanitise_optional_remote_report_path` functions to strictly validate remote report paths, enforcing absolute paths, prohibiting control characters, and imposing length limits. These are now used by `RemoteConnection` and `RemoteReportFolder` models via new field validators to ensure all paths are sanitized before use. [[1]](diffhunk://#diff-c22eca001a8884812b4ab8e5fce0a552cb3c82988049b63f260f5dfd6d261ba2R371-R427) [[2]](diffhunk://#diff-c22eca001a8884812b4ab8e5fce0a552cb3c82988049b63f260f5dfd6d261ba2R450-R459) [[3]](diffhunk://#diff-c22eca001a8884812b4ab8e5fce0a552cb3c82988049b63f260f5dfd6d261ba2R531-R538)
* Updated deserialization logic for stored remote connections and report folders to gracefully handle and ignore legacy or invalid data, preventing server errors due to bad persisted values. [[1]](diffhunk://#diff-c22eca001a8884812b4ab8e5fce0a552cb3c82988049b63f260f5dfd6d261ba2R558-R574) [[2]](diffhunk://#diff-c22eca001a8884812b4ab8e5fce0a552cb3c82988049b63f260f5dfd6d261ba2L564-R660)

**Remote command construction and security:**

* Introduced `remote_command.py` with the `RemoteCommand` class and related helpers (`remote_arg`, `remote_glob_arg`, `remote_scp_target`), centralizing and enforcing safe quoting for all remote shell commands. This replaces ad-hoc quoting and direct shell string formatting throughout the backend.
* Refactored all backend modules (`mlir.py`, `sftp_operations.py`) to use `RemoteCommand` and its helpers for constructing and executing remote shell commands, eliminating direct use of `shlex.quote` and reducing the risk of shell injection. [[1]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3L29) [[2]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3R43) [[3]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3L150-R157) [[4]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3L215-R231) [[5]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3L241-R244) [[6]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3L391-R394) [[7]](diffhunk://#diff-6321fff5c6b5f9442c1df9c9cabdba9b5cdd6c0f49bdbcfe6cd3bcd8476372a3L401-R405) [[8]](diffhunk://#diff-ab709cffd664d1dc76554fab2a4fc70dd7b21c1bc42be7ac4ed8fa3c56304076L9) [[9]](diffhunk://#diff-ab709cffd664d1dc76554fab2a4fc70dd7b21c1bc42be7ac4ed8fa3c56304076R35-R40) [[10]](diffhunk://#diff-ab709cffd664d1dc76554fab2a4fc70dd7b21c1bc42be7ac4ed8fa3c56304076L68-L78) [[11]](diffhunk://#diff-ab709cffd664d1dc76554fab2a4fc70dd7b21c1bc42be7ac4ed8fa3c56304076R136-R147)

**Error handling and user feedback:**

* Added `InvalidRequestPayload` exception and error handler to return clear 400 responses for invalid request bodies, especially when stricter model validation rejects legacy or malformed user data. [[1]](diffhunk://#diff-14674be812616fc4545d50f7661dafc8f85a2727687bda0471eda8b372f6af3eR32) [[2]](diffhunk://#diff-14674be812616fc4545d50f7661dafc8f85a2727687bda0471eda8b372f6af3eR231-R234) [[3]](diffhunk://#diff-24cf4e97bf85bbbf38aaf2e6f852a3afc27ba7e0bf072992dc11f23307c77b52R122-R131)

**Documentation and configuration:**

* Updated `.env.sample` with detailed comments clarifying the need for absolute report paths and the behavior of path expansion, improving onboarding and reducing user error.

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1839.
