### PR TITLE
Route remaining store/fileTransferRegistry imports through store/app

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -280,7 +280,7 @@ The alias resolves `styles/` to `src/scss/` so the path inside the import maps 1
 
 Prefer declaring atoms in **`src/store/app.ts`**, organized into commented sections (`// App state`, `// Reports`, `// Operations route`, etc.) — add new atoms to the section that matches their feature area. **Components don't declare module-scope atoms.** If you need component-local state, use `useState`.
 
-When atoms must be co-located with mutators in another `store/` module (e.g. `store/fileTransferRegistry.ts`, to avoid a circular import with `app.ts`), still **re-export the atoms and mutators from `app.ts`**. Call sites **import from `app.ts`**, not from the co-located module — that file exists only to break the cycle; it is not a second public API. Existing direct imports from `fileTransferRegistry` (and similar) are on-touch cleanup, not a pattern to copy.
+When atoms must be co-located with mutators in another `store/` module (e.g. `store/fileTransferRegistry.ts`, to avoid a circular import with `app.ts`), still **re-export the atoms and mutators from `app.ts`**. Call sites **import from `app.ts`**, not from the co-located module — that file exists only to break the cycle; it is not a second public API. The only legitimate direct importers are the co-located module's own unit test and any test that has to `vi.mock` its real specifier.
 
 ### Atom names end with `Atom`
 
