### PR TITLE
Add launch mode to logging

### DIFF
--- a/backend/ttnn_visualizer/tests/test_usage.py
+++ b/backend/ttnn_visualizer/tests/test_usage.py
@@ -39,11 +39,13 @@ from ttnn_visualizer.usage import (
     RUN_ID_FIELD,
     USAGE_DISABLED_ENV_VAR,
     DeploymentMode,
+    LaunchMode,
     ReportKind,
     ReportLoadFailureReason,
     UsageEvent,
     UsageView,
     get_deployment_mode,
+    get_launch_mode,
     get_usage_log_path,
     is_recording_enabled,
     record_app_start,
@@ -454,6 +456,7 @@ def test_app_start_carries_the_baseline_fields(usage_directory):
 
     assert fields["event"] == "app_start"
     assert fields["deployment_mode"] == DeploymentMode.LOCAL_UPLOAD.value
+    assert fields["launch_mode"] in {mode.value for mode in LaunchMode}
     assert fields["python_version"].count(".") == 1
     assert fields["version"]
     assert fields["os"]
@@ -471,6 +474,7 @@ def test_disabled_recording_does_not_build_the_app_start_payload(
 
     monkeypatch.setattr(usage, "get_application_version", fail_if_called)
     monkeypatch.setattr(usage, "get_deployment_mode", fail_if_called)
+    monkeypatch.setattr(usage, "get_launch_mode", fail_if_called)
     monkeypatch.setattr(usage, "get_operating_system", fail_if_called)
     monkeypatch.setattr(usage, "get_python_version", fail_if_called)
 
@@ -531,6 +535,32 @@ def test_deployment_mode_falls_back_to_local_upload(monkeypatch):
     monkeypatch.setattr(usage, "is_running_in_container", lambda: False)
 
     assert get_deployment_mode("   ") == DeploymentMode.LOCAL_UPLOAD
+
+
+def test_launch_mode_is_source_for_an_editable_install(monkeypatch):
+    monkeypatch.setattr(
+        usage,
+        "distribution",
+        lambda _name: SimpleNamespace(
+            read_text=lambda _path: '{"dir_info": {"editable": true}}'
+        ),
+    )
+
+    assert get_launch_mode() == LaunchMode.SOURCE
+
+
+def test_launch_mode_is_wheel_for_a_regular_distribution(monkeypatch):
+    monkeypatch.setattr(
+        usage,
+        "distribution",
+        lambda _name: SimpleNamespace(read_text=lambda _path: None),
+    )
+
+    assert get_launch_mode() == LaunchMode.WHEEL
+
+
+def test_launch_mode_is_hosted_in_server_mode():
+    assert get_launch_mode(server_mode=True) == LaunchMode.HOSTED
 
 
 def write_log(directory: Path, lines):

--- a/backend/ttnn_visualizer/tests/test_usage_frontend_parity.py
+++ b/backend/ttnn_visualizer/tests/test_usage_frontend_parity.py
@@ -47,7 +47,7 @@ _ENDPOINTS = _REPOSITORY_ROOT / "src" / "definitions" / "Endpoints.ts"
 # process runs on, and only the server can know them. Named here so that adding a
 # client-facing enum without a TypeScript copy fails
 # :func:`test_every_client_facing_enum_is_paired`, rather than going unnoticed.
-_SERVER_ONLY_ENUMS = frozenset({"DeploymentMode", "OperatingSystem"})
+_SERVER_ONLY_ENUMS = frozenset({"DeploymentMode", "LaunchMode", "OperatingSystem"})
 
 _PAIRED_ENUMS: Dict[str, Type[Enum]] = {
     "UsageEvent": UsageEvent,

--- a/backend/ttnn_visualizer/usage.py
+++ b/backend/ttnn_visualizer/usage.py
@@ -45,6 +45,7 @@ application's own version. No report, file, directory, operation or host names,
 and no free-form text, may ever be written here.
 """
 
+import json
 import logging
 import os
 import platform
@@ -53,7 +54,7 @@ import sys
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from importlib.metadata import PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, distribution
 from importlib.metadata import version as distribution_version
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Type
@@ -201,6 +202,12 @@ class DeploymentMode(str, Enum):
     TT_METAL_HOME = "tt_metal_home"
     CONTAINER = "container"
     LOCAL_UPLOAD = "local_upload"
+
+
+class LaunchMode(str, Enum):
+    SOURCE = "source"
+    WHEEL = "wheel"
+    HOSTED = "hosted"
 
 
 class OperatingSystem(str, Enum):
@@ -478,6 +485,22 @@ def get_deployment_mode(tt_metal_home: Optional[str]) -> DeploymentMode:
         return DeploymentMode.CONTAINER
 
     return DeploymentMode.LOCAL_UPLOAD
+
+
+def get_launch_mode(server_mode: Any = False) -> LaunchMode:
+    """How this process was launched, without exposing an installation path."""
+    if _as_bool(server_mode):
+        return LaunchMode.HOSTED
+
+    try:
+        direct_url = distribution(DISTRIBUTION_NAME).read_text("direct_url.json")
+        if direct_url and json.loads(direct_url).get("dir_info", {}).get("editable"):
+            return LaunchMode.SOURCE
+    except (PackageNotFoundError, OSError, ValueError):
+        # A direct source invocation has no distribution metadata.
+        return LaunchMode.SOURCE
+
+    return LaunchMode.WHEEL
 
 
 def get_operating_system() -> OperatingSystem:
@@ -914,6 +937,7 @@ def record_app_start(config: Any, server_mode: Optional[Any] = None) -> None:
             server_mode=server_mode,
             version=get_application_version(),
             deployment_mode=get_deployment_mode(getattr(config, "TT_METAL_HOME", None)),
+            launch_mode=get_launch_mode(server_mode),
             os=get_operating_system(),
             python_version=get_python_version(),
         )


### PR DESCRIPTION
Captures the launch mode in the local logs (source, wheel or hosted).