### PR TITLE
Add Github Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# TT-NN Visualizer Copilot Instructions
+
+Before making or reviewing changes, read and follow [AGENTS.md](../AGENTS.md) and [CONVENTIONS.md](../CONVENTIONS.md). These are the canonical repository instructions for architecture, security, coding standards, testing, and review priorities.
+
+Check the relevant sections of both files rather than relying on assumptions. Preserve unrelated user changes, keep edits focused, and validate changed behaviour with the repository's documented checks.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,3 @@
 # TT-NN Visualizer Copilot Instructions
 
 Before making or reviewing changes, read and follow [AGENTS.md](../AGENTS.md) and [CONVENTIONS.md](../CONVENTIONS.md). These are the canonical repository instructions for architecture, security, coding standards, testing, and review priorities.
-
-Check the relevant sections of both files rather than relying on assumptions. Preserve unrelated user changes, keep edits focused, and validate changed behaviour with the repository's documented checks.


### PR DESCRIPTION
This pull request adds a new documentation file, `.github/copilot-instructions.md`, providing clear instructions for contributors and reviewers. The file directs users to consult the main architecture, security, coding standards, and review guidelines before making changes.

Documentation improvements:
* Added `.github/copilot-instructions.md` to instruct contributors and reviewers to read `AGENTS.md` and `CONVENTIONS.md` for repository standards and best practices.