### PR TITLE
Extend `createToastNotification` to cover the `useBufferFocus` persistent-toast case

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ Applies on touch to views that draw data-proportional visuals (NPE chip cluster 
 ### Errors and toasts
 
 - Funnel error-string extraction through **`getResponseError(error, fallback?)`** (`src/functions/getResponseError.ts`). Don't reach into `error.response.data.error` ad-hoc — the helper handles AxiosError, Error, and string fallbacks consistently.
-- Emit toasts via **`createToastNotification(message, fileName, ToastType.X)`** (`src/functions/createToastNotification.tsx`; `ToastType` lives in `src/definitions/ToastType.ts`). For a toast needing its own body, per-toast options, or the `Id` to dismiss it later, the same module exports **`createToast(content, options?, type?)`** and **`dismissToast(toastId?)`** — `useBufferFocus` is the case they exist for. That module is the only one that may import `toast` from `react-toastify` — `no-restricted-imports` enforces it — though importing its *types* elsewhere is unrestricted. Defaults belong on the `<ToastContainer>`, mounted once in `Layout.tsx`.
+- Emit toasts via **`createToastNotification(message, fileName, ToastType.X)`** (`src/functions/createToastNotification.tsx`; `ToastType` lives in `src/definitions/ToastType.ts`); the same module exports **`createToast`** and **`dismissToast`** for a custom body or a toast you must dismiss later. Only that module may import `toast` from `react-toastify` — `no-restricted-imports` enforces it. [Signatures and the `<ToastContainer>` rule](./CONVENTIONS.md#emit-toasts-via-createtoastnotification).
 
 ### Usage recording (frontend)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ Applies on touch to views that draw data-proportional visuals (NPE chip cluster 
 ### Errors and toasts
 
 - Funnel error-string extraction through **`getResponseError(error, fallback?)`** (`src/functions/getResponseError.ts`). Don't reach into `error.response.data.error` ad-hoc — the helper handles AxiosError, Error, and string fallbacks consistently.
-- Emit toasts via **`createToastNotification(message, fileName, ToastType.X)`** (`src/functions/createToastNotification.tsx`; `ToastType` lives in `src/definitions/ToastType.ts`). Don't import `toast` from `react-toastify` directly in components. The `<ToastContainer>` is mounted once in `Layout.tsx`.
+- Emit toasts via **`createToastNotification(message, fileName, ToastType.X)`** (`src/functions/createToastNotification.tsx`; `ToastType` lives in `src/definitions/ToastType.ts`). For a toast needing its own body, per-toast options, or the `Id` to dismiss it later, the same module exports **`createToast(content, options?, type?)`** and **`dismissToast(toastId?)`** — `useBufferFocus` is the case they exist for. That module is the only one that may import `toast` from `react-toastify` — `no-restricted-imports` enforces it — though importing its *types* elsewhere is unrestricted. Defaults belong on the `<ToastContainer>`, mounted once in `Layout.tsx`.
 
 ### Usage recording (frontend)
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -568,7 +568,7 @@ try {
 
 ### Emit toasts via `createToastNotification`
 
-`src/functions/createToastNotification.tsx` is the single entry point. It wraps `react-toastify`'s `toast` with the `ToastFileChange` template the rest of the app uses, and it delegates to `toast[type](...)` so the same call site can produce info/success/warning/error toasts.
+`src/functions/createToastNotification.tsx` is the single entry point, and the only module that calls `react-toastify`'s `toast`. The default export wraps the `ToastFileChange` template the rest of the app uses and delegates to `toast[type](...)`, so the same call site can produce info/success/warning/error toasts.
 
 ```ts
 import createToastNotification from '../functions/createToastNotification';
@@ -577,7 +577,22 @@ import { ToastType } from '../definitions/ToastType';
 createToastNotification('MLIR', file.name, ToastType.SUCCESS);
 ```
 
-**Don't.** Importing `toast` from `react-toastify` directly in a component creates two parallel toast pipelines and breaks the visual contract. The `<ToastContainer>` is mounted once in `Layout.tsx`.
+Two named exports cover the cases the template doesn't. Reach for them only when you need what they add — a different toast body, per-toast options, or the toast's `Id`:
+
+- **`createToast(content, options?, type?)`** takes arbitrary content and returns the `Id`, for a toast the app has to address later.
+- **`dismissToast(toastId?)`** closes one toast, or every open toast when called with no argument.
+
+`useBufferFocus` is the case they exist for: its toast persists until dismissed (`autoClose: false`), and its `Id` goes into `activeToastAtom` so selecting a different buffer can dismiss the previous one.
+
+```tsx
+const toastInstance: Id = createToast(<ToastTensorMessage … />, { autoClose: false, onClick: resetToasts });
+
+setActiveToast(toastInstance);
+```
+
+Defaults belong on the `<ToastContainer>` in `Layout.tsx`, which is mounted once; `options` is for per-toast departures from them, not a second place to set defaults.
+
+**Don't.** Importing `toast` from `react-toastify` anywhere else creates two parallel toast pipelines and breaks the visual contract, and `no-restricted-imports` fails the build for it — the wrapper module carries the only override. Importing the *types* (`Id`, `ToastOptions`) at a call site is unrestricted; `activeToastAtom` is typed `Id | null`.
 
 ---
 
@@ -1379,7 +1394,6 @@ These exist in the codebase today and don't yet have a single canonical answer. 
 - **`errorMessage` vs `statusMessage` in file loaders.** `MlirJsonFileLoader.tsx` and `NPEFileLoader.tsx` overload `errorMessage` with both success and failure text. Rename to `statusMessage` is pending. (#1914)
 - **Upload size cap.** `MAX_CONTENT_LENGTH` is a real, honoured setting but **unset by default**, so out of the box large uploads succeed until they exhaust memory. Choosing a shipped default is tracked separately. (#1915)
 - **Default-export vs named-export of components.** Components are predominantly default-exported, hooks and utilities named-exported. Mirror the file you're editing. (#1916)
-- **Raw `toast()` in `useBufferFocus`.** Needs `autoClose: false` and persists the returned `Id` into `activeToastAtom` — capabilities `createToastNotification` doesn't expose. An intentional exception, not a precedent: extend the wrapper if you need richer options. (#1917)
 - **`Config.__new__` lacks a return annotation**, surfacing a mypy `attr-defined` error in `database_migrations.py`. Fix is `def __new__(cls) -> "DefaultConfig":`; tracked as a follow-up. (#1919)
 - **`USAGE_RECORDING_ACTIVE` is a config attribute with no matching variable** — it is fed by `USAGE_RECORDING_DISABLED`, the opposite polarity, so it is named for the state instead. Borrowing the variable's name would make `PRINT_ENV` publish `true` when recording is off. (#1921)
 - **`DEBUG` and `FLASK_DEBUG` are different knobs with confusable names.** `FLASK_DEBUG` feeds the `DEBUG` *config* value (Flask's debug mode); the `DEBUG` *environment variable* raises the root log level and is what `pnpm flask:start-debug` sets. Both are in `.env.sample`. Read the name at the call site rather than assuming. (#1922)

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -146,6 +146,23 @@ module.exports = defineConfig([
             'import/prefer-default-export': 'off',
             'max-classes-per-file': 'off',
             'no-plusplus': 'off',
+            // `src/functions/createToastNotification.tsx` is the only module that may call
+            // `toast`, so every toast shares the one `<ToastContainer>` in `Layout.tsx`.
+            // Types are unrestricted -- `activeToastAtom` is typed `Id | null`.
+            'no-restricted-imports': [
+                'error',
+                {
+                    paths: [
+                        {
+                            name: 'react-toastify',
+                            importNames: ['toast'],
+                            message:
+                                'Emit toasts through src/functions/createToastNotification: createToastNotification for the file-change template, createToast/dismissToast for custom content.',
+                        },
+                    ],
+                },
+            ],
+
             'no-restricted-syntax': [
                 'error',
                 {
@@ -232,6 +249,14 @@ module.exports = defineConfig([
                     argsIgnorePattern: '^_',
                 },
             ],
+        },
+    },
+    {
+        // The toast wrapper is the one place the restriction above exists to funnel into.
+        files: ['src/functions/createToastNotification.tsx'],
+
+        rules: {
+            'no-restricted-imports': 'off',
         },
     },
     {

--- a/src/functions/createToastNotification.tsx
+++ b/src/functions/createToastNotification.tsx
@@ -2,11 +2,29 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { ToastOptions, toast } from 'react-toastify';
+import { Id, ToastContent, ToastOptions, toast } from 'react-toastify';
 import ToastFileChange from '../components/ToastFileChange';
 import { ToastType } from '../definitions/ToastType';
 
-export default function createToastNotification(message: string, fileName: string, type?: ToastType) {
+// Everything below is the only code allowed to call `react-toastify`'s `toast`, so every
+// toast in the app shares the single `<ToastContainer>` mounted in `Layout.tsx`. Defaults
+// belong on that container -- `options` is for a toast's departures from them, such as the
+// `autoClose: false` a toast that must survive until dismissed needs.
+export function createToast(content: ToastContent, options?: ToastOptions, type?: ToastType): Id {
+    return type ? toast[type](content, options) : toast(content, options);
+}
+
+// Omitting `toastId` dismisses every open toast, matching `toast.dismiss()`.
+export function dismissToast(toastId?: Id) {
+    toast.dismiss(toastId);
+}
+
+export default function createToastNotification(
+    message: string,
+    fileName: string,
+    type?: ToastType,
+    options?: ToastOptions,
+): Id {
     const template = (
         <ToastFileChange
             message={message}
@@ -14,12 +32,5 @@ export default function createToastNotification(message: string, fileName: strin
         />
     );
 
-    // Moved args to the ToastContainer level but keeping this here in the short term in case we need to restore any (e.g. because bugs)
-    const args: ToastOptions = {};
-
-    if (type) {
-        toast[type](template, args);
-    } else {
-        toast(template, args);
-    }
+    return createToast(template, options, type);
 }

--- a/src/functions/createToastNotification.tsx
+++ b/src/functions/createToastNotification.tsx
@@ -19,12 +19,7 @@ export function dismissToast(toastId?: Id) {
     toast.dismiss(toastId);
 }
 
-export default function createToastNotification(
-    message: string,
-    fileName: string,
-    type?: ToastType,
-    options?: ToastOptions,
-): Id {
+export default function createToastNotification(message: string, fileName: string, type?: ToastType): Id {
     const template = (
         <ToastFileChange
             message={message}
@@ -32,5 +27,5 @@ export default function createToastNotification(
         />
     );
 
-    return createToast(template, options, type);
+    return createToast(template, undefined, type);
 }

--- a/src/hooks/useBufferFocus.tsx
+++ b/src/hooks/useBufferFocus.tsx
@@ -2,9 +2,10 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { Id, toast } from 'react-toastify';
+import { Id } from 'react-toastify';
 import { useCallback } from 'react';
 import { useAtom } from 'jotai';
+import { createToast, dismissToast } from '../functions/createToastNotification';
 import { getBufferColor, getTensorColor } from '../functions/colorGenerator';
 import isValidNumber from '../functions/isValidNumber';
 import ToastTensorMessage from '../components/operation-details/ToastTensorMessage';
@@ -21,7 +22,7 @@ const useBufferFocus = () => {
         setSelectedAddress(null);
         setSelectedBufferColour(null);
         setActiveToast(null);
-        toast.dismiss();
+        dismissToast();
     }, [setActiveToast, setSelectedAddress, setSelectedBufferColour, setSelectedTensorId]);
 
     const updateBufferFocus = useCallback(
@@ -30,7 +31,7 @@ const useBufferFocus = () => {
             let colour = getTensorColor(tensorId);
 
             if (previousToast) {
-                toast.dismiss(previousToast);
+                dismissToast(previousToast);
             }
 
             if (isValidNumber(address) && !colour) {
@@ -39,7 +40,7 @@ const useBufferFocus = () => {
 
             setSelectedBufferColour(colour ?? null);
 
-            const toastInstance: Id = toast(
+            const toastInstance: Id = createToast(
                 <ToastTensorMessage
                     tensorId={tensorId}
                     address={address}

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -33,10 +33,11 @@ vi.mock('../src/hooks/useMlirRemote', () => ({
     default: () => ({ setActiveMlir, uploadMlirFileToServer }),
 }));
 
-vi.mock('../src/functions/createToastNotification', () => ({
-    default: createToastNotification,
-    ToastType: { SUCCESS: 'success', ERROR: 'error' },
-}));
+vi.mock('../src/functions/createToastNotification', async () => {
+    const { toastNotificationModuleMock } = await import('./helpers/mockToastNotification');
+
+    return toastNotificationModuleMock(createToastNotification);
+});
 
 const GRAPH: GraphBundle = { graphs: [{ id: 'g', nodes: [] }] };
 const SERVER: MlirServerConnection = {

--- a/tests/NPEFileLoader.spec.tsx
+++ b/tests/NPEFileLoader.spec.tsx
@@ -14,7 +14,11 @@ vi.mock('../src/hooks/useLocal', () => ({
     default: () => ({ uploadNpeFile }),
 }));
 
-vi.mock('../src/functions/createToastNotification', () => ({ default: vi.fn() }));
+vi.mock('../src/functions/createToastNotification', async () => {
+    const { toastNotificationModuleMock } = await import('./helpers/mockToastNotification');
+
+    return toastNotificationModuleMock();
+});
 
 afterEach(() => {
     cleanup();

--- a/tests/NPEViewControlledTimestep.spec.tsx
+++ b/tests/NPEViewControlledTimestep.spec.tsx
@@ -34,7 +34,11 @@ vi.mock('../src/components/npe/NPEMetadata', () => ({ default: () => null }));
 vi.mock('../src/components/npe/EmptyChipRenderer', () => ({ EmptyChipRenderer: () => null }));
 vi.mock('../src/components/npe/NPEZoneFilterComponent', () => ({ default: () => null }));
 vi.mock('../src/components/GlobalSwitch', () => ({ default: () => null }));
-vi.mock('../src/functions/createToastNotification', () => ({ default: vi.fn() }));
+vi.mock('../src/functions/createToastNotification', async () => {
+    const { toastNotificationModuleMock } = await import('./helpers/mockToastNotification');
+
+    return toastNotificationModuleMock();
+});
 vi.mock('../src/components/npe/useNPEHandlers', () => ({
     useSelectedTransferGrouping: () => ({ transferListSelectionRendering: new Map(), groupedTransfersByNoCID: {} }),
     useShowActiveTransfers: () => vi.fn(),

--- a/tests/NPEViewTransferOriginsGate.spec.tsx
+++ b/tests/NPEViewTransferOriginsGate.spec.tsx
@@ -44,7 +44,11 @@ vi.mock('../src/components/npe/EmptyChipRenderer', () => ({
 }));
 vi.mock('../src/components/npe/NPEZoneFilterComponent', () => ({ default: () => null }));
 vi.mock('../src/components/GlobalSwitch', () => ({ default: () => null }));
-vi.mock('../src/functions/createToastNotification', () => ({ default: vi.fn() }));
+vi.mock('../src/functions/createToastNotification', async () => {
+    const { toastNotificationModuleMock } = await import('./helpers/mockToastNotification');
+
+    return toastNotificationModuleMock();
+});
 // `useShowActiveTransfers` is deliberately NOT mocked away: it returns a new
 // callback on every scrub, and the whole point of the `showActiveTransfersRef`
 // indirection is to absorb that so the memoized children keep stable props.

--- a/tests/createToastNotification.spec.tsx
+++ b/tests/createToastNotification.spec.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { ReactElement } from 'react';
+import { act, render, renderHook } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import type { Id, ToastContent, ToastOptions } from 'react-toastify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import createToastNotification, { createToast, dismissToast } from '../src/functions/createToastNotification';
+import { ToastType } from '../src/definitions/ToastType';
+import { TEST_IDS } from '../src/definitions/TestIds';
+import useBufferFocus from '../src/hooks/useBufferFocus';
+import { activeToastAtom } from '../src/store/app';
+
+// The wrapper's whole job is what it hands `react-toastify`, so the spec asserts on the
+// calls rather than on rendered output -- no `<ToastContainer>` is mounted here.
+const { dismiss, toastFn, toastSuccess } = vi.hoisted(() => ({
+    dismiss: vi.fn(),
+    toastFn: vi.fn((_content: ToastContent, _options?: ToastOptions): Id => 'toast-id'),
+    toastSuccess: vi.fn((_content: ToastContent, _options?: ToastOptions): Id => 'success-id'),
+}));
+
+vi.mock('react-toastify', () => ({
+    toast: Object.assign(toastFn, {
+        dismiss,
+        success: toastSuccess,
+        info: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+const lastToastContent = () => render(toastFn.mock.calls.at(-1)![0] as ReactElement);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getDefaultStore().set(activeToastAtom, null);
+});
+
+describe('createToastNotification', () => {
+    it('hands over the shared file-change template and returns the toast id', () => {
+        expect(createToastNotification('MLIR', 'model.json')).toBe('toast-id');
+
+        const { container } = lastToastContent();
+
+        expect(container).toHaveTextContent('MLIR');
+        expect(container.querySelector(`[data-testid="${TEST_IDS.TOAST_FILENAME}"]`)).toHaveTextContent('model.json');
+    });
+
+    it('routes through the typed toast when given a ToastType', () => {
+        expect(createToastNotification('MLIR', 'model.json', ToastType.SUCCESS)).toBe('success-id');
+
+        expect(toastSuccess).toHaveBeenCalledTimes(1);
+        expect(toastFn).not.toHaveBeenCalled();
+    });
+
+    it('passes per-toast options through', () => {
+        createToastNotification('MLIR', 'model.json', undefined, { autoClose: false });
+
+        expect(toastFn).toHaveBeenCalledWith(expect.anything(), { autoClose: false });
+    });
+});
+
+describe('createToast', () => {
+    it('takes arbitrary content and returns the id the toast was given', () => {
+        expect(createToast(<span>Custom body</span>, { hideProgressBar: true })).toBe('toast-id');
+
+        expect(toastFn).toHaveBeenCalledWith(expect.anything(), { hideProgressBar: true });
+        expect(lastToastContent().container).toHaveTextContent('Custom body');
+    });
+});
+
+describe('dismissToast', () => {
+    it('dismisses a single toast by id', () => {
+        dismissToast('toast-id');
+
+        expect(dismiss).toHaveBeenCalledWith('toast-id');
+    });
+
+    it('dismisses every open toast when called with no id', () => {
+        dismissToast();
+
+        expect(dismiss).toHaveBeenCalledWith(undefined);
+    });
+});
+
+describe('useBufferFocus', () => {
+    it('opens a toast that persists until dismissed and keeps its id in activeToastAtom', () => {
+        const { result } = renderHook(() => useBufferFocus());
+
+        act(() => result.current.updateBufferFocus(1024, 7));
+
+        expect(toastFn).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ autoClose: false }));
+        expect(result.current.activeToast).toBe('toast-id');
+    });
+
+    it('dismisses the previous toast before opening the next one', () => {
+        const { result } = renderHook(() => useBufferFocus());
+
+        act(() => result.current.updateBufferFocus(1024, 7));
+        act(() => result.current.updateBufferFocus(2048, 8));
+
+        expect(dismiss).toHaveBeenCalledWith('toast-id');
+    });
+
+    it('dismisses every toast when the selection is reset', () => {
+        const { result } = renderHook(() => useBufferFocus());
+
+        act(() => result.current.updateBufferFocus(1024, 7));
+        act(() => result.current.resetToasts());
+
+        expect(dismiss).toHaveBeenLastCalledWith(undefined);
+        expect(result.current.activeToast).toBeNull();
+    });
+});

--- a/tests/createToastNotification.spec.tsx
+++ b/tests/createToastNotification.spec.tsx
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import '@testing-library/jest-dom/vitest';
-import { ReactElement } from 'react';
-import { act, render, renderHook } from '@testing-library/react';
+import { MouseEvent, ReactElement } from 'react';
+import { act, render, renderHook, within } from '@testing-library/react';
 import { getDefaultStore } from 'jotai';
 import type { Id, ToastContent, ToastOptions } from 'react-toastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,24 +15,36 @@ import useBufferFocus from '../src/hooks/useBufferFocus';
 import { activeToastAtom } from '../src/store/app';
 
 // The wrapper's whole job is what it hands `react-toastify`, so the spec asserts on the
-// calls rather than on rendered output -- no `<ToastContainer>` is mounted here.
-const { dismiss, toastFn, toastSuccess } = vi.hoisted(() => ({
-    dismiss: vi.fn(),
-    toastFn: vi.fn((_content: ToastContent, _options?: ToastOptions): Id => 'toast-id'),
-    toastSuccess: vi.fn((_content: ToastContent, _options?: ToastOptions): Id => 'success-id'),
-}));
+// calls rather than on rendered output -- no `<ToastContainer>` is mounted here. Every
+// mocked toast issues a *fresh* id, without which an assertion about which toast was
+// dismissed passes whether or not the right one was named.
+const { dismiss, toastFn, typedToasts } = vi.hoisted(() => {
+    let issued = 0;
+    const issueId = (_content: ToastContent, _options?: ToastOptions): Id => {
+        issued += 1;
+        return `toast-${issued}`;
+    };
+
+    return {
+        dismiss: vi.fn(),
+        toastFn: vi.fn(issueId),
+        // Keyed by the `ToastType` values themselves; `vi.hoisted` runs before imports,
+        // so the enum cannot be referenced here.
+        typedToasts: {
+            info: vi.fn(issueId),
+            success: vi.fn(issueId),
+            warning: vi.fn(issueId),
+            error: vi.fn(issueId),
+        },
+    };
+});
 
 vi.mock('react-toastify', () => ({
-    toast: Object.assign(toastFn, {
-        dismiss,
-        success: toastSuccess,
-        info: vi.fn(),
-        warning: vi.fn(),
-        error: vi.fn(),
-    }),
+    toast: Object.assign(toastFn, { ...typedToasts, dismiss }),
 }));
 
-const lastToastContent = () => render(toastFn.mock.calls.at(-1)![0] as ReactElement);
+const lastToastCall = () => toastFn.mock.calls.at(-1)!;
+const renderLastToastContent = () => render(lastToastCall()[0] as ReactElement);
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -41,42 +53,38 @@ beforeEach(() => {
 
 describe('createToastNotification', () => {
     it('hands over the shared file-change template and returns the toast id', () => {
-        expect(createToastNotification('MLIR', 'model.json')).toBe('toast-id');
+        expect(createToastNotification('MLIR', 'model.json')).toBe(toastFn.mock.results[0].value);
 
-        const { container } = lastToastContent();
+        const { container } = renderLastToastContent();
 
         expect(container).toHaveTextContent('MLIR');
-        expect(container.querySelector(`[data-testid="${TEST_IDS.TOAST_FILENAME}"]`)).toHaveTextContent('model.json');
+        expect(within(container).getByTestId(TEST_IDS.TOAST_FILENAME)).toHaveTextContent('model.json');
     });
 
-    it('routes through the typed toast when given a ToastType', () => {
-        expect(createToastNotification('MLIR', 'model.json', ToastType.SUCCESS)).toBe('success-id');
+    it.each(Object.values(ToastType))('routes a %s toast through the matching typed toast', (type) => {
+        const toastId = createToastNotification('MLIR', 'model.json', type);
 
-        expect(toastSuccess).toHaveBeenCalledTimes(1);
+        expect(typedToasts[type]).toHaveBeenCalledTimes(1);
+        expect(typedToasts[type]).toHaveReturnedWith(toastId);
         expect(toastFn).not.toHaveBeenCalled();
-    });
-
-    it('passes per-toast options through', () => {
-        createToastNotification('MLIR', 'model.json', undefined, { autoClose: false });
-
-        expect(toastFn).toHaveBeenCalledWith(expect.anything(), { autoClose: false });
     });
 });
 
 describe('createToast', () => {
-    it('takes arbitrary content and returns the id the toast was given', () => {
-        expect(createToast(<span>Custom body</span>, { hideProgressBar: true })).toBe('toast-id');
+    it('takes arbitrary content, passes options through, and returns the id', () => {
+        const toastId = createToast(<span>Custom body</span>, { hideProgressBar: true });
 
         expect(toastFn).toHaveBeenCalledWith(expect.anything(), { hideProgressBar: true });
-        expect(lastToastContent().container).toHaveTextContent('Custom body');
+        expect(toastId).toBe(toastFn.mock.results[0].value);
+        expect(renderLastToastContent().container).toHaveTextContent('Custom body');
     });
 });
 
 describe('dismissToast', () => {
     it('dismisses a single toast by id', () => {
-        dismissToast('toast-id');
+        dismissToast('toast-1');
 
-        expect(dismiss).toHaveBeenCalledWith('toast-id');
+        expect(dismiss).toHaveBeenCalledWith('toast-1');
     });
 
     it('dismisses every open toast when called with no id', () => {
@@ -87,28 +95,58 @@ describe('dismissToast', () => {
 });
 
 describe('useBufferFocus', () => {
-    it('opens a toast that persists until dismissed and keeps its id in activeToastAtom', () => {
+    const focusBuffer = () => {
         const { result } = renderHook(() => useBufferFocus());
 
         act(() => result.current.updateBufferFocus(1024, 7));
+
+        return result;
+    };
+
+    it('opens a toast that persists until dismissed and records the selection', () => {
+        const result = focusBuffer();
 
         expect(toastFn).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ autoClose: false }));
-        expect(result.current.activeToast).toBe('toast-id');
+        expect(result.current.activeToast).toBe(toastFn.mock.results[0].value);
+        expect(result.current.selectedAddress).toBe(1024);
+        expect(result.current.selectedTensorId).toBe(7);
+        expect(result.current.selectedBufferColour).toEqual(expect.any(String));
     });
 
-    it('dismisses the previous toast before opening the next one', () => {
-        const { result } = renderHook(() => useBufferFocus());
+    it('opens the first toast without dismissing anything', () => {
+        focusBuffer();
 
-        act(() => result.current.updateBufferFocus(1024, 7));
+        expect(dismiss).not.toHaveBeenCalled();
+    });
+
+    it('dismisses the previous toast, not the new one, before opening the next', () => {
+        const result = focusBuffer();
+        const previousToast = result.current.activeToast;
+
         act(() => result.current.updateBufferFocus(2048, 8));
 
-        expect(dismiss).toHaveBeenCalledWith('toast-id');
+        expect(result.current.activeToast).not.toBe(previousToast);
+        expect(dismiss).toHaveBeenCalledTimes(1);
+        expect(dismiss).toHaveBeenCalledWith(previousToast);
+        expect(dismiss.mock.invocationCallOrder[0]).toBeLessThan(toastFn.mock.invocationCallOrder[1]);
+    });
+
+    it('clears the selection when the toast itself is clicked', () => {
+        const result = focusBuffer();
+        const { onClick } = lastToastCall()[1]!;
+
+        act(() => onClick!({} as MouseEvent<HTMLElement>));
+
+        expect(result.current.activeToast).toBeNull();
+        expect(result.current.selectedAddress).toBeNull();
+        expect(result.current.selectedTensorId).toBeNull();
+        expect(result.current.selectedBufferColour).toBeNull();
+        expect(dismiss).toHaveBeenLastCalledWith(undefined);
     });
 
     it('dismisses every toast when the selection is reset', () => {
-        const { result } = renderHook(() => useBufferFocus());
+        const result = focusBuffer();
 
-        act(() => result.current.updateBufferFocus(1024, 7));
         act(() => result.current.resetToasts());
 
         expect(dismiss).toHaveBeenLastCalledWith(undefined);

--- a/tests/helpers/mockToastNotification.ts
+++ b/tests/helpers/mockToastNotification.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Mock, vi } from 'vitest';
+
+// `vi.mock('.../createToastNotification', () => toastNotificationModuleMock())` -- one shape
+// for every spec that only wants toasts neutralised. Supplying the whole module matters:
+// a factory that returns `default` alone leaves `createToast`/`dismissToast` undefined, so
+// any component that later reaches the persistent-toast path fails as "not a function"
+// rather than as the assertion the spec was written for.
+export function toastNotificationModuleMock(createToastNotification: Mock = vi.fn()) {
+    return {
+        default: createToastNotification,
+        createToast: vi.fn(() => 'mock-toast-id'),
+        dismissToast: vi.fn(),
+    };
+}


### PR DESCRIPTION
Closes #1917.

`src/hooks/useBufferFocus.tsx` imported `toast` from `react-toastify` directly because the wrapper exposed neither of the two things it needs: per-toast options (`autoClose: false`, so the toast survives until dismissed) and the returned `Id` (stored in `activeToastAtom`, so selecting a different buffer can dismiss the previous toast). Guidance treated that as an intentional exception. This removes the exception rather than documenting it.

## Changes

**`src/functions/createToastNotification.tsx`** — two named exports alongside the existing default:

- `createToast(content, options?, type?): Id` — arbitrary content, per-toast options, returns the id. This is the options pass-through the issue asks for.
- `dismissToast(toastId?)` — closes one toast, or all of them when called with no argument.

`createToastNotification` keeps its `(message, fileName, type?)` signature and behaviour, now returns the `Id`, and delegates to `createToast`. Its `const args: ToastOptions = {}` placeholder and the comment explaining why it was empty are gone.

The default export takes **no** `options` argument. An earlier revision of this branch gave it one; it was dropped on review because no call site passed it and it created a second documented route to per-toast options, contradicting the guidance added in the same commit. Options belong on `createToast`, which is what the one real consumer — `useBufferFocus`, whose toast body is `ToastTensorMessage`, not the `ToastFileChange` template — actually calls.

**`src/hooks/useBufferFocus.tsx`** — moved onto `createToast` / `dismissToast`. Only the type import from `react-toastify` remains. No behavioural change: the same options object is passed through, and `dismissToast()` with no argument is `toast.dismiss()`.

**`eslint.config.cjs`** — with the last direct caller gone, `no-restricted-imports` now enforces what the docs previously only stated: `react-toastify`'s `toast` may be imported by the wrapper module and nowhere else, and that module carries the sole override. airbnb-base ships this rule `off` with an empty config, so nothing pre-existing is displaced. Type imports (`Id`, `ToastOptions`) are deliberately unrestricted — `activeToastAtom` is typed `Id | null`.

**`tests/createToastNotification.spec.tsx`** (new, 13 tests) — the module had no coverage. Mocks `react-toastify` and asserts on what reaches it: the file-change template and its `TOAST_FILENAME` testid, `ToastType` routing table-driven over all four enum members, `createToast`'s options pass-through and returned id, both `dismissToast` arities, and five `useBufferFocus` behaviours (persistent toast, id into `activeToastAtom`, the selection writes, the previous toast dismissed — by id, before the next opens — and `onClick` clearing the selection).

Each mocked toast issues a **fresh** id rather than a constant, so an assertion naming which toast was dismissed cannot pass by coincidence. Verified by mutation: hard-coding the dismissed id, dropping `onClick: resetToasts`, and dropping `setSelectedAddress` each fail exactly one test.

**`tests/helpers/mockToastNotification.ts`** (new) — supplies the whole module shape to the four specs that previously mocked `default` alone, which left the new named exports `undefined` for anything reaching the persistent-toast path.

**`CONVENTIONS.md` / `AGENTS.md`** — documented the two new exports and when to reach for them, removed the now-resolved Known-inconsistencies entry. The `AGENTS.md` bullet stays a summary and links to the expanded `CONVENTIONS.md` section.

## A note on scope

The lint rule goes slightly beyond the issue text, which asks only to extend the wrapper and move the hook. It is included because the issue's stated goal is that the rule "has no carve-out" — and a convention with zero remaining exceptions is exactly the point at which it becomes cheap to enforce mechanically rather than at review. Happy to drop that hunk if you would rather keep it docs-only.

## Verification

- `pnpm lint` — clean. Confirmed the new rule fires by temporarily restoring the direct import in `useBufferFocus` (`error ... no-restricted-imports`), then reverting.
- `tsc --noEmit` — clean.
- `pnpm lint:spdx` — clean.
- `vitest run` — full suite, 2164 tests across 198 files, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