@@ -1375,7 +1375,6 @@ These exist in the codebase today and don't yet have a single canonical answer. 
 
 - **`definitions/` still holds some domain-shaped types** (`PerfTable.ts`, `RemoteConnection.ts`, `MlirServer.ts`, `PlotConfigurations.ts`). New types follow the [`definitions/` vs `model/` boundary](#srcdefinitions-vs-srcmodel); leftovers migrate **on-touch**, not in a big-bang move. (#1910)
 - **Two accessors for CSS-custom-property colours.** `GRAPH_COLORS` resolves at module load; `getPerfChartChrome()` re-reads per call. Both are legitimate and both keep the literal in `_base.scss` — pick per [No hex literals in TS/TSX](#no-hex-literals-in-tstsx), and don't add a third mechanism. (#1911)
-- **Direct imports from `store/fileTransferRegistry.ts`.** New call sites import the re-exports from `app.ts`; older ones are on-touch cleanup. (#1912)
 - **`extract_npe_name` is a misnomer** — used by both NPE and MLIR upload handlers. A rename to `extract_uploaded_name` is a tracked follow-up; don't perpetuate the NPE-specific name in new helpers. (#1913)
 - **`errorMessage` vs `statusMessage` in file loaders.** `MlirJsonFileLoader.tsx` and `NPEFileLoader.tsx` overload `errorMessage` with both success and failure text. Rename to `statusMessage` is pending. (#1914)
 - **Upload size cap.** `MAX_CONTENT_LENGTH` is a real, honoured setting but **unset by default**, so out of the box large uploads succeed until they exhaust memory. Choosing a shipped default is tracked separately. (#1915)

--- a/src/components/report-selection/RemoteSyncButton.tsx
+++ b/src/components/report-selection/RemoteSyncButton.tsx
@@ -7,7 +7,7 @@ import { useAtomValue } from 'jotai';
 import React from 'react';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import { FileTransferSource } from '../../definitions/FileTransferSource';
-import { fileTransferProgressBySourceAtom } from '../../store/fileTransferRegistry';
+import { fileTransferProgressBySourceAtom } from '../../store/app';
 import { FileProgress, FileStatus } from '../../model/APIData';
 import {
     NEVER_SYNCED_LABEL,

--- a/src/hooks/useLocal.tsx
+++ b/src/hooks/useLocal.tsx
@@ -5,7 +5,7 @@
 import { AxiosProgressEvent } from 'axios';
 import axiosInstance from '../libs/axiosInstance';
 import { FileTransferSource } from '../definitions/FileTransferSource';
-import { clearFileTransferProgressForSource, setFileTransferProgressForSource } from '../store/fileTransferRegistry';
+import { clearFileTransferProgressForSource, setFileTransferProgressForSource } from '../store/app';
 import { FileStatus } from '../model/APIData';
 import Endpoints from '../definitions/Endpoints';
 

--- a/src/hooks/useMlirRemote.tsx
+++ b/src/hooks/useMlirRemote.tsx
@@ -9,7 +9,7 @@ import {
     clearFileTransferProgressForSource,
     getInactiveFileTransferProgress,
     setFileTransferProgressForSource,
-} from '../store/fileTransferRegistry';
+} from '../store/app';
 import { FileStatus } from '../model/APIData';
 import Endpoints from '../definitions/Endpoints';
 import { ConnectionStatus, ConnectionTestStates } from '../definitions/ConnectionStatus';

--- a/src/hooks/useRemote.tsx
+++ b/src/hooks/useRemote.tsx
@@ -10,7 +10,7 @@ import { FileTransferSource } from '../definitions/FileTransferSource';
 import { MountRemoteFolder, RemoteConnection, RemoteFolder } from '../definitions/RemoteConnection';
 import { REMOTE_SYNC_REQUEST_TIMEOUT_MS } from '../definitions/RemoteSync';
 import { StackSourceOrigin } from '../definitions/StackTrace';
-import { clearFileTransferProgressForSource } from '../store/fileTransferRegistry';
+import { clearFileTransferProgressForSource } from '../store/app';
 import { isSameConnection, remoteConnectionKey } from '../functions/remoteConnection';
 import { beginRemoteSyncRequest, endRemoteSyncRequest } from '../functions/remoteSyncRequest';
 import { normaliseReportFolder } from '../functions/validateReportFolder';

--- a/src/libs/SocketProvider.tsx
+++ b/src/libs/SocketProvider.tsx
@@ -7,7 +7,7 @@ import { ReactNode, createContext, useEffect } from 'react';
 import { Socket, io } from 'socket.io-client';
 import { getOrCreateInstanceId } from './axiosInstance';
 import { FileTransferSource } from '../definitions/FileTransferSource';
-import { clearStaleRemoteSyncOnReconnect, setFileTransferProgressForSource } from '../store/fileTransferRegistry';
+import { clearStaleRemoteSyncOnReconnect, setFileTransferProgressForSource } from '../store/app';
 import getServerConfig from '../functions/getServerConfig';
 
 type SocketContextType = Socket | null;

--- a/src/routes/Styleguide.tsx
+++ b/src/routes/Styleguide.tsx
@@ -23,7 +23,6 @@ import { useAtomValue } from 'jotai';
 import ConnectionTestMessage from '../components/report-selection/ConnectionTestMessage';
 import { ConnectionTestStates } from '../definitions/ConnectionStatus';
 import { FileTransferSource } from '../definitions/FileTransferSource';
-import { clearFileTransferProgressForSource, setFileTransferProgressForSource } from '../store/fileTransferRegistry';
 import ProgressBar from '../components/ProgressBar';
 import SearchField from '../components/SearchField';
 import AppVersionStatus from '../components/AppVersionStatus';
@@ -33,7 +32,11 @@ import GlobalSwitch from '../components/GlobalSwitch';
 import useClearSelectedBuffer from '../hooks/useClearSelectedBuffer';
 import MemoryTag from '../components/MemoryTag';
 import { BufferType, BufferTypeLabel } from '../model/BufferType';
-import { fileTransferProgressAtom } from '../store/app';
+import {
+    clearFileTransferProgressForSource,
+    fileTransferProgressAtom,
+    setFileTransferProgressForSource,
+} from '../store/app';
 import { FileProgress, FileStatus } from '../model/APIData';
 import NPEProcessingStatus from '../components/NPEProcessingStatus';
 import PerfOverlayLegend from '../components/perf-overlay/PerfOverlayLegend';

--- a/tests/FileStatusOverlay.spec.tsx
+++ b/tests/FileStatusOverlay.spec.tsx
@@ -10,8 +10,7 @@ import { getFileStatusLabel } from '../src/functions/getFileStatusLabel';
 import { FileProgress, FileStatus } from '../src/model/APIData';
 import { ConnectionTestStates } from '../src/definitions/ConnectionStatus';
 import { FileTransferSource } from '../src/definitions/FileTransferSource';
-import { fileTransferRegistryAtom } from '../src/store/fileTransferRegistry';
-import { mlirFileResultsAtom } from '../src/store/app';
+import { fileTransferRegistryAtom, mlirFileResultsAtom } from '../src/store/app';
 import { TestProviders } from './helpers/TestProviders';
 
 function renderOverlay(progress: FileProgress, source: FileTransferSource = FileTransferSource.REMOTE_SYNC) {

--- a/tests/RemoteSyncButton.spec.tsx
+++ b/tests/RemoteSyncButton.spec.tsx
@@ -14,7 +14,7 @@ import {
     clearAllFileTransferProgress,
     fileTransferRegistryAtom,
     getInactiveFileTransferProgress,
-} from '../src/store/fileTransferRegistry';
+} from '../src/store/app';
 import { FileStatus } from '../src/model/APIData';
 import { TestProviders } from './helpers/TestProviders';
 

--- a/tests/useMlirRemote.spec.tsx
+++ b/tests/useMlirRemote.spec.tsx
@@ -18,15 +18,13 @@ import { FileTransferSource } from '../src/definitions/FileTransferSource';
 import {
     clearAllFileTransferProgress,
     clearFileTransferProgressForSource,
+    fileTransferProgressAtom,
     fileTransferRegistryAtom,
     getInactiveFileTransferProgress,
-    setFileTransferProgressForSource,
-} from '../src/store/fileTransferRegistry';
-import {
-    fileTransferProgressAtom,
     mlirFileResultsAtom,
     mlirFileResultsOpenAtom,
     mlirRetryFilesAtom,
+    setFileTransferProgressForSource,
 } from '../src/store/app';
 import { FileStatus } from '../src/model/APIData';
 

--- a/tests/useRemote.spec.tsx
+++ b/tests/useRemote.spec.tsx
@@ -15,7 +15,7 @@ import {
     fileTransferRegistryAtom,
     getInactiveFileTransferProgress,
     setFileTransferProgressForSource,
-} from '../src/store/fileTransferRegistry';
+} from '../src/store/app';
 import { abortActiveRemoteSyncRequest } from '../src/functions/remoteSyncRequest';
 import useRemoteConnection, {
     LOCAL_STORAGE_KEY_CONNECTIONS,


### PR DESCRIPTION
Closes https://github.com/tenstorrent/ttnn-visualizer/issues/1912.

This pull request refactors how file transfer state management is imported throughout the codebase. All imports of file transfer-related atoms and mutators are now centralized through `store/app.ts`, rather than being imported directly from `store/fileTransferRegistry.ts`. This change enforces the intended public API boundary, simplifies dependencies, and clarifies the proper import locations for these shared state utilities. The documentation is updated to match this convention, and all affected code and tests are updated accordingly.

**Refactoring file transfer state imports:**

* All production and test files that previously imported atoms and mutators directly from `store/fileTransferRegistry.ts` now import them from `store/app.ts` instead. This includes hooks (`useLocal.tsx`, `useMlirRemote.tsx`, `useRemote.tsx`), components (`RemoteSyncButton.tsx`, `SocketProvider.tsx`), routes (`Styleguide.tsx`), and test files. [[1]](diffhunk://#diff-bc0111215de66ab133230c3ee4f917e6e2344e481497d49c135d55208b2c4e02L10-R10) [[2]](diffhunk://#diff-4ee8a8320020eed5af3685433a85b5c6351822f7c2900f1342d1be650866bb11L8-R8) [[3]](diffhunk://#diff-b55165b971acd54ec976979c1cc187aab20abdf9a113b55a0e551d942ca20f1aL12-R12) [[4]](diffhunk://#diff-f7cfb535298cc5b5a94f68f56d793e7cd060556c507047571948dbf426d7d0ccL13-R13) [[5]](diffhunk://#diff-2e11e7b1f151fac8271b3811e4d1d83f7cd8f4ccb2a2fa15f611cbbc935d5c35L10-R10) [[6]](diffhunk://#diff-52a0eb62b4f502da21d786251a5ba88bf4b0f6c058f2cc6e1f88555fa44449c3L26) [[7]](diffhunk://#diff-52a0eb62b4f502da21d786251a5ba88bf4b0f6c058f2cc6e1f88555fa44449c3L36-R39) [[8]](diffhunk://#diff-11c5831698eb6064290f2f59d838f3cbcfafd88dbd37d7335422a20ea5578c73L13-R13) [[9]](diffhunk://#diff-4e9f427271231411047ec1c44534707a91ef357c342028290d5d71383b1ae9a3L17-R17) [[10]](diffhunk://#diff-8cca91a0d1d181f4b916fe06feb95aa77fe213ace0a03e5aba80a11b1aa9af4dR21-R27) [[11]](diffhunk://#diff-84188e640666692040240bd2e650ae66ba8e5faa617d1440273e5258a57d0e8eL18-R18)

**Documentation updates:**

* The conventions documentation (`CONVENTIONS.md`) is updated to clarify that only `app.ts` should be used as the public import location for file transfer atoms and mutators. The only exceptions for direct imports from `fileTransferRegistry.ts` are its own unit tests and tests that need to mock the module.
* The section listing existing non-canonical patterns is updated to remove direct imports from `fileTransferRegistry.ts` as an accepted pattern, reflecting the new convention.