### PR TITLE
Scope circular-buffer accounting to the device that owns the cores

### DIFF
--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -701,6 +701,7 @@ const CircularBufferPressureBody = ({
                                         <span className='size'>{formatMemorySize(cb.size, 2)}</span>
                                         <span className='cores'>
                                             {cb.numCores > 0 ? `× ${cb.numCores} cores` : 'unattributed'}
+                                            {cb.deviceCount > 1 && ` × ${cb.deviceCount} devices`}
                                         </span>
                                     </span>
                                     {isAliased && (

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -21,6 +21,7 @@ import classNames from 'classnames';
 import { useDevices } from '../../hooks/useAPI';
 import LoadingSpinner from '../LoadingSpinner';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
+import { getCoreCountLabel, getDeviceCountLabel } from '../../functions/formatting';
 import { getBufferColor } from '../../functions/colorGenerator';
 import { CBAllocationSummary, CBPressureSnapshot } from '../../model/MemoryAllocations';
 import 'styles/components/CircularBufferPressureModal.scss';
@@ -700,8 +701,8 @@ const CircularBufferPressureBody = ({
                                         <span className='addr'>{prettyPrintAddress(cb.address, l1Budget)}</span>
                                         <span className='size'>{formatMemorySize(cb.size, 2)}</span>
                                         <span className='cores'>
-                                            {cb.numCores > 0 ? `x ${cb.numCores} cores` : 'unattributed'}
-                                            {cb.deviceCount > 1 && ` x ${cb.deviceCount} devices`}
+                                            {cb.numCores > 0 ? getCoreCountLabel(cb.numCores) : 'unattributed'}
+                                            {cb.deviceCount > 1 && ` ${getDeviceCountLabel(cb.deviceCount)}`}
                                         </span>
                                     </span>
                                     {isAliased && (

--- a/src/components/operation-details/CircularBufferPressureModal.tsx
+++ b/src/components/operation-details/CircularBufferPressureModal.tsx
@@ -700,8 +700,8 @@ const CircularBufferPressureBody = ({
                                         <span className='addr'>{prettyPrintAddress(cb.address, l1Budget)}</span>
                                         <span className='size'>{formatMemorySize(cb.size, 2)}</span>
                                         <span className='cores'>
-                                            {cb.numCores > 0 ? `× ${cb.numCores} cores` : 'unattributed'}
-                                            {cb.deviceCount > 1 && ` × ${cb.deviceCount} devices`}
+                                            {cb.numCores > 0 ? `x ${cb.numCores} cores` : 'unattributed'}
+                                            {cb.deviceCount > 1 && ` x ${cb.deviceCount} devices`}
                                         </span>
                                     </span>
                                     {isAliased && (

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -236,7 +236,8 @@ function useDeviceOperationsFullRenderModel(args: {
     } = args;
 
     const selectedAddress = useAtomValue(selectedAddressAtom);
-    const { memoryAllocationList, peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(deviceOperations);
+    const { memoryAllocationList, peakMemoryLoad, cbPressureByOpId, cbFanout } =
+        processMemoryAllocations(deviceOperations);
 
     const formatTensor = useCallback((node: Node) => formatTensorRendering(node, details), [details]);
 
@@ -448,8 +449,15 @@ function useDeviceOperationsFullRenderModel(args: {
                         />
                     );
                 } else if (nodeType === NodeType.circular_buffer_allocate) {
+                    // Returning rather than falling through leaves
+                    // `consecutiveCBsOutput` set, so the devices we skip here
+                    // don't re-emit the "CBs" heading. #1844
+                    if (cbFanout.duplicateNodeIds.has(node.id)) {
+                        return;
+                    }
                     const cb = node.params;
                     const numCores = parseInt(cb.num_cores, 10) || 1;
+                    const deviceCount = cbFanout.deviceCountByNodeId.get(node.id) ?? 1;
 
                     const variance = cb.allocateOperationId;
                     // `globally_allocated='1'` CBs alias an existing L1
@@ -509,6 +517,7 @@ function useDeviceOperationsFullRenderModel(args: {
                                     onLegendClick={onLegendClick}
                                     colorVariance={variance}
                                     isGloballyAllocated={isGloballyAllocated}
+                                    deviceCount={deviceCount}
                                 />
                                 {memoryInfo}
                             </div>
@@ -534,6 +543,7 @@ function useDeviceOperationsFullRenderModel(args: {
             return output;
         },
         [
+            cbFanout,
             cbPressureByOpId,
             details,
             formatTensor,

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import React, { Fragment, JSX, useCallback, useState } from 'react';
+import React, { Fragment, JSX, useCallback, useMemo, useState } from 'react';
 import {
     Button,
     ButtonVariant,
@@ -236,8 +236,20 @@ function useDeviceOperationsFullRenderModel(args: {
     } = args;
 
     const selectedAddress = useAtomValue(selectedAddressAtom);
-    const { memoryAllocationList, peakMemoryLoad, cbPressureByOpId, cbFanout } =
-        processMemoryAllocations(deviceOperations);
+    // Walking the graph is proportional to node count, which a mesh capture
+    // multiplies by the device count, so it cannot run on renders driven by
+    // `selectedAddress` — every legend click is one. Memoising also makes the
+    // three returned objects stable, without which the `renderNodes`
+    // `useCallback` below memoises nothing. #1844
+    const { memoryAllocationList, peakMemoryLoad, cbPressureByOpId, cbFanout } = useMemo(
+        () => processMemoryAllocations(deviceOperations),
+        [deviceOperations],
+    );
+    // A linear scan per node is quadratic over a graph with one entry per node.
+    const memoryDetailsByNodeId = useMemo(
+        () => new Map<number, AllocationDetails>(memoryAllocationList.map((data) => [data.id, data])),
+        [memoryAllocationList],
+    );
 
     const formatTensor = useCallback((node: Node) => formatTensorRendering(node, details), [details]);
 
@@ -254,7 +266,14 @@ function useDeviceOperationsFullRenderModel(args: {
 
             nodes.forEach((node, index) => {
                 const nodeType = node.node_type;
-                const memoryDetails = memoryAllocationList.find((data) => data.id === node.id);
+                // Ahead of the lookup and `renderMemoryInfo` below, both of
+                // which were being paid for rows that are then dropped — most
+                // CB nodes in a mesh capture. Returning here keeps the "CBs"
+                // heading latch untouched, same as the guard it replaces. #1844
+                if (nodeType === NodeType.circular_buffer_allocate && cbFanout.duplicateNodeIds.has(node.id)) {
+                    return;
+                }
+                const memoryDetails = memoryDetailsByNodeId.get(node.id);
                 const memoryInfo = renderMemoryInfo(memoryDetails, peakMemoryLoad);
 
                 if (nodeType === NodeType.function_start) {
@@ -449,9 +468,6 @@ function useDeviceOperationsFullRenderModel(args: {
                         />
                     );
                 } else if (nodeType === NodeType.circular_buffer_allocate) {
-                    if (cbFanout.duplicateNodeIds.has(node.id)) {
-                        return;
-                    }
                     const cb = node.params;
                     const numCores = parseInt(cb.num_cores, 10) || 1;
                     const deviceCount = cbFanout.deviceCountByNodeId.get(node.id) ?? 1;
@@ -544,7 +560,7 @@ function useDeviceOperationsFullRenderModel(args: {
             cbPressureByOpId,
             details,
             formatTensor,
-            memoryAllocationList,
+            memoryDetailsByNodeId,
             onLegendClick,
             peakMemoryLoad,
             selectedAddress,

--- a/src/components/operation-details/DeviceOperationsFullRender.tsx
+++ b/src/components/operation-details/DeviceOperationsFullRender.tsx
@@ -449,9 +449,6 @@ function useDeviceOperationsFullRenderModel(args: {
                         />
                     );
                 } else if (nodeType === NodeType.circular_buffer_allocate) {
-                    // Returning rather than falling through leaves
-                    // `consecutiveCBsOutput` set, so the devices we skip here
-                    // don't re-emit the "CBs" heading. #1844
                     if (cbFanout.duplicateNodeIds.has(node.id)) {
                         return;
                     }

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -43,10 +43,6 @@ interface MemoryLegendElementProps {
      * reads as a tensor view rather than a fresh allocation.
      */
     isGloballyAllocated?: boolean;
-    /**
-     * Devices this row stands for, when a mesh op allocated the same CB on each
-     * of them and the duplicate rows were collapsed into this one. #1844
-     */
     deviceCount?: number;
 }
 

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -11,7 +11,7 @@ import { DeviceOperationLayoutTypes, FragmentationEntry, MarkerType, MarkerTypeL
 import { OperationDetails } from '../../model/OperationDetails';
 import { getBufferColor, getTensorColor } from '../../functions/colorGenerator';
 import { formatMemorySize, prettyPrintAddress } from '../../functions/math';
-import { toReadableShape, toReadableType } from '../../functions/formatting';
+import { getCoreCountLabel, getDeviceCountLabel, toReadableShape, toReadableType } from '../../functions/formatting';
 import 'styles/components/MemoryLegendElement.scss';
 import { L1_SMALL_MARKER_COLOR, L1_START_MARKER_COLOR } from '../../definitions/PlotConfigurations';
 import { selectedBufferColourAtom, showHexAtom } from '../../store/app';
@@ -86,9 +86,8 @@ export const MemoryLegendElement = ({
 
     const derivedTensor = operationDetails.getTensorForAddress(chunk.address);
     const isPerCoreBuffer = bufferType !== StringBufferType.DRAM && bufferType !== StringBufferType.SYSTEM_MEMORY;
-    const numCoresLabel =
-        isPerCoreBuffer && numCores && numCores > 0 ? ` x ${numCores} ${numCores === 1 ? 'core' : 'cores'}` : '';
-    const deviceCountLabel = deviceCount > 1 ? ` x ${deviceCount} devices` : '';
+    const numCoresLabel = isPerCoreBuffer && numCores && numCores > 0 ? ` ${getCoreCountLabel(numCores)}` : '';
+    const deviceCountLabel = deviceCount > 1 ? ` ${getDeviceCountLabel(deviceCount)}` : '';
 
     const resolvedColour =
         chunk.tensorId || derivedTensor

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -43,6 +43,11 @@ interface MemoryLegendElementProps {
      * reads as a tensor view rather than a fresh allocation.
      */
     isGloballyAllocated?: boolean;
+    /**
+     * Devices this row stands for, when a mesh op allocated the same CB on each
+     * of them and the duplicate rows were collapsed into this one. #1844
+     */
+    deviceCount?: number;
 }
 
 export const MemoryLegendElement = ({
@@ -60,6 +65,7 @@ export const MemoryLegendElement = ({
     numCores,
     userL1ZoomRange,
     isGloballyAllocated = false,
+    deviceCount = 1,
 }: MemoryLegendElementProps) => {
     const showHex = useAtomValue(showHexAtom);
     const selectedBufferColour = useAtomValue(selectedBufferColourAtom);
@@ -86,6 +92,7 @@ export const MemoryLegendElement = ({
     const isPerCoreBuffer = bufferType !== StringBufferType.DRAM && bufferType !== StringBufferType.SYSTEM_MEMORY;
     const numCoresLabel =
         isPerCoreBuffer && numCores && numCores > 0 ? ` x ${numCores} ${numCores === 1 ? 'core' : 'cores'}` : '';
+    const deviceCountLabel = deviceCount > 1 ? ` x ${deviceCount} devices` : '';
 
     const resolvedColour =
         chunk.tensorId || derivedTensor
@@ -169,6 +176,7 @@ export const MemoryLegendElement = ({
                     <>
                         {formatMemorySize(chunk.size, 2)}
                         {numCoresLabel}
+                        {deviceCountLabel}
                         {isGloballyAllocated && (
                             <Tooltip
                                 content={

--- a/src/functions/formatting.ts
+++ b/src/functions/formatting.ts
@@ -107,3 +107,11 @@ export const getUTCFromEpoch = (epoch: number): Date => new Date(epoch * 1000);
 /** Dropdown label for a `~/.ssh/config` alias, disambiguated by its HostName. */
 export const getSshConfigHostLabel = (host: SshConfigHost): string =>
     host.hostName ? `${host.host} — ${host.hostName}` : host.host;
+
+// The CB legend row and the pressure modal both spell out these multipliers.
+// Written twice, they drifted on pluralisation; callers keep their own gating,
+// which genuinely differs, and share only the wording. #1844
+export const getCoreCountLabel = (numCores: number): string => `x ${numCores} ${numCores === 1 ? 'core' : 'cores'}`;
+
+export const getDeviceCountLabel = (deviceCount: number): string =>
+    `x ${deviceCount} ${deviceCount === 1 ? 'device' : 'devices'}`;

--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { CoreCoord } from '../model/CoreCoord';
+import { CoreCoord, CoreCoordList } from '../model/CoreCoord';
 
 const LOCALE = 'en-US';
 
@@ -139,7 +139,17 @@ const CORE_COORD_RE = /\(x=(\d+),y=(\d+)\)|(\d+)-(\d+)/g;
  * Accepts both `{[(x=N,y=N) - (x=N,y=N)]}` (legacy) and `{[N-N - N-N]}` (modern),
  * multi-rectangle unions, and `{}`.
  */
-export const getCoresInRangeList = (rangeString: string): CoreCoord[] => {
+// A mesh op repeats one `core_range_set` string per device, so the parse below
+// runs identically N times for the N devices this expansion exists to
+// distinguish. Entries are handed out shared, which the `readonly` return type
+// is what keeps safe. #1844
+const coresInRangeCache = new Map<string, CoreCoordList>();
+
+export const getCoresInRangeList = (rangeString: string): CoreCoordList => {
+    const cached = coresInRangeCache.get(rangeString);
+    if (cached) {
+        return cached;
+    }
     const cores = new Map<string, CoreCoord>();
     for (const rect of rangeString.matchAll(CORE_RANGE_RECT_RE)) {
         const corners: CoreCoord[] = [];
@@ -168,7 +178,9 @@ export const getCoresInRangeList = (rangeString: string): CoreCoord[] => {
             }
         }
     }
-    return Array.from(cores.values());
+    const expanded: CoreCoordList = Array.from(cores.values());
+    coresInRangeCache.set(rangeString, expanded);
+    return expanded;
 };
 
 export const getCoresInRange = (rangeString: string): number => getCoresInRangeList(rangeString).length;

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -5,8 +5,12 @@
 import { DeviceOperationNode, Node, NodeType } from '../model/APIData';
 import { L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { StringBufferType } from '../model/BufferType';
-import { AllocationDetails, CBAllocationSummary, CBPressureSnapshot } from '../model/MemoryAllocations';
+import { AllocationDetails, CBAllocationSummary, CBDeviceFanout, CBPressureSnapshot } from '../model/MemoryAllocations';
 import { getCoresInRangeList } from './math';
+
+// Stands in for `device_id` when the graph omits it, so a report with no device
+// dimension accumulates into one bucket exactly as it did before #1844.
+const SINGLE_DEVICE_KEY = 'single';
 
 export function processMemoryAllocations(
     graph: Node[],
@@ -15,39 +19,64 @@ export function processMemoryAllocations(
     peakMemoryLoad: number;
     memoryAllocationList: AllocationDetails[];
     cbPressureByOpId: Map<number, CBPressureSnapshot>;
+    cbFanout: CBDeviceFanout;
 } {
     let peakMemoryLoad = 0;
     const memoryAllocationList: AllocationDetails[] = [];
     const curOpList: { name: string; id: number; deviceId?: string | number }[] = [];
-    const cbBytesByCore = new Map<string, number>();
+    // Keyed `${device}|${x},${y}` because core (0,0) of device 0 is not core
+    // (0,0) of device 6; summing the mesh's identical CBs is what inflated every
+    // total by the device count. #1844
+    const cbBytesByDeviceCore = new Map<string, number>();
+    // CBs whose `core_range_set` resolved to no cores, per device.
+    const unattributedByDevice = new Map<string, number>();
     // Live CB allocations since the last `circular_buffer_deallocate_all` (or
-    // since the DeviceOp started, whichever came last). Mirrors `cbBytesByCore`
-    // so the snapshot can attribute pressure back to specific CB events.
+    // since the DeviceOp started, whichever came last), one entry per CB rather
+    // than per device. Mirrors `cbBytesByDeviceCore` so the snapshot can
+    // attribute pressure back to specific CB events.
     let liveCBs: CBAllocationSummary[] = [];
+    // Lets a later device bump an existing CB's `deviceCount` instead of adding
+    // a row. Same lifetime as `liveCBs`.
+    let liveCBByIdentity = new Map<string, { summary: CBAllocationSummary; deviceKeys: Set<string> }>();
     const cbPressureByOpId = new Map<number, CBPressureSnapshot>();
+    const cbFanout: CBDeviceFanout = {
+        deviceCountByNodeId: new Map<number, number>(),
+        duplicateNodeIds: new Set<number>(),
+    };
+
+    const resetLiveCBs = () => {
+        liveCBs = [];
+        liveCBByIdentity = new Map();
+    };
 
     const snapshotCBPressure = (opId: number) => {
-        if (liveCBs.length === 0 && cbBytesByCore.size === 0) {
+        if (liveCBs.length === 0 && cbBytesByDeviceCore.size === 0 && unattributedByDevice.size === 0) {
             return;
         }
         const byCore: Record<string, number> = {};
         let maxBytes = 0;
-        let unattributedBytes = 0;
-        for (const [k, v] of cbBytesByCore.entries()) {
-            byCore[k] = v;
-            if (k === '?') {
-                unattributedBytes = v;
-            } else if (v > maxBytes) {
-                maxBytes = v;
+        for (const [key, bytes] of cbBytesByDeviceCore.entries()) {
+            const core = key.slice(key.indexOf('|') + 1);
+            const perCore = Math.max(byCore[core] ?? 0, bytes);
+            byCore[core] = perCore;
+            if (perCore > maxBytes) {
+                maxBytes = perCore;
             }
         }
-        // Last writer wins if a DeviceOp triggers multiple snapshots. v1
-        // assumption: one `circular_buffer_deallocate_all` per DeviceOp.
+        let unattributedBytes = 0;
+        for (const bytes of unattributedByDevice.values()) {
+            unattributedBytes = Math.max(unattributedBytes, bytes);
+        }
+        if (unattributedByDevice.size > 0) {
+            byCore['?'] = unattributedBytes;
+        }
+        // Copied per entry because `deviceCount` stays mutable on the live
+        // objects; a snapshot must not change after it is taken.
         cbPressureByOpId.set(opId, {
             byCore,
             maxBytes,
             unattributedBytes,
-            allocations: liveCBs.slice(),
+            allocations: liveCBs.map((cb) => ({ ...cb })),
         });
     };
 
@@ -55,12 +84,12 @@ export function processMemoryAllocations(
 
     const maxCbPerCore = (): number => {
         let m = 0;
-        // Skip the '?' bucket — those bytes have no core attribution so
+        // Unattributed bytes are excluded — they have no core attribution so
         // they don't belong in a per-core peak. Mirrors the same exclusion
         // in snapshotCBPressure() so cbPeak and snapshot.maxBytes agree.
-        for (const [k, v] of cbBytesByCore.entries()) {
-            if (k !== '?' && v > m) {
-                m = v;
+        for (const bytes of cbBytesByDeviceCore.values()) {
+            if (bytes > m) {
+                m = bytes;
             }
         }
         return m;
@@ -98,27 +127,45 @@ export function processMemoryAllocations(
             // forward-compat with future tt-metal emit changes. #1651
             const rawGlobalFlag = node.params.globally_allocated as unknown;
             const globallyAllocated = rawGlobalFlag === '1' || rawGlobalFlag === 1;
+            const deviceKey = String(node.params.device_id ?? SINGLE_DEVICE_KEY);
             if (!globallyAllocated) {
                 if (cores.length === 0) {
-                    cbBytesByCore.set('?', (cbBytesByCore.get('?') ?? 0) + size);
+                    unattributedByDevice.set(deviceKey, (unattributedByDevice.get(deviceKey) ?? 0) + size);
                 } else {
                     for (const { x, y } of cores) {
-                        const k = `${x},${y}`;
-                        cbBytesByCore.set(k, (cbBytesByCore.get(k) ?? 0) + size);
+                        const k = `${deviceKey}|${x},${y}`;
+                        cbBytesByDeviceCore.set(k, (cbBytesByDeviceCore.get(k) ?? 0) + size);
                     }
                 }
             }
-            liveCBs.push({
-                nodeId: node.id,
-                address: parseInt(node.params.address, 10),
-                size,
-                numCores: cores.length,
-                coreRangeSet: node.params.core_range_set,
-                cores,
-                allocateOperationId: currentOp?.id,
-                allocateOperationName: currentOp?.name,
-                globallyAllocated,
-            });
+
+            const address = parseInt(node.params.address, 10);
+            const identity = `${address}|${size}|${node.params.core_range_set}|${globallyAllocated}`;
+            const existing = liveCBByIdentity.get(identity);
+            // A repeat within one device is a genuine second allocation, not mesh
+            // fan-out, so it keeps its own row.
+            if (existing && !existing.deviceKeys.has(deviceKey)) {
+                existing.deviceKeys.add(deviceKey);
+                existing.summary.deviceCount = existing.deviceKeys.size;
+                cbFanout.deviceCountByNodeId.set(existing.summary.nodeId, existing.deviceKeys.size);
+                cbFanout.duplicateNodeIds.add(node.id);
+            } else {
+                const summary: CBAllocationSummary = {
+                    nodeId: node.id,
+                    address,
+                    size,
+                    numCores: cores.length,
+                    coreRangeSet: node.params.core_range_set,
+                    cores,
+                    allocateOperationId: currentOp?.id,
+                    allocateOperationName: currentOp?.name,
+                    globallyAllocated,
+                    deviceCount: 1,
+                };
+                liveCBs.push(summary);
+                liveCBByIdentity.set(identity, { summary, deviceKeys: new Set([deviceKey]) });
+                cbFanout.deviceCountByNodeId.set(node.id, 1);
+            }
         }
 
         if (node.node_type === NodeType.circular_buffer_deallocate_all) {
@@ -129,8 +176,9 @@ export function processMemoryAllocations(
             if (currentOp) {
                 snapshotCBPressure(currentOp.id);
             }
-            cbBytesByCore.clear();
-            liveCBs = [];
+            cbBytesByDeviceCore.clear();
+            unattributedByDevice.clear();
+            resetLiveCBs();
         }
 
         if (node.node_type === NodeType.buffer_allocate && node.params.type === StringBufferType.L1) {
@@ -177,7 +225,7 @@ export function processMemoryAllocations(
         peakMemoryLoad = Math.max(peakMemoryLoad, cbPeak + totalBuffer);
     }
 
-    return { peakMemoryLoad, memoryAllocationList, cbPressureByOpId };
+    return { peakMemoryLoad, memoryAllocationList, cbPressureByOpId, cbFanout };
 }
 
 export const processInputsOutputs = (graph: Node[]): DeviceOperationNode[] => {

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -83,18 +83,15 @@ export function processMemoryAllocations(
 
     let totalBuffer = 0;
 
-    const maxCbPerCore = (): number => {
-        let m = 0;
-        // Unattributed bytes are excluded — they have no core attribution so
-        // they don't belong in a per-core peak. Mirrors the same exclusion
-        // in snapshotCBPressure() so cbPeak and snapshot.maxBytes agree.
-        for (const bytes of cbBytesByDeviceCore.values()) {
-            if (bytes > m) {
-                m = bytes;
-            }
-        }
-        return m;
-    };
+    // Maintained at the two places `cbBytesByDeviceCore` changes rather than
+    // rescanned per node: the map is read once per graph node but only grows by
+    // accumulation and resets wholesale, so a running max is exact. Rescanning
+    // cost the device count once the key gained a device. #1844
+    //
+    // Unattributed bytes are excluded — they have no core attribution so they
+    // don't belong in a per-core peak. Mirrors the same exclusion in
+    // snapshotCBPressure() so cbPeak and snapshot.maxBytes agree.
+    let cbPeakPerCore = 0;
 
     let i = 1;
     while (i < graph.length) {
@@ -135,13 +132,23 @@ export function processMemoryAllocations(
                 } else {
                     for (const { x, y } of cores) {
                         const k = `${deviceKey}|${x},${y}`;
-                        cbBytesByDeviceCore.set(k, (cbBytesByDeviceCore.get(k) ?? 0) + size);
+                        const coreBytes = (cbBytesByDeviceCore.get(k) ?? 0) + size;
+                        cbBytesByDeviceCore.set(k, coreBytes);
+                        if (coreBytes > cbPeakPerCore) {
+                            cbPeakPerCore = coreBytes;
+                        }
                     }
                 }
             }
 
             const address = parseInt(node.params.address, 10);
-            const identity = `${address}|${size}|${node.params.core_range_set}|${globallyAllocated}`;
+            // Scoped to the enclosing op because `function_end` can snapshot and
+            // unwind without a `circular_buffer_deallocate_all` to reset this;
+            // unscoped, a later op's device folded onto an already-snapshotted
+            // row and moved a count the modal had recorded. Every device's copy
+            // of a CB shares one `function_start`, so the collapse still sees
+            // them all. #1844
+            const identity = `${currentOp?.id}|${address}|${size}|${node.params.core_range_set}|${globallyAllocated}`;
             // A repeat on the same device is a real second allocation, not mesh
             // fan-out, so it needs its own row. Keying by the device's repeat
             // count gives it one, and pairs it with the other devices' repeats
@@ -185,6 +192,7 @@ export function processMemoryAllocations(
                 snapshotCBPressure(currentOp.id);
             }
             cbBytesByDeviceCore.clear();
+            cbPeakPerCore = 0;
             unattributedByDevice.clear();
             resetLiveCBs();
         }
@@ -215,7 +223,7 @@ export function processMemoryAllocations(
             }
         }
 
-        const cbPeak = maxCbPerCore();
+        const cbPeak = cbPeakPerCore;
 
         if (curOpList.length > 0) {
             const obj: AllocationDetails = {

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -8,8 +8,7 @@ import { StringBufferType } from '../model/BufferType';
 import { AllocationDetails, CBAllocationSummary, CBDeviceFanout, CBPressureSnapshot } from '../model/MemoryAllocations';
 import { getCoresInRangeList } from './math';
 
-// Stands in for `device_id` when the graph omits it, so a report with no device
-// dimension accumulates into one bucket exactly as it did before #1844.
+// Keeps a graph with no device dimension accumulating into one bucket. #1844
 const SINGLE_DEVICE_KEY = 'single';
 
 export function processMemoryAllocations(
@@ -24,19 +23,17 @@ export function processMemoryAllocations(
     let peakMemoryLoad = 0;
     const memoryAllocationList: AllocationDetails[] = [];
     const curOpList: { name: string; id: number; deviceId?: string | number }[] = [];
-    // Keyed `${device}|${x},${y}` because core (0,0) of device 0 is not core
-    // (0,0) of device 6; summing the mesh's identical CBs is what inflated every
-    // total by the device count. #1844
+    // Core (0,0) of device 0 is not core (0,0) of device 6; summing the mesh's
+    // identical CBs is what inflated every total by the device count. #1844
     const cbBytesByDeviceCore = new Map<string, number>();
-    // CBs whose `core_range_set` resolved to no cores, per device.
+    // CBs whose `core_range_set` resolved to no cores.
     const unattributedByDevice = new Map<string, number>();
     // Live CB allocations since the last `circular_buffer_deallocate_all` (or
     // since the DeviceOp started, whichever came last), one entry per CB rather
     // than per device. Mirrors `cbBytesByDeviceCore` so the snapshot can
     // attribute pressure back to specific CB events.
     let liveCBs: CBAllocationSummary[] = [];
-    // Lets a later device bump an existing CB's `deviceCount` instead of adding
-    // a row. Same lifetime as `liveCBs`.
+    // Lets a later device bump an existing CB's count instead of adding a row.
     let liveCBByIdentity = new Map<string, { summary: CBAllocationSummary; deviceKeys: Set<string> }>();
     const cbPressureByOpId = new Map<number, CBPressureSnapshot>();
     const cbFanout: CBDeviceFanout = {
@@ -142,7 +139,7 @@ export function processMemoryAllocations(
             const address = parseInt(node.params.address, 10);
             const identity = `${address}|${size}|${node.params.core_range_set}|${globallyAllocated}`;
             const existing = liveCBByIdentity.get(identity);
-            // A repeat within one device is a genuine second allocation, not mesh
+            // A repeat on the same device is a real second allocation, not mesh
             // fan-out, so it keeps its own row.
             if (existing && !existing.deviceKeys.has(deviceKey)) {
                 existing.deviceKeys.add(deviceKey);

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -35,6 +35,9 @@ export function processMemoryAllocations(
     let liveCBs: CBAllocationSummary[] = [];
     // Lets a later device bump an existing CB's count instead of adding a row.
     let liveCBByIdentity = new Map<string, { summary: CBAllocationSummary; deviceKeys: Set<string> }>();
+    // How many times each device has already allocated a given CB, so the key
+    // above can separate repeats.
+    let cbRepeatsByDevice = new Map<string, number>();
     const cbPressureByOpId = new Map<number, CBPressureSnapshot>();
     const cbFanout: CBDeviceFanout = {
         deviceCountByNodeId: new Map<number, number>(),
@@ -44,6 +47,7 @@ export function processMemoryAllocations(
     const resetLiveCBs = () => {
         liveCBs = [];
         liveCBByIdentity = new Map();
+        cbRepeatsByDevice = new Map();
     };
 
     const snapshotCBPressure = (opId: number) => {
@@ -138,10 +142,17 @@ export function processMemoryAllocations(
 
             const address = parseInt(node.params.address, 10);
             const identity = `${address}|${size}|${node.params.core_range_set}|${globallyAllocated}`;
-            const existing = liveCBByIdentity.get(identity);
             // A repeat on the same device is a real second allocation, not mesh
-            // fan-out, so it keeps its own row.
-            if (existing && !existing.deviceKeys.has(deviceKey)) {
+            // fan-out, so it needs its own row. Keying by the device's repeat
+            // count gives it one, and pairs it with the other devices' repeats
+            // instead of letting it displace the first allocation as the row
+            // they all collapse onto.
+            const repeatKey = `${identity}|${deviceKey}`;
+            const repeat = (cbRepeatsByDevice.get(repeatKey) ?? 0) + 1;
+            cbRepeatsByDevice.set(repeatKey, repeat);
+            const identitySlot = `${identity}|${repeat}`;
+            const existing = liveCBByIdentity.get(identitySlot);
+            if (existing) {
                 existing.deviceKeys.add(deviceKey);
                 existing.summary.deviceCount = existing.deviceKeys.size;
                 cbFanout.deviceCountByNodeId.set(existing.summary.nodeId, existing.deviceKeys.size);
@@ -160,7 +171,7 @@ export function processMemoryAllocations(
                     deviceCount: 1,
                 };
                 liveCBs.push(summary);
-                liveCBByIdentity.set(identity, { summary, deviceKeys: new Set([deviceKey]) });
+                liveCBByIdentity.set(identitySlot, { summary, deviceKeys: new Set([deviceKey]) });
                 cbFanout.deviceCountByNodeId.set(node.id, 1);
             }
         }

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -279,7 +279,10 @@ export interface CircularBufferDeallocateParams {
 
 interface BaseMemoryParams {
     address: string; // '1259520';
-    device_id: number;
+    // Absent in older captures and emitted as a string by at least one other,
+    // both present in the local report corpus, so consumers must normalise
+    // rather than read this as a number. #1844
+    device_id?: number | string;
     num_cores: string; // '64';
     page_size: string; // '448';
     size: string; // '7340032';

--- a/src/model/CoreCoord.ts
+++ b/src/model/CoreCoord.ts
@@ -6,3 +6,7 @@ export interface CoreCoord {
     x: number;
     y: number;
 }
+
+// Expansions of a `core_range_set` are cached and handed to every caller that
+// passes the same string, so the elements are shared. #1844
+export type CoreCoordList = readonly Readonly<CoreCoord>[];

--- a/src/model/MemoryAllocations.ts
+++ b/src/model/MemoryAllocations.ts
@@ -35,11 +35,7 @@ export type CBAllocationSummary = {
     /** Op id/name that created the CB, used downstream for color-variance/highlighting. */
     allocateOperationId?: number;
     allocateOperationName?: string;
-    /**
-     * Devices that allocated this CB — a mesh op emits one identical
-     * `circular_buffer_allocate` per device, folded into one summary. 1 on a
-     * single-device report. #1844
-     */
+    /** Devices whose identical allocations were folded into this row; 1 off a mesh. #1844 */
     deviceCount: number;
     /**
      * `true` when the source node had `globally_allocated=1`. These CBs are
@@ -70,9 +66,8 @@ export type CBPressureSnapshot = {
 };
 
 /**
- * Which `circular_buffer_allocate` nodes the renderer should draw, and how many
- * devices each stands for. A mesh op emits the same CB once per device; only the
- * first is worth a row, so the rest are listed as duplicates to skip. #1844
+ * A mesh op emits the same CB once per device; only the first earns a row, so the
+ * rest are listed here for the renderer to skip. #1844
  */
 export type CBDeviceFanout = {
     deviceCountByNodeId: Map<number, number>;

--- a/src/model/MemoryAllocations.ts
+++ b/src/model/MemoryAllocations.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { NodeType } from './APIData';
-import { CoreCoord } from './CoreCoord';
+import { CoreCoordList } from './CoreCoord';
 
 export type AllocationDetails = {
     id: number;
@@ -31,7 +31,7 @@ export type CBAllocationSummary = {
     /** Raw `core_range_set` string from the graph node (for display + reproducibility). */
     coreRangeSet: string;
     /** Expanded cores; empty when the allocation falls into the `'?'` bucket. */
-    cores: CoreCoord[];
+    cores: CoreCoordList;
     /** Op id/name that created the CB, used downstream for color-variance/highlighting. */
     allocateOperationId?: number;
     allocateOperationName?: string;

--- a/src/model/MemoryAllocations.ts
+++ b/src/model/MemoryAllocations.ts
@@ -36,6 +36,12 @@ export type CBAllocationSummary = {
     allocateOperationId?: number;
     allocateOperationName?: string;
     /**
+     * Devices that allocated this CB — a mesh op emits one identical
+     * `circular_buffer_allocate` per device, folded into one summary. 1 on a
+     * single-device report. #1844
+     */
+    deviceCount: number;
+    /**
      * `true` when the source node had `globally_allocated=1`. These CBs are
      * kernel-side views bound to an existing L1 sharded buffer (the tensor at
      * the same address) rather than fresh allocations. They are intentionally
@@ -61,4 +67,14 @@ export type CBPressureSnapshot = {
     unattributedBytes: number;
     /** Ordered list of CBs that were live when the snapshot was taken. */
     allocations: CBAllocationSummary[];
+};
+
+/**
+ * Which `circular_buffer_allocate` nodes the renderer should draw, and how many
+ * devices each stands for. A mesh op emits the same CB once per device; only the
+ * first is worth a row, so the rest are listed as duplicates to skip. #1844
+ */
+export type CBDeviceFanout = {
+    deviceCountByNodeId: Map<number, number>;
+    duplicateNodeIds: Set<number>;
 };

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 @use '../definitions/colours' as *;
+@use '../definitions/variables' as variables;
 
 .device-operations-full-render-wrap {
     .peak-load {
@@ -159,21 +160,58 @@
     // 320px right gutter (either the in-flow `.memory-info` for CB rows, or
     // the invisible `.memory-info-placeholder` for buffer rows where totals
     // live in the h4 above) keeps every legend grid computed against the
-    // same available width. Combined with the default `.legend-item` grid
-    // templates (5-col `15px 0.5fr 2fr 13fr 3fr` and 6-col extra-info
-    // `15px 0.5fr 2fr 10fr 3fr 3fr` — both sum to 18.5fr after the swatch),
-    // this makes swatch / address / size / shape columns line up
-    // column-for-column across buffer and CB rows. Scoped under
-    // `.device-operations-full-render` so it doesn't bleed into the L1 /
-    // DRAM plot legends.
+    // same available width. Scoped under `.device-operations-full-render` so
+    // it doesn't bleed into the L1 / DRAM plot legends.
     .memory-legend-row {
         display: flex;
         align-items: flex-start;
         gap: 10px;
 
+        // Anchor the data columns to the row's shared right edge instead of its
+        // left. Rows sit at different collapsible depths (up to 80px apart) and
+        // carry addresses of differing digit counts (25px), and with left-anchored
+        // share-based tracks both of those shifted every column downstream. The
+        // address is now the only flexible track, so it swallows that variation,
+        // and everything right of it is definite and lands identically on every
+        // row. `minmax(0, …)` lets those tracks give way under space pressure
+        // rather than overflowing the row.
         .legend-item {
             flex: 1 1 auto;
             min-width: 0;
+            grid-template-columns:
+                15px
+                minmax(variables.$legend-address-column, 1fr)
+                variables.$legend-size-column
+                minmax(0, variables.$legend-tensor-column)
+                minmax(0, variables.$legend-buffer-type-column)
+                minmax(0, variables.$legend-shape-column);
+
+            // Placed by class, not by source order: a row carrying no buffer
+            // type leaves track 5 empty rather than pulling its shape info into
+            // the column where other rows show `L1 HEIGHT_SHARDED`.
+            > .extra-info-slot {
+                grid-column: 5;
+            }
+
+            > .shape-info-slot {
+                grid-column: 6;
+            }
+
+            // The size cell is right-aligned, so an in-flow marker shortens the
+            // text run only on aliased rows. Hold its slot open on every row and
+            // position the marker into it.
+            > .format-numbers:nth-child(3) {
+                position: relative;
+                padding-right: variables.$legend-marker-slot;
+            }
+
+            .globally-allocated-marker {
+                position: absolute;
+                top: 50%;
+                right: 0;
+                margin-left: 0;
+                transform: translateY(-50%);
+            }
         }
 
         .memory-info,

--- a/src/scss/components/DeviceOperationFullRender.scss
+++ b/src/scss/components/DeviceOperationFullRender.scss
@@ -167,14 +167,11 @@
         align-items: flex-start;
         gap: 10px;
 
-        // Anchor the data columns to the row's shared right edge instead of its
-        // left. Rows sit at different collapsible depths (up to 80px apart) and
-        // carry addresses of differing digit counts (25px), and with left-anchored
-        // share-based tracks both of those shifted every column downstream. The
-        // address is now the only flexible track, so it swallows that variation,
-        // and everything right of it is definite and lands identically on every
-        // row. `minmax(0, …)` lets those tracks give way under space pressure
-        // rather than overflowing the row.
+        // Each row is its own grid, so columns only line up across rows if a
+        // single track absorbs the width each row doesn't share — here the
+        // address, leaving the rest definite. Rows differ by collapsible depth
+        // (up to 80px) and address digit count (25px). Below ~1400px the address
+        // hits its floor and those offsets reappear.
         .legend-item {
             flex: 1 1 auto;
             min-width: 0;
@@ -186,9 +183,8 @@
                 minmax(0, variables.$legend-buffer-type-column)
                 minmax(0, variables.$legend-shape-column);
 
-            // Placed by class, not by source order: a row carrying no buffer
-            // type leaves track 5 empty rather than pulling its shape info into
-            // the column where other rows show `L1 HEIGHT_SHARDED`.
+            // Placed by class so a row with no buffer type leaves track 5 empty
+            // instead of pulling its shape info a column left.
             > .extra-info-slot {
                 grid-column: 5;
             }
@@ -197,9 +193,8 @@
                 grid-column: 6;
             }
 
-            // The size cell is right-aligned, so an in-flow marker shortens the
-            // text run only on aliased rows. Hold its slot open on every row and
-            // position the marker into it.
+            // The cell is right-aligned, so an in-flow marker would shorten the
+            // text run on aliased rows only.
             > .format-numbers:nth-child(3) {
                 position: relative;
                 padding-right: variables.$legend-marker-slot;

--- a/src/scss/components/MemoryLegendElement.scss
+++ b/src/scss/components/MemoryLegendElement.scss
@@ -103,11 +103,12 @@
         box-sizing: border-box;
     }
 
-    // Inline "aliased" marker. Renders icon-only in the per-DeviceOp row to
-    // preserve the existing grid template (`15px 0.5fr 2fr 13fr 3fr`) - the
-    // full "Globally allocated" text label only fits in the wider modal
-    // legend. Tooltip + aria-label still carry the semantic payload here so
-    // mouse and AT users get the same information.
+    // Inline "aliased" marker, icon-only outside the modal legend because only
+    // the wider modal fits the full "Globally allocated" text. Tooltip +
+    // aria-label carry the semantic payload wherever the text is dropped.
+    // The per-DeviceOp row overrides the flow and margin below in
+    // `DeviceOperationFullRender.scss`, where the marker sits in a reserved
+    // slot instead. #1844
     .globally-allocated-marker {
         display: inline-flex;
         align-items: center;

--- a/src/scss/definitions/_variables.scss
+++ b/src/scss/definitions/_variables.scss
@@ -43,27 +43,19 @@ $z-index-4-popover: 15;
 // Component-specific variables
 $active-transfer-width: 380px;
 
-// Width of the "size x cores x devices" column in a device-operation memory
-// legend. Fixed rather than proportional: that cell is `nowrap`, so its text
-// sets the grid track's automatic minimum, and since each row is its own
-// `inline-grid` a share-based track resolves differently per row as soon as the
-// strings differ in length. Fits every realistic string bar one — a 3-digit
-// core count alongside the aliased-CB icon spills 11px, which the 15px column
-// gap absorbs before it can reach the next column.
+// Device-operation memory legend columns. Definite widths, because the cells are
+// `nowrap` and each row is its own grid — a share-based track takes its minimum
+// from the row's own text and so resolves differently per row. Sized to the
+// widest observed content plus headroom; the size column overflows by 11px on a
+// 3-digit core count beside the aliased-CB icon, absorbed by the column gap.
 $legend-size-column: 300px;
-
-// Slot held open at the right of that column for the aliased-CB marker, which
-// is positioned into it rather than left in the text flow — in flow it only
-// consumes width on aliased rows, landing identical strings 25px apart.
-$legend-marker-slot: 25px;
-
-// Remaining device-operation legend columns. All definite so that the address
-// track stays the only flexible one and absorbs every source of row-to-row
-// variation; widths are the widest observed content plus headroom.
 $legend-address-column: 90px;
 $legend-tensor-column: 180px;
 $legend-buffer-type-column: 130px;
 $legend-shape-column: 170px;
+
+// Reserved at the right of the size column for the aliased-CB marker.
+$legend-marker-slot: 25px;
 
 // Every report-selection control on the Home page sizes to this, so the local, remote and
 // MLIR pickers line up regardless of how long the label they display happens to be.

--- a/src/scss/definitions/_variables.scss
+++ b/src/scss/definitions/_variables.scss
@@ -43,6 +43,28 @@ $z-index-4-popover: 15;
 // Component-specific variables
 $active-transfer-width: 380px;
 
+// Width of the "size x cores x devices" column in a device-operation memory
+// legend. Fixed rather than proportional: that cell is `nowrap`, so its text
+// sets the grid track's automatic minimum, and since each row is its own
+// `inline-grid` a share-based track resolves differently per row as soon as the
+// strings differ in length. Fits every realistic string bar one — a 3-digit
+// core count alongside the aliased-CB icon spills 11px, which the 15px column
+// gap absorbs before it can reach the next column.
+$legend-size-column: 300px;
+
+// Slot held open at the right of that column for the aliased-CB marker, which
+// is positioned into it rather than left in the text flow — in flow it only
+// consumes width on aliased rows, landing identical strings 25px apart.
+$legend-marker-slot: 25px;
+
+// Remaining device-operation legend columns. All definite so that the address
+// track stays the only flexible one and absorbs every source of row-to-row
+// variation; widths are the widest observed content plus headroom.
+$legend-address-column: 90px;
+$legend-tensor-column: 180px;
+$legend-buffer-type-column: 130px;
+$legend-shape-column: 170px;
+
 // Every report-selection control on the Home page sizes to this, so the local, remote and
 // MLIR pickers line up regardless of how long the label they display happens to be.
 $report-select-width: 250px;

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -268,6 +268,7 @@ describe('CircularBufferPressureModal - selection flows', () => {
                     coreRangeSet: '{[(x=1,y=1) - (x=1,y=1)]}',
                     cores: [{ x: 1, y: 1 }],
                     globallyAllocated: false,
+                    deviceCount: 1,
                 },
             ],
         };
@@ -306,6 +307,7 @@ describe('CircularBufferPressureModal - legend totals', () => {
                     coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
                     cores: [{ x: 0, y: 0 }],
                     globallyAllocated: false,
+                    deviceCount: 1,
                 },
                 {
                     nodeId: 12,
@@ -315,6 +317,7 @@ describe('CircularBufferPressureModal - legend totals', () => {
                     coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
                     cores: [{ x: 0, y: 0 }],
                     globallyAllocated: false,
+                    deviceCount: 1,
                 },
             ],
         };
@@ -331,6 +334,16 @@ describe('CircularBufferPressureModal - legend totals', () => {
 
         expect(screen.getByText('Peak per core')).toBeInTheDocument();
         expect(screen.getByText('Total CBs')).toBeInTheDocument();
+    });
+
+    it('says how many devices a collapsed row stands for, and stays silent for one (#1844)', () => {
+        const snapshot = buildSnapshot();
+        snapshot.allocations[0].deviceCount = 8;
+        renderModal(snapshot);
+
+        const [meshRow, singleRow] = document.querySelectorAll('button.cb-row .cores');
+        expect(meshRow).toHaveTextContent('× 8 devices');
+        expect(singleRow).not.toHaveTextContent('devices');
     });
 
     it('shows the empty-state message when there are no CBs in the snapshot', () => {
@@ -369,6 +382,7 @@ describe('CircularBufferPressureModal - legend totals', () => {
                     coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
                     cores: [{ x: 0, y: 0 }],
                     globallyAllocated: true,
+                    deviceCount: 1,
                 },
                 {
                     nodeId: 2,
@@ -378,6 +392,7 @@ describe('CircularBufferPressureModal - legend totals', () => {
                     coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
                     cores: [{ x: 0, y: 0 }],
                     globallyAllocated: false,
+                    deviceCount: 1,
                 },
             ],
         };
@@ -603,6 +618,7 @@ describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)
                     coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
                     cores: [{ x: 0, y: 0 }],
                     globallyAllocated: true,
+                    deviceCount: 1,
                 },
                 {
                     nodeId: 2,
@@ -612,6 +628,7 @@ describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)
                     coreRangeSet: '{[(x=0,y=0) - (x=0,y=0)]}',
                     cores: [{ x: 0, y: 0 }],
                     globallyAllocated: false,
+                    deviceCount: 1,
                 },
                 {
                     nodeId: 3,
@@ -621,6 +638,7 @@ describe('CircularBufferPressureModal - show/hide globally allocated CBs (#1655)
                     coreRangeSet: '{[(x=1,y=0) - (x=1,y=0)]}',
                     cores: [{ x: 1, y: 0 }],
                     globallyAllocated: false,
+                    deviceCount: 1,
                 },
             ],
         };
@@ -688,6 +706,7 @@ function buildAliasedSnapshot(): CBPressureSnapshot {
                 allocateOperationId: 100,
                 allocateOperationName: 'halo',
                 globallyAllocated: true,
+                deviceCount: 1,
             },
             {
                 nodeId: 2,
@@ -699,6 +718,7 @@ function buildAliasedSnapshot(): CBPressureSnapshot {
                 allocateOperationId: 100,
                 allocateOperationName: 'halo',
                 globallyAllocated: false,
+                deviceCount: 1,
             },
         ],
     };
@@ -725,6 +745,7 @@ function buildSnapshot(overrides: Partial<CBPressureSnapshot> = {}): CBPressureS
                 allocateOperationId: 100,
                 allocateOperationName: 'demo_op',
                 globallyAllocated: false,
+                deviceCount: 1,
             },
             {
                 nodeId: 2,
@@ -736,6 +757,7 @@ function buildSnapshot(overrides: Partial<CBPressureSnapshot> = {}): CBPressureS
                 allocateOperationId: 100,
                 allocateOperationName: 'demo_op',
                 globallyAllocated: false,
+                deviceCount: 1,
             },
         ],
         ...overrides,

--- a/tests/CircularBufferPressureModal.spec.tsx
+++ b/tests/CircularBufferPressureModal.spec.tsx
@@ -342,7 +342,8 @@ describe('CircularBufferPressureModal - legend totals', () => {
         renderModal(snapshot);
 
         const [meshRow, singleRow] = document.querySelectorAll('button.cb-row .cores');
-        expect(meshRow).toHaveTextContent('× 8 devices');
+        // Same multiplier form as the legend rows this modal drills into.
+        expect(meshRow).toHaveTextContent('x 8 devices');
         expect(singleRow).not.toHaveTextContent('devices');
     });
 

--- a/tests/DeviceOperationsFullRender.spec.tsx
+++ b/tests/DeviceOperationsFullRender.spec.tsx
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DeviceOperationsFullRender from '../src/components/operation-details/DeviceOperationsFullRender';
+import { Node, NodeType } from '../src/model/APIData';
+import { OperationDetails } from '../src/model/OperationDetails';
+import { TestProviders } from './helpers/TestProviders';
+
+// `CircularBufferPressureModal` is always mounted (closed) inside the render, and
+// `useDevices` is the only API hook the subtree touches.
+const mockUseDevices = vi.fn();
+vi.mock('../src/hooks/useAPI.tsx', () => ({
+    useDevices: () => mockUseDevices(),
+}));
+
+// Device ids in the order a real mesh capture emits them — unsorted, so a test
+// that only ever sees 0..N-1 can't accidentally depend on ascending order.
+// Mirrors the `[6, 4, 5, 7, 3, 2, 0, 1]` sequence recorded in #1844.
+const MESH_DEVICE_IDS = [6, 4, 5, 7, 3, 2, 0, 1];
+const CORE_RANGE = '{[(x=0,y=0) - (x=1,y=0)]}';
+
+let nextId = 0;
+
+function mkNode<T extends Partial<Node>>(node: T): Node {
+    nextId += 1;
+    return {
+        id: nextId,
+        connections: [],
+        inputs: [],
+        outputs: [],
+        stacking_level: 0,
+        ...node,
+    } as Node;
+}
+
+function captureStart(): Node {
+    return mkNode({ node_type: NodeType.capture_start, params: { name: 'capture' } } as unknown as Partial<Node>);
+}
+
+function functionStart(name: string): Node {
+    return mkNode({ node_type: NodeType.function_start, params: { name } } as unknown as Partial<Node>);
+}
+
+function functionEnd(name: string): Node {
+    return mkNode({ node_type: NodeType.function_end, params: { name } } as unknown as Partial<Node>);
+}
+
+function cbAllocate(size: number, address: number, deviceId?: number): Node {
+    return mkNode({
+        node_type: NodeType.circular_buffer_allocate,
+        params: {
+            core_range_set: CORE_RANGE,
+            size: String(size),
+            address: String(address),
+            num_cores: '2',
+            globally_allocated: '0',
+            ...(deviceId !== undefined && { device_id: deviceId }),
+        },
+    } as unknown as Partial<Node>);
+}
+
+function cbDeallocateAll(): Node {
+    return mkNode({ node_type: NodeType.circular_buffer_deallocate_all, params: {} } as unknown as Partial<Node>);
+}
+
+/**
+ * One DeviceOp allocating each of `sizes` on every device in `deviceIds`,
+ * interleaved per CB the way a mesh capture emits them.
+ */
+function meshGraph(sizes: { size: number; address: number }[], deviceIds: (number | undefined)[]): Node[] {
+    const cbs = sizes.flatMap(({ size, address }) => deviceIds.map((id) => cbAllocate(size, address, id)));
+    return [captureStart(), functionStart('MeshOp'), ...cbs, cbDeallocateAll(), functionEnd('MeshOp')];
+}
+
+const details = {
+    l1_sizes: [1_000_000],
+    getTensorForAddress: () => undefined,
+    getTensorProducerConsumer: () => [],
+} as unknown as OperationDetails;
+
+function renderGraph(graph: Node[]) {
+    const { container } = render(
+        <TestProviders>
+            <DeviceOperationsFullRender
+                deviceOperations={graph}
+                details={details}
+                onLegendClick={vi.fn()}
+            />
+        </TestProviders>,
+    );
+    return container;
+}
+
+const legendRows = (container: HTMLElement) => container.querySelectorAll('.memory-legend-row');
+const peakLoad = (container: HTMLElement) => container.querySelector('.peak-load .format-numbers')?.textContent;
+
+beforeEach(() => {
+    nextId = 0;
+    mockUseDevices.mockReturnValue({ data: [{ num_x_cores: 2, num_y_cores: 2, worker_l1_size: 1_000_000 }] });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('DeviceOperationsFullRender - per-device CB fan-out (#1844)', () => {
+    const TWO_CBS = [
+        { size: 4096, address: 0x1000 },
+        //
+        { size: 2048, address: 0x2000 },
+    ];
+
+    it('renders one row per logical CB rather than one per device', () => {
+        const container = renderGraph(meshGraph(TWO_CBS, MESH_DEVICE_IDS));
+
+        // 2 CBs x 8 devices = 16 allocate nodes in the graph.
+        expect(legendRows(container)).toHaveLength(2);
+    });
+
+    it('labels each collapsed row with the number of devices behind it', () => {
+        const container = renderGraph(meshGraph(TWO_CBS, MESH_DEVICE_IDS));
+
+        const labels = [...legendRows(container)].map((row) => row.textContent);
+        expect(labels.every((text) => text?.includes('x 8 devices'))).toBe(true);
+    });
+
+    it('emits the CBs heading once even though later devices are skipped', () => {
+        const container = renderGraph(meshGraph(TWO_CBS, MESH_DEVICE_IDS));
+
+        // The suppression path returns early, which must leave the
+        // `consecutiveCBsOutput` latch set — otherwise every skipped device
+        // re-opens a fresh "CBs" section.
+        expect(container.querySelectorAll('.cbs-heading')).toHaveLength(1);
+    });
+
+    it('reports the same peak L1 load as the equivalent single-device graph', () => {
+        const mesh = renderGraph(meshGraph(TWO_CBS, MESH_DEVICE_IDS));
+        const meshPeak = peakLoad(mesh);
+        cleanup();
+
+        nextId = 0;
+        const single = renderGraph(meshGraph(TWO_CBS, [0]));
+
+        expect(meshPeak).toBe(peakLoad(single));
+        // Guards against both readings being an empty/absent heading.
+        expect(meshPeak).toMatch(/\d/);
+    });
+
+    it('keeps a repeat allocation on the same device as its own row', () => {
+        // Same CB twice on one device is a genuine second allocation, not mesh
+        // fan-out, so collapsing it would hide real memory pressure.
+        const container = renderGraph(meshGraph([{ size: 4096, address: 0x1000 }], [0, 0]));
+
+        expect(legendRows(container)).toHaveLength(2);
+        expect([...legendRows(container)].some((row) => row.textContent?.includes('devices'))).toBe(false);
+    });
+
+    it('renders one row per CB and no device label when the graph carries no device_id', () => {
+        const container = renderGraph(meshGraph(TWO_CBS, [undefined]));
+
+        expect(legendRows(container)).toHaveLength(2);
+        expect([...legendRows(container)].some((row) => row.textContent?.includes('devices'))).toBe(false);
+    });
+});

--- a/tests/DeviceOperationsFullRender.spec.tsx
+++ b/tests/DeviceOperationsFullRender.spec.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DeviceOperationsFullRender from '../src/components/operation-details/DeviceOperationsFullRender';
@@ -156,5 +156,43 @@ describe('DeviceOperationsFullRender - per-device CB fan-out (#1844)', () => {
 
         expect(legendRows(container)).toHaveLength(2);
         expect([...legendRows(container)].some((row) => row.textContent?.includes('devices'))).toBe(false);
+    });
+
+    // The snapshot reaches the modal only through this button, so without
+    // opening it nothing would catch the wrong DeviceOp being wired up.
+    // The dialog renders through a portal, so its rows are not under `container`.
+    const openPressureModal = () => {
+        fireEvent.click(screen.getByRole('button', { name: /View per-core allocations/ }));
+        return document.querySelectorAll('.cb-row');
+    };
+
+    it('carries the collapsed device counts through to the pressure modal', () => {
+        renderGraph(meshGraph(TWO_CBS, MESH_DEVICE_IDS));
+
+        const rows = openPressureModal();
+        expect(rows).toHaveLength(2);
+        expect([...rows].every((row) => /x 8 devices/.test(row.textContent ?? ''))).toBe(true);
+    });
+
+    it('counts devices per CB in the modal rather than applying one count to all', () => {
+        // dev0 allocates both CBs, dev1 only the first, so a blanket count would
+        // pass a homogeneous fixture but not this one.
+        const shared = { size: 4096, address: 0x1000 };
+        const dev0Only = { size: 2048, address: 0x2000 };
+        const graph = [
+            captureStart(),
+            functionStart('MeshOp'),
+            cbAllocate(shared.size, shared.address, 0),
+            cbAllocate(dev0Only.size, dev0Only.address, 0),
+            cbAllocate(shared.size, shared.address, 1),
+            cbDeallocateAll(),
+            functionEnd('MeshOp'),
+        ];
+        renderGraph(graph);
+
+        const rows = [...openPressureModal()].map((row) => row.textContent ?? '');
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatch(/x 2 devices/);
+        expect(rows[1]).not.toMatch(/devices/);
     });
 });

--- a/tests/DeviceOperationsFullRender.spec.tsx
+++ b/tests/DeviceOperationsFullRender.spec.tsx
@@ -10,16 +10,14 @@ import { Node, NodeType } from '../src/model/APIData';
 import { OperationDetails } from '../src/model/OperationDetails';
 import { TestProviders } from './helpers/TestProviders';
 
-// `CircularBufferPressureModal` is always mounted (closed) inside the render, and
-// `useDevices` is the only API hook the subtree touches.
+// The always-mounted `CircularBufferPressureModal` is the subtree's only API caller.
 const mockUseDevices = vi.fn();
 vi.mock('../src/hooks/useAPI.tsx', () => ({
     useDevices: () => mockUseDevices(),
 }));
 
-// Device ids in the order a real mesh capture emits them — unsorted, so a test
-// that only ever sees 0..N-1 can't accidentally depend on ascending order.
-// Mirrors the `[6, 4, 5, 7, 3, 2, 0, 1]` sequence recorded in #1844.
+// Unsorted, as a real capture emits them, so nothing here can lean on ascending
+// order. The sequence recorded in #1844.
 const MESH_DEVICE_IDS = [6, 4, 5, 7, 3, 2, 0, 1];
 const CORE_RANGE = '{[(x=0,y=0) - (x=1,y=0)]}';
 
@@ -67,10 +65,6 @@ function cbDeallocateAll(): Node {
     return mkNode({ node_type: NodeType.circular_buffer_deallocate_all, params: {} } as unknown as Partial<Node>);
 }
 
-/**
- * One DeviceOp allocating each of `sizes` on every device in `deviceIds`,
- * interleaved per CB the way a mesh capture emits them.
- */
 function meshGraph(sizes: { size: number; address: number }[], deviceIds: (number | undefined)[]): Node[] {
     const cbs = sizes.flatMap(({ size, address }) => deviceIds.map((id) => cbAllocate(size, address, id)));
     return [captureStart(), functionStart('MeshOp'), ...cbs, cbDeallocateAll(), functionEnd('MeshOp')];
@@ -132,9 +126,8 @@ describe('DeviceOperationsFullRender - per-device CB fan-out (#1844)', () => {
     it('emits the CBs heading once even though later devices are skipped', () => {
         const container = renderGraph(meshGraph(TWO_CBS, MESH_DEVICE_IDS));
 
-        // The suppression path returns early, which must leave the
-        // `consecutiveCBsOutput` latch set — otherwise every skipped device
-        // re-opens a fresh "CBs" section.
+        // Skipping a row must not clear the heading latch, or each skipped
+        // device opens a fresh "CBs" section.
         expect(container.querySelectorAll('.cbs-heading')).toHaveLength(1);
     });
 
@@ -152,8 +145,6 @@ describe('DeviceOperationsFullRender - per-device CB fan-out (#1844)', () => {
     });
 
     it('keeps a repeat allocation on the same device as its own row', () => {
-        // Same CB twice on one device is a genuine second allocation, not mesh
-        // fan-out, so collapsing it would hide real memory pressure.
         const container = renderGraph(meshGraph([{ size: 4096, address: 0x1000 }], [0, 0]));
 
         expect(legendRows(container)).toHaveLength(2);

--- a/tests/MemoryLegendElement.spec.tsx
+++ b/tests/MemoryLegendElement.spec.tsx
@@ -119,6 +119,38 @@ describe('MemoryLegendElement core count label', () => {
     });
 });
 
+describe('MemoryLegendElement device count label (#1844)', () => {
+    const chunk = { address: 0x4000, size: 1024 };
+
+    it('omits the label when deviceCount is unset', () => {
+        renderLegendElement(chunk);
+        expect(screen.queryByText(/devices?/)).not.toBeInTheDocument();
+    });
+
+    it('omits the label for a single device, which is every non-mesh row', () => {
+        renderLegendElement(chunk, { deviceCount: 1 });
+        expect(screen.queryByText(/devices?/)).not.toBeInTheDocument();
+    });
+
+    it('renders "x 8 devices" when a mesh op collapsed eight rows into one', () => {
+        renderLegendElement(chunk, { deviceCount: 8 });
+        expect(screen.getByText(/x 8 devices/)).toBeInTheDocument();
+    });
+
+    it('reads cores then devices when both apply', () => {
+        renderLegendElement(chunk, { numCores: 2, bufferType: StringBufferType.L1, deviceCount: 8 });
+        expect(screen.getByText(/x 2 cores x 8 devices/)).toBeInTheDocument();
+    });
+
+    it('renders the device label on DRAM rows, which drop the core context', () => {
+        // Unreachable from the only call site today, but the prop is public and
+        // unlike `numCores` it is not gated on the buffer being per-core.
+        renderLegendElement(chunk, { numCores: 2, bufferType: StringBufferType.DRAM, deviceCount: 8 });
+        expect(screen.queryByText(/cores?/)).not.toBeInTheDocument();
+        expect(screen.getByText(/x 8 devices/)).toBeInTheDocument();
+    });
+});
+
 describe('MemoryLegendElement globally_allocated marker (#1651)', () => {
     const chunk = { address: 0x4000, size: 1024 };
 

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -776,6 +776,95 @@ describe('processMemoryAllocations - per-device CB fan-out (#1844)', () => {
         expect(cbPressureByOpId.get(opStart.id)!.allocations.map((cb) => cb.nodeId)).toEqual([first.id, repeat.id]);
     });
 
+    it('does not let a later op fold a device onto an already-snapshotted row', () => {
+        // No `deallocate_all`, so both ops leave via the `function_end` safety
+        // net. Unscoped, op2's second device folded onto op1's row and moved a
+        // count op1's snapshot had already recorded, so its legend row and its
+        // modal disagreed.
+        const op1 = functionStart('op1');
+        const op1Cb = cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 });
+        const op2 = functionStart('op2');
+        const op2Dev0 = cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 });
+        const op2Dev1 = cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 1 });
+        const graph = [captureStart(), op1, op1Cb, functionEnd('op1'), op2, op2Dev0, op2Dev1, functionEnd('op2')];
+
+        const { cbPressureByOpId, cbFanout } = processMemoryAllocations(graph);
+
+        expect(cbFanout.deviceCountByNodeId.get(op1Cb.id)).toBe(1);
+        expect(cbFanout.deviceCountByNodeId.get(op2Dev0.id)).toBe(2);
+        expect(cbFanout.duplicateNodeIds).toEqual(new Set([op2Dev1.id]));
+        // The count the legend renders has to match the one the modal shows.
+        const op1Row = cbPressureByOpId.get(op1.id)!.allocations[0];
+        expect(op1Row.deviceCount).toBe(cbFanout.deviceCountByNodeId.get(op1Cb.id));
+    });
+
+    it('collapses only the CB the devices share when one allocates an extra', () => {
+        // Where "max across devices" and "sum" diverge: dev0 carries both CBs,
+        // dev1 only the first.
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [
+            captureStart(),
+            opStart,
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 }),
+            cbAllocate(TWO_CORES, 2048, 0x2000, { deviceId: 0 }),
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 1 }),
+            cbDeallocateAll(),
+            functionEnd('mesh_op'),
+        ];
+
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const { allocations, maxBytes } = cbPressureByOpId.get(opStart.id)!;
+        expect(allocations.map((cb) => cb.deviceCount)).toEqual([2, 1]);
+        // dev0's cores hold both CBs; dev1's hold one. The busiest core wins.
+        expect(maxBytes).toBe(4096 + 2048);
+        expect(peakMemoryLoad).toBe(4096 + 2048);
+    });
+
+    it('takes the larger size when devices disagree at one address', () => {
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [
+            captureStart(),
+            opStart,
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 }),
+            cbAllocate(TWO_CORES, 8192, 0x1000, { deviceId: 1 }),
+            cbDeallocateAll(),
+            functionEnd('mesh_op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const { allocations, maxBytes } = cbPressureByOpId.get(opStart.id)!;
+        // Differing sizes are different allocations, so neither row absorbs the
+        // other and the per-core figure is the larger, never the sum.
+        expect(allocations.map((cb) => cb.deviceCount)).toEqual([1, 1]);
+        expect(maxBytes).toBe(8192);
+    });
+
+    it('collapses a batch allocated after deallocate_all by more devices than the last', () => {
+        // The repeat counter has to reset with the live set: carried over, dev1's
+        // first allocation and dev0's second land in different slots and the
+        // second batch reports two rows of one device instead of one of two.
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [
+            captureStart(),
+            opStart,
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 }),
+            cbDeallocateAll(),
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 }),
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 1 }),
+            cbDeallocateAll(),
+            functionEnd('mesh_op'),
+        ];
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        // Only the last snapshot for an op survives, so this is batch two.
+        const { allocations } = cbPressureByOpId.get(opStart.id)!;
+        expect(allocations).toHaveLength(1);
+        expect(allocations[0].deviceCount).toBe(2);
+    });
+
     it('takes the per-device figure for unattributed CBs rather than their sum', () => {
         // `unattributedBytes` has to stay comparable with the per-core numbers
         // beside it, so it collapses across devices the same way.

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -738,6 +738,44 @@ describe('processMemoryAllocations - per-device CB fan-out (#1844)', () => {
         expect(peakMemoryLoad).toBe(4096 * 2);
     });
 
+    it("groups each device's repeat with the other devices' repeats, not with the row before it", () => {
+        // Every device allocates the CB twice, emitted device-major. The two
+        // rows must each stand for both devices; folding a device onto whichever
+        // repeat happened to be stored last would strand rows at a count of 1.
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [captureStart(), opStart];
+        for (const deviceId of [0, 1]) {
+            graph.push(cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId }));
+            graph.push(cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId }));
+        }
+        graph.push(cbDeallocateAll(), functionEnd('mesh_op'));
+
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const { allocations } = cbPressureByOpId.get(opStart.id)!;
+        expect(allocations).toHaveLength(2);
+        expect(allocations.map((cb) => cb.deviceCount)).toEqual([2, 2]);
+        // Two allocations per device, so the per-core figure is still doubled.
+        expect(peakMemoryLoad).toBe(4096 * 2);
+    });
+
+    it('keeps the first node in graph order as the row the rest collapse onto', () => {
+        const opStart = functionStart('mesh_op');
+        const first = cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 });
+        const repeat = cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 });
+        const otherDevice = cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 1 });
+        const graph = [captureStart(), opStart, first, repeat, otherDevice, cbDeallocateAll(), functionEnd('mesh_op')];
+
+        const { cbPressureByOpId, cbFanout } = processMemoryAllocations(graph);
+
+        // Device 1's allocation is its first, so it belongs to `first` — not to
+        // `repeat`, which is device 0's second.
+        expect(cbFanout.deviceCountByNodeId.get(first.id)).toBe(2);
+        expect(cbFanout.deviceCountByNodeId.get(repeat.id)).toBe(1);
+        expect(cbFanout.duplicateNodeIds).toEqual(new Set([otherDevice.id]));
+        expect(cbPressureByOpId.get(opStart.id)!.allocations.map((cb) => cb.nodeId)).toEqual([first.id, repeat.id]);
+    });
+
     it('takes the per-device figure for unattributed CBs rather than their sum', () => {
         // `unattributedBytes` has to stay comparable with the per-core numbers
         // beside it, so it collapses across devices the same way.

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -51,7 +51,7 @@ function cbAllocate(
     coreRangeSet: string,
     size: number,
     address?: number,
-    options: { globallyAllocated?: boolean } = {},
+    options: { globallyAllocated?: boolean; deviceId?: number } = {},
 ): Node {
     // Default to the next slot in our monotonic CB address counter so every node
     // round-trips through `processMemoryAllocations()` with a real numeric address.
@@ -66,6 +66,9 @@ function cbAllocate(
             address: String(resolvedAddress),
             // Matches the on-wire string form emitted by tt-metal.
             globally_allocated: options.globallyAllocated ? '1' : '0',
+            // Omitted unless asked for: single-device reports carry no device
+            // dimension and must accumulate exactly as they did before #1844.
+            ...(options.deviceId !== undefined && { device_id: options.deviceId }),
         },
     } as unknown as Partial<Node>);
 }
@@ -622,5 +625,167 @@ describe('processMemoryAllocations - globally_allocated CBs (#1651)', () => {
         const snap = cbPressureByOpId.get(opStart.id)!;
         expect(snap.maxBytes).toBe(size);
         expect(snap.allocations[0].globallyAllocated).toBe(false);
+    });
+});
+
+describe('processMemoryAllocations - per-device CB fan-out (#1844)', () => {
+    // The device ids a mesh op emits, in the unsorted order the graph carries
+    // them (from `multihost_poc_jun24_2321`, op 2 rank 0).
+    const MESH_DEVICE_IDS = [6, 4, 5, 7, 3, 2, 0, 1];
+    const TWO_CORES = '{[(x=0,y=0) - (x=1,y=0)]}';
+
+    // One DeviceOp allocating each of `sizes` on every device in `deviceIds`,
+    // grouped CB-by-CB the way a mesh op emits them.
+    function meshGraph(sizes: number[], deviceIds: (number | undefined)[]): { graph: Node[]; opStart: Node } {
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [captureStart(), opStart];
+        sizes.forEach((size, cbIndex) => {
+            for (const deviceId of deviceIds) {
+                graph.push(cbAllocate(TWO_CORES, size, 0x1000 + cbIndex * 0x1000, { deviceId }));
+            }
+        });
+        graph.push(cbDeallocateAll(), functionEnd('mesh_op'));
+        return { graph, opStart };
+    }
+
+    beforeEach(() => {
+        nextId = 0;
+        nextCbAddress = 0x1000;
+    });
+
+    it('reports the same per-core peak for an 8-device report as for one device', () => {
+        // The headline regression: bytes used to accumulate per core position
+        // regardless of device, so this returned 8x the true figure.
+        const sizes = [4096, 2048];
+        const perCoreTruth = sizes.reduce((total, size) => total + size, 0);
+
+        const mesh = processMemoryAllocations(meshGraph(sizes, MESH_DEVICE_IDS).graph);
+        nextId = 0;
+        nextCbAddress = 0x1000;
+        const single = processMemoryAllocations(meshGraph(sizes, [0]).graph);
+
+        expect(mesh.peakMemoryLoad).toBe(perCoreTruth);
+        expect(mesh.peakMemoryLoad).toBe(single.peakMemoryLoad);
+    });
+
+    it('collapses the fan-out to one allocation per CB carrying the device count', () => {
+        const { graph, opStart } = meshGraph([4096, 2048], MESH_DEVICE_IDS);
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.allocations).toHaveLength(2);
+        expect(snap.allocations.map((cb) => cb.deviceCount)).toEqual([MESH_DEVICE_IDS.length, MESH_DEVICE_IDS.length]);
+        expect(snap.allocations.map((cb) => cb.size)).toEqual([4096, 2048]);
+    });
+
+    it('keeps byCore keyed by core position so the pressure grid still reads it', () => {
+        // The device dimension exists only inside the accumulator; leaking it
+        // into `byCore` would break the modal's `"x,y"` lookup.
+        const { graph, opStart } = meshGraph([4096], MESH_DEVICE_IDS);
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.byCore).toEqual({ '0,0': 4096, '1,0': 4096 });
+        expect(snap.maxBytes).toBe(4096);
+    });
+
+    it('marks every device beyond the first as a duplicate row to skip', () => {
+        const sizes = [4096, 2048];
+        const { graph } = meshGraph(sizes, MESH_DEVICE_IDS);
+
+        const { cbFanout } = processMemoryAllocations(graph);
+
+        expect(cbFanout.duplicateNodeIds.size).toBe(sizes.length * (MESH_DEVICE_IDS.length - 1));
+        const rendered = [...cbFanout.deviceCountByNodeId.entries()].filter(
+            ([nodeId]) => !cbFanout.duplicateNodeIds.has(nodeId),
+        );
+        expect(rendered).toHaveLength(sizes.length);
+        expect(rendered.every(([, deviceCount]) => deviceCount === MESH_DEVICE_IDS.length)).toBe(true);
+    });
+
+    it('collapses the fan-out when devices are interleaved rather than grouped', () => {
+        // Emission order is not guaranteed: the same CB set can arrive
+        // device-major instead of CB-major.
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [captureStart(), opStart];
+        for (const deviceId of [0, 1]) {
+            graph.push(cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId }));
+            graph.push(cbAllocate(TWO_CORES, 2048, 0x2000, { deviceId }));
+        }
+        graph.push(cbDeallocateAll(), functionEnd('mesh_op'));
+
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
+
+        expect(peakMemoryLoad).toBe(4096 + 2048);
+        expect(cbPressureByOpId.get(opStart.id)!.allocations).toHaveLength(2);
+    });
+
+    it('keeps a repeat allocation on the same device as its own row', () => {
+        // Two identical CBs on one device is a genuine second allocation, so
+        // collapsing on identity alone would hide real memory.
+        const opStart = functionStart('op');
+        const graph = [
+            captureStart(),
+            opStart,
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 }),
+            cbAllocate(TWO_CORES, 4096, 0x1000, { deviceId: 0 }),
+            cbDeallocateAll(),
+            functionEnd('op'),
+        ];
+
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
+
+        expect(cbPressureByOpId.get(opStart.id)!.allocations).toHaveLength(2);
+        expect(peakMemoryLoad).toBe(4096 * 2);
+    });
+
+    it('takes the per-device figure for unattributed CBs rather than their sum', () => {
+        // `unattributedBytes` has to stay comparable with the per-core numbers
+        // beside it, so it collapses across devices the same way.
+        const size = 512;
+        const opStart = functionStart('mesh_op');
+        const graph: Node[] = [captureStart(), opStart];
+        for (const deviceId of MESH_DEVICE_IDS) {
+            graph.push(cbAllocate('', size, 0x1000, { deviceId }));
+        }
+        graph.push(cbDeallocateAll(), functionEnd('mesh_op'));
+
+        const { cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.unattributedBytes).toBe(size);
+        expect(snap.byCore).toEqual({ '?': size });
+        expect(snap.maxBytes).toBe(0);
+    });
+
+    it('collapses aliased CBs across devices while keeping them out of byCore', () => {
+        const opStart = functionStart('halo');
+        const graph: Node[] = [captureStart(), opStart];
+        for (const deviceId of MESH_DEVICE_IDS) {
+            graph.push(cbAllocate(TWO_CORES, 100_000, 0x1000, { deviceId, globallyAllocated: true }));
+            graph.push(cbAllocate(TWO_CORES, 32, 0x9000, { deviceId }));
+        }
+        graph.push(cbDeallocateAll(), functionEnd('halo'));
+
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(snap.allocations).toHaveLength(2);
+        expect(snap.allocations.every((cb) => cb.deviceCount === MESH_DEVICE_IDS.length)).toBe(true);
+        expect(snap.byCore).toEqual({ '0,0': 32, '1,0': 32 });
+        expect(peakMemoryLoad).toBe(32);
+    });
+
+    it('leaves a report with no device_id accumulating as a single device', () => {
+        const { graph, opStart } = meshGraph([4096, 2048], [undefined]);
+
+        const { peakMemoryLoad, cbPressureByOpId } = processMemoryAllocations(graph);
+
+        const snap = cbPressureByOpId.get(opStart.id)!;
+        expect(peakMemoryLoad).toBe(4096 + 2048);
+        expect(snap.allocations.map((cb) => cb.deviceCount)).toEqual([1, 1]);
+        expect(snap.byCore).toEqual({ '0,0': 6144, '1,0': 6144 });
     });
 });

--- a/tests/processMemoryAllocations.spec.ts
+++ b/tests/processMemoryAllocations.spec.ts
@@ -66,8 +66,7 @@ function cbAllocate(
             address: String(resolvedAddress),
             // Matches the on-wire string form emitted by tt-metal.
             globally_allocated: options.globallyAllocated ? '1' : '0',
-            // Omitted unless asked for: single-device reports carry no device
-            // dimension and must accumulate exactly as they did before #1844.
+            // Omitted unless asked for, so the no-device-dimension path stays covered.
             ...(options.deviceId !== undefined && { device_id: options.deviceId }),
         },
     } as unknown as Partial<Node>);
@@ -634,8 +633,7 @@ describe('processMemoryAllocations - per-device CB fan-out (#1844)', () => {
     const MESH_DEVICE_IDS = [6, 4, 5, 7, 3, 2, 0, 1];
     const TWO_CORES = '{[(x=0,y=0) - (x=1,y=0)]}';
 
-    // One DeviceOp allocating each of `sizes` on every device in `deviceIds`,
-    // grouped CB-by-CB the way a mesh op emits them.
+    // Grouped CB-by-CB, the way a mesh op emits them.
     function meshGraph(sizes: number[], deviceIds: (number | undefined)[]): { graph: Node[]; opStart: Node } {
         const opStart = functionStart('mesh_op');
         const graph: Node[] = [captureStart(), opStart];
@@ -654,8 +652,7 @@ describe('processMemoryAllocations - per-device CB fan-out (#1844)', () => {
     });
 
     it('reports the same per-core peak for an 8-device report as for one device', () => {
-        // The headline regression: bytes used to accumulate per core position
-        // regardless of device, so this returned 8x the true figure.
+        // The headline regression: this returned 8x the true figure.
         const sizes = [4096, 2048];
         const perCoreTruth = sizes.reduce((total, size) => total + size, 0);
 


### PR DESCRIPTION
Closes #1844

## Summary

On a multi-device report the DeviceOp **CBs** list repeated every circular buffer once per device with no device shown, and every figure derived from per-core CB pressure was multiplied by the device count — a 4 KiB CB on an 8-device mesh reported 32 KiB.

The emitted graph was correct. A mesh op allocates each CB on every device and mesh addressing is uniform, so address, size and core range legitimately match across devices. The visualizer dropped the device dimension: `processMemoryAllocations` keyed its per-core accumulator by position alone, so all eight devices' allocations landed in the same `"0,0"` bucket and summed.

Per-core accumulation is now keyed by `(device_id, x, y)` and collapsed with a **max** across devices, so a per-core figure stays per-core. Identical CBs across devices fold into one row carrying a device count (`4 KiB x 120 cores x 8 devices`); the duplicate graph nodes are suppressed at render time rather than filtered out of the graph, because `mergeDevices` and `preprocessConnections` reference nodes by id. A repeat allocation of the same CB *on the same device* is a genuine second allocation and keeps its own row. Reports with no `device_id` accumulate into a single bucket exactly as before.

The pressure modal and the legend rows it drills into previously printed the same figure two ways (`× 120 cores` vs `x 120 cores`); both now use the legend's form. MLIR shape labels keep `×`, where it separates dimensions rather than multiplying a count.

## Legend column alignment

The longer size string made a pre-existing layout problem obvious: legend rows are independent grids sitting at different collapsible depths, and with left-anchored share-based tracks both the nesting indent (up to 80px between a `Buffer allocate` row and a CB row) and the address digit count (25px between a 7- and a 10-digit address) shifted every column downstream.

Since every row already ends at the same right edge, the address is now the only flexible track — it swallows both sources of variation — and every track to its right has a definite width. The two optional slots are placed by class rather than source order, so a row with no buffer type leaves that column empty instead of pulling its shape info left, which collapses the old 5-track / 6-track split into one template. Measured across all 34 legend rows of a multihost report, every column resolves to a single position. Alignment holds to roughly 1400px viewport width; below that the address track reaches its floor and the indent shows through again as it did before, without overflowing or clipping.

## Test plan

- [x] 9 cases in `tests/processMemoryAllocations.spec.ts` covering per-core peak parity against the single-device equivalent, collapse to one allocation per CB, `byCore` staying keyed by core position, interleaved device emission, same-device repeats, unattributed CBs, aliased CBs, and the no-`device_id` path.
- [x] 6 cases in `tests/DeviceOperationsFullRender.spec.tsx` closing the same loop at the render layer: row count, device label, a single `CBs` heading, and peak parity.
- [x] 1 case in `tests/CircularBufferPressureModal.spec.tsx` for the device count on collapsed modal rows.
- [x] Mutation-checked, since a collapse test can pass vacuously: disabling the row suppression reports 16 rows instead of 2; clearing the heading latch on skip yields three headings instead of one; reverting the per-device keying prints 48 KiB where the single-device graph prints 6 KiB.
- [x] Full suite green (1667 tests), `tsc`, `eslint`, `stylelint` clean.
- [x] Verified by hand against a multihost resnet50 report at `/operations/5`.

## Notes

The canonical surviving row is the first CB node seen in graph order, not the lowest `device_id` — device ids are not emitted sorted. Identities are slotted by how many times the device has already allocated that CB, so a genuine second allocation on one device keeps its own row and groups with the other devices' seconds rather than displacing the first (c189a9aa, reported by Copilot).

`cbFanout` is deliberately not cleared at `circular_buffer_deallocate_all`. It is read after the graph walk completes, so clearing it per-operation would leave only the last DeviceOp's records and every earlier one would render its full per-device fan-out again. Retention is bounded by graph size and dies with the memoised result.

Two related issues stay open and are deliberately out of scope. #1842 is the rank union across processes, of which this is the sibling bug *within* a rank; and the graph params carry `device_id` 0–7 while `buffers.device_id` is always 0, so the graph describes eight devices where the buffers table covers one.

<img width="1532" height="918" alt="image" src="https://github.com/user-attachments/assets/905f5698-d1e4-40bc-8e5c-3e0eb2a59ac6" />
<img width="1532" height="191" alt="image" src="https://github.com/user-attachments/assets/584e2f17-ce46-463c-b520-43d01e7131a7" />

## Review round 2 (@dcblundell)

Four must-fixes and nine should-fixes, all addressed in 3c71aaf5.

**Correctness.** The CB identity is now scoped to the enclosing op. `resetLiveCBs()` only ran at `circular_buffer_deallocate_all`, so on the `function_end` safety-net path a later op's second device folded onto an already-snapshotted row, making its legend read "x 2 devices" while its own modal snapshot still said 1. Probed the capture to confirm the scoping is safe: 0 of 128 CB identities in `multihost_poc_jun24_2321` span more than one enclosing `function_start`.

**Performance.** The branch had regressed the graph walk by re-keying the per-core map by device: `maxCbPerCore()` rescanned it once per node, and `getCoresInRangeList` re-expanded the same `core_range_set` per device. Both fixed (running max; module-level cache with a `CoreCoordList` readonly type so the shared arrays are safe by construction). In the renderer, the duplicate skip now precedes the allocation lookup and `renderMemoryInfo`, the lookup is a Map rather than a per-node linear scan, and `processMemoryAllocations` is memoised so it no longer reruns on every legend click.

200 ops x 8 CBs x 64 cores, `dev` and the reviewed commit rewired to an uncached expander so the cache cannot flatter them:

| devices | nodes | `dev` | @c189a9aa | now |
|---|---|---|---|---|
| 1 | 2,202 | 11 ms | 11 ms | 6 ms |
| 8 | 13,402 | 75 ms | 89 ms | 47 ms |
| 32 | 51,802 | 303 ms | 474 ms | **198 ms** |

**Tidy-up.** `getCoreCountLabel` / `getDeviceCountLabel` in `formatting.ts` replace the copy duplicated across both CB surfaces, which had already drifted again (the modal rendered `x 1 cores`). `BaseMemoryParams.device_id` is now `?: number | string`, which is what the corpus actually holds: one report omits it on all 20 CB nodes, another emits it as a string.

**Tests.** The leak above; the repeat counter resetting with the live set; devices disagreeing on size at one address; one device allocating an extra CB; and the snapshot reaching the modal through its button, including a mixed graph that a blanket device count would pass. Each new invariant was mutation-verified to fail against the previous code.

### Scope decisions

- **Buffer half of the peak** — probed all 24 local reports: 5510 L1 `buffer_allocate` nodes, max distinct `device_id` per `(address, size)` is **1**, and the multihost capture has **zero** L1 buffer nodes. `totalBuffer` is not inflated. Caveat recorded on #1844, since absence in the only mesh capture is not proof.
- **L1 plot legend** — a third CB list (`cbList` via `L1Plots`) still repeats per device. Row repetition only; the numbers are envelope-based and safe. Split to #1879 rather than bundled, as it merges with fragmentation entries and needs its own grouping design.
