### PR TITLE
Rename `extract_npe_name` to `extract_uploaded_name`

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1376,7 +1376,6 @@ Don't `raise Exception("...")` — there's an existing class for almost every ca
 These exist in the codebase today and don't yet have a single canonical answer. Reviewers should flag new code that goes either direction without considering both. Each entry names the inconsistency, the direction new code takes, and its tracking issue; the rule itself lives in the section above that owns it.
 
 - **Two accessors for CSS-custom-property colours.** `GRAPH_COLORS` resolves at module load; `getPerfChartChrome()` re-reads per call. Both are legitimate and both keep the literal in `_base.scss` — pick per [No hex literals in TS/TSX](#no-hex-literals-in-tstsx), and don't add a third mechanism. (#1911)
-- **`extract_npe_name` is a misnomer** — used by both NPE and MLIR upload handlers. A rename to `extract_uploaded_name` is a tracked follow-up; don't perpetuate the NPE-specific name in new helpers. (#1913)
 - **`errorMessage` vs `statusMessage` in file loaders.** `MlirJsonFileLoader.tsx` and `NPEFileLoader.tsx` overload `errorMessage` with both success and failure text. Rename to `statusMessage` is pending. (#1914)
 - **Upload size cap.** `MAX_CONTENT_LENGTH` is a real, honoured setting but **unset by default**, so out of the box large uploads succeed until they exhaust memory. Choosing a shipped default is tracked separately. (#1915)
 - **Default-export vs named-export of components.** Components are predominantly default-exported, hooks and utilities named-exported. Mirror the file you're editing. (#1916)

--- a/backend/ttnn_visualizer/file_uploads.py
+++ b/backend/ttnn_visualizer/file_uploads.py
@@ -106,7 +106,7 @@ def resolve_parent_folder_name(files, folder_name):
     return _extract_folder_name_from_files(files)
 
 
-def extract_npe_name(files):
+def extract_uploaded_name(files):
     if not files:
         return None
 

--- a/backend/ttnn_visualizer/tests/test_file_uploads.py
+++ b/backend/ttnn_visualizer/tests/test_file_uploads.py
@@ -8,7 +8,7 @@ PR #1467 Copilot review (round 2) flagged that upload paths used
 `file.filename` verbatim when constructing the destination path, allowing a
 crafted multipart filename like `"../etc/passwd.json"` or `"/etc/passwd.json"`
 to escape `target_directory`. These tests pin the hardening (`Path(...).name`
-in `construct_dest_path` and `extract_npe_name`) so a future refactor can't
+in `construct_dest_path` and `extract_uploaded_name`) so a future refactor can't
 silently undo it.
 """
 
@@ -22,7 +22,7 @@ from ttnn_visualizer.enums import ConnectionTestStates
 from ttnn_visualizer.exceptions import DataFormatError
 from ttnn_visualizer.file_uploads import (
     construct_dest_path,
-    extract_npe_name,
+    extract_uploaded_name,
     resolve_parent_folder_name,
     validate_files,
 )
@@ -212,31 +212,31 @@ def test_construct_dest_path_folder_branch_allows_intermediate_dotdot(app, tmp_p
         assert resolved.parent.parent == tmp_path.resolve()
 
 
-# ---- extract_npe_name: feeds the DB; rebuilt into a read path later --------
+# ---- extract_uploaded_name: feeds the DB; rebuilt into a read path later ---
 
 
-def test_extract_npe_name_strips_traversal_from_db_name():
+def test_extract_uploaded_name_strips_traversal_from_db_name():
     """`mlir_name` is rebuilt by `get_mlir_path` — must not contain `..`."""
-    name = extract_npe_name([_faux_file("../etc/passwd.json")])
+    name = extract_uploaded_name([_faux_file("../etc/passwd.json")])
     assert name == "passwd"
     assert ".." not in name
     assert "/" not in name
 
 
-def test_extract_npe_name_strips_absolute_path_from_db_name():
-    name = extract_npe_name([_faux_file("/etc/passwd.json")])
+def test_extract_uploaded_name_strips_absolute_path_from_db_name():
+    name = extract_uploaded_name([_faux_file("/etc/passwd.json")])
     assert name == "passwd"
     assert "/" not in name
 
 
-def test_extract_npe_name_preserves_legitimate_basename():
+def test_extract_uploaded_name_preserves_legitimate_basename():
     """Plain filenames must produce the same DB name they always did."""
-    assert extract_npe_name([_faux_file("my-model.json")]) == "my-model"
-    assert extract_npe_name([_faux_file("my-trace.npeviz.zst")]) == "my-trace"
+    assert extract_uploaded_name([_faux_file("my-model.json")]) == "my-model"
+    assert extract_uploaded_name([_faux_file("my-trace.npeviz.zst")]) == "my-trace"
 
 
-def test_extract_npe_name_handles_empty_input():
-    assert extract_npe_name([]) is None
+def test_extract_uploaded_name_handles_empty_input():
+    assert extract_uploaded_name([]) is None
 
 
 # ---- resolve_parent_folder_name: keeps both upload handlers aligned --------

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -981,11 +981,11 @@ def get_npe_path(npe_name, current_app, remote_connection=None):
 
 def get_mlir_path(mlir_name, current_app, remote_connection=None, **_kwargs):
     # MLIR uploads are saved as `<MLIR_DIRECTORY_NAME>/<mlir_name>.json`
-    # (the upload endpoint enforces `.json` suffix; `extract_npe_name` strips
-    # it back off when deriving `mlir_name`). Reconstruct the file path the
-    # same way so callers like `_resolve_report_path` get an openable file —
-    # returning just the directory previously caused `get_mlir_json()` to try
-    # `open()` on a directory after any unrelated instance update.
+    # (the upload handler stores the source filename's stem, so `mlir_name`
+    # carries no suffix). Reconstruct the file path the same way so callers
+    # like `_resolve_report_path` get an openable file — returning just the
+    # directory previously caused `get_mlir_json()` to try `open()` on a
+    # directory after any unrelated instance update.
     #
     # MLIR server uploads are stored under
     # REMOTE_DATA_DIRECTORY/<remote_host>/mlir-reports/<name>.json, matching

--- a/backend/ttnn_visualizer/views.py
+++ b/backend/ttnn_visualizer/views.py
@@ -51,7 +51,7 @@ from ttnn_visualizer.exceptions import (
     response_unprocessable_entity,
 )
 from ttnn_visualizer.file_uploads import (
-    extract_npe_name,
+    extract_uploaded_name,
     resolve_parent_folder_name,
     save_uploaded_files,
     validate_files,
@@ -1539,7 +1539,7 @@ def create_npe_files():
                 message="NPE requires a valid .json or .zst file",
             ).model_dump()
 
-    npe_name = extract_npe_name(files)
+    npe_name = extract_uploaded_name(files)
     target_directory = data_directory / current_app.config["NPE_DIRECTORY_NAME"]
     target_directory.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/generate_smoke_perf_fixture.py
+++ b/scripts/generate_smoke_perf_fixture.py
@@ -152,7 +152,7 @@ def _read_source_manifest(source_report: Path) -> dict[int, str]:
     chose, so it is collapsed to a bare basename before it ever reaches a path
     join. Without that, a report carrying `"file": "../../../etc/passwd"` would
     steer the copy below out of the report directory. Same reasoning as
-    `extract_npe_name` in `backend/ttnn_visualizer/file_uploads.py`.
+    `extract_uploaded_name` in `backend/ttnn_visualizer/file_uploads.py`.
     """
     manifest_path = source_report / NPE_FOLDER / NPE_MANIFEST_NAME
     if not manifest_path.is_file():


### PR DESCRIPTION
Closes #1913.

`extract_npe_name` strips directory components and a `.json` / `.npeviz.zst` suffix from an uploaded filename — nothing about it is NPE-specific. It was catalogued in `CONVENTIONS.md` § Known inconsistencies as a misnomer; this renames it and everything that references it.

## Changes

- `backend/ttnn_visualizer/file_uploads.py` — the helper itself.
- `backend/ttnn_visualizer/views.py` — import and the one call site.
- `backend/ttnn_visualizer/tests/test_file_uploads.py` — import, module docstring, section banner, and the four `test_extract_npe_name_*` tests renamed with it, as the issue asked.
- `scripts/generate_smoke_perf_fixture.py` — comment reference.
- `CONVENTIONS.md` — removed the now-resolved Known-inconsistencies entry.

## One change beyond a pure rename

The `get_mlir_path` comment in `utils.py` named the helper as the thing that strips `.json` when deriving `mlir_name`. The MLIR upload handler no longer calls it — it takes `Path(Path(filename).name).stem` directly (`views.py`, `upload_mlir_server`) — so the comment described the actual code path incorrectly, not merely under an old name. Corrected rather than carrying the wrong reference across.

For the same reason, the issue's premise ("used by **both** the NPE and MLIR upload handlers") is out of date: only the NPE handler uses it today. The rename still stands on its own.

## Verification

- `uv run python -m pytest backend/ttnn_visualizer/tests` — 1121 passed.
- `pnpm run flask:lint` — clean.
- `pnpm run flask:mypy` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)