### PR TITLE
fix: scope MLIRViewReactFlow.scss under .mlir-page to prevent style leaks (#1899)

### DIFF
--- a/src/scss/components/MLIRViewReactFlow.scss
+++ b/src/scss/components/MLIRViewReactFlow.scss
@@ -5,7 +5,7 @@
 @use '../definitions/colours' as *;
 
 /* stylelint-disable selector-class-pattern */
-.react-flow {
+.mlir-page .react-flow {
     --xy-edge-label-color: #{$tt-grey-7};
     --xy-edge-label-background-color: transparent;
     --xy-controls-button-background-color-hover-props: #{$tt-grey-6};
@@ -62,12 +62,12 @@
     box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
-.react-flow__edge-text {
+.mlir-page .react-flow__edge-text {
     font-size: 10px;
     font-family: monospace;
 }
 
-.react-flow__node-default {
+.mlir-page .react-flow__node-default {
     color: #222;
 
     /* DefaultNode renders label as a raw text node; clip when width is capped by layout. */
@@ -75,7 +75,7 @@
     white-space: nowrap;
 }
 
-.react-flow__node-mlirOp {
+.mlir-page .react-flow__node-mlirOp {
     /* Visual chrome formerly inline-set by `makeOpNode` in mlirGraphBuilder.ts. */
     position: relative;
     display: flex;
@@ -95,8 +95,8 @@
     }
 }
 
-.react-flow__node-group.selected,
-.react-flow__node-mlirGroup.selected {
+.mlir-page .react-flow__node-group.selected,
+.mlir-page .react-flow__node-mlirGroup.selected {
     box-shadow: 0 0 0 3px var(--graph-selected);
     outline: none;
 }
@@ -116,7 +116,7 @@
  * own clicks/drags never trigger a stray canvas pan; that combined with
  * `onMouseDown stopPropagation()` in the React component keeps the collapse
  * click clean. */
-.react-flow__node.react-flow__node-mlirGroup {
+.mlir-page .react-flow__node.react-flow__node-mlirGroup {
     background: transparent;
     padding: 0;
     border: none;


### PR DESCRIPTION
## Summary
Scopes all React Flow styles in `MLIRViewReactFlow.scss` under `.mlir-page` to prevent them from leaking to other views.

## Changes
- Changed bare `.react-flow` block to `.mlir-page .react-flow` to scope CSS custom properties, minimap background, and panel positioning
- Scoped all other React Flow selectors (`.react-flow__edge-text`, `.react-flow__node-default`, `.react-flow__node-mlirOp`, etc.) under `.mlir-page`

## Why
`.react-flow` is the class `@xyflow/react` puts on every flow instance. Without scoping, these styles apply app-wide — to the operation graph and any future React Flow surface. The operation graph has a compensating rule to override the leaked styles; scoping the MLIR view properly removes the need for that specificity race.

Closes #1899