### PR TITLE
Add CLAUDE.md wrapper pointing at AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+**[AGENTS.md](./AGENTS.md) is the canonical guidance file for this repository.** Read it before working on this codebase.
+
+This file exists only so that Claude Code picks up that guidance; it is intentionally a thin wrapper and holds no rules of its own. Anything Claude-specific still belongs in `AGENTS.md`, alongside the guidance every other agent reads — put new instructions there, not here.
+
+`AGENTS.md` links out to [`CONVENTIONS.md`](./CONVENTIONS.md), the expanded reference for the same code-style and architecture rules with examples and rationale. Follow the link when a convention needs more context than the summary gives.


### PR DESCRIPTION
`AGENTS.md` is the canonical agent guidance file for this repo, since Cursor has been the primary agent tool in use and that is the file it reads.

This adds a thin `CLAUDE.md` so Claude Code picks up the same guidance without duplicating it. The wrapper holds no rules of its own — it points at `AGENTS.md` (and onward to `CONVENTIONS.md`) and says that new instructions belong there rather than in the wrapper.

`pnpm lint:spdx` covers `.js`/`.ts`/`.py`/`.json` families only, not markdown, and neither `AGENTS.md` nor `README.md` carries an SPDX header — so the new file matches them and omits one. Prettier passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)