### PR TITLE
Refuse report deletion where the app does not own the reports

### DIFF
--- a/backend/ttnn_visualizer/decorators.py
+++ b/backend/ttnn_visualizer/decorators.py
@@ -5,6 +5,7 @@
 import logging
 import re
 from functools import wraps
+from typing import Any, Callable
 
 from flask import abort, request, session
 from ttnn_visualizer.enums import ConnectionTestStates
@@ -17,6 +18,7 @@ from ttnn_visualizer.exceptions import (
     RemoteConnectionException,
     RemoteFileReadException,
     SSHException,
+    response_forbidden,
 )
 from ttnn_visualizer.instances import get_or_create_instance
 from ttnn_visualizer.ssh_client import SSH_AUTH_FAILURE_MESSAGE
@@ -162,6 +164,35 @@ def local_only(f):
     def decorated_function(*args, **kwargs):
         if current_app.config["SERVER_MODE"]:
             abort(403, description="Endpoint not accessible")
+
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
+DIRECT_REPORT_MODE_DELETE_REFUSAL = (
+    "Reports read from TT_METAL_HOME are not managed by TT-NN Visualizer "
+    "and cannot be deleted."
+)
+
+
+def refuse_in_direct_report_mode(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Refuse a report delete when the paired listing reads the TT-Metal tree.
+
+    In direct-report mode ``GET /profiler`` and ``GET /performance`` list
+    ``$TT_METAL_HOME/generated/...``, which the app neither created nor manages. Saying so
+    is more honest than a 404 against a local data directory the client never saw listed.
+
+    Returns the refusal rather than calling ``abort`` so the body carries the reason as
+    ``{"error": ...}``, which is the shape the SPA's ``getResponseError`` reads.
+    """
+    from flask import current_app
+    from ttnn_visualizer.utils import create_path_resolver
+
+    @wraps(f)
+    def decorated_function(*args: Any, **kwargs: Any) -> Any:
+        if create_path_resolver(current_app).is_direct_report_mode:
+            return response_forbidden(DIRECT_REPORT_MODE_DELETE_REFUSAL)
 
         return f(*args, **kwargs)
 

--- a/backend/ttnn_visualizer/tests/views/test_report_deletion.py
+++ b/backend/ttnn_visualizer/tests/views/test_report_deletion.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 from ttnn_visualizer.app import create_app
+from ttnn_visualizer.decorators import DIRECT_REPORT_MODE_DELETE_REFUSAL
 from ttnn_visualizer.extensions import db
 from ttnn_visualizer.instances import (
     KEY_PERFORMANCE_LOCATION,
@@ -25,7 +26,6 @@ from ttnn_visualizer.instances import (
 )
 from ttnn_visualizer.models import InstanceTable, RemoteConnection, ReportLocation
 from ttnn_visualizer.utils import create_path_resolver
-from ttnn_visualizer.views import _DIRECT_REPORT_MODE_DELETE_REFUSAL
 
 API = "/api"
 HOST = "yyzc-wh-05"
@@ -33,13 +33,21 @@ HOST = "yyzc-wh-05"
 
 @pytest.fixture
 def app():
-    """A local-mode app: ``@local_only`` refuses these routes under SERVER_MODE."""
+    """A local-mode app: ``@local_only`` refuses these routes under SERVER_MODE.
+
+    ``TT_METAL_HOME`` is pinned off because it is otherwise read from the developer's own
+    environment (via ``DefaultConfig`` and ``create_app``'s ``load_dotenv``), and it is
+    exported on any machine that profiles TT-Metal. Left unpinned, every upload/sync-mode
+    case here meets the direct-report-mode refusal and fails in a way indistinguishable
+    from a real regression.
+    """
     tmpdir = tempfile.mkdtemp()
     try:
         settings = {
             "TESTING": True,
             "SQLALCHEMY_DATABASE_URI": f"sqlite:///{Path(tmpdir) / 'app.db'}",
             "SERVER_MODE": False,
+            "TT_METAL_HOME": None,
             "APP_DATA_DIRECTORY": tmpdir,
             "REPORT_DATA_DIRECTORY": tmpdir,
             "LOCAL_DATA_DIRECTORY": str(Path(tmpdir) / "local"),
@@ -306,7 +314,7 @@ class TestDirectReportModeDeletion:
         assert response.status_code == 403
         # The UI renders this through getResponseError, so a bare "Forbidden" would leave
         # the user with a refusal that says nothing about why.
-        assert response.get_json()["error"] == _DIRECT_REPORT_MODE_DELETE_REFUSAL
+        assert response.get_json()["error"] == DIRECT_REPORT_MODE_DELETE_REFUSAL
         assert (parent / "listed_report").is_dir()
 
     def test_refuses_to_delete_a_listed_performance_report(
@@ -321,7 +329,7 @@ class TestDirectReportModeDeletion:
         )
 
         assert response.status_code == 403
-        assert response.get_json()["error"] == _DIRECT_REPORT_MODE_DELETE_REFUSAL
+        assert response.get_json()["error"] == DIRECT_REPORT_MODE_DELETE_REFUSAL
         assert (parent / "listed_report").is_dir()
 
     def test_refusal_does_not_reach_the_local_data_directory(

--- a/backend/ttnn_visualizer/tests/views/test_report_deletion.py
+++ b/backend/ttnn_visualizer/tests/views/test_report_deletion.py
@@ -4,9 +4,10 @@
 
 """Tests for the profiler and performance report ``DELETE`` routes.
 
-The listings these routes are paired with only ever read the local data
-directory, so every case here pins the blast radius of a delete to the single
-directory the client asked for.
+In upload/sync mode the listings these routes are paired with read the local data
+directory, so those cases pin the blast radius of a delete to the single directory
+the client asked for. In direct-report mode the listings read the TT-Metal tree
+instead, which these routes do not manage, so the delete is refused outright.
 """
 
 import shutil
@@ -23,6 +24,8 @@ from ttnn_visualizer.instances import (
     KEY_PROFILER_NAME,
 )
 from ttnn_visualizer.models import InstanceTable, RemoteConnection, ReportLocation
+from ttnn_visualizer.utils import create_path_resolver
+from ttnn_visualizer.views import _DIRECT_REPORT_MODE_DELETE_REFUSAL
 
 API = "/api"
 HOST = "yyzc-wh-05"
@@ -65,6 +68,39 @@ def _synced_remote_reports(app, directory_key, *names):
     parent = (
         Path(app.config["REMOTE_DATA_DIRECTORY"]) / HOST / app.config[directory_key]
     )
+    for name in names:
+        (parent / name).mkdir(parents=True)
+    return parent
+
+
+@pytest.fixture
+def direct_mode_app():
+    """A direct-report-mode app: the listings read ``$TT_METAL_HOME/generated``."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        settings = {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{Path(tmpdir) / 'app.db'}",
+            "SERVER_MODE": False,
+            "TT_METAL_HOME": str(Path(tmpdir) / "tt-metal"),
+            "APP_DATA_DIRECTORY": tmpdir,
+            "REPORT_DATA_DIRECTORY": tmpdir,
+            "LOCAL_DATA_DIRECTORY": str(Path(tmpdir) / "local"),
+            "REMOTE_DATA_DIRECTORY": str(Path(tmpdir) / "remote"),
+        }
+        yield create_app(settings_override=settings)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def direct_mode_client(direct_mode_app):
+    return direct_mode_app.test_client()
+
+
+def _tt_metal_reports(app, report_type, *names):
+    """Create reports where direct-report mode lists them, and return their parent."""
+    parent = create_path_resolver(app).get_base_report_path(report_type)
     for name in names:
         (parent / name).mkdir(parents=True)
     return parent
@@ -246,3 +282,61 @@ class TestProfilerReportDeletion:
         assert response.status_code in {400, 404}
         assert parent.is_dir()
         assert (parent / "keep_me").is_dir()
+
+
+class TestDirectReportModeDeletion:
+    """With ``TT_METAL_HOME`` set, the listings read a tree these routes cannot delete from.
+
+    Deleting resolved against the app's own data directory regardless, so every delete of
+    a listed report 404'd and the UI showed nothing at all. Refuse instead of 404ing
+    against a tree the client never saw listed.
+    """
+
+    def test_refuses_to_delete_a_listed_profiler_report(
+        self, direct_mode_app, direct_mode_client
+    ):
+        parent = _tt_metal_reports(direct_mode_app, "profiler", "listed_report")
+        _register_instance(direct_mode_app, "profiler-direct", {})
+
+        response = direct_mode_client.delete(
+            f"{API}/profiler/listed_report",
+            query_string={"instanceId": "profiler-direct"},
+        )
+
+        assert response.status_code == 403
+        # The UI renders this through getResponseError, so a bare "Forbidden" would leave
+        # the user with a refusal that says nothing about why.
+        assert response.get_json()["error"] == _DIRECT_REPORT_MODE_DELETE_REFUSAL
+        assert (parent / "listed_report").is_dir()
+
+    def test_refuses_to_delete_a_listed_performance_report(
+        self, direct_mode_app, direct_mode_client
+    ):
+        parent = _tt_metal_reports(direct_mode_app, "performance", "listed_report")
+        _register_instance(direct_mode_app, "perf-direct", {})
+
+        response = direct_mode_client.delete(
+            f"{API}/performance/listed_report",
+            query_string={"instanceId": "perf-direct"},
+        )
+
+        assert response.status_code == 403
+        assert response.get_json()["error"] == _DIRECT_REPORT_MODE_DELETE_REFUSAL
+        assert (parent / "listed_report").is_dir()
+
+    def test_refusal_does_not_reach_the_local_data_directory(
+        self, direct_mode_app, direct_mode_client
+    ):
+        """A same-named report in the app's own tree must survive the refusal too."""
+        local_parent = _local_reports(
+            direct_mode_app, "PROFILER_DIRECTORY_NAME", "listed_report"
+        )
+        _register_instance(direct_mode_app, "profiler-direct-local", {})
+
+        response = direct_mode_client.delete(
+            f"{API}/profiler/listed_report",
+            query_string={"instanceId": "profiler-direct-local"},
+        )
+
+        assert response.status_code == 403
+        assert (local_parent / "listed_report").is_dir()

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -26,7 +26,11 @@ from ttnn_visualizer.csv_queries import (
     OpsPerformanceQueries,
     OpsPerformanceReportQueries,
 )
-from ttnn_visualizer.decorators import local_only, with_instance
+from ttnn_visualizer.decorators import (
+    local_only,
+    refuse_in_direct_report_mode,
+    with_instance,
+)
 from ttnn_visualizer.enums import ConnectionTestStates, StackSourceOrigin
 from ttnn_visualizer.exceptions import (
     AuthenticationFailedException,
@@ -995,31 +999,13 @@ def get_profiler_data_list(instance: Instance):
     return Response(orjson.dumps(valid_dirs), mimetype="application/json")
 
 
-_DIRECT_REPORT_MODE_DELETE_REFUSAL = (
-    "Reports read from TT_METAL_HOME are not managed by TT-NN Visualizer "
-    "and cannot be deleted."
-)
-
-
-def _direct_report_mode_refusal():
-    """Refuse a delete when the paired listing reads the TT-Metal tree.
-
-    In direct-report mode ``GET /profiler`` and ``GET /performance`` list
-    ``$TT_METAL_HOME/generated/...``, which the app neither created nor manages. Saying so
-    is more honest than a 404 against a local data directory the client never saw listed.
-    """
-    if create_path_resolver(current_app).is_direct_report_mode:
-        return response_forbidden(_DIRECT_REPORT_MODE_DELETE_REFUSAL)
-    return None
-
-
 def _report_directory_to_delete(directory_name_key: str, report_name: str) -> Path:
     """Resolve a delete request to one report directory under the local data directory.
 
-    Direct-report mode is refused before this runs, so the listings these deletes are
-    paired with (``GET /profiler``, ``GET /performance``) only ever read the local data
-    directory, making that the only tree a delete may reach — and only one report inside
-    it, since anything wider removes reports the client never listed.
+    ``refuse_in_direct_report_mode`` rejects the request before this runs, so the listings
+    these deletes are paired with (``GET /profiler``, ``GET /performance``) only ever read
+    the local data directory, making that the only tree a delete may reach — and only one
+    report inside it, since anything wider removes reports the client never listed.
     """
     return (
         Path(current_app.config["LOCAL_DATA_DIRECTORY"])
@@ -1031,11 +1017,8 @@ def _report_directory_to_delete(directory_name_key: str, report_name: str) -> Pa
 @api.route("/profiler/<profiler_name>", methods=["DELETE"])
 @with_instance
 @local_only
+@refuse_in_direct_report_mode
 def delete_profiler_report(profiler_name, instance: Instance):
-    refusal = _direct_report_mode_refusal()
-    if refusal is not None:
-        return refusal
-
     if not profiler_name:
         return response_bad_request("Report name is required.")
 
@@ -1147,11 +1130,8 @@ def get_profiler_performance_data(instance: Instance):
 @api.route("/performance/<performance_name>", methods=["DELETE"])
 @with_instance
 @local_only
+@refuse_in_direct_report_mode
 def delete_performance_report(performance_name, instance: Instance):
-    refusal = _direct_report_mode_refusal()
-    if refusal is not None:
-        return refusal
-
     if not performance_name:
         return response_bad_request("Report name is required.")
 

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -995,13 +995,31 @@ def get_profiler_data_list(instance: Instance):
     return Response(orjson.dumps(valid_dirs), mimetype="application/json")
 
 
+_DIRECT_REPORT_MODE_DELETE_REFUSAL = (
+    "Reports read from TT_METAL_HOME are not managed by TT-NN Visualizer "
+    "and cannot be deleted."
+)
+
+
+def _direct_report_mode_refusal():
+    """Refuse a delete when the paired listing reads the TT-Metal tree.
+
+    In direct-report mode ``GET /profiler`` and ``GET /performance`` list
+    ``$TT_METAL_HOME/generated/...``, which the app neither created nor manages. Saying so
+    is more honest than a 404 against a local data directory the client never saw listed.
+    """
+    if create_path_resolver(current_app).is_direct_report_mode:
+        return response_forbidden(_DIRECT_REPORT_MODE_DELETE_REFUSAL)
+    return None
+
+
 def _report_directory_to_delete(directory_name_key: str, report_name: str) -> Path:
     """Resolve a delete request to one report directory under the local data directory.
 
-    The listings these deletes are paired with (``GET /profiler``, ``GET /performance``)
-    only ever read the local data directory, so that is the only tree a delete may
-    reach, and only one report inside it — anything wider removes reports the client
-    never listed.
+    Direct-report mode is refused before this runs, so the listings these deletes are
+    paired with (``GET /profiler``, ``GET /performance``) only ever read the local data
+    directory, making that the only tree a delete may reach — and only one report inside
+    it, since anything wider removes reports the client never listed.
     """
     return (
         Path(current_app.config["LOCAL_DATA_DIRECTORY"])
@@ -1014,6 +1032,10 @@ def _report_directory_to_delete(directory_name_key: str, report_name: str) -> Pa
 @with_instance
 @local_only
 def delete_profiler_report(profiler_name, instance: Instance):
+    refusal = _direct_report_mode_refusal()
+    if refusal is not None:
+        return refusal
+
     if not profiler_name:
         return response_bad_request("Report name is required.")
 
@@ -1126,6 +1148,10 @@ def get_profiler_performance_data(instance: Instance):
 @with_instance
 @local_only
 def delete_performance_report(performance_name, instance: Instance):
+    refusal = _direct_report_mode_refusal()
+    if refusal is not None:
+        return refusal
+
     if not performance_name:
         return response_bad_request("Report name is required.")
 

--- a/docs/src/running-the-application.md
+++ b/docs/src/running-the-application.md
@@ -54,5 +54,10 @@ on the remote machine or container are accessible to the browser on your local m
 working directly with the TT-Metal home directory, the remote sync and upload features are
 disabled, and you can see the reports generated on that machine only.
 
+Report deletion is disabled in this mode too: the reports listed belong to the TT-Metal
+checkout, which `ttnn-visualizer` reads but does not manage. The delete control is hidden,
+and the `DELETE /api/profiler/<name>` and `DELETE /api/performance/<name>` routes refuse
+with a 403.
+
 This feature is intended for custom tools and integrations only, that bypass the default ways
 of loading data into `ttnn-visualizer`.

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -62,13 +62,19 @@ const LocalFolderPicker = ({
     const isDisabled = disabled || loading || !items || items.length === 0 || !instance;
     const activePath = value;
     const activeName = value ? (valueLabel ?? value) : null;
-    const isServerMode = !!getServerConfig()?.SERVER_MODE;
+    const serverConfig = getServerConfig();
+    const isServerMode = !!serverConfig?.SERVER_MODE;
+    // Direct-report mode lists reports out of the TT-Metal tree, which the app neither created nor
+    // manages — the delete routes only ever reach the app's own data directory, so the control could
+    // never remove the report the row shows.
+    const isDirectReportMode = !!serverConfig?.TT_METAL_HOME;
     // Gates the trash button and its confirmation together — rendering one without the other leaves
     // either a delete with no confirmation step or an alert nothing can open.
-    const canDeleteReports = !!handleDelete && !isServerMode;
+    const canDeleteReports = !!handleDelete && !isServerMode && !isDirectReportMode;
     // Loading disables the Select, so in practice the popover and its rows are already gone by the
     // time this matters; the guard on the alert's onConfirm is what actually stops a delete landing
-    // mid-load, since the alert outlives the popover. canDeleteReports covers SERVER_MODE.
+    // mid-load, since the alert outlives the popover. canDeleteReports covers SERVER_MODE and
+    // direct-report mode.
     const isDeleteDisabled = loading;
     const showLinkStatus = shouldShowFolderLinkStatus(linkedIds, unlinkedIds);
 

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../functions/folderLinkStatus';
 import { ReportFolder } from '../../definitions/Reports';
 import getServerConfig from '../../functions/getServerConfig';
+import isDirectReportMode from '../../functions/isDirectReportMode';
 import { getReportId } from '../../functions/reportLinks';
 import { formatSyncedReportName } from '../../functions/reportRank';
 import { ManagedEntity } from '../../definitions/ManagedEntity';
@@ -62,15 +63,12 @@ const LocalFolderPicker = ({
     const isDisabled = disabled || loading || !items || items.length === 0 || !instance;
     const activePath = value;
     const activeName = value ? (valueLabel ?? value) : null;
-    const serverConfig = getServerConfig();
-    const isServerMode = !!serverConfig?.SERVER_MODE;
+    const isServerMode = !!getServerConfig()?.SERVER_MODE;
     // Direct-report mode lists reports out of the TT-Metal tree, which the app neither created nor
-    // manages — the delete routes only ever reach the app's own data directory, so the control could
-    // never remove the report the row shows.
-    const isDirectReportMode = !!serverConfig?.TT_METAL_HOME;
+    // manages — the delete routes refuse it outright, so the control could never act on the row.
     // Gates the trash button and its confirmation together — rendering one without the other leaves
     // either a delete with no confirmation step or an alert nothing can open.
-    const canDeleteReports = !!handleDelete && !isServerMode && !isDirectReportMode;
+    const canDeleteReports = !!handleDelete && !isServerMode && !isDirectReportMode();
     // Loading disables the Select, so in practice the popover and its rows are already gone by the
     // time this matters; the guard on the alert's onConfirm is what actually stops a delete landing
     // mid-load, since the alert outlives the popover. canDeleteReports covers SERVER_MODE and

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -19,11 +19,15 @@ import { ConnectionStatus, ConnectionTestStates } from '../../definitions/Connec
 import {
     ACTIVE_MEMORY_REPORT_TOAST_TITLE,
     ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE,
+    MEMORY_REPORT_DELETED_TOAST_TITLE,
+    MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE,
+    PERFORMANCE_REPORT_DELETED_TOAST_TITLE,
+    PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE,
 } from '../../definitions/notifyActiveReport';
 import createToastNotification from '../../functions/createToastNotification';
 import { ToastType } from '../../definitions/ToastType';
 import getResponseError from '../../functions/getResponseError';
-import getServerConfig from '../../functions/getServerConfig';
+import isDirectReportMode from '../../functions/isDirectReportMode';
 import {
     PERFORMANCE_FOLDER_QUERY_KEY,
     PROFILER_FOLDER_QUERY_KEY,
@@ -83,8 +87,17 @@ const directoryErrorStatus: ConnectionStatus = {
     message: 'Selected directory does not contain a valid report',
 };
 
-const MEMORY_REPORT_DELETE_FAILED_TITLE = 'Unable to delete memory report';
-const PERFORMANCE_REPORT_DELETE_FAILED_TITLE = 'Unable to delete performance report';
+const CHOOSE_DIRECTORY_LABEL = 'Choose directory...';
+
+/** The parts a report delete differs by; the sequence around them is identical for both kinds. */
+interface DeleteReportOptions {
+    sendDelete: (reportPath: string) => Promise<unknown>;
+    folderQueryKey: string;
+    failedTitle: string;
+    deletedTitle: string;
+    isActive: boolean;
+    clearActive: () => void;
+}
 
 const LocalFolderOptions = () => {
     const queryClient = useQueryClient();
@@ -121,9 +134,9 @@ const LocalFolderOptions = () => {
     const [profilerFolder, setProfilerFolder] = useState<ConnectionStatus | undefined>();
     const [isUploadingReport, setIsUploadingReport] = useState(false);
     const [isUploadingPerformance, setIsPerformanceUploading] = useState(false);
-    const [profilerUploadLabel, setProfilerUploadLabel] = useState('Choose directory...');
+    const [profilerUploadLabel, setProfilerUploadLabel] = useState(CHOOSE_DIRECTORY_LABEL);
     const [performanceFolder, setPerformanceFolder] = useState<ConnectionStatus | undefined>();
-    const [performanceDataUploadLabel, setPerformanceDataUploadLabel] = useState('Choose directory...');
+    const [performanceDataUploadLabel, setPerformanceDataUploadLabel] = useState(CHOOSE_DIRECTORY_LABEL);
 
     const isProfilerLocal = profilerReportLocation === ReportLocation.LOCAL;
     const isPerformanceLocal = performanceReportLocation === ReportLocation.LOCAL;
@@ -148,7 +161,6 @@ const LocalFolderOptions = () => {
         [activePerformanceReport, perfFolderList, isPerformanceLocal],
     );
 
-    const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
     const { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds } =
         useReportLinkBadgeIds();
 
@@ -251,24 +263,36 @@ const LocalFolderOptions = () => {
         });
     };
 
-    const handleDeleteProfiler = async (folder: ReportFolder) => {
+    const deleteReport = async (folder: ReportFolder, options: DeleteReportOptions) => {
         try {
-            await deleteProfiler(folder.path);
+            await options.sendDelete(folder.path);
         } catch (err: unknown) {
-            createToastNotification(MEMORY_REPORT_DELETE_FAILED_TITLE, getResponseError(err), ToastType.ERROR);
+            createToastNotification(options.failedTitle, getResponseError(err), ToastType.ERROR);
             return;
         }
 
-        await queryClient.invalidateQueries({ queryKey: [PROFILER_FOLDER_QUERY_KEY] });
+        await queryClient.invalidateQueries({ queryKey: [options.folderQueryKey] });
 
-        createToastNotification('Memory report deleted', folder.reportName, ToastType.INFO);
+        createToastNotification(options.deletedTitle, folder.reportName, ToastType.INFO);
 
-        if (activeProfilerReport?.path === folder.path) {
-            setActiveProfilerReport(null);
-            setProfilerUploadLabel('Choose directory...');
-            setProfilerFolder(undefined);
+        if (options.isActive) {
+            options.clearActive();
         }
     };
+
+    const handleDeleteProfiler = (folder: ReportFolder) =>
+        deleteReport(folder, {
+            sendDelete: deleteProfiler,
+            folderQueryKey: PROFILER_FOLDER_QUERY_KEY,
+            failedTitle: MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE,
+            deletedTitle: MEMORY_REPORT_DELETED_TOAST_TITLE,
+            isActive: activeProfilerReport?.path === folder.path,
+            clearActive: () => {
+                setActiveProfilerReport(null);
+                setProfilerUploadLabel(CHOOSE_DIRECTORY_LABEL);
+                setProfilerFolder(undefined);
+            },
+        });
 
     const handleSelectPerformance = async (folder: ReportFolder) => {
         await withActivatingReport(async () => {
@@ -283,24 +307,19 @@ const LocalFolderOptions = () => {
         });
     };
 
-    const handleDeletePerformance = async (folder: ReportFolder) => {
-        try {
-            await deletePerformance(folder.path);
-        } catch (err: unknown) {
-            createToastNotification(PERFORMANCE_REPORT_DELETE_FAILED_TITLE, getResponseError(err), ToastType.ERROR);
-            return;
-        }
-
-        await queryClient.invalidateQueries({ queryKey: [PERFORMANCE_FOLDER_QUERY_KEY] });
-
-        createToastNotification(`Performance report deleted`, folder.reportName, ToastType.INFO);
-
-        if (activePerformanceReport?.path === folder.path) {
-            setActivePerformanceReport(null);
-            setPerformanceDataUploadLabel('Choose directory...');
-            setPerformanceFolder(undefined);
-        }
-    };
+    const handleDeletePerformance = (folder: ReportFolder) =>
+        deleteReport(folder, {
+            sendDelete: deletePerformance,
+            folderQueryKey: PERFORMANCE_FOLDER_QUERY_KEY,
+            failedTitle: PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE,
+            deletedTitle: PERFORMANCE_REPORT_DELETED_TOAST_TITLE,
+            isActive: activePerformanceReport?.path === folder.path,
+            clearActive: () => {
+                setActivePerformanceReport(null);
+                setPerformanceDataUploadLabel(CHOOSE_DIRECTORY_LABEL);
+                setPerformanceFolder(undefined);
+            },
+        });
 
     return (
         <>
@@ -322,7 +341,7 @@ const LocalFolderOptions = () => {
                 />
             </FormGroup>
 
-            {!isDirectReportMode && (
+            {!isDirectReportMode() && (
                 <FormGroup subLabel='Upload a local memory report'>
                     <div className='form-container'>
                         <FileInput
@@ -372,7 +391,7 @@ const LocalFolderOptions = () => {
                 />
             </FormGroup>
 
-            {!isDirectReportMode && (
+            {!isDirectReportMode() && (
                 <FormGroup subLabel='Upload a local performance report'>
                     <div className='form-container'>
                         <FileInput

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -83,6 +83,9 @@ const directoryErrorStatus: ConnectionStatus = {
     message: 'Selected directory does not contain a valid report',
 };
 
+const MEMORY_REPORT_DELETE_FAILED_TITLE = 'Unable to delete memory report';
+const PERFORMANCE_REPORT_DELETE_FAILED_TITLE = 'Unable to delete performance report';
+
 const LocalFolderOptions = () => {
     const queryClient = useQueryClient();
     const [profilerReportLocation, setProfilerReportLocation] = useAtom(profilerReportLocationAtom);
@@ -249,7 +252,13 @@ const LocalFolderOptions = () => {
     };
 
     const handleDeleteProfiler = async (folder: ReportFolder) => {
-        await deleteProfiler(folder.path);
+        try {
+            await deleteProfiler(folder.path);
+        } catch (err: unknown) {
+            createToastNotification(MEMORY_REPORT_DELETE_FAILED_TITLE, getResponseError(err), ToastType.ERROR);
+            return;
+        }
+
         await queryClient.invalidateQueries({ queryKey: [PROFILER_FOLDER_QUERY_KEY] });
 
         createToastNotification('Memory report deleted', folder.reportName, ToastType.INFO);
@@ -275,7 +284,13 @@ const LocalFolderOptions = () => {
     };
 
     const handleDeletePerformance = async (folder: ReportFolder) => {
-        await deletePerformance(folder.path);
+        try {
+            await deletePerformance(folder.path);
+        } catch (err: unknown) {
+            createToastNotification(PERFORMANCE_REPORT_DELETE_FAILED_TITLE, getResponseError(err), ToastType.ERROR);
+            return;
+        }
+
         await queryClient.invalidateQueries({ queryKey: [PERFORMANCE_FOLDER_QUERY_KEY] });
 
         createToastNotification(`Performance report deleted`, folder.reportName, ToastType.INFO);

--- a/src/definitions/notifyActiveReport.ts
+++ b/src/definitions/notifyActiveReport.ts
@@ -4,3 +4,8 @@
 
 export const ACTIVE_MEMORY_REPORT_TOAST_TITLE = 'Active memory report';
 export const ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE = 'Active performance report';
+
+export const MEMORY_REPORT_DELETED_TOAST_TITLE = 'Memory report deleted';
+export const PERFORMANCE_REPORT_DELETED_TOAST_TITLE = 'Performance report deleted';
+export const MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE = 'Unable to delete memory report';
+export const PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE = 'Unable to delete performance report';

--- a/src/functions/isDirectReportMode.ts
+++ b/src/functions/isDirectReportMode.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import getServerConfig from './getServerConfig';
+
+/**
+ * Whether the app is reading reports straight out of a TT-Metal checkout.
+ *
+ * One home for the whole rule — `TT_METAL_HOME` present means no upload, no remote sync, no
+ * delete, because the app neither created those reports nor manages them. Gates read this
+ * rather than re-deriving the condition, so a new one can't land on some of the three.
+ *
+ * Kept out of `getServerConfig.ts` deliberately: that module is mocked wholesale by a dozen
+ * specs, and a predicate living there would have to be re-stated inside every such mock —
+ * re-deriving the rule in test code instead of in components. Here it composes with whatever
+ * config a spec has already mocked.
+ */
+export default function isDirectReportMode(): boolean {
+    return !!getServerConfig()?.TT_METAL_HOME;
+}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -9,6 +9,7 @@ import RemoteSyncConfigurator from '../components/report-selection/RemoteSyncCon
 import 'styles/routes/Home.scss';
 import useClearSelectedBuffer from '../hooks/useClearSelectedBuffer';
 import getServerConfig from '../functions/getServerConfig';
+import isDirectReportMode from '../functions/isDirectReportMode';
 import InitialMessage from '../components/InitialMessage';
 import FolderFieldset from '../components/report-selection/FolderFieldset';
 
@@ -16,7 +17,6 @@ function Home() {
     useClearSelectedBuffer();
 
     const isServerMode = !!getServerConfig()?.SERVER_MODE;
-    const isDirectReportMode = !!getServerConfig()?.TT_METAL_HOME;
 
     return (
         <div className='home'>
@@ -31,7 +31,7 @@ function Home() {
                 <FolderFieldset
                     title='Remote sync'
                     icon={IconNames.CLOUD}
-                    isFeatureDisabled={isServerMode || isDirectReportMode}
+                    isFeatureDisabled={isServerMode || isDirectReportMode()}
                 >
                     <RemoteSyncConfigurator />
                 </FolderFieldset>

--- a/tests/LocalFolderPicker.spec.tsx
+++ b/tests/LocalFolderPicker.spec.tsx
@@ -8,12 +8,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import LocalFolderPicker from '../src/components/report-selection/LocalFolderPicker';
 import { CONFIRM_DELETE_LABEL, ManagedEntity } from '../src/definitions/ManagedEntity';
 import { ReportFolder } from '../src/definitions/Reports';
+import { ServerConfig } from '../src/definitions/ServerConfig';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { getDeleteActionLabel } from '../src/functions/managedEntityLabels';
 import testForPortal from './helpers/testForPortal';
 import { TestProviders } from './helpers/TestProviders';
 
-const getServerConfigMock = vi.hoisted(() => vi.fn(() => ({ SERVER_MODE: false })));
+const getServerConfigMock = vi.hoisted(() => vi.fn((): Partial<ServerConfig> => ({ SERVER_MODE: false })));
 
 afterEach(cleanup);
 
@@ -174,6 +175,29 @@ describe('LocalFolderPicker link badges', () => {
 
     it('offers no delete action or confirmation in server mode', async () => {
         getServerConfigMock.mockReturnValue({ SERVER_MODE: true });
+
+        render(
+            <TestProviders>
+                <LocalFolderPicker
+                    items={folders}
+                    value={null}
+                    handleSelect={vi.fn()}
+                    handleDelete={vi.fn()}
+                />
+            </TestProviders>,
+        );
+
+        fireEvent.click(screen.getByText(SELECT_REPORT_TEXT));
+        await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+        // The rows still render, so this is the gate being asserted rather than an empty dropdown.
+        expect(screen.getAllByTestId(TEST_IDS.FOLDER_PICKER_ROW)).toHaveLength(folders.length);
+        folders.forEach((folder) => expect(screen.queryByLabelText(deleteLabel(folder))).toBeNull());
+        expect(document.querySelectorAll('[role="alertdialog"]')).toHaveLength(0);
+    });
+
+    it('offers no delete action or confirmation in direct-report mode', async () => {
+        getServerConfigMock.mockReturnValue({ SERVER_MODE: false, TT_METAL_HOME: '/opt/tt-metal' });
 
         render(
             <TestProviders>

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -28,9 +28,10 @@ const mockPerfFolderList = [...mockPerformanceReportFolders];
 
 // The folder list is the mocked query's only source of truth, so deleting has to remove from it
 // for anything downstream of the delete to be observable.
-const { mockUpdateInstance, mockDeleteProfiler, mockProfilerFolders } = vi.hoisted(() => ({
+const { mockUpdateInstance, mockDeleteProfiler, mockDeletePerformance, mockProfilerFolders } = vi.hoisted(() => ({
     mockUpdateInstance: vi.fn(),
     mockDeleteProfiler: vi.fn(),
+    mockDeletePerformance: vi.fn(),
     mockProfilerFolders: [] as { path: string; reportName: string }[],
 }));
 
@@ -71,7 +72,7 @@ vi.mock('../src/hooks/useAPI', async () => {
         useReportFolderList: () => ({ data: mockProfilerFolders }),
         updateInstance: (...args: unknown[]) => mockUpdateInstance(...args),
         deleteProfiler: (...args: unknown[]) => mockDeleteProfiler(...args),
-        deletePerformance: vi.fn().mockResolvedValue({ success: true }),
+        deletePerformance: (...args: unknown[]) => mockDeletePerformance(...args),
     };
 });
 
@@ -107,6 +108,8 @@ afterEach(() => {
 beforeEach(() => {
     // Restore the list in place: the mock factory closed over this array reference.
     mockProfilerFolders.splice(0, mockProfilerFolders.length, ...mockProfilerFolderList);
+    mockDeletePerformance.mockReset();
+    mockDeletePerformance.mockResolvedValue({ success: true });
     mockDeleteProfiler.mockReset();
     mockDeleteProfiler.mockImplementation((path: string) => {
         const folderIndex = mockProfilerFolders.findIndex((folder) => folder.path === path);
@@ -438,4 +441,78 @@ it('deletes memory report and updates state', async () => {
     mockProfilerFolders.forEach((folder) => {
         expect(menuRows.some((row) => row?.includes(`/${folder.path}`) && row?.includes(folder.reportName))).toBe(true);
     });
+});
+
+// What the backend returns when the report belongs to the TT-Metal tree, which is the failure
+// that motivated surfacing these at all.
+const DELETE_REFUSAL_MESSAGE =
+    'Reports read from TT_METAL_HOME are not managed by TT-NN Visualizer and cannot be deleted.';
+
+/** Opens the picker, deletes the named report through the confirmation, and waits for the toast. */
+async function confirmDeleteOf(select: HTMLElement, folder: ReportFolder) {
+    select.click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    fireEvent.click(screen.getByLabelText(getDeleteActionLabel(ManagedEntity.REPORT, folder.reportName)));
+
+    await waitFor(() => expect(document.querySelector('[role="alertdialog"]')).not.toBe(null), WAIT_FOR_OPTIONS);
+
+    fireEvent.click(screen.getByRole('button', { name: CONFIRM_DELETE_LABEL }));
+
+    // The failure is what the user sees — without this the delete is silent.
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(DELETE_REFUSAL_MESSAGE),
+        WAIT_FOR_OPTIONS,
+    );
+}
+
+it('surfaces an error toast and keeps the report when the memory delete fails', async () => {
+    mockDeleteProfiler.mockRejectedValueOnce(new Error(DELETE_REFUSAL_MESSAGE));
+
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+    const deletedFolder = mockProfilerFolderList[0];
+    const profilerSelect = getAllButtonsWithText(SELECT_REPORT_TEXT)[0];
+
+    await confirmDeleteOf(profilerSelect, deletedFolder);
+
+    expect(screen.getByText('Unable to delete memory report')).not.toBeNull();
+
+    profilerSelect.click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    const menuRows = screen.getAllByTestId(TEST_IDS.FOLDER_PICKER_ROW).map((row) => row.textContent);
+
+    expect(menuRows).toHaveLength(mockProfilerFolderList.length);
+    expect(menuRows.some((row) => row?.includes(`/${deletedFolder.path}`))).toBe(true);
+});
+
+it('surfaces an error toast and keeps the report when the performance delete fails', async () => {
+    mockDeletePerformance.mockRejectedValueOnce(new Error(DELETE_REFUSAL_MESSAGE));
+
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+    const deletedFolder = mockPerfFolderList[0];
+    // An earlier test uploads into this list, so read its length rather than assuming the fixture's.
+    const listedCount = mockPerfFolderList.length;
+    const performanceSelect = getAllButtonsWithText(SELECT_REPORT_TEXT)[1];
+
+    await confirmDeleteOf(performanceSelect, deletedFolder);
+
+    expect(screen.getByText('Unable to delete performance report')).not.toBeNull();
+    expect(mockDeletePerformance).toHaveBeenCalledWith(deletedFolder.path);
+
+    performanceSelect.click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    const menuRows = screen.getAllByTestId(TEST_IDS.FOLDER_PICKER_ROW).map((row) => row.textContent);
+
+    expect(menuRows).toHaveLength(listedCount);
+    expect(menuRows.some((row) => row?.includes(`/${deletedFolder.path}`))).toBe(true);
 });

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { Classes } from '@blueprintjs/core';
+import { HttpStatusCode } from 'axios';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { TestProviders } from './helpers/TestProviders';
@@ -13,6 +14,12 @@ import mockPerformanceReportFolders from './data/mockPerformanceReportFolders.js
 import { ReportFolder } from '../src/definitions/Reports';
 import LocalFolderSelector from '../src/components/report-selection/LocalFolderSelector';
 import { CONFIRM_DELETE_LABEL, ManagedEntity } from '../src/definitions/ManagedEntity';
+import {
+    MEMORY_REPORT_DELETED_TOAST_TITLE,
+    MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE,
+    PERFORMANCE_REPORT_DELETED_TOAST_TITLE,
+    PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE,
+} from '../src/definitions/notifyActiveReport';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { getDeleteActionLabel } from '../src/functions/managedEntityLabels';
 import { isActivatingReportAtom } from '../src/store/app';
@@ -106,10 +113,19 @@ afterEach(() => {
 });
 
 beforeEach(() => {
-    // Restore the list in place: the mock factory closed over this array reference.
+    // Restore both lists in place: the mock factories closed over these array references.
     mockProfilerFolders.splice(0, mockProfilerFolders.length, ...mockProfilerFolderList);
+    mockPerfFolderList.splice(0, mockPerfFolderList.length, ...mockPerformanceReportFolders);
     mockDeletePerformance.mockReset();
-    mockDeletePerformance.mockResolvedValue({ success: true });
+    mockDeletePerformance.mockImplementation((path: string) => {
+        const folderIndex = mockPerfFolderList.findIndex((folder) => folder.path === path);
+
+        if (folderIndex !== -1) {
+            mockPerfFolderList.splice(folderIndex, 1);
+        }
+
+        return Promise.resolve({ success: true });
+    });
     mockDeleteProfiler.mockReset();
     mockDeleteProfiler.mockImplementation((path: string) => {
         const folderIndex = mockProfilerFolders.findIndex((folder) => folder.path === path);
@@ -424,6 +440,7 @@ it('deletes memory report and updates state', async () => {
         WAIT_FOR_OPTIONS,
     );
 
+    expect(screen.getByText(MEMORY_REPORT_DELETED_TOAST_TITLE)).not.toBeNull();
     expect(mockDeleteProfiler).toHaveBeenCalledTimes(1);
     expect(mockDeleteProfiler).toHaveBeenCalledWith(deletedFolder.path);
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(2);
@@ -443,10 +460,55 @@ it('deletes memory report and updates state', async () => {
     });
 });
 
-// What the backend returns when the report belongs to the TT-Metal tree, which is the failure
-// that motivated surfacing these at all.
-const DELETE_REFUSAL_MESSAGE =
-    'Reports read from TT_METAL_HOME are not managed by TT-NN Visualizer and cannot be deleted.';
+it('deletes performance report and updates state', async () => {
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+    const deletedFolder = mockPerfFolderList[0];
+    const performanceSelect = getAllButtonsWithText(SELECT_REPORT_TEXT)[1];
+
+    performanceSelect.click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    fireEvent.click(screen.getByLabelText(getDeleteActionLabel(ManagedEntity.REPORT, deletedFolder.reportName)));
+
+    await waitFor(() => expect(document.querySelector('[role="alertdialog"]')).not.toBe(null), WAIT_FOR_OPTIONS);
+
+    fireEvent.click(screen.getByRole('button', { name: CONFIRM_DELETE_LABEL }));
+
+    await waitFor(
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(deletedFolder.reportName),
+        WAIT_FOR_OPTIONS,
+    );
+
+    expect(screen.getByText(PERFORMANCE_REPORT_DELETED_TOAST_TITLE)).not.toBeNull();
+    expect(mockDeletePerformance).toHaveBeenCalledTimes(1);
+    expect(mockDeletePerformance).toHaveBeenCalledWith(deletedFolder.path);
+
+    performanceSelect.click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+
+    // Scoped to the dropdown rows: the delete toast is still on screen and carries the report name
+    // too, so an unscoped query would match it and hide the row's disappearance.
+    const menuRows = screen.getAllByTestId(TEST_IDS.FOLDER_PICKER_ROW).map((row) => row.textContent);
+
+    expect(menuRows).toHaveLength(mockPerformanceReportFolders.length - 1);
+    expect(menuRows.some((row) => row?.includes(`/${deletedFolder.path}`))).toBe(false);
+});
+
+// A stand-in for whatever the server puts in the 403's `error` field, not a copy of it — the
+// backend's exact wording is pinned where it is defined (test_report_deletion.py asserts against
+// the imported constant). What these tests pin is the plumbing: server `error` reaches the toast.
+const SERVER_ERROR_DETAIL = 'Reports in the TT-Metal tree are not managed here';
+
+/** Shaped like the AxiosError a refused DELETE actually rejects with, which is the branch of
+ *  getResponseError the handlers depend on — a bare Error takes a different path. */
+const refusedDelete = () => ({
+    isAxiosError: true,
+    response: { status: HttpStatusCode.Forbidden, data: { error: SERVER_ERROR_DETAIL } },
+});
 
 /** Opens the picker, deletes the named report through the confirmation, and waits for the toast. */
 async function confirmDeleteOf(select: HTMLElement, folder: ReportFolder) {
@@ -461,13 +523,13 @@ async function confirmDeleteOf(select: HTMLElement, folder: ReportFolder) {
 
     // The failure is what the user sees — without this the delete is silent.
     await waitFor(
-        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(DELETE_REFUSAL_MESSAGE),
+        () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(SERVER_ERROR_DETAIL),
         WAIT_FOR_OPTIONS,
     );
 }
 
 it('surfaces an error toast and keeps the report when the memory delete fails', async () => {
-    mockDeleteProfiler.mockRejectedValueOnce(new Error(DELETE_REFUSAL_MESSAGE));
+    mockDeleteProfiler.mockRejectedValueOnce(refusedDelete());
 
     render(
         <TestProviders>
@@ -479,7 +541,7 @@ it('surfaces an error toast and keeps the report when the memory delete fails', 
 
     await confirmDeleteOf(profilerSelect, deletedFolder);
 
-    expect(screen.getByText('Unable to delete memory report')).not.toBeNull();
+    expect(screen.getByText(MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE)).not.toBeNull();
 
     profilerSelect.click();
     await waitFor(testForPortal, WAIT_FOR_OPTIONS);
@@ -491,7 +553,7 @@ it('surfaces an error toast and keeps the report when the memory delete fails', 
 });
 
 it('surfaces an error toast and keeps the report when the performance delete fails', async () => {
-    mockDeletePerformance.mockRejectedValueOnce(new Error(DELETE_REFUSAL_MESSAGE));
+    mockDeletePerformance.mockRejectedValueOnce(refusedDelete());
 
     render(
         <TestProviders>
@@ -499,13 +561,11 @@ it('surfaces an error toast and keeps the report when the performance delete fai
         </TestProviders>,
     );
     const deletedFolder = mockPerfFolderList[0];
-    // An earlier test uploads into this list, so read its length rather than assuming the fixture's.
-    const listedCount = mockPerfFolderList.length;
     const performanceSelect = getAllButtonsWithText(SELECT_REPORT_TEXT)[1];
 
     await confirmDeleteOf(performanceSelect, deletedFolder);
 
-    expect(screen.getByText('Unable to delete performance report')).not.toBeNull();
+    expect(screen.getByText(PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE)).not.toBeNull();
     expect(mockDeletePerformance).toHaveBeenCalledWith(deletedFolder.path);
 
     performanceSelect.click();
@@ -513,6 +573,6 @@ it('surfaces an error toast and keeps the report when the performance delete fai
 
     const menuRows = screen.getAllByTestId(TEST_IDS.FOLDER_PICKER_ROW).map((row) => row.textContent);
 
-    expect(menuRows).toHaveLength(listedCount);
+    expect(menuRows).toHaveLength(mockPerformanceReportFolders.length);
     expect(menuRows.some((row) => row?.includes(`/${deletedFolder.path}`))).toBe(true);
 });

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -863,7 +863,9 @@ it('does not activate remote report when a local report is chosen mid-sync', asy
     // Activate a local performance report while the remote sync is still in flight.
     getAllButtonsWithText(SELECT_LOCAL_REPORT_TEXT)[1].click();
     await waitFor(testForPortal, WAIT_FOR_OPTIONS);
-    screen.getByText(new RegExp(localPerfFolder.path, 'i')).click();
+    // Both selectors are mounted here with a sync in flight, so testForPortal can be satisfied by
+    // a portal other than this menu — wait for the row itself rather than querying it synchronously.
+    (await screen.findByText(new RegExp(localPerfFolder.path, 'i'), undefined, WAIT_FOR_OPTIONS)).click();
 
     await waitFor(
         () => expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain(localPerfFolder.reportName),


### PR DESCRIPTION
Closes #1821

In direct-report mode (`TT_METAL_HOME` set) the report listings and the report deletes resolved against different trees, so deleting a listed report could never succeed — and nothing said so.

`GET /profiler` and `GET /performance` resolve their base path through `PathResolver.get_base_report_path()`, which in direct mode points into the TT-Metal checkout. Both `DELETE` routes were pinned to `LOCAL_DATA_DIRECTORY/{profiler-reports,performance-reports}/<name>` instead. Nothing the listing returned exists there, so every delete fell through to `response_not_found`.

The UI didn't hide the control either: `LocalFolderSelector` gated only the upload `FileInput`s on `isDirectReportMode`, while `LocalFolderPicker` renders its trash button whenever a `handleDelete` prop is supplied — which both pickers did unconditionally. The handlers didn't catch, so the rejected request produced no toast. The user confirmed the delete alert and nothing observable happened.

## What this does

**Hides the control.** The gate goes in `LocalFolderPicker` alongside the `SERVER_MODE` gate it already owns, rather than dropping `handleDelete` at the two call sites. That component's existing comment records why the trash button and its confirmation alert must be gated *together* — one gate keeps that invariant, covers both pickers, and can't be forgotten by a future call site. `ComparisonReportSelector` passes no `handleDelete`, so it is unaffected.

**Refuses the routes.** `_direct_report_mode_refusal()` returns 403 from both `DELETE` routes in direct mode, reusing the `PathResolver.is_direct_report_mode` predicate the listings already use rather than adding a second `TT_METAL_HOME` check. A 404 against a tree the client never saw listed is a misleading answer to an API caller; per `AGENTS.md`, local-only behaviour is gated on both sides.

This deliberately does **not** point deletes at the TT-Metal tree. That would mean `shutil.rmtree` inside the user's checkout against reports the app neither created nor owns — a product decision to take on its own terms, not one to fall out of a path fix. `docs/src/running-the-application.md` already documents that sync and upload are disabled in this mode; deletion is now named there too.

**Surfaces failures.** `handleDeleteProfiler` and `handleDeletePerformance` now catch, emit the response error via the existing `getResponseError` + `ToastType.ERROR` convention (as `notifyFolderSyncError.ts` does), and return before claiming success or clearing the active report. So a delete that fails for any other reason is visible rather than silent.

## Testing

Backend 817 passed, frontend 1618 passed; eslint, `tsc --noEmit`, isort, black and mypy clean.

New coverage: the picker offering no delete action or confirmation in direct-report mode (asserting the rows still render, so it's the gate under test rather than an empty dropdown); a rejected delete surfacing an error toast and leaving the report listed; and both `DELETE` routes refusing with 403 in direct mode, with the report still on disk — including a same-named report in the app's own data directory, which must survive the refusal too.

I confirmed the new tests fail without the source changes rather than merely passing alongside them.

## Notes for review

- `_report_directory_to_delete`'s docstring asserted that the paired listings "only ever read the local data directory". That was false in direct mode; it now states the precondition the new guard establishes.
- Branched off `origin/dev` at `58a0166e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)