### PR TITLE
Operations graph: collapse repeated subgraphs

### DIFF
--- a/src/components/GraphOpFilter.tsx
+++ b/src/components/GraphOpFilter.tsx
@@ -20,15 +20,14 @@ interface GraphOpFilterProps {
     // True only when in regex mode and the current query fails to compile —
     // drives the danger-intent input styling and the counter text.
     isRegexInvalid: boolean;
-    // What prev/next steps through. In MLIR a collapsed anchor standing in for
-    // buried descendants counts as one.
+    // What prev/next steps through. A collapsed MLIR namespace or folded repeat
+    // block standing in for buried matches counts as one.
     matchCount: number;
     // 0-based cursor within `matchCount`, or null when no match is focused.
     currentMatchIndex: number | null;
     onPrev: () => void;
     onNext: () => void;
-    // Matches hidden inside collapsed namespaces, which drives the "+K inside"
-    // suffix. Only MLIR has a hierarchy deep enough to bury one.
+    // Matches hidden inside collapsed namespaces or folded repeat blocks.
     hiddenMatchCount?: number;
     isDisabled?: boolean;
 }
@@ -81,8 +80,8 @@ const GraphOpFilterInner = forwardRef<GraphOpFilterHandle, GraphOpFilterProps>(
         const isRegexMode = mode === GraphFilterMode.REGEX;
         const hiddenSuffix = hiddenMatchCount > 0 ? ` (+${hiddenMatchCount} inside)` : '';
         // A cursor left over from a wider match set would render an impossible
-        // ratio like "5 / 2" after the query narrows — or, in MLIR, after an
-        // expand/collapse changed which reps are visible.
+        // ratio like "5 / 2" after the query narrows — or after an expand/fold
+        // changed which reps are visible.
         const activeMatchIndex =
             currentMatchIndex !== null && currentMatchIndex < matchCount ? currentMatchIndex : null;
         let counterText: string | null = null;

--- a/src/components/operation-graph/OpGraphBlockExpander.tsx
+++ b/src/components/operation-graph/OpGraphBlockExpander.tsx
@@ -2,7 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { type MouseEvent as ReactMouseEvent, memo, useContext } from 'react';
+import { memo, useContext } from 'react';
+import OpGraphNodeExpander from './OpGraphNodeExpander';
 import { OpGraphBlockExpansionContext } from './opGraphExpansionContext';
 
 interface OpGraphBlockExpanderProps {
@@ -14,44 +15,13 @@ interface OpGraphBlockExpanderProps {
 const OpGraphBlockExpander = memo(({ instanceId, opCount, isExpanded }: OpGraphBlockExpanderProps) => {
     const toggleBlock = useContext(OpGraphBlockExpansionContext);
 
-    // React Flow reads selection off `mousedown`, so without this the expander
-    // would also select the operation and start the centring tween that goes with
-    // it — the graph would jump before it expanded. Structural navigation and
-    // selection stay separate gestures.
-    const handleMouseDown = (event: ReactMouseEvent) => event.stopPropagation();
-
-    const handleClick = (event: ReactMouseEvent) => {
-        event.stopPropagation();
-        toggleBlock(instanceId);
-    };
-
-    // Also the accessible name: `title` only supplies one when the element has no
-    // content, and the count is content — so without this the button announced as
-    // the bare number.
-    const action = isExpanded ? `Fold ${opCount} operations` : `Unroll ${opCount} operations`;
-
     return (
-        <button
-            type='button'
-            // `nodrag`/`nopan` keep the button from doubling as a drag or pan surface.
-            className='op-graph-node-expander nodrag nopan'
-            title={action}
-            aria-label={action}
-            aria-expanded={isExpanded}
-            onMouseDown={handleMouseDown}
-            onClick={handleClick}
-        >
-            {/* Down opens, up closes — a chevron that only reported the current
-                state read as "expand further". Same glyph, rotated: `▴` sits
-                high in the em-box and the count looks dropped beside it. */}
-            <span
-                aria-hidden='true'
-                className='op-graph-node-expander-icon'
-            >
-                ▾
-            </span>
-            {opCount}
-        </button>
+        <OpGraphNodeExpander
+            action={isExpanded ? `Fold ${opCount} operations` : `Unroll ${opCount} operations`}
+            count={opCount}
+            isExpanded={isExpanded}
+            onToggle={() => toggleBlock(instanceId)}
+        />
     );
 });
 

--- a/src/components/operation-graph/OpGraphBlockExpander.tsx
+++ b/src/components/operation-graph/OpGraphBlockExpander.tsx
@@ -21,7 +21,7 @@ const OpGraphBlockExpander = memo(({ instanceId, opCount, isExpanded }: OpGraphB
         toggleBlock(instanceId);
     };
 
-    const action = isExpanded ? 'Collapse repeated block' : `Expand ${opCount} operations`;
+    const action = isExpanded ? `Fold ${opCount} operations` : `Unroll ${opCount} operations`;
 
     return (
         <button

--- a/src/components/operation-graph/OpGraphBlockExpander.tsx
+++ b/src/components/operation-graph/OpGraphBlockExpander.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { type MouseEvent as ReactMouseEvent, memo, useContext } from 'react';
+import { OpGraphBlockExpansionContext } from './opGraphExpansionContext';
+
+interface OpGraphBlockExpanderProps {
+    instanceId: string;
+    opCount: number;
+    isExpanded: boolean;
+}
+
+const OpGraphBlockExpander = memo(({ instanceId, opCount, isExpanded }: OpGraphBlockExpanderProps) => {
+    const toggleBlock = useContext(OpGraphBlockExpansionContext);
+
+    const handleMouseDown = (event: ReactMouseEvent) => event.stopPropagation();
+
+    const handleClick = (event: ReactMouseEvent) => {
+        event.stopPropagation();
+        toggleBlock(instanceId);
+    };
+
+    const action = isExpanded ? 'Collapse repeated block' : `Expand ${opCount} operations`;
+
+    return (
+        <button
+            type='button'
+            className='op-graph-node-expander nodrag nopan'
+            title={action}
+            aria-label={action}
+            aria-expanded={isExpanded}
+            onMouseDown={handleMouseDown}
+            onClick={handleClick}
+        >
+            <span
+                aria-hidden='true'
+                className='op-graph-node-expander-icon'
+            >
+                ▾
+            </span>
+            {opCount}
+        </button>
+    );
+});
+
+OpGraphBlockExpander.displayName = 'OpGraphBlockExpander';
+
+export default OpGraphBlockExpander;

--- a/src/components/operation-graph/OpGraphBlockExpander.tsx
+++ b/src/components/operation-graph/OpGraphBlockExpander.tsx
@@ -14,6 +14,10 @@ interface OpGraphBlockExpanderProps {
 const OpGraphBlockExpander = memo(({ instanceId, opCount, isExpanded }: OpGraphBlockExpanderProps) => {
     const toggleBlock = useContext(OpGraphBlockExpansionContext);
 
+    // React Flow reads selection off `mousedown`, so without this the expander
+    // would also select the operation and start the centring tween that goes with
+    // it — the graph would jump before it expanded. Structural navigation and
+    // selection stay separate gestures.
     const handleMouseDown = (event: ReactMouseEvent) => event.stopPropagation();
 
     const handleClick = (event: ReactMouseEvent) => {
@@ -21,11 +25,15 @@ const OpGraphBlockExpander = memo(({ instanceId, opCount, isExpanded }: OpGraphB
         toggleBlock(instanceId);
     };
 
+    // Also the accessible name: `title` only supplies one when the element has no
+    // content, and the count is content — so without this the button announced as
+    // the bare number.
     const action = isExpanded ? `Fold ${opCount} operations` : `Unroll ${opCount} operations`;
 
     return (
         <button
             type='button'
+            // `nodrag`/`nopan` keep the button from doubling as a drag or pan surface.
             className='op-graph-node-expander nodrag nopan'
             title={action}
             aria-label={action}
@@ -33,6 +41,9 @@ const OpGraphBlockExpander = memo(({ instanceId, opCount, isExpanded }: OpGraphB
             onMouseDown={handleMouseDown}
             onClick={handleClick}
         >
+            {/* Down opens, up closes — a chevron that only reported the current
+                state read as "expand further". Same glyph, rotated: `▴` sits
+                high in the em-box and the count looks dropped beside it. */}
             <span
                 aria-hidden='true'
                 className='op-graph-node-expander-icon'

--- a/src/components/operation-graph/OpGraphBlockNode.tsx
+++ b/src/components/operation-graph/OpGraphBlockNode.tsx
@@ -4,21 +4,8 @@
 
 import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { memo } from 'react';
-import { formatMemorySize, formatSize } from '../../functions/math';
 import OpGraphBlockExpander from './OpGraphBlockExpander';
 import type { OpGraphFlowNode } from './opGraphTypes';
-
-const blockMeta = (opCount: number, durationSeconds: number, memoryDeltaBytes: number): string => {
-    const parts = [`${opCount} ops`];
-    if (durationSeconds > 0) {
-        parts.push(`${formatSize(durationSeconds, 2)} s`);
-    }
-    if (memoryDeltaBytes !== 0) {
-        const sign = memoryDeltaBytes > 0 ? '+' : '-';
-        parts.push(`${sign}${formatMemorySize(Math.abs(memoryDeltaBytes), 0)}`);
-    }
-    return parts.join(' · ');
-};
 
 const OpGraphBlockNode = memo(({ data }: NodeProps<OpGraphFlowNode>) => {
     const instanceId = data.blockInstanceId;
@@ -34,9 +21,7 @@ const OpGraphBlockNode = memo(({ data }: NodeProps<OpGraphFlowNode>) => {
                 position={Position.Top}
             />
             <div className='op-graph-node-label'>{data.label}</div>
-            <div className='op-graph-node-file'>
-                {blockMeta(opCount, data.durationSeconds ?? 0, data.memoryDeltaBytes ?? 0)}
-            </div>
+            <div className='op-graph-node-file'>{data.fileIdentifier}</div>
             <OpGraphBlockExpander
                 instanceId={instanceId}
                 opCount={opCount}

--- a/src/components/operation-graph/OpGraphBlockNode.tsx
+++ b/src/components/operation-graph/OpGraphBlockNode.tsx
@@ -29,7 +29,7 @@ const OpGraphBlockNode = memo(({ data }: NodeProps<OpGraphFlowNode>) => {
             >
                 {data.label}
             </div>
-            <div className='op-graph-node-file'>{data.fileIdentifier}</div>
+            <div className='op-graph-node-meta'>{data.metaLine}</div>
             <OpGraphBlockExpander
                 instanceId={instanceId}
                 opCount={opCount}

--- a/src/components/operation-graph/OpGraphBlockNode.tsx
+++ b/src/components/operation-graph/OpGraphBlockNode.tsx
@@ -20,7 +20,15 @@ const OpGraphBlockNode = memo(({ data }: NodeProps<OpGraphFlowNode>) => {
                 type='target'
                 position={Position.Top}
             />
-            <div className='op-graph-node-label'>{data.label}</div>
+            {/* The label is capped at `NODE_MAX_WIDTH` and ellipsised, and a block
+                naming several modules can outrun it. The native tooltip is the only
+                place the whole name is readable, on the node or in the panel. */}
+            <div
+                className='op-graph-node-label'
+                title={data.label}
+            >
+                {data.label}
+            </div>
             <div className='op-graph-node-file'>{data.fileIdentifier}</div>
             <OpGraphBlockExpander
                 instanceId={instanceId}

--- a/src/components/operation-graph/OpGraphBlockNode.tsx
+++ b/src/components/operation-graph/OpGraphBlockNode.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { Handle, type NodeProps, Position } from '@xyflow/react';
+import { memo } from 'react';
+import { formatMemorySize, formatSize } from '../../functions/math';
+import OpGraphBlockExpander from './OpGraphBlockExpander';
+import type { OpGraphFlowNode } from './opGraphTypes';
+
+const blockMeta = (opCount: number, durationSeconds: number, memoryDeltaBytes: number): string => {
+    const parts = [`${opCount} ops`];
+    if (durationSeconds > 0) {
+        parts.push(`${formatSize(durationSeconds, 2)} s`);
+    }
+    if (memoryDeltaBytes !== 0) {
+        const sign = memoryDeltaBytes > 0 ? '+' : '-';
+        parts.push(`${sign}${formatMemorySize(Math.abs(memoryDeltaBytes), 0)}`);
+    }
+    return parts.join(' · ');
+};
+
+const OpGraphBlockNode = memo(({ data }: NodeProps<OpGraphFlowNode>) => {
+    const instanceId = data.blockInstanceId;
+    const opCount = data.opCount ?? 0;
+    if (instanceId === undefined) {
+        return null;
+    }
+
+    return (
+        <>
+            <Handle
+                type='target'
+                position={Position.Top}
+            />
+            <div className='op-graph-node-label'>{data.label}</div>
+            <div className='op-graph-node-file'>
+                {blockMeta(opCount, data.durationSeconds ?? 0, data.memoryDeltaBytes ?? 0)}
+            </div>
+            <OpGraphBlockExpander
+                instanceId={instanceId}
+                opCount={opCount}
+                isExpanded={false}
+            />
+            {data.buriedMatchCount ? (
+                <span
+                    className='op-graph-node-buried-badge'
+                    title={`${data.buriedMatchCount} filter ${
+                        data.buriedMatchCount === 1 ? 'match' : 'matches'
+                    } inside`}
+                >
+                    {`+${data.buriedMatchCount}`}
+                </span>
+            ) : null}
+            <Handle
+                type='source'
+                position={Position.Bottom}
+            />
+        </>
+    );
+});
+
+OpGraphBlockNode.displayName = 'OpGraphBlockNode';
+
+export default OpGraphBlockNode;

--- a/src/components/operation-graph/OpGraphDeviceOpExpander.tsx
+++ b/src/components/operation-graph/OpGraphDeviceOpExpander.tsx
@@ -2,7 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { type MouseEvent as ReactMouseEvent, memo, useContext } from 'react';
+import { memo, useContext } from 'react';
+import OpGraphNodeExpander from './OpGraphNodeExpander';
 import { OpGraphExpansionContext } from './opGraphExpansionContext';
 
 interface OpGraphDeviceOpExpanderProps {
@@ -14,44 +15,16 @@ interface OpGraphDeviceOpExpanderProps {
 const OpGraphDeviceOpExpander = memo(({ operationId, count, isExpanded }: OpGraphDeviceOpExpanderProps) => {
     const toggleExpansion = useContext(OpGraphExpansionContext);
 
-    // React Flow reads selection off `mousedown`, so without this the expander
-    // would also select the operation and start the centring tween that goes with
-    // it — the graph would jump before it expanded. Structural navigation and
-    // selection stay separate gestures.
-    const handleMouseDown = (event: ReactMouseEvent) => event.stopPropagation();
-
-    const handleClick = (event: ReactMouseEvent) => {
-        event.stopPropagation();
-        toggleExpansion(operationId);
-    };
-
-    // Also the accessible name: `title` only supplies one when the element has no
-    // content, and the count is content — so without this the button announced as
-    // the bare number.
-    const action = isExpanded ? 'Hide device operations' : `Show ${count} device operations`;
-
     return (
-        <button
-            type='button'
-            // `nodrag`/`nopan` keep the button from doubling as a drag or pan surface.
-            className='op-graph-node-expander nodrag nopan'
-            title={action}
-            aria-label={action}
-            aria-expanded={isExpanded}
-            onMouseDown={handleMouseDown}
-            onClick={handleClick}
-        >
-            {/* Down opens, up closes — a chevron that only reported the current
-                state read as "expand further". Same glyph, rotated: `▴` sits
-                high in the em-box and the count looks dropped beside it. */}
-            <span
-                aria-hidden='true'
-                className='op-graph-node-expander-icon'
-            >
-                ▾
-            </span>
-            {count}
-        </button>
+        <OpGraphNodeExpander
+            // Also the accessible name: `title` only supplies one when the element
+            // has no content, and the count is content — so without this the button
+            // announced as the bare number.
+            action={isExpanded ? 'Hide device operations' : `Show ${count} device operations`}
+            count={count}
+            isExpanded={isExpanded}
+            onToggle={() => toggleExpansion(operationId)}
+        />
     );
 });
 

--- a/src/components/operation-graph/OpGraphInfoPanel.tsx
+++ b/src/components/operation-graph/OpGraphInfoPanel.tsx
@@ -20,7 +20,6 @@ import MemoryConfigRow from '../MemoryConfigRow';
 import MemoryTag from '../MemoryTag';
 import SourceFileButton from '../operation-details/SourceFileButton';
 import PerfOverlayOpMetric from '../perf-overlay/PerfOverlayOpMetric';
-import { sumOptional } from './opGraphRepeatBlocks';
 import type { OpGraphBlockSummary } from './opGraphTypes';
 
 interface ConnectedOpGroup {
@@ -72,9 +71,6 @@ const getConnectedOpGroups = (
 
     return Array.from(groupsByKey.values());
 };
-
-const tensorBytes = (tensors: { size: number | null }[]): number =>
-    tensors.reduce((total, tensor) => total + (tensor.size ?? 0), 0);
 
 const uniqueNameCounts = (names: readonly string[]): Array<{ name: string; count: number }> => {
     const counts: Array<{ name: string; count: number }> = [];
@@ -273,10 +269,9 @@ const OpGraphBlockPanel = ({
         [members, memberIds, operationNamesById],
     );
     const typeCounts = useMemo(() => uniqueNameCounts(members.map((member) => member.name)), [members]);
-    const durationSeconds = sumOptional(members.map((member) => member.duration));
-    const memoryDeltaBytes = sumOptional(
-        members.map((member) => tensorBytes(member.outputs) - tensorBytes(member.inputs)),
-    );
+    // Carried on the summary, not re-derived: the node's meta line is on screen at
+    // the same time and is formatted from these same two numbers.
+    const { durationSeconds, memoryDeltaBytes } = block;
     const firstOpId = block.operationIds[0];
     const lastOpId = block.operationIds[block.operationIds.length - 1];
     const inputCount = inputGroups.reduce((total, group) => total + group.tensors.length, 0);

--- a/src/components/operation-graph/OpGraphInfoPanel.tsx
+++ b/src/components/operation-graph/OpGraphInfoPanel.tsx
@@ -290,7 +290,12 @@ const OpGraphBlockPanel = ({
         >
             <header className='op-graph-panel-header'>
                 <div className='op-graph-panel-titles'>
-                    <h2 className='op-graph-panel-label'>{block.label}</h2>
+                    <h2
+                        className='op-graph-panel-label'
+                        title={block.label}
+                    >
+                        {block.label}
+                    </h2>
                     <p className='op-graph-panel-id'>
                         {`ops ${firstOpId}–${lastOpId} · instance ${block.instanceIndex + 1} of ${block.instanceCount}`}
                     </p>
@@ -434,7 +439,10 @@ const OpGraphInfoPanel = memo(
             >
                 <header className='op-graph-panel-header'>
                     <div className='op-graph-panel-titles'>
-                        <h2 className='op-graph-panel-label'>
+                        <h2
+                            className='op-graph-panel-label'
+                            title={`${operationId} ${operation?.name ?? ''}`.trim()}
+                        >
                             {operationId} {operation?.name}
                         </h2>
                         <p

--- a/src/components/operation-graph/OpGraphInfoPanel.tsx
+++ b/src/components/operation-graph/OpGraphInfoPanel.tsx
@@ -231,7 +231,7 @@ const ConnectedOpGroupList = ({ groups, keyPrefix, onLocate }: ConnectedOpGroupL
 
 interface OpGraphBlockPanelProps {
     block: OpGraphBlockSummary;
-    operationList: OperationDescription[];
+    operationById: Map<number, OperationDescription>;
     operationNamesById: Map<number, string>;
     onLocateOperation: (operationId: number) => void;
     isPerfOverlayActive: boolean;
@@ -240,7 +240,7 @@ interface OpGraphBlockPanelProps {
 
 const OpGraphBlockPanel = ({
     block,
-    operationList,
+    operationById,
     operationNamesById,
     onLocateOperation,
     isPerfOverlayActive,
@@ -250,9 +250,9 @@ const OpGraphBlockPanel = ({
     const members = useMemo(
         () =>
             block.operationIds
-                .map((id) => operationList.find((operation) => operation.id === id))
+                .map((id) => operationById.get(id))
                 .filter((operation): operation is OperationDescription => operation !== undefined),
-        [block.operationIds, operationList],
+        [block.operationIds, operationById],
     );
     const inputGroups = useMemo(
         () =>
@@ -377,7 +377,7 @@ const OpGraphBlockPanel = ({
 
 interface OpGraphInfoPanelProps {
     operationId: number;
-    operationList: OperationDescription[];
+    operationById: Map<number, OperationDescription>;
     operationNamesById: Map<number, string>;
     onLocateOperation: (operationId: number) => void;
     isPerfOverlayActive: boolean;
@@ -391,7 +391,7 @@ interface OpGraphInfoPanelProps {
 const OpGraphInfoPanel = memo(
     ({
         operationId,
-        operationList,
+        operationById,
         operationNamesById,
         onLocateOperation,
         isPerfOverlayActive,
@@ -400,7 +400,7 @@ const OpGraphInfoPanel = memo(
         block = null,
     }: OpGraphInfoPanelProps) => {
         const navigate = useNavigate();
-        const operation = operationList.find((op) => op.id === operationId);
+        const operation = operationById.get(operationId);
         const operationSourceData = operation ? extractOperationSourceData(operation) : null;
 
         const inputGroups = useMemo(
@@ -418,7 +418,7 @@ const OpGraphInfoPanel = memo(
             return (
                 <OpGraphBlockPanel
                     block={block}
-                    operationList={operationList}
+                    operationById={operationById}
                     operationNamesById={operationNamesById}
                     onLocateOperation={onLocateOperation}
                     isPerfOverlayActive={isPerfOverlayActive}

--- a/src/components/operation-graph/OpGraphInfoPanel.tsx
+++ b/src/components/operation-graph/OpGraphInfoPanel.tsx
@@ -12,6 +12,7 @@ import ROUTES from '../../definitions/Routes';
 import { StackTraceLanguage } from '../../definitions/StackTrace';
 import { toReadableShape, toReadableType } from '../../functions/formatting';
 import { formatMemorySize, formatSize } from '../../functions/math';
+import { getBlockBoundaryTensors } from './opGraphBlockBoundary';
 import { extractOperationSourceData } from '../../functions/stackTraceSource';
 import type { OperationDescription, Tensor } from '../../model/APIData';
 import { BufferTypeLabel } from '../../model/BufferType';
@@ -85,45 +86,6 @@ const uniqueNameCounts = (names: readonly string[]): Array<{ name: string; count
         }
     }
     return counts;
-};
-
-const withExternalEndpoints = (tensor: Tensor, memberIds: ReadonlySet<number>, direction: NodeRelation): Tensor => {
-    if (direction === NodeRelation.Input) {
-        const producers = tensor.producers ?? [];
-        const producerNames = tensor.producerNames ?? [];
-        const keep = producers
-            .map((id, index) => ({ id, name: producerNames[index] ?? '' }))
-            .filter((entry) => !memberIds.has(entry.id));
-        return { ...tensor, producers: keep.map((entry) => entry.id), producerNames: keep.map((entry) => entry.name) };
-    }
-    const consumers = tensor.consumers ?? [];
-    const consumerNames = tensor.consumerNames ?? [];
-    const keep = consumers
-        .map((id, index) => ({ id, name: consumerNames[index] ?? '' }))
-        .filter((entry) => !memberIds.has(entry.id));
-    return { ...tensor, consumers: keep.map((entry) => entry.id), consumerNames: keep.map((entry) => entry.name) };
-};
-
-const getBlockBoundaryTensors = (
-    members: OperationDescription[],
-    memberIds: ReadonlySet<number>,
-    direction: NodeRelation,
-): Tensor[] => {
-    const tensors: Tensor[] = [];
-    const seenIds = new Set<number>();
-    for (const member of members) {
-        const list = (direction === NodeRelation.Input ? member.inputs : member.outputs) ?? [];
-        for (const tensor of list) {
-            if (!seenIds.has(tensor.id)) {
-                const counterparts = (direction === NodeRelation.Input ? tensor.producers : tensor.consumers) ?? [];
-                if (counterparts.length === 0 || counterparts.some((id) => !memberIds.has(id))) {
-                    seenIds.add(tensor.id);
-                    tensors.push(withExternalEndpoints(tensor, memberIds, direction));
-                }
-            }
-        }
-    }
-    return tensors;
 };
 
 interface TensorDetailsProps {

--- a/src/components/operation-graph/OpGraphInfoPanel.tsx
+++ b/src/components/operation-graph/OpGraphInfoPanel.tsx
@@ -11,6 +11,7 @@ import { NodeRelation } from '../../definitions/NodeRelation';
 import ROUTES from '../../definitions/Routes';
 import { StackTraceLanguage } from '../../definitions/StackTrace';
 import { toReadableShape, toReadableType } from '../../functions/formatting';
+import { formatMemorySize, formatSize } from '../../functions/math';
 import { extractOperationSourceData } from '../../functions/stackTraceSource';
 import type { OperationDescription, Tensor } from '../../model/APIData';
 import { BufferTypeLabel } from '../../model/BufferType';
@@ -19,6 +20,8 @@ import MemoryConfigRow from '../MemoryConfigRow';
 import MemoryTag from '../MemoryTag';
 import SourceFileButton from '../operation-details/SourceFileButton';
 import PerfOverlayOpMetric from '../perf-overlay/PerfOverlayOpMetric';
+import { sumOptional } from './opGraphRepeatBlocks';
+import type { OpGraphBlockSummary } from './opGraphTypes';
 
 interface ConnectedOpGroup {
     key: string;
@@ -68,6 +71,63 @@ const getConnectedOpGroups = (
     });
 
     return Array.from(groupsByKey.values());
+};
+
+const tensorBytes = (tensors: { size: number | null }[]): number =>
+    tensors.reduce((total, tensor) => total + (tensor.size ?? 0), 0);
+
+const uniqueNameCounts = (names: readonly string[]): Array<{ name: string; count: number }> => {
+    const counts: Array<{ name: string; count: number }> = [];
+    const indexByName = new Map<string, number>();
+    for (const name of names) {
+        const existing = indexByName.get(name);
+        if (existing === undefined) {
+            indexByName.set(name, counts.length);
+            counts.push({ name, count: 1 });
+        } else {
+            counts[existing].count += 1;
+        }
+    }
+    return counts;
+};
+
+const withExternalEndpoints = (tensor: Tensor, memberIds: ReadonlySet<number>, direction: NodeRelation): Tensor => {
+    if (direction === NodeRelation.Input) {
+        const producers = tensor.producers ?? [];
+        const producerNames = tensor.producerNames ?? [];
+        const keep = producers
+            .map((id, index) => ({ id, name: producerNames[index] ?? '' }))
+            .filter((entry) => !memberIds.has(entry.id));
+        return { ...tensor, producers: keep.map((entry) => entry.id), producerNames: keep.map((entry) => entry.name) };
+    }
+    const consumers = tensor.consumers ?? [];
+    const consumerNames = tensor.consumerNames ?? [];
+    const keep = consumers
+        .map((id, index) => ({ id, name: consumerNames[index] ?? '' }))
+        .filter((entry) => !memberIds.has(entry.id));
+    return { ...tensor, consumers: keep.map((entry) => entry.id), consumerNames: keep.map((entry) => entry.name) };
+};
+
+const getBlockBoundaryTensors = (
+    members: OperationDescription[],
+    memberIds: ReadonlySet<number>,
+    direction: NodeRelation,
+): Tensor[] => {
+    const tensors: Tensor[] = [];
+    const seenIds = new Set<number>();
+    for (const member of members) {
+        const list = (direction === NodeRelation.Input ? member.inputs : member.outputs) ?? [];
+        for (const tensor of list) {
+            if (!seenIds.has(tensor.id)) {
+                const counterparts = (direction === NodeRelation.Input ? tensor.producers : tensor.consumers) ?? [];
+                if (counterparts.length === 0 || counterparts.some((id) => !memberIds.has(id))) {
+                    seenIds.add(tensor.id);
+                    tensors.push(withExternalEndpoints(tensor, memberIds, direction));
+                }
+            }
+        }
+    }
+    return tensors;
 };
 
 interface TensorDetailsProps {
@@ -169,6 +229,152 @@ const ConnectedOpGroupList = ({ groups, keyPrefix, onLocate }: ConnectedOpGroupL
     </div>
 );
 
+interface OpGraphBlockPanelProps {
+    block: OpGraphBlockSummary;
+    operationList: OperationDescription[];
+    operationNamesById: Map<number, string>;
+    onLocateOperation: (operationId: number) => void;
+    isPerfOverlayActive: boolean;
+    perfDeviceTimeNs?: number;
+}
+
+const OpGraphBlockPanel = ({
+    block,
+    operationList,
+    operationNamesById,
+    onLocateOperation,
+    isPerfOverlayActive,
+    perfDeviceTimeNs,
+}: OpGraphBlockPanelProps) => {
+    const memberIds = useMemo(() => new Set(block.operationIds), [block.operationIds]);
+    const members = useMemo(
+        () =>
+            block.operationIds
+                .map((id) => operationList.find((operation) => operation.id === id))
+                .filter((operation): operation is OperationDescription => operation !== undefined),
+        [block.operationIds, operationList],
+    );
+    const inputGroups = useMemo(
+        () =>
+            getConnectedOpGroups(
+                getBlockBoundaryTensors(members, memberIds, NodeRelation.Input),
+                NodeRelation.Input,
+                operationNamesById,
+            ),
+        [members, memberIds, operationNamesById],
+    );
+    const outputGroups = useMemo(
+        () =>
+            getConnectedOpGroups(
+                getBlockBoundaryTensors(members, memberIds, NodeRelation.Output),
+                NodeRelation.Output,
+                operationNamesById,
+            ),
+        [members, memberIds, operationNamesById],
+    );
+    const typeCounts = useMemo(() => uniqueNameCounts(members.map((member) => member.name)), [members]);
+    const durationSeconds = sumOptional(members.map((member) => member.duration));
+    const memoryDeltaBytes = sumOptional(
+        members.map((member) => tensorBytes(member.outputs) - tensorBytes(member.inputs)),
+    );
+    const firstOpId = block.operationIds[0];
+    const lastOpId = block.operationIds[block.operationIds.length - 1];
+    const inputCount = inputGroups.reduce((total, group) => total + group.tensors.length, 0);
+    const outputCount = outputGroups.reduce((total, group) => total + group.tensors.length, 0);
+    const locateId = firstOpId;
+
+    return (
+        <aside
+            className='op-graph-panel'
+            aria-label='Selected block details'
+        >
+            <header className='op-graph-panel-header'>
+                <div className='op-graph-panel-titles'>
+                    <h2 className='op-graph-panel-label'>{block.label}</h2>
+                    <p className='op-graph-panel-id'>
+                        {`ops ${firstOpId}–${lastOpId} · instance ${block.instanceIndex + 1} of ${block.instanceCount}`}
+                    </p>
+                </div>
+                {locateId !== undefined && (
+                    <div className='op-graph-panel-actions'>
+                        <Tooltip
+                            content='Recenter'
+                            compact
+                        >
+                            <Button
+                                icon={IconNames.LOCATE}
+                                size={Size.SMALL}
+                                variant={ButtonVariant.MINIMAL}
+                                onClick={() => onLocateOperation(locateId)}
+                                aria-label={`Recenter on ${block.label}`}
+                            />
+                        </Tooltip>
+                    </div>
+                )}
+            </header>
+
+            <dl className='op-graph-panel-stats'>
+                <dt>Operations</dt>
+                <dd>{block.operationIds.length}</dd>
+                {durationSeconds > 0 ? (
+                    <>
+                        <dt>Python duration</dt>
+                        <dd>{`${formatSize(durationSeconds, 2)} s`}</dd>
+                    </>
+                ) : null}
+                {memoryDeltaBytes !== 0 ? (
+                    <>
+                        <dt>Memory delta</dt>
+                        <dd>
+                            {`${memoryDeltaBytes > 0 ? '+' : '-'}${formatMemorySize(Math.abs(memoryDeltaBytes), 0)}`}
+                        </dd>
+                    </>
+                ) : null}
+            </dl>
+
+            {isPerfOverlayActive ? <PerfOverlayOpMetric perfDeviceTimeNs={perfDeviceTimeNs} /> : null}
+
+            <PanelSection
+                title='Operation types'
+                count={typeCounts.length}
+                emptyHint='No operations in this instance.'
+            >
+                <ul className='op-graph-panel-device-ops'>
+                    {typeCounts.map((entry) => (
+                        <li key={entry.name}>{entry.count > 1 ? `${entry.name} × ${entry.count}` : entry.name}</li>
+                    ))}
+                </ul>
+            </PanelSection>
+
+            <PanelSection
+                title='Inputs'
+                count={inputCount}
+                emptyHint='No tensors enter this instance.'
+                modifierClass='op-graph-panel-inputs'
+            >
+                <ConnectedOpGroupList
+                    groups={inputGroups}
+                    keyPrefix={`block-input-${block.instanceId}`}
+                    onLocate={onLocateOperation}
+                />
+            </PanelSection>
+
+            <PanelSection
+                title='Outputs'
+                count={outputCount}
+                emptyHint='No tensors leave this instance.'
+                modifierClass='op-graph-panel-outputs'
+            >
+                <ConnectedOpGroupList
+                    groups={outputGroups}
+                    keyPrefix={`block-output-${block.instanceId}`}
+                    onLocate={onLocateOperation}
+                />
+            </PanelSection>
+        </aside>
+    );
+};
+
 interface OpGraphInfoPanelProps {
     operationId: number;
     operationList: OperationDescription[];
@@ -177,6 +383,7 @@ interface OpGraphInfoPanelProps {
     isPerfOverlayActive: boolean;
     perfDeviceTimeNs?: number;
     perfColor?: string;
+    block?: OpGraphBlockSummary | null;
 }
 
 // Node drag re-renders the graph every pointer frame, and re-rendering each
@@ -190,6 +397,7 @@ const OpGraphInfoPanel = memo(
         isPerfOverlayActive,
         perfDeviceTimeNs,
         perfColor,
+        block = null,
     }: OpGraphInfoPanelProps) => {
         const navigate = useNavigate();
         const operation = operationList.find((op) => op.id === operationId);
@@ -205,6 +413,19 @@ const OpGraphInfoPanel = memo(
         );
 
         const deviceOperationNames = operation?.deviceOperationNameList ?? [];
+
+        if (block !== null) {
+            return (
+                <OpGraphBlockPanel
+                    block={block}
+                    operationList={operationList}
+                    operationNamesById={operationNamesById}
+                    onLocateOperation={onLocateOperation}
+                    isPerfOverlayActive={isPerfOverlayActive}
+                    perfDeviceTimeNs={perfDeviceTimeNs}
+                />
+            );
+        }
 
         return (
             <aside

--- a/src/components/operation-graph/OpGraphInfoPanel.tsx
+++ b/src/components/operation-graph/OpGraphInfoPanel.tsx
@@ -348,9 +348,11 @@ interface OpGraphInfoPanelProps {
     block?: OpGraphBlockSummary | null;
 }
 
+type OpGraphOperationPanelProps = Omit<OpGraphInfoPanelProps, 'block'>;
+
 // Node drag re-renders the graph every pointer frame, and re-rendering each
 // tensor's memory-config table with it stutters. Every prop must be stable.
-const OpGraphInfoPanel = memo(
+const OpGraphOperationPanel = memo(
     ({
         operationId,
         operationById,
@@ -359,8 +361,7 @@ const OpGraphInfoPanel = memo(
         isPerfOverlayActive,
         perfDeviceTimeNs,
         perfColor,
-        block = null,
-    }: OpGraphInfoPanelProps) => {
+    }: OpGraphOperationPanelProps) => {
         const navigate = useNavigate();
         const operation = operationById.get(operationId);
         const operationSourceData = operation ? extractOperationSourceData(operation) : null;
@@ -375,19 +376,6 @@ const OpGraphInfoPanel = memo(
         );
 
         const deviceOperationNames = operation?.deviceOperationNameList ?? [];
-
-        if (block !== null) {
-            return (
-                <OpGraphBlockPanel
-                    block={block}
-                    operationById={operationById}
-                    operationNamesById={operationNamesById}
-                    onLocateOperation={onLocateOperation}
-                    isPerfOverlayActive={isPerfOverlayActive}
-                    perfDeviceTimeNs={perfDeviceTimeNs}
-                />
-            );
-        }
 
         return (
             <aside
@@ -494,6 +482,30 @@ const OpGraphInfoPanel = memo(
             </aside>
         );
     },
+);
+
+OpGraphOperationPanel.displayName = 'OpGraphOperationPanel';
+
+/**
+ * @description Picks the panel for what is selected. A dispatcher rather than one
+ * component with an early return: hooks run before a return, so selecting a block
+ * used to pay for the operation panel's source extraction and both connected-group
+ * memos and then discard them — on a component whose own contract is that it
+ * re-renders per drag frame.
+ */
+const OpGraphInfoPanel = memo(({ block = null, ...operationProps }: OpGraphInfoPanelProps) =>
+    block !== null ? (
+        <OpGraphBlockPanel
+            block={block}
+            operationById={operationProps.operationById}
+            operationNamesById={operationProps.operationNamesById}
+            onLocateOperation={operationProps.onLocateOperation}
+            isPerfOverlayActive={operationProps.isPerfOverlayActive}
+            perfDeviceTimeNs={operationProps.perfDeviceTimeNs}
+        />
+    ) : (
+        <OpGraphOperationPanel {...operationProps} />
+    ),
 );
 
 OpGraphInfoPanel.displayName = 'OpGraphInfoPanel';

--- a/src/components/operation-graph/OpGraphNodeExpander.tsx
+++ b/src/components/operation-graph/OpGraphNodeExpander.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { type MouseEvent as ReactMouseEvent, memo } from 'react';
+
+interface OpGraphNodeExpanderProps {
+    /** Title and accessible name; the two toggles word it differently. */
+    action: string;
+    count: number;
+    isExpanded: boolean;
+    onToggle: () => void;
+}
+
+/**
+ * @description The count chip on a node that opens into something — device
+ * operations, or a folded block's members. Presentational: the callers own the
+ * wording and bind the context toggle, which is all the two of them ever differed
+ * in. They were otherwise identical down to the comments, so a fix to the
+ * mousedown behaviour had to land twice or one comment started lying.
+ */
+const OpGraphNodeExpander = memo(({ action, count, isExpanded, onToggle }: OpGraphNodeExpanderProps) => {
+    // React Flow reads selection off `mousedown`, so without this the expander
+    // would also select the operation and start the centring tween that goes with
+    // it — the graph would jump before it expanded. Structural navigation and
+    // selection stay separate gestures.
+    const handleMouseDown = (event: ReactMouseEvent) => event.stopPropagation();
+
+    const handleClick = (event: ReactMouseEvent) => {
+        event.stopPropagation();
+        onToggle();
+    };
+
+    return (
+        <button
+            type='button'
+            // `nodrag`/`nopan` keep the button from doubling as a drag or pan surface.
+            className='op-graph-node-expander nodrag nopan'
+            title={action}
+            aria-label={action}
+            aria-expanded={isExpanded}
+            onMouseDown={handleMouseDown}
+            onClick={handleClick}
+        >
+            {/* Down opens, up closes — a chevron that only reported the current
+                state read as "expand further". Same glyph, rotated: `▴` sits
+                high in the em-box and the count looks dropped beside it. */}
+            <span
+                aria-hidden='true'
+                className='op-graph-node-expander-icon'
+            >
+                ▾
+            </span>
+            {count}
+        </button>
+    );
+});
+
+OpGraphNodeExpander.displayName = 'OpGraphNodeExpander';
+
+export default OpGraphNodeExpander;

--- a/src/components/operation-graph/OpGraphToolbar.tsx
+++ b/src/components/operation-graph/OpGraphToolbar.tsx
@@ -182,25 +182,6 @@ const OpGraphToolbar = memo(
                     />
                 </Tooltip>
 
-                {hasBlocks ? (
-                    <>
-                        <Button
-                            variant={ButtonVariant.OUTLINED}
-                            disabled={isDisabled || areAllBlocksExpanded}
-                            onClick={onExpandAllBlocks}
-                        >
-                            Expand all blocks
-                        </Button>
-                        <Button
-                            variant={ButtonVariant.OUTLINED}
-                            disabled={isDisabled || areAllBlocksCollapsed}
-                            onClick={onCollapseAllBlocks}
-                        >
-                            Collapse all blocks
-                        </Button>
-                    </>
-                ) : null}
-
                 <Switch
                     className='op-graph-toolbar-switch'
                     checked={hideDeallocate}
@@ -233,6 +214,28 @@ const OpGraphToolbar = memo(
                     isDisabled={isDisabled}
                 />
             </div>
+
+            {hasBlocks ? (
+                <div className='op-graph-toolbar-row'>
+                    <span className='op-graph-toolbar-group-label'>Repeats</span>
+                    <Button
+                        variant={ButtonVariant.OUTLINED}
+                        disabled={isDisabled || areAllBlocksExpanded}
+                        onClick={onExpandAllBlocks}
+                        aria-label='Unroll all repeats'
+                    >
+                        Unroll
+                    </Button>
+                    <Button
+                        variant={ButtonVariant.OUTLINED}
+                        disabled={isDisabled || areAllBlocksCollapsed}
+                        onClick={onCollapseAllBlocks}
+                        aria-label='Fold all repeats'
+                    >
+                        Fold
+                    </Button>
+                </div>
+            ) : null}
         </div>
     ),
 );

--- a/src/components/operation-graph/OpGraphToolbar.tsx
+++ b/src/components/operation-graph/OpGraphToolbar.tsx
@@ -73,6 +73,12 @@ interface OpGraphToolbarProps {
     linkedOpCount: number;
     totalOpCount: number;
     isDisabled: boolean;
+    hiddenMatchCount?: number;
+    hasBlocks?: boolean;
+    areAllBlocksExpanded?: boolean;
+    areAllBlocksCollapsed?: boolean;
+    onExpandAllBlocks?: () => void;
+    onCollapseAllBlocks?: () => void;
 }
 
 const OpGraphToolbar = memo(
@@ -101,6 +107,12 @@ const OpGraphToolbar = memo(
         linkedOpCount,
         totalOpCount,
         isDisabled,
+        hiddenMatchCount = 0,
+        hasBlocks = false,
+        areAllBlocksExpanded = false,
+        areAllBlocksCollapsed = true,
+        onExpandAllBlocks,
+        onCollapseAllBlocks,
     }: OpGraphToolbarProps) => (
         <div className='op-graph-toolbar'>
             <GraphOpFilter
@@ -114,6 +126,7 @@ const OpGraphToolbar = memo(
                 currentMatchIndex={currentMatchIndex}
                 onPrev={onPrevMatch}
                 onNext={onNextMatch}
+                hiddenMatchCount={hiddenMatchCount}
                 isDisabled={isDisabled}
             />
 
@@ -168,6 +181,25 @@ const OpGraphToolbar = memo(
                         }
                     />
                 </Tooltip>
+
+                {hasBlocks ? (
+                    <>
+                        <Button
+                            variant={ButtonVariant.OUTLINED}
+                            disabled={isDisabled || areAllBlocksExpanded}
+                            onClick={onExpandAllBlocks}
+                        >
+                            Expand all blocks
+                        </Button>
+                        <Button
+                            variant={ButtonVariant.OUTLINED}
+                            disabled={isDisabled || areAllBlocksCollapsed}
+                            onClick={onCollapseAllBlocks}
+                        >
+                            Collapse all blocks
+                        </Button>
+                    </>
+                ) : null}
 
                 <Switch
                     className='op-graph-toolbar-switch'

--- a/src/components/operation-graph/OpGraphToolbar.tsx
+++ b/src/components/operation-graph/OpGraphToolbar.tsx
@@ -65,6 +65,8 @@ interface OpGraphToolbarProps {
     onGoToOperation: (operationId: number) => void;
     hideDeallocate: boolean;
     onHideDeallocateChange: (next: boolean) => void;
+    focusUnrelatedEdges: boolean;
+    onFocusUnrelatedEdgesChange: (next: boolean) => void;
     isPerfOverlayActive: boolean;
     onPerfOverlayChange: (next: boolean) => void;
     isCriticalPathActive: boolean;
@@ -99,6 +101,8 @@ const OpGraphToolbar = memo(
         onGoToOperation,
         hideDeallocate,
         onHideDeallocateChange,
+        focusUnrelatedEdges,
+        onFocusUnrelatedEdgesChange,
         isPerfOverlayActive,
         onPerfOverlayChange,
         isCriticalPathActive,
@@ -189,6 +193,16 @@ const OpGraphToolbar = memo(
                         onHideDeallocateChange(event.currentTarget.checked)
                     }
                     label='Hide deallocate ops'
+                    disabled={isDisabled}
+                />
+
+                <Switch
+                    className='op-graph-toolbar-switch'
+                    checked={focusUnrelatedEdges}
+                    onChange={(event: FormEvent<HTMLInputElement>) =>
+                        onFocusUnrelatedEdgesChange(event.currentTarget.checked)
+                    }
+                    label='Dim unrelated edges'
                     disabled={isDisabled}
                 />
 

--- a/src/components/operation-graph/OpGraphToolbar.tsx
+++ b/src/components/operation-graph/OpGraphToolbar.tsx
@@ -65,8 +65,8 @@ interface OpGraphToolbarProps {
     onGoToOperation: (operationId: number) => void;
     hideDeallocate: boolean;
     onHideDeallocateChange: (next: boolean) => void;
-    focusUnrelatedEdges: boolean;
-    onFocusUnrelatedEdgesChange: (next: boolean) => void;
+    isDimUnrelatedEdges: boolean;
+    onDimUnrelatedEdgesChange: (next: boolean) => void;
     isPerfOverlayActive: boolean;
     onPerfOverlayChange: (next: boolean) => void;
     isCriticalPathActive: boolean;
@@ -76,11 +76,14 @@ interface OpGraphToolbarProps {
     totalOpCount: number;
     isDisabled: boolean;
     hiddenMatchCount?: number;
-    hasBlocks?: boolean;
-    areAllBlocksExpanded?: boolean;
-    areAllBlocksCollapsed?: boolean;
-    onExpandAllBlocks?: () => void;
-    onCollapseAllBlocks?: () => void;
+    // Required, though the sole caller supplies them anyway: optional handlers let
+    // `disabled={isDisabled || areAllBlocksExpanded}` render an enabled button whose
+    // onClick is undefined — a silent no-op the type system should be catching.
+    hasBlocks: boolean;
+    areAllBlocksExpanded: boolean;
+    areAllBlocksCollapsed: boolean;
+    onExpandAllBlocks: () => void;
+    onCollapseAllBlocks: () => void;
 }
 
 const OpGraphToolbar = memo(
@@ -101,8 +104,8 @@ const OpGraphToolbar = memo(
         onGoToOperation,
         hideDeallocate,
         onHideDeallocateChange,
-        focusUnrelatedEdges,
-        onFocusUnrelatedEdgesChange,
+        isDimUnrelatedEdges,
+        onDimUnrelatedEdgesChange,
         isPerfOverlayActive,
         onPerfOverlayChange,
         isCriticalPathActive,
@@ -112,9 +115,9 @@ const OpGraphToolbar = memo(
         totalOpCount,
         isDisabled,
         hiddenMatchCount = 0,
-        hasBlocks = false,
-        areAllBlocksExpanded = false,
-        areAllBlocksCollapsed = true,
+        hasBlocks,
+        areAllBlocksExpanded,
+        areAllBlocksCollapsed,
         onExpandAllBlocks,
         onCollapseAllBlocks,
     }: OpGraphToolbarProps) => (
@@ -198,9 +201,9 @@ const OpGraphToolbar = memo(
 
                 <Switch
                     className='op-graph-toolbar-switch'
-                    checked={focusUnrelatedEdges}
+                    checked={isDimUnrelatedEdges}
                     onChange={(event: FormEvent<HTMLInputElement>) =>
-                        onFocusUnrelatedEdgesChange(event.currentTarget.checked)
+                        onDimUnrelatedEdgesChange(event.currentTarget.checked)
                     }
                     label='Dim unrelated edges'
                     disabled={isDisabled}

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -165,6 +165,24 @@ const NO_DEVICE_SUBGRAPHS: OpGraphDeviceSubgraph[] = [];
 const EMPTY_NODE_ID_BY_OP = new Map<number, string>();
 const EMPTY_BLOCK_IDS: string[] = [];
 
+const areSameBlockSummaries = (left: OpGraphBlockSummary[], right: OpGraphBlockSummary[]): boolean => {
+    if (left === right) {
+        return true;
+    }
+    if (left.length !== right.length) {
+        return false;
+    }
+    return left.every((block, index) => {
+        const other = right[index];
+        return (
+            block.instanceId === other.instanceId &&
+            block.label === other.label &&
+            block.operationIds.length === other.operationIds.length &&
+            block.operationIds.every((id, idIndex) => id === other.operationIds[idIndex])
+        );
+    });
+};
+
 const SELECTED_NODE_CLASS = 'op-graph-node-selected';
 
 // Filter dimming is a container rule with an exemption for the matched set,
@@ -445,7 +463,10 @@ const OperationGraphInner = ({
             }
             setNodeIndex(indexEntries);
             setNodeIdByOperationId(renderedByOpId);
-            setDetectedBlocks(graph.blocks && graph.blocks.length > 0 ? graph.blocks : NO_BLOCKS);
+            // A new array with the same detections rebuilds `deviceSubgraphs` and
+            // `runBuild` loops; each pass restarts the focus tween toward op 0.
+            const nextBlocks = graph.blocks && graph.blocks.length > 0 ? graph.blocks : NO_BLOCKS;
+            setDetectedBlocks((previous) => (areSameBlockSummaries(previous, nextBlocks) ? previous : nextBlocks));
 
             // An op can drop out between builds (isolated, or filtered as a
             // deallocate), so selection falls back rather than point at nothing.

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -1156,10 +1156,39 @@ const OperationGraphInner = ({
         [isPerfOverlayActive, perfHover, perfOverlay],
     );
 
+    const selectedBlock = useMemo(() => {
+        if (selectedOperationId === null) {
+            return null;
+        }
+        return (
+            detectedBlocks.find(
+                (block) => !expandedBlockIds.has(block.instanceId) && block.operationIds.includes(selectedOperationId),
+            ) ?? null
+        );
+    }, [selectedOperationId, detectedBlocks, expandedBlockIds]);
+
     const selectedPerfAggregate =
         selectedOperationId === null ? undefined : perfOverlay.aggregatesByOpId.get(selectedOperationId);
     const selectedPerfScore =
         selectedOperationId === null ? undefined : perfOverlay.scoreByOpId.get(selectedOperationId);
+    const selectedPerfDeviceTimeNs = useMemo(() => {
+        if (!isPerfOverlayActive) {
+            return undefined;
+        }
+        if (selectedBlock === null) {
+            return selectedPerfAggregate?.deviceTimeNs;
+        }
+        let totalNs = 0;
+        let found = false;
+        for (const memberId of selectedBlock.operationIds) {
+            const aggregate = perfOverlay.aggregatesByOpId.get(memberId);
+            if (aggregate !== undefined) {
+                totalNs += aggregate.deviceTimeNs;
+                found = true;
+            }
+        }
+        return found ? totalNs : undefined;
+    }, [isPerfOverlayActive, selectedBlock, selectedPerfAggregate, perfOverlay]);
 
     // Closed mid-build so the panel can't describe an operation the graph being
     // laid out is about to drop.
@@ -1293,8 +1322,13 @@ const OperationGraphInner = ({
                     operationNamesById={operationNamesById}
                     onLocateOperation={focusOperation}
                     isPerfOverlayActive={isPerfOverlayActive}
-                    perfDeviceTimeNs={selectedPerfAggregate?.deviceTimeNs}
-                    perfColor={selectedPerfScore ? perfColorScale(selectedPerfScore.t) : undefined}
+                    perfDeviceTimeNs={selectedPerfDeviceTimeNs}
+                    perfColor={
+                        selectedBlock === null && selectedPerfScore !== undefined
+                            ? perfColorScale(selectedPerfScore.t)
+                            : undefined
+                    }
+                    block={selectedBlock}
                 />
             ) : null}
         </div>

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -55,8 +55,10 @@ import {
     buildPerfNodeStyleByNodeId,
     getPerfHoverLabel,
     getQuantisedPerfZoom,
+    getRenderedPerfRange,
 } from './opGraphPerfOverlay';
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
+import { getAdjacentOperationIds } from './opGraphNavigation';
 import { useOpGraphLayoutWorker } from './useOpGraphLayoutWorker';
 import {
     type OpGraphBlockSummary,
@@ -801,16 +803,10 @@ const OperationGraphInner = ({
     // every node to 18%, which reads as a rendering fault.
     const matchedIds = matches.ids.size > 0 ? matches.ids : null;
 
-    const { previousOperationId, nextOperationId } = useMemo(() => {
-        const position = nodeIndex.findIndex((entry) => entry.operationId === selectedOperationId);
-        if (position === -1) {
-            return { previousOperationId: null, nextOperationId: nodeIndex[0]?.operationId ?? null };
-        }
-        return {
-            previousOperationId: nodeIndex[position - 1]?.operationId ?? null,
-            nextOperationId: nodeIndex[position + 1]?.operationId ?? null,
-        };
-    }, [nodeIndex, selectedOperationId]);
+    const { previousOperationId, nextOperationId } = useMemo(
+        () => getAdjacentOperationIds(nodeIndex, selectedOperationId),
+        [nodeIndex, selectedOperationId],
+    );
 
     // Stepping matches only moves the viewport. Selection is the user's anchor —
     // and the reason a node stays lit while everything around it fades — so a
@@ -986,6 +982,10 @@ const OperationGraphInner = ({
         () => buildPerfNodeStyleByNodeId(perfOverlay, isPerfOverlayActive, nodeIndex),
         [isPerfOverlayActive, perfOverlay, nodeIndex],
     );
+
+    // The legend is the key for the node bars, so it reads the range those bars
+    // are drawn against rather than the overlay's per-operation one. #1944
+    const renderedPerfRange = useMemo(() => getRenderedPerfRange(perfOverlay, nodeIndex), [perfOverlay, nodeIndex]);
 
     const styledNodes = useMemo(() => {
         if (!highlight && !matchedIds && !perfStyleByNodeId && !criticalPathNodeIds) {
@@ -1327,8 +1327,8 @@ const OperationGraphInner = ({
                 ) : null}
                 {isPerfOverlayActive && !isBuilding ? (
                     <PerfOverlayLegend
-                        minNs={perfOverlay.minNs}
-                        maxNs={perfOverlay.maxNs}
+                        minNs={renderedPerfRange.minNs}
+                        maxNs={renderedPerfRange.maxNs}
                     />
                 ) : null}
             </div>

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -59,7 +59,7 @@ import {
 } from './opGraphPerfOverlay';
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
 import { REVEALED_NODE_CLASS, revealPanShift } from './opGraphRevealPan';
-import { getAdjacentOperationIds } from './opGraphNavigation';
+import { buildPositionByOperationId, getAdjacentOperationIds } from './opGraphNavigation';
 import { useOpGraphLayoutWorker } from './useOpGraphLayoutWorker';
 import {
     type OpGraphBlockSummary,
@@ -422,6 +422,21 @@ const OperationGraphInner = ({
         return memberIds;
     }, [detectedBlocks, expandedBlockIds]);
 
+    // "Which block owns this op?" was four separate linear scans, two of them inside
+    // per-render memos. Instances are disjoint, and first-wins matches the `find`
+    // these replace.
+    const blockByMemberOperationId = useMemo(() => {
+        const byOperationId = new Map<number, OpGraphBlockSummary>();
+        for (const block of detectedBlocks) {
+            for (const memberOpId of block.operationIds) {
+                if (!byOperationId.has(memberOpId)) {
+                    byOperationId.set(memberOpId, block);
+                }
+            }
+        }
+        return byOperationId;
+    }, [detectedBlocks]);
+
     // Only the expanded operations are assembled: one operation's frame stream
     // runs to thousands of nodes, so deriving all of them up front would pay for
     // the ones nobody opens.
@@ -452,6 +467,8 @@ const OperationGraphInner = ({
         }
         return idsByNodeId;
     }, [nodeIndex]);
+
+    const positionByOperationId = useMemo(() => buildPositionByOperationId(nodeIndex), [nodeIndex]);
 
     const operationNamesById = useMemo(() => {
         const namesById = new Map<number, string>();
@@ -730,7 +747,7 @@ const OperationGraphInner = ({
 
     if (operationId !== undefined && revealedOperationId !== operationId && detectedBlocks.length > 0) {
         setRevealedOperationId(operationId);
-        const buried = detectedBlocks.find((block) => block.operationIds.includes(operationId));
+        const buried = blockByMemberOperationId.get(operationId);
         if (buried !== undefined && !expandedBlockIds.has(buried.instanceId)) {
             setExpandedBlockIds(new Set([...expandedBlockIds, buried.instanceId]));
         }
@@ -877,8 +894,8 @@ const OperationGraphInner = ({
     const matchedIds = matches.ids.size > 0 ? matches.ids : null;
 
     const { previousOperationId, nextOperationId } = useMemo(
-        () => getAdjacentOperationIds(nodeIndex, selectedOperationId),
-        [nodeIndex, selectedOperationId],
+        () => getAdjacentOperationIds(nodeIndex, selectedOperationId, positionByOperationId),
+        [nodeIndex, selectedOperationId, positionByOperationId],
     );
 
     // Stepping matches only moves the viewport. Selection is the user's anchor —
@@ -1184,14 +1201,12 @@ const OperationGraphInner = ({
                 toggleBlockExpansion(node.data.blockInstanceId);
                 return;
             }
-            const instance = detectedBlocks.find(
-                (block) => expandedBlockIds.has(block.instanceId) && block.operationIds.includes(node.data.operationId),
-            );
-            if (instance !== undefined) {
+            const instance = blockByMemberOperationId.get(node.data.operationId);
+            if (instance !== undefined && expandedBlockIds.has(instance.instanceId)) {
                 toggleBlockExpansion(instance.instanceId);
             }
         },
-        [detectedBlocks, expandedBlockIds, toggleBlockExpansion],
+        [blockByMemberOperationId, expandedBlockIds, toggleBlockExpansion],
     );
 
     const handlePaneClick = useCallback(() => {
@@ -1264,12 +1279,9 @@ const OperationGraphInner = ({
         if (selectedOperationId === null) {
             return null;
         }
-        return (
-            detectedBlocks.find(
-                (block) => !expandedBlockIds.has(block.instanceId) && block.operationIds.includes(selectedOperationId),
-            ) ?? null
-        );
-    }, [selectedOperationId, detectedBlocks, expandedBlockIds]);
+        const owner = blockByMemberOperationId.get(selectedOperationId);
+        return owner !== undefined && !expandedBlockIds.has(owner.instanceId) ? owner : null;
+    }, [selectedOperationId, blockByMemberOperationId, expandedBlockIds]);
 
     const selectedPerfAggregate =
         selectedOperationId === null ? undefined : perfOverlay.aggregatesByOpId.get(selectedOperationId);

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -58,7 +58,7 @@ import {
     getRenderedPerfRange,
 } from './opGraphPerfOverlay';
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
-import { REVEALED_NODE_CLASS, REVEAL_HIGHLIGHT_MS, revealPanShift } from './opGraphRevealPan';
+import { REVEALED_NODE_CLASS, revealPanShift } from './opGraphRevealPan';
 import { getAdjacentOperationIds } from './opGraphNavigation';
 import { useOpGraphLayoutWorker } from './useOpGraphLayoutWorker';
 import {
@@ -308,7 +308,6 @@ const OperationGraphInner = ({
     // put them outside it. #1944
     const pendingRevealRef = useRef<{ nodeIds: Set<string>; reportScope: ReportScope } | null>(null);
     const [revealedNodeIds, setRevealedNodeIds] = useState<Set<string> | null>(null);
-    const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [revealedOperationId, setRevealedOperationId] = useState<number | null>(null);
     const { setCenter, getNode, getViewport, setViewport } = useReactFlow<OpGraphFlowNode, OpGraphFlowEdge>();
     const flowStore = useStoreApi();
@@ -563,6 +562,9 @@ const OperationGraphInner = ({
         if (nodes.length === 0 || staleScope) {
             pendingViewportAnchorRef.current = null;
             pendingRevealRef.current = null;
+            if (staleScope) {
+                setRevealedNodeIds(null);
+            }
             return;
         }
         pendingViewportAnchorRef.current = null;
@@ -602,29 +604,15 @@ const OperationGraphInner = ({
                 viewport = { ...viewport, x: viewport.x + dx, y: viewport.y + dy };
             }
 
+            // No timer: the ring pulses for attention and then rests faint, and the
+            // faint state is worth keeping — it is the answer to "which ones did I
+            // just open", which stays useful for as long as they are open. The next
+            // toggle replaces the set, so only one group is ever marked.
             setRevealedNodeIds(reveal.nodeIds);
-            if (revealTimerRef.current !== null) {
-                clearTimeout(revealTimerRef.current);
-            }
-            revealTimerRef.current = setTimeout(() => {
-                revealTimerRef.current = null;
-                setRevealedNodeIds(null);
-            }, REVEAL_HIGHLIGHT_MS);
         }
 
         void setViewport(viewport, { duration: FOCUS_DURATION_MS });
     }, [nodes, reportScope, getViewport, setViewport]);
-
-    // A report swap or unmount while the highlight is up would otherwise leave the
-    // timer to fire against a graph it was never armed for.
-    useEffect(
-        () => () => {
-            if (revealTimerRef.current !== null) {
-                clearTimeout(revealTimerRef.current);
-            }
-        },
-        [],
-    );
 
     const toggleOperationExpansion = useCallback(
         (targetOperationId: number) => {
@@ -732,6 +720,8 @@ const OperationGraphInner = ({
         setHideDeallocate(next);
         setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
         setExpandedOperationIds(NOTHING_EXPANDED);
+        // Nothing is open any more, so nothing was "just opened".
+        setRevealedNodeIds(null);
     }, []);
 
     if (operationId !== undefined && revealedOperationId !== operationId && detectedBlocks.length > 0) {

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -164,6 +164,22 @@ const EMPTY_MATCHES: OpGraphMatches = {
 const NOTHING_EXPANDED: ReadonlySet<number> = new Set<number>();
 const NOTHING_EXPANDED_BLOCKS: ReadonlySet<string> = new Set<string>();
 const NO_BLOCKS: OpGraphBlockSummary[] = [];
+
+// Folding a block makes its members' device-op expansions unreachable, so they are
+// dropped with it. Shared by the three places that fold: one block, all blocks, and
+// the deallocate filter (which re-runs detection and invalidates every instance).
+const withoutBlockMembers = (
+    expandedOperationIds: ReadonlySet<number>,
+    blocks: readonly OpGraphBlockSummary[],
+): Set<number> => {
+    const remaining = new Set(expandedOperationIds);
+    for (const block of blocks) {
+        for (const memberOpId of block.operationIds) {
+            remaining.delete(memberOpId);
+        }
+    }
+    return remaining;
+};
 const NO_DEVICE_SUBGRAPHS: OpGraphDeviceSubgraph[] = [];
 const EMPTY_NODE_ID_BY_OP = new Map<number, string>();
 const EMPTY_BLOCK_IDS: string[] = [];
@@ -394,9 +410,6 @@ const OperationGraphInner = ({
         return byId;
     }, [operationList]);
 
-    // Only the expanded operations are assembled: one operation's frame stream
-    // runs to thousands of nodes, so deriving all of them up front would pay for
-    // the ones nobody opens.
     const collapsedMemberIds = useMemo(() => {
         const memberIds = new Set<number>();
         for (const block of detectedBlocks) {
@@ -409,6 +422,9 @@ const OperationGraphInner = ({
         return memberIds;
     }, [detectedBlocks, expandedBlockIds]);
 
+    // Only the expanded operations are assembled: one operation's frame stream
+    // runs to thousands of nodes, so deriving all of them up front would pay for
+    // the ones nobody opens.
     const deviceSubgraphs = useMemo<OpGraphDeviceSubgraph[]>(() => {
         const assembled: OpGraphDeviceSubgraph[] = [];
         for (const expandedOperationId of expandedOperationIds) {
@@ -614,35 +630,6 @@ const OperationGraphInner = ({
         void setViewport(viewport, { duration: FOCUS_DURATION_MS });
     }, [nodes, reportScope, getViewport, setViewport]);
 
-    const toggleOperationExpansion = useCallback(
-        (targetOperationId: number) => {
-            const nodeId = String(targetOperationId);
-            const node = getNode(nodeId);
-            if (node) {
-                const { x, y, zoom } = getViewport();
-                pendingViewportAnchorRef.current = {
-                    nodeId,
-                    fallbackNodeId: nodeId,
-                    paneX: node.position.x * zoom + x,
-                    paneY: node.position.y * zoom + y,
-                    reportScope,
-                };
-            }
-            setExpandedOperationIds((previous) => {
-                const next = new Set(previous);
-                // A failed delete means it wasn't expanded, so this is the expand.
-                if (!next.delete(targetOperationId)) {
-                    next.add(targetOperationId);
-                }
-                return next;
-            });
-            // Both directions: folding shrinks the node back and is just as easy to
-            // lose track of as expanding.
-            pendingRevealRef.current = { nodeIds: new Set([nodeId]), reportScope };
-        },
-        [getNode, getViewport, reportScope],
-    );
-
     const armViewportAnchor = useCallback(
         (nodeId: string, fallbackNodeId: string) => {
             const node = getNode(nodeId) ?? getNode(fallbackNodeId);
@@ -659,6 +646,27 @@ const OperationGraphInner = ({
             };
         },
         [getNode, getViewport, reportScope],
+    );
+
+    const toggleOperationExpansion = useCallback(
+        (targetOperationId: number) => {
+            const nodeId = String(targetOperationId);
+            // An op node is its own fallback: unlike a block toggle, the anchor id
+            // does not flip to a member.
+            armViewportAnchor(nodeId, nodeId);
+            setExpandedOperationIds((previous) => {
+                const next = new Set(previous);
+                // A failed delete means it wasn't expanded, so this is the expand.
+                if (!next.delete(targetOperationId)) {
+                    next.add(targetOperationId);
+                }
+                return next;
+            });
+            // Both directions: folding shrinks the node back and is just as easy to
+            // lose track of as expanding.
+            pendingRevealRef.current = { nodeIds: new Set([nodeId]), reportScope };
+        },
+        [armViewportAnchor, reportScope],
     );
 
     const toggleBlockExpansion = useCallback(
@@ -679,23 +687,20 @@ const OperationGraphInner = ({
                 ),
                 reportScope,
             };
+            // Siblings rather than nested: a state updater must be pure, and
+            // `isUnrolling` already decides the branch outside it.
             setExpandedBlockIds((previous) => {
                 const next = new Set(previous);
-                if (next.delete(instanceId)) {
-                    if (block !== undefined) {
-                        setExpandedOperationIds((expandedOps) => {
-                            const remaining = new Set(expandedOps);
-                            for (const memberOpId of block.operationIds) {
-                                remaining.delete(memberOpId);
-                            }
-                            return remaining;
-                        });
-                    }
-                } else {
+                if (isUnrolling) {
                     next.add(instanceId);
+                } else {
+                    next.delete(instanceId);
                 }
                 return next;
             });
+            if (!isUnrolling && block !== undefined) {
+                setExpandedOperationIds((previous) => withoutBlockMembers(previous, [block]));
+            }
         },
         [armViewportAnchor, detectedBlocks, expandedBlockIds, reportScope],
     );
@@ -706,23 +711,22 @@ const OperationGraphInner = ({
 
     const collapseAllBlocks = useCallback(() => {
         setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
-        const collapsedMembers = new Set(detectedBlocks.flatMap((block) => block.operationIds));
-        setExpandedOperationIds((previous) => {
-            const next = new Set(previous);
-            for (const memberOpId of collapsedMembers) {
-                next.delete(memberOpId);
-            }
-            return next;
-        });
+        setExpandedOperationIds((previous) => withoutBlockMembers(previous, detectedBlocks));
     }, [detectedBlocks]);
 
-    const handleHideDeallocateChange = useCallback((next: boolean) => {
-        setHideDeallocate(next);
-        setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
-        setExpandedOperationIds(NOTHING_EXPANDED);
-        // Nothing is open any more, so nothing was "just opened".
-        setRevealedNodeIds(null);
-    }, []);
+    const handleHideDeallocateChange = useCallback(
+        (next: boolean) => {
+            setHideDeallocate(next);
+            setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
+            // Only block members: detection re-runs on this filter so every instance
+            // folds, but an expansion on an op belonging to no block is untouched by
+            // that and was kept before this feature existed.
+            setExpandedOperationIds((previous) => withoutBlockMembers(previous, detectedBlocks));
+            // Nothing is folded open any more, so nothing was "just opened".
+            setRevealedNodeIds(null);
+        },
+        [detectedBlocks],
+    );
 
     if (operationId !== undefined && revealedOperationId !== operationId && detectedBlocks.length > 0) {
         setRevealedOperationId(operationId);

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -229,7 +229,7 @@ const EDGE_CLASS_BY_RELATION: Record<NodeRelation, string> = {
 const CRITICAL_PATH_CLASS = 'op-graph-critical-path';
 const CRITICAL_PATH_NODE_CLASS = 'op-graph-node-critical-path';
 const CRITICAL_PATH_EDGE_CLASS = 'op-graph-edge-critical-path';
-const FOCUS_EDGES_CLASS = 'op-graph-focus-edges';
+const DIM_UNRELATED_EDGES_CLASS = 'op-graph-dim-unrelated-edges';
 
 interface OperationGraphReactFlowProps {
     operationList: OperationDescription[];
@@ -266,7 +266,7 @@ const OperationGraphInner = ({
     // selecting an edge doesn't pay for a traversal. #1613
     const [builtEdges, setBuiltEdges] = useState<OpGraphFlowEdge[]>([]);
     const [hideDeallocate, setHideDeallocate] = useState(true);
-    const [focusUnrelatedEdges, setFocusUnrelatedEdges] = useState(false);
+    const [isDimUnrelatedEdges, setIsDimUnrelatedEdges] = useState(false);
     // Local like the perf overlay rather than an atom: expansion describes a
     // reading position in one graph, and the MLIR view scopes its own namespace
     // expansion the same way. #1195
@@ -1312,7 +1312,7 @@ const OperationGraphInner = ({
         'operation-graph-react-flow',
         ...(matchedIds ? [FILTERING_CLASS] : []),
         ...(hasCriticalPath ? [CRITICAL_PATH_CLASS] : []),
-        ...(focusUnrelatedEdges && highlight !== null ? [FOCUS_EDGES_CLASS] : []),
+        ...(isDimUnrelatedEdges && highlight !== null ? [DIM_UNRELATED_EDGES_CLASS] : []),
     ].join(' ');
 
     return (
@@ -1342,8 +1342,8 @@ const OperationGraphInner = ({
                 onGoToOperation={selectOperation}
                 hideDeallocate={hideDeallocate}
                 onHideDeallocateChange={handleHideDeallocateChange}
-                focusUnrelatedEdges={focusUnrelatedEdges}
-                onFocusUnrelatedEdgesChange={setFocusUnrelatedEdges}
+                isDimUnrelatedEdges={isDimUnrelatedEdges}
+                onDimUnrelatedEdgesChange={setIsDimUnrelatedEdges}
                 hiddenMatchCount={matches.hiddenMatchCount}
                 hasBlocks={detectedBlocks.length > 0}
                 areAllBlocksExpanded={

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -58,6 +58,7 @@ import {
     getRenderedPerfRange,
 } from './opGraphPerfOverlay';
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
+import { REVEALED_NODE_CLASS, REVEAL_HIGHLIGHT_MS, revealPanShift } from './opGraphRevealPan';
 import { getAdjacentOperationIds } from './opGraphNavigation';
 import { useOpGraphLayoutWorker } from './useOpGraphLayoutWorker';
 import {
@@ -207,6 +208,10 @@ const EDGE_CLASS_BY_RELATION: Record<NodeRelation, string> = {
 
 // Off-path edges dim from the container for the same identity reason as the
 // filter above; only the path itself gets per-element classes. #1613
+// Marks the nodes a structural toggle just produced, so an expand or fold is
+// visibly *something appearing* rather than the graph rearranging itself. Cleared
+// on a timer: it answers "where did it go", which stops being a question once the
+// user has seen the answer. #1944
 const CRITICAL_PATH_CLASS = 'op-graph-critical-path';
 const CRITICAL_PATH_NODE_CLASS = 'op-graph-node-critical-path';
 const CRITICAL_PATH_EDGE_CLASS = 'op-graph-edge-critical-path';
@@ -298,6 +303,12 @@ const OperationGraphInner = ({
         paneY: number;
         reportScope: ReportScope;
     } | null>(null);
+    // Armed by a toggle and spent once the rebuilt graph commits, alongside the
+    // anchor above: which nodes to light up, and to pan into view if the rebuild
+    // put them outside it. #1944
+    const pendingRevealRef = useRef<{ nodeIds: Set<string>; reportScope: ReportScope } | null>(null);
+    const [revealedNodeIds, setRevealedNodeIds] = useState<Set<string> | null>(null);
+    const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [revealedOperationId, setRevealedOperationId] = useState<number | null>(null);
     const { setCenter, getNode, getViewport, setViewport } = useReactFlow<OpGraphFlowNode, OpGraphFlowEdge>();
     const flowStore = useStoreApi();
@@ -542,26 +553,78 @@ const OperationGraphInner = ({
     // by a tick and would translate against the pre-rebuild position.
     useEffect(() => {
         const anchor = pendingViewportAnchorRef.current;
-        if (anchor === null) {
+        const reveal = pendingRevealRef.current;
+        if (anchor === null && reveal === null) {
             return;
         }
-        if (nodes.length === 0 || !isSameReportScope(anchor.reportScope, reportScope)) {
+        const staleScope =
+            (anchor !== null && !isSameReportScope(anchor.reportScope, reportScope)) ||
+            (reveal !== null && !isSameReportScope(reveal.reportScope, reportScope));
+        if (nodes.length === 0 || staleScope) {
             pendingViewportAnchorRef.current = null;
+            pendingRevealRef.current = null;
             return;
         }
         pendingViewportAnchorRef.current = null;
-        const anchored =
-            nodes.find((node) => node.id === anchor.nodeId) ?? nodes.find((node) => node.id === anchor.fallbackNodeId);
-        if (anchored === undefined) {
-            return;
+        pendingRevealRef.current = null;
+
+        let viewport = getViewport();
+        if (anchor !== null) {
+            const anchored =
+                nodes.find((node) => node.id === anchor.nodeId) ??
+                nodes.find((node) => node.id === anchor.fallbackNodeId);
+            if (anchored !== undefined) {
+                viewport = {
+                    zoom: viewport.zoom,
+                    x: anchor.paneX - anchored.position.x * viewport.zoom,
+                    y: anchor.paneY - anchored.position.y * viewport.zoom,
+                };
+            }
         }
-        const { zoom } = getViewport();
-        void setViewport({
-            x: anchor.paneX - anchored.position.x * zoom,
-            y: anchor.paneY - anchored.position.y * zoom,
-            zoom,
-        });
+
+        if (reveal !== null) {
+            // The anchor pins one node; the rest of the revealed set can still land
+            // outside the pane, which is the "I opened one and can't see it" half of
+            // the report. Pan by the minimum that brings the whole set in. #1944
+            const revealed = nodes.filter((node) => reveal.nodeIds.has(node.id));
+            const pane = containerRef.current?.getBoundingClientRect();
+            if (revealed.length > 0 && pane !== undefined) {
+                const bounds = revealed.reduce(
+                    (acc, node) => ({
+                        minX: Math.min(acc.minX, node.position.x),
+                        minY: Math.min(acc.minY, node.position.y),
+                        maxX: Math.max(acc.maxX, node.position.x + (node.width ?? node.measured?.width ?? 0)),
+                        maxY: Math.max(acc.maxY, node.position.y + (node.height ?? node.measured?.height ?? 0)),
+                    }),
+                    { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+                );
+                const { dx, dy } = revealPanShift(bounds, viewport, pane);
+                viewport = { ...viewport, x: viewport.x + dx, y: viewport.y + dy };
+            }
+
+            setRevealedNodeIds(reveal.nodeIds);
+            if (revealTimerRef.current !== null) {
+                clearTimeout(revealTimerRef.current);
+            }
+            revealTimerRef.current = setTimeout(() => {
+                revealTimerRef.current = null;
+                setRevealedNodeIds(null);
+            }, REVEAL_HIGHLIGHT_MS);
+        }
+
+        void setViewport(viewport, { duration: FOCUS_DURATION_MS });
     }, [nodes, reportScope, getViewport, setViewport]);
+
+    // A report swap or unmount while the highlight is up would otherwise leave the
+    // timer to fire against a graph it was never armed for.
+    useEffect(
+        () => () => {
+            if (revealTimerRef.current !== null) {
+                clearTimeout(revealTimerRef.current);
+            }
+        },
+        [],
+    );
 
     const toggleOperationExpansion = useCallback(
         (targetOperationId: number) => {
@@ -585,6 +648,9 @@ const OperationGraphInner = ({
                 }
                 return next;
             });
+            // Both directions: folding shrinks the node back and is just as easy to
+            // lose track of as expanding.
+            pendingRevealRef.current = { nodeIds: new Set([nodeId]), reportScope };
         },
         [getNode, getViewport, reportScope],
     );
@@ -612,6 +678,19 @@ const OperationGraphInner = ({
             const block = detectedBlocks.find((entry) => entry.instanceId === instanceId);
             const firstOpId = block?.operationIds[0];
             armViewportAnchor(instanceId, firstOpId === undefined ? instanceId : String(firstOpId));
+            // Highlight what this toggle *produces*: the member operations when
+            // unrolling, the block itself when folding. Folding needs it most — a
+            // double-click on a member replaces the very node the user clicked, which
+            // is the "I'm going to click op 49, where has it gone" report. #1944
+            const isUnrolling = !expandedBlockIds.has(instanceId);
+            pendingRevealRef.current = {
+                nodeIds: new Set(
+                    isUnrolling && block !== undefined
+                        ? block.operationIds.map((memberId) => String(memberId))
+                        : [instanceId],
+                ),
+                reportScope,
+            };
             setExpandedBlockIds((previous) => {
                 const next = new Set(previous);
                 if (next.delete(instanceId)) {
@@ -630,7 +709,7 @@ const OperationGraphInner = ({
                 return next;
             });
         },
-        [armViewportAnchor, detectedBlocks],
+        [armViewportAnchor, detectedBlocks, expandedBlockIds, reportScope],
     );
 
     const expandAllBlocks = useCallback(() => {
@@ -988,7 +1067,7 @@ const OperationGraphInner = ({
     const renderedPerfRange = useMemo(() => getRenderedPerfRange(perfOverlay, nodeIndex), [perfOverlay, nodeIndex]);
 
     const styledNodes = useMemo(() => {
-        if (!highlight && !matchedIds && !perfStyleByNodeId && !criticalPathNodeIds) {
+        if (!highlight && !matchedIds && !perfStyleByNodeId && !criticalPathNodeIds && !revealedNodeIds) {
             return nodes;
         }
         return nodes.map((node) => {
@@ -1017,6 +1096,9 @@ const OperationGraphInner = ({
             }
             if (criticalPathNodeIds?.has(node.id)) {
                 classNames.push(CRITICAL_PATH_NODE_CLASS);
+            }
+            if (revealedNodeIds?.has(node.id)) {
+                classNames.push(REVEALED_NODE_CLASS);
             }
             const className = classNames.length > 0 ? classNames.join(' ') : undefined;
             // Custom properties only, so perf stacks with selection, the
@@ -1070,6 +1152,7 @@ const OperationGraphInner = ({
         perfStyleByNodeId,
         criticalPathNodeIds,
         styledNodeCache,
+        revealedNodeIds,
     ]);
 
     const styledEdges = useMemo(() => {

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -208,6 +208,7 @@ const EDGE_CLASS_BY_RELATION: Record<NodeRelation, string> = {
 const CRITICAL_PATH_CLASS = 'op-graph-critical-path';
 const CRITICAL_PATH_NODE_CLASS = 'op-graph-node-critical-path';
 const CRITICAL_PATH_EDGE_CLASS = 'op-graph-edge-critical-path';
+const FOCUS_EDGES_CLASS = 'op-graph-focus-edges';
 
 interface OperationGraphReactFlowProps {
     operationList: OperationDescription[];
@@ -244,6 +245,7 @@ const OperationGraphInner = ({
     // selecting an edge doesn't pay for a traversal. #1613
     const [builtEdges, setBuiltEdges] = useState<OpGraphFlowEdge[]>([]);
     const [hideDeallocate, setHideDeallocate] = useState(true);
+    const [focusUnrelatedEdges, setFocusUnrelatedEdges] = useState(false);
     // Local like the perf overlay rather than an atom: expansion describes a
     // reading position in one graph, and the MLIR view scopes its own namespace
     // expansion the same way. #1195
@@ -1223,6 +1225,7 @@ const OperationGraphInner = ({
         'operation-graph-react-flow',
         ...(matchedIds ? [FILTERING_CLASS] : []),
         ...(hasCriticalPath ? [CRITICAL_PATH_CLASS] : []),
+        ...(focusUnrelatedEdges && highlight !== null ? [FOCUS_EDGES_CLASS] : []),
     ].join(' ');
 
     return (
@@ -1252,6 +1255,8 @@ const OperationGraphInner = ({
                 onGoToOperation={selectOperation}
                 hideDeallocate={hideDeallocate}
                 onHideDeallocateChange={handleHideDeallocateChange}
+                focusUnrelatedEdges={focusUnrelatedEdges}
+                onFocusUnrelatedEdgesChange={setFocusUnrelatedEdges}
                 hiddenMatchCount={matches.hiddenMatchCount}
                 hasBlocks={detectedBlocks.length > 0}
                 areAllBlocksExpanded={

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -52,10 +52,9 @@ import { OpGraphBlockExpansionContext, OpGraphExpansionContext } from './opGraph
 import {
     PERF_BAR_ZOOM_VAR,
     buildOpGraphPerfOverlay,
-    buildPerfNodeStyleByNodeId,
+    buildRenderedPerfStyling,
     getPerfHoverLabel,
     getQuantisedPerfZoom,
-    getRenderedPerfRange,
 } from './opGraphPerfOverlay';
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
 import { REVEALED_NODE_CLASS, revealPanShift } from './opGraphRevealPan';
@@ -1065,15 +1064,15 @@ const OperationGraphInner = ({
     const criticalPathEdgeIds = hasCriticalPath ? criticalPath.edgeIds : null;
 
     // Built once per score change so the styling pass reuses these identities
-    // instead of allocating one per node on every drag frame.
-    const perfStyleByNodeId = useMemo(
-        () => buildPerfNodeStyleByNodeId(perfOverlay, isPerfOverlayActive, nodeIndex),
+    // instead of allocating one per node on every drag frame. The legend is the
+    // key for these same bars, so its range comes out of the same pass rather than
+    // a second walk of the whole node set — and neither runs with the overlay off,
+    // when the legend is not rendered at all. #1944
+    const renderedPerfStyling = useMemo(
+        () => buildRenderedPerfStyling(perfOverlay, isPerfOverlayActive, nodeIndex),
         [isPerfOverlayActive, perfOverlay, nodeIndex],
     );
-
-    // The legend is the key for the node bars, so it reads the range those bars
-    // are drawn against rather than the overlay's per-operation one. #1944
-    const renderedPerfRange = useMemo(() => getRenderedPerfRange(perfOverlay, nodeIndex), [perfOverlay, nodeIndex]);
+    const perfStyleByNodeId = renderedPerfStyling?.styleByNodeId ?? null;
 
     const styledNodes = useMemo(() => {
         if (!highlight && !matchedIds && !perfStyleByNodeId && !criticalPathNodeIds && !revealedNodeIds) {
@@ -1414,8 +1413,8 @@ const OperationGraphInner = ({
                 ) : null}
                 {isPerfOverlayActive && !isBuilding ? (
                     <PerfOverlayLegend
-                        minNs={renderedPerfRange.minNs}
-                        maxNs={renderedPerfRange.maxNs}
+                        minNs={renderedPerfStyling?.minNs ?? perfOverlay.minNs}
+                        maxNs={renderedPerfStyling?.maxNs ?? perfOverlay.maxNs}
                     />
                 ) : null}
             </div>

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -60,6 +60,7 @@ import {
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
 import { REVEALED_NODE_CLASS, revealPanShift } from './opGraphRevealPan';
 import { buildPositionByOperationId, getAdjacentOperationIds } from './opGraphNavigation';
+import { tensorBytes } from '../../functions/math';
 import { useOpGraphLayoutWorker } from './useOpGraphLayoutWorker';
 import {
     type OpGraphBlockSummary,
@@ -125,9 +126,6 @@ const bothEndsMatched = (
     const target = operationNodeIdOf(targetOperationIdOf(edge), nodeIdByOperationId);
     return source !== null && target !== null && matchedIds.has(source) && matchedIds.has(target);
 };
-
-const tensorBytes = (tensors: { size: number | null }[]): number =>
-    tensors.reduce((total, tensor) => total + (tensor.size ?? 0), 0);
 
 // A large report only fits at extreme zoom-out; 3 caps zoom-in as vis did.
 const MAX_ZOOM = 3;

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -40,6 +40,7 @@ import type { GraphOpFilterHandle } from '../GraphOpFilter';
 import LoadingSpinner from '../LoadingSpinner';
 import PerfOverlayLegend from '../perf-overlay/PerfOverlayLegend';
 import CriticalPathAnnotation from './CriticalPathAnnotation';
+import OpGraphBlockNode from './OpGraphBlockNode';
 import OpGraphDeviceGroupNode from './OpGraphDeviceGroupNode';
 import OpGraphDeviceOpNode from './OpGraphDeviceOpNode';
 import OpGraphEdge from './OpGraphEdge';
@@ -47,7 +48,7 @@ import OpGraphInfoPanel from './OpGraphInfoPanel';
 import OpGraphNode from './OpGraphNode';
 import OpGraphToolbar from './OpGraphToolbar';
 import { buildDeviceOperationSubgraph, countDeviceOperations } from './opGraphDeviceSubgraph';
-import { OpGraphExpansionContext } from './opGraphExpansionContext';
+import { OpGraphBlockExpansionContext, OpGraphExpansionContext } from './opGraphExpansionContext';
 import {
     PERF_BAR_ZOOM_VAR,
     buildOpGraphPerfOverlay,
@@ -58,6 +59,7 @@ import {
 import { EMPTY_CRITICAL_PATH, findCriticalPath } from './opGraphCriticalPath';
 import { useOpGraphLayoutWorker } from './useOpGraphLayoutWorker';
 import {
+    type OpGraphBlockSummary,
     type OpGraphBuildOptions,
     type OpGraphBuiltGraph,
     type OpGraphDeviceSubgraph,
@@ -74,6 +76,7 @@ const NODE_TYPES = {
     [OpGraphNodeType.OP]: OpGraphNode,
     [OpGraphNodeType.DEVICE_GROUP]: OpGraphDeviceGroupNode,
     [OpGraphNodeType.DEVICE_OP]: OpGraphDeviceOpNode,
+    [OpGraphNodeType.BLOCK]: OpGraphBlockNode,
 };
 const EDGE_TYPES = { [OpGraphEdgeType.OP]: OpGraphEdge };
 
@@ -85,26 +88,43 @@ const targetOperationIdOf = (edge: OpGraphFlowEdge): number | undefined => edge.
 const isInternalDeviceEdge = (edge: OpGraphFlowEdge): boolean =>
     sourceOperationIdOf(edge) === targetOperationIdOf(edge);
 
-const operationNodeIdOf = (operationId: number | undefined): string | null =>
-    operationId === undefined ? null : String(operationId);
+const operationNodeIdOf = (
+    operationId: number | undefined,
+    nodeIdByOperationId: ReadonlyMap<number, string>,
+): string | null => {
+    if (operationId === undefined) {
+        return null;
+    }
+    return nodeIdByOperationId.get(operationId) ?? String(operationId);
+};
 
-const operationBoundaryOf = (edge: OpGraphFlowEdge): { source: string; target: string } | null => {
+const operationBoundaryOf = (
+    edge: OpGraphFlowEdge,
+    nodeIdByOperationId: ReadonlyMap<number, string>,
+): { source: string; target: string } | null => {
     if (isInternalDeviceEdge(edge)) {
         return null;
     }
-    const source = operationNodeIdOf(sourceOperationIdOf(edge));
-    const target = operationNodeIdOf(targetOperationIdOf(edge));
+    const source = operationNodeIdOf(sourceOperationIdOf(edge), nodeIdByOperationId);
+    const target = operationNodeIdOf(targetOperationIdOf(edge), nodeIdByOperationId);
     if (source === null || target === null) {
         return null;
     }
     return { source, target };
 };
 
-const bothEndsMatched = (edge: OpGraphFlowEdge, matchedIds: ReadonlySet<string>): boolean => {
-    const source = operationNodeIdOf(sourceOperationIdOf(edge));
-    const target = operationNodeIdOf(targetOperationIdOf(edge));
+const bothEndsMatched = (
+    edge: OpGraphFlowEdge,
+    matchedIds: ReadonlySet<string>,
+    nodeIdByOperationId: ReadonlyMap<number, string>,
+): boolean => {
+    const source = operationNodeIdOf(sourceOperationIdOf(edge), nodeIdByOperationId);
+    const target = operationNodeIdOf(targetOperationIdOf(edge), nodeIdByOperationId);
     return source !== null && target !== null && matchedIds.has(source) && matchedIds.has(target);
 };
+
+const tensorBytes = (tensors: { size: number | null }[]): number =>
+    tensors.reduce((total, tensor) => total + (tensor.size ?? 0), 0);
 
 // A large report only fits at extreme zoom-out; 3 caps zoom-in as vis did.
 const MAX_ZOOM = 3;
@@ -123,15 +143,27 @@ const FILTER_MODE_STORAGE_KEY = 'opGraphFilterMode';
 interface OpGraphMatches {
     ids: Set<string>;
     operationIdsInOrder: number[];
+    hiddenMatchCount: number;
+    buriedCountById: Map<string, number>;
 }
 
 // Shared so an idle filter yields one stable identity instead of a fresh empty
 // set per render, which would invalidate every memo downstream.
-const EMPTY_MATCHES: OpGraphMatches = { ids: new Set<string>(), operationIdsInOrder: [] };
+const EMPTY_MATCHES: OpGraphMatches = {
+    ids: new Set<string>(),
+    operationIdsInOrder: [],
+    hiddenMatchCount: 0,
+    buriedCountById: new Map<string, number>(),
+};
 
 // Same reason: resetting expansion to a fresh set would rebuild the graph even
 // when nothing was expanded to begin with.
 const NOTHING_EXPANDED: ReadonlySet<number> = new Set<number>();
+const NOTHING_EXPANDED_BLOCKS: ReadonlySet<string> = new Set<string>();
+const NO_BLOCKS: OpGraphBlockSummary[] = [];
+const NO_DEVICE_SUBGRAPHS: OpGraphDeviceSubgraph[] = [];
+const EMPTY_NODE_ID_BY_OP = new Map<number, string>();
+const EMPTY_BLOCK_IDS: string[] = [];
 
 const SELECTED_NODE_CLASS = 'op-graph-node-selected';
 
@@ -198,6 +230,9 @@ const OperationGraphInner = ({
     // reading position in one graph, and the MLIR view scopes its own namespace
     // expansion the same way. #1195
     const [expandedOperationIds, setExpandedOperationIds] = useState<ReadonlySet<number>>(NOTHING_EXPANDED);
+    const [expandedBlockIds, setExpandedBlockIds] = useState<ReadonlySet<string>>(NOTHING_EXPANDED_BLOCKS);
+    const [detectedBlocks, setDetectedBlocks] = useState<OpGraphBlockSummary[]>(NO_BLOCKS);
+    const [nodeIdByOperationId, setNodeIdByOperationId] = useState<ReadonlyMap<number, string>>(EMPTY_NODE_ID_BY_OP);
     const [isPerfOverlayEnabled, setIsPerfOverlayEnabled] = useState(false);
     const [criticalPathScope, setCriticalPathScope] = useAtom(criticalPathScopeAtom);
     const [perfHover, setPerfHover] = useState<PerfHover | null>(null);
@@ -236,10 +271,12 @@ const OperationGraphInner = ({
     // report it was armed for so a swap cannot spend it against a same-id node.
     const pendingViewportAnchorRef = useRef<{
         nodeId: string;
+        fallbackNodeId: string;
         paneX: number;
         paneY: number;
         reportScope: ReportScope;
     } | null>(null);
+    const [revealedOperationId, setRevealedOperationId] = useState<number | null>(null);
     const { setCenter, getNode, getViewport, setViewport } = useReactFlow<OpGraphFlowNode, OpGraphFlowEdge>();
     const flowStore = useStoreApi();
 
@@ -265,6 +302,10 @@ const OperationGraphInner = ({
         // Operation ids restart per report, so a surviving expansion would open
         // whichever unrelated operation now answers to that id.
         setExpandedOperationIds(NOTHING_EXPANDED);
+        setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
+        setDetectedBlocks(NO_BLOCKS);
+        setNodeIdByOperationId(EMPTY_NODE_ID_BY_OP);
+        setRevealedOperationId(null);
         deviceSubgraphCache.clear();
     }
 
@@ -306,6 +347,9 @@ const OperationGraphInner = ({
                 // than from `deviceOperationNameList`, which the details panel uses
                 // and which screens out the `Tensor::` frames the graph draws.
                 deviceOperationCount: countDeviceOperations(operation),
+                inputShapes: operation.inputs.map((tensor) => toReadableShape(tensor.shape)),
+                durationSeconds: operation.duration,
+                memoryDeltaBytes: tensorBytes(operation.outputs) - tensorBytes(operation.inputs),
             })),
         [operationList],
     );
@@ -321,21 +365,35 @@ const OperationGraphInner = ({
     // Only the expanded operations are assembled: one operation's frame stream
     // runs to thousands of nodes, so deriving all of them up front would pay for
     // the ones nobody opens.
+    const collapsedMemberIds = useMemo(() => {
+        const memberIds = new Set<number>();
+        for (const block of detectedBlocks) {
+            if (!expandedBlockIds.has(block.instanceId)) {
+                for (const memberOpId of block.operationIds) {
+                    memberIds.add(memberOpId);
+                }
+            }
+        }
+        return memberIds;
+    }, [detectedBlocks, expandedBlockIds]);
+
     const deviceSubgraphs = useMemo<OpGraphDeviceSubgraph[]>(() => {
         const assembled: OpGraphDeviceSubgraph[] = [];
         for (const expandedOperationId of expandedOperationIds) {
-            let subgraph = deviceSubgraphCache.get(expandedOperationId);
-            if (subgraph === undefined) {
-                const operation = operationById.get(expandedOperationId);
-                subgraph = operation === undefined ? null : buildDeviceOperationSubgraph(operation);
-                deviceSubgraphCache.set(expandedOperationId, subgraph);
-            }
-            if (subgraph !== null) {
-                assembled.push(subgraph);
+            if (!collapsedMemberIds.has(expandedOperationId)) {
+                let subgraph = deviceSubgraphCache.get(expandedOperationId);
+                if (subgraph === undefined) {
+                    const operation = operationById.get(expandedOperationId);
+                    subgraph = operation === undefined ? null : buildDeviceOperationSubgraph(operation);
+                    deviceSubgraphCache.set(expandedOperationId, subgraph);
+                }
+                if (subgraph !== null) {
+                    assembled.push(subgraph);
+                }
             }
         }
-        return assembled;
-    }, [expandedOperationIds, operationById, deviceSubgraphCache]);
+        return assembled.length === 0 ? NO_DEVICE_SUBGRAPHS : assembled;
+    }, [expandedOperationIds, collapsedMemberIds, operationById, deviceSubgraphCache]);
 
     // React Flow reports selection by node id; the panel and the toolbar work in
     // operation ids.
@@ -366,15 +424,28 @@ const OperationGraphInner = ({
             // over, and a child has no duration, no name worth matching and no
             // place in the operation sequence. Leaving them out is what keeps them
             // from being scored as zero-cost operations. #1195
-            setNodeIndex(
-                graph.nodes
-                    .filter((node) => node.type !== OpGraphNodeType.DEVICE_OP)
-                    .map((node) => ({
+            const indexEntries: OpGraphNodeIndexEntry[] = [];
+            const renderedByOpId = new Map<number, string>();
+            for (const node of graph.nodes) {
+                if (node.type !== OpGraphNodeType.DEVICE_OP) {
+                    indexEntries.push({
                         id: node.id,
                         operationId: node.data.operationId,
                         name: node.data.filterString,
-                    })),
-            );
+                        memberNames: node.data.memberNames,
+                    });
+                    if (node.data.memberOperationIds !== undefined) {
+                        for (const memberId of node.data.memberOperationIds) {
+                            renderedByOpId.set(memberId, node.id);
+                        }
+                    } else {
+                        renderedByOpId.set(node.data.operationId, node.id);
+                    }
+                }
+            }
+            setNodeIndex(indexEntries);
+            setNodeIdByOperationId(renderedByOpId);
+            setDetectedBlocks(graph.blocks && graph.blocks.length > 0 ? graph.blocks : NO_BLOCKS);
 
             // An op can drop out between builds (isolated, or filtered as a
             // deallocate), so selection falls back rather than point at nothing.
@@ -398,8 +469,12 @@ const OperationGraphInner = ({
     // The only inputs that change the node set or the layout geometry, and so the
     // only ones that may trigger a rebuild.
     const buildOptions = useMemo<OpGraphBuildOptions>(
-        () => ({ hideDeallocate, deviceSubgraphs }),
-        [hideDeallocate, deviceSubgraphs],
+        () => ({
+            hideDeallocate,
+            deviceSubgraphs,
+            expandedBlockIds: expandedBlockIds.size === 0 ? EMPTY_BLOCK_IDS : [...expandedBlockIds],
+        }),
+        [hideDeallocate, deviceSubgraphs, expandedBlockIds],
     );
 
     // `sourceOperations` isn't read here — it's the signal that the worker holds a
@@ -410,7 +485,7 @@ const OperationGraphInner = ({
 
     const focusOperation = useCallback(
         (id: number) => {
-            const node = getNode(String(id));
+            const node = getNode(nodeIdByOperationId.get(id) ?? String(id));
             if (!node) {
                 return;
             }
@@ -419,7 +494,7 @@ const OperationGraphInner = ({
                 duration: FOCUS_DURATION_MS,
             });
         },
-        [getNode, setCenter],
+        [getNode, setCenter, nodeIdByOperationId],
     );
 
     useEffect(() => {
@@ -443,7 +518,8 @@ const OperationGraphInner = ({
             return;
         }
         pendingViewportAnchorRef.current = null;
-        const anchored = nodes.find((node) => node.id === anchor.nodeId);
+        const anchored =
+            nodes.find((node) => node.id === anchor.nodeId) ?? nodes.find((node) => node.id === anchor.fallbackNodeId);
         if (anchored === undefined) {
             return;
         }
@@ -463,6 +539,7 @@ const OperationGraphInner = ({
                 const { x, y, zoom } = getViewport();
                 pendingViewportAnchorRef.current = {
                     nodeId,
+                    fallbackNodeId: nodeId,
                     paneX: node.position.x * zoom + x,
                     paneY: node.position.y * zoom + y,
                     reportScope,
@@ -479,6 +556,79 @@ const OperationGraphInner = ({
         },
         [getNode, getViewport, reportScope],
     );
+
+    const armViewportAnchor = useCallback(
+        (nodeId: string, fallbackNodeId: string) => {
+            const node = getNode(nodeId) ?? getNode(fallbackNodeId);
+            if (!node) {
+                return;
+            }
+            const { x, y, zoom } = getViewport();
+            pendingViewportAnchorRef.current = {
+                nodeId,
+                fallbackNodeId,
+                paneX: node.position.x * zoom + x,
+                paneY: node.position.y * zoom + y,
+                reportScope,
+            };
+        },
+        [getNode, getViewport, reportScope],
+    );
+
+    const toggleBlockExpansion = useCallback(
+        (instanceId: string) => {
+            const block = detectedBlocks.find((entry) => entry.instanceId === instanceId);
+            const firstOpId = block?.operationIds[0];
+            armViewportAnchor(instanceId, firstOpId === undefined ? instanceId : String(firstOpId));
+            setExpandedBlockIds((previous) => {
+                const next = new Set(previous);
+                if (next.delete(instanceId)) {
+                    if (block !== undefined) {
+                        setExpandedOperationIds((expandedOps) => {
+                            const remaining = new Set(expandedOps);
+                            for (const memberOpId of block.operationIds) {
+                                remaining.delete(memberOpId);
+                            }
+                            return remaining;
+                        });
+                    }
+                } else {
+                    next.add(instanceId);
+                }
+                return next;
+            });
+        },
+        [armViewportAnchor, detectedBlocks],
+    );
+
+    const expandAllBlocks = useCallback(() => {
+        setExpandedBlockIds(new Set(detectedBlocks.map((block) => block.instanceId)));
+    }, [detectedBlocks]);
+
+    const collapseAllBlocks = useCallback(() => {
+        setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
+        const collapsedMembers = new Set(detectedBlocks.flatMap((block) => block.operationIds));
+        setExpandedOperationIds((previous) => {
+            const next = new Set(previous);
+            for (const memberOpId of collapsedMembers) {
+                next.delete(memberOpId);
+            }
+            return next;
+        });
+    }, [detectedBlocks]);
+
+    const handleHideDeallocateChange = useCallback((next: boolean) => {
+        setHideDeallocate(next);
+        setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
+    }, []);
+
+    if (operationId !== undefined && revealedOperationId !== operationId && detectedBlocks.length > 0) {
+        setRevealedOperationId(operationId);
+        const buried = detectedBlocks.find((block) => block.operationIds.includes(operationId));
+        if (buried !== undefined && !expandedBlockIds.has(buried.instanceId)) {
+            setExpandedBlockIds(new Set([...expandedBlockIds, buried.instanceId]));
+        }
+    }
 
     // Recentre on the operation the URL names. A no-op on first mount, where the
     // graph hasn't been laid out yet and `onBuilt`'s pending focus does the work.
@@ -592,13 +742,28 @@ const OperationGraphInner = ({
         }
         const ids = new Set<string>();
         const operationIdsInOrder: number[] = [];
+        const buriedCountById = new Map<string, number>();
+        let hiddenMatchCount = 0;
         for (const entry of nodeIndex) {
             if (filterMatcher.test(entry.name)) {
                 ids.add(entry.id);
                 operationIdsInOrder.push(entry.operationId);
+            } else {
+                let buried = 0;
+                for (const memberName of entry.memberNames ?? []) {
+                    if (filterMatcher.test(memberName)) {
+                        buried += 1;
+                    }
+                }
+                if (buried > 0) {
+                    ids.add(entry.id);
+                    operationIdsInOrder.push(entry.operationId);
+                    buriedCountById.set(entry.id, buried);
+                    hiddenMatchCount += buried;
+                }
             }
         }
-        return { ids, operationIdsInOrder };
+        return { ids, operationIdsInOrder, hiddenMatchCount, buriedCountById };
     }, [nodeIndex, filterMatcher]);
 
     // A query that matches nothing leaves the canvas alone rather than dimming
@@ -647,7 +812,7 @@ const OperationGraphInner = ({
         const bySource = new Map<string, OpGraphFlowEdge[]>();
         const byTarget = new Map<string, OpGraphFlowEdge[]>();
         for (const edge of edges) {
-            const boundary = operationBoundaryOf(edge);
+            const boundary = operationBoundaryOf(edge, nodeIdByOperationId);
             if (boundary !== null) {
                 const outgoing = bySource.get(boundary.source);
                 if (outgoing) {
@@ -664,13 +829,13 @@ const OperationGraphInner = ({
             }
         }
         return { edgesBySource: bySource, edgesByTarget: byTarget };
-    }, [edges]);
+    }, [edges, nodeIdByOperationId]);
 
     const highlight = useMemo(() => {
         if (selectedOperationId === null) {
             return null;
         }
-        const selectedId = String(selectedOperationId);
+        const selectedId = operationNodeIdOf(selectedOperationId, nodeIdByOperationId) ?? String(selectedOperationId);
         const relationByNodeId = new Map<string, NodeRelation>();
         const relationByEdgeId = new Map<string, NodeRelation>();
         // Outputs first: a neighbour on both sides of a cycle reads as an input,
@@ -678,21 +843,21 @@ const OperationGraphInner = ({
         // The neighbour is marked by its operation node, whether that renders
         // collapsed or as the group around an expanded subgraph.
         for (const edge of edgesBySource.get(selectedId) ?? []) {
-            const targetId = operationNodeIdOf(targetOperationIdOf(edge));
+            const targetId = operationNodeIdOf(targetOperationIdOf(edge), nodeIdByOperationId);
             if (targetId !== null) {
                 relationByNodeId.set(targetId, NodeRelation.Output);
                 relationByEdgeId.set(edge.id, NodeRelation.Output);
             }
         }
         for (const edge of edgesByTarget.get(selectedId) ?? []) {
-            const sourceId = operationNodeIdOf(sourceOperationIdOf(edge));
+            const sourceId = operationNodeIdOf(sourceOperationIdOf(edge), nodeIdByOperationId);
             if (sourceId !== null) {
                 relationByNodeId.set(sourceId, NodeRelation.Input);
                 relationByEdgeId.set(edge.id, NodeRelation.Input);
             }
         }
         return { selectedId, relationByNodeId, relationByEdgeId };
-    }, [selectedOperationId, edgesBySource, edgesByTarget]);
+    }, [selectedOperationId, edgesBySource, edgesByTarget, nodeIdByOperationId]);
 
     const graphOperationIds = useMemo(() => nodeIndex.map((entry) => entry.operationId), [nodeIndex]);
 
@@ -736,13 +901,13 @@ const OperationGraphInner = ({
     const topologyEdges = useMemo(() => {
         const topology: Array<{ id: string; source: string; target: string }> = [];
         for (const edge of builtEdges) {
-            const boundary = operationBoundaryOf(edge);
+            const boundary = operationBoundaryOf(edge, nodeIdByOperationId);
             if (boundary !== null) {
                 topology.push({ id: edge.id, ...boundary });
             }
         }
         return topology;
-    }, [builtEdges]);
+    }, [builtEdges, nodeIdByOperationId]);
 
     const criticalPath = useMemo(() => {
         if (!isCriticalPathActive) {
@@ -816,7 +981,13 @@ const OperationGraphInner = ({
             // Custom properties only, so perf stacks with selection, the
             // highlight and the inherited filter dim instead of displacing any.
             const perfStyle = perfStyleByNodeId?.get(node.id);
-            if (className === undefined && perfStyle === undefined) {
+            const buriedMatchCount = matches.buriedCountById.get(node.id) ?? 0;
+            const nextData =
+                buriedMatchCount > 0 && node.data.buriedMatchCount !== buriedMatchCount
+                    ? { ...node.data, buriedMatchCount }
+                    : node.data;
+
+            if (className === undefined && perfStyle === undefined && nextData === node.data) {
                 return node;
             }
 
@@ -826,12 +997,18 @@ const OperationGraphInner = ({
             // scores change — so an untouched node hits the cache and keeps the
             // object it was given.
             const cached = styledNodeCache.get(node);
-            if (cached !== undefined && cached.className === className && cached.perfStyle === perfStyle) {
+            if (
+                cached !== undefined &&
+                cached.className === className &&
+                cached.perfStyle === perfStyle &&
+                cached.styled.data.buriedMatchCount === nextData.buriedMatchCount
+            ) {
                 return cached.styled;
             }
 
             const styled = {
                 ...node,
+                data: nextData,
                 ...(perfStyle ? { style: { ...node.style, ...perfStyle } } : {}),
                 ...(className === undefined ? {} : { className }),
                 // Selection is mirrored into React Flow's own flag so its keyboard
@@ -844,7 +1021,15 @@ const OperationGraphInner = ({
             styledNodeCache.set(node, { className, perfStyle, styled });
             return styled;
         });
-    }, [nodes, highlight, matchedIds, perfStyleByNodeId, criticalPathNodeIds, styledNodeCache]);
+    }, [
+        nodes,
+        highlight,
+        matchedIds,
+        matches.buriedCountById,
+        perfStyleByNodeId,
+        criticalPathNodeIds,
+        styledNodeCache,
+    ]);
 
     const styledEdges = useMemo(() => {
         if (!highlight && !matchedIds && !criticalPathEdgeIds) {
@@ -861,18 +1046,27 @@ const OperationGraphInner = ({
             }
             // An edge between two matches stays lit so the matched subset is
             // traceable; a selection edge outranks the filter either way.
-            if (matchedIds && (relation || bothEndsMatched(edge, matchedIds))) {
+            if (matchedIds && (relation || bothEndsMatched(edge, matchedIds, nodeIdByOperationId))) {
                 classNames.push(MATCHED_EDGE_CLASS);
             }
             return classNames.length > 0 ? { ...edge, className: classNames.join(' ') } : edge;
         });
-    }, [edges, highlight, matchedIds, criticalPathEdgeIds]);
+    }, [edges, highlight, matchedIds, criticalPathEdgeIds, nodeIdByOperationId]);
 
     const handleNodeClick = useCallback(
         (_event: ReactMouseEvent, node: OpGraphFlowNode) => {
             selectOperation(node.data.operationId);
         },
         [selectOperation],
+    );
+
+    const handleNodeDoubleClick = useCallback(
+        (_event: ReactMouseEvent, node: OpGraphFlowNode) => {
+            if (node.data.blockInstanceId !== undefined) {
+                toggleBlockExpansion(node.data.blockInstanceId);
+            }
+        },
+        [toggleBlockExpansion],
     );
 
     const handlePaneClick = useCallback(() => {
@@ -982,7 +1176,18 @@ const OperationGraphInner = ({
                 nextOperationId={nextOperationId}
                 onGoToOperation={selectOperation}
                 hideDeallocate={hideDeallocate}
-                onHideDeallocateChange={setHideDeallocate}
+                onHideDeallocateChange={handleHideDeallocateChange}
+                hiddenMatchCount={matches.hiddenMatchCount}
+                hasBlocks={detectedBlocks.length > 0}
+                areAllBlocksExpanded={
+                    detectedBlocks.length > 0 && detectedBlocks.every((block) => expandedBlockIds.has(block.instanceId))
+                }
+                areAllBlocksCollapsed={
+                    detectedBlocks.length === 0 ||
+                    detectedBlocks.every((block) => !expandedBlockIds.has(block.instanceId))
+                }
+                onExpandAllBlocks={expandAllBlocks}
+                onCollapseAllBlocks={collapseAllBlocks}
                 isPerfOverlayActive={isPerfOverlayActive}
                 onPerfOverlayChange={handlePerfOverlayChange}
                 isCriticalPathActive={isCriticalPathActive}
@@ -993,40 +1198,43 @@ const OperationGraphInner = ({
                 isDisabled={isBuilding}
             />
             <OpGraphExpansionContext.Provider value={toggleOperationExpansion}>
-                <ReactFlow<OpGraphFlowNode, OpGraphFlowEdge>
-                    nodes={styledNodes}
-                    edges={styledEdges}
-                    nodeTypes={NODE_TYPES}
-                    edgeTypes={EDGE_TYPES}
-                    onNodesChange={handleNodesChange}
-                    onEdgesChange={onEdgesChange}
-                    onNodeClick={handleNodeClick}
-                    onPaneClick={handlePaneClick}
-                    onNodeMouseEnter={isPerfOverlayActive ? handleNodeMouseEnter : undefined}
-                    // Always attached so any exit clears a hover the overlay left
-                    // behind; clearing a null hover bails out of the render.
-                    onNodeMouseLeave={handleNodeMouseLeave}
-                    minZoom={MIN_ZOOM}
-                    maxZoom={MAX_ZOOM}
-                    nodesConnectable={false}
-                    selectNodesOnDrag={false}
-                    // The graph is a read-only view of a report, but React Flow's
-                    // stock delete key still reaches `onNodesChange`, so a selected
-                    // node can be removed until the next relayout puts it back.
-                    deleteKeyCode={null}
-                    proOptions={{ hideAttribution: true }}
-                >
-                    <Background />
-                    <Controls />
-                    {/* Docked left rather than in React Flow's default corner: the
+                <OpGraphBlockExpansionContext.Provider value={toggleBlockExpansion}>
+                    <ReactFlow<OpGraphFlowNode, OpGraphFlowEdge>
+                        nodes={styledNodes}
+                        edges={styledEdges}
+                        nodeTypes={NODE_TYPES}
+                        edgeTypes={EDGE_TYPES}
+                        onNodesChange={handleNodesChange}
+                        onEdgesChange={onEdgesChange}
+                        onNodeClick={handleNodeClick}
+                        onNodeDoubleClick={handleNodeDoubleClick}
+                        onPaneClick={handlePaneClick}
+                        onNodeMouseEnter={isPerfOverlayActive ? handleNodeMouseEnter : undefined}
+                        // Always attached so any exit clears a hover the overlay left
+                        // behind; clearing a null hover bails out of the render.
+                        onNodeMouseLeave={handleNodeMouseLeave}
+                        minZoom={MIN_ZOOM}
+                        maxZoom={MAX_ZOOM}
+                        nodesConnectable={false}
+                        selectNodesOnDrag={false}
+                        // The graph is a read-only view of a report, but React Flow's
+                        // stock delete key still reaches `onNodesChange`, so a selected
+                        // node can be removed until the next relayout puts it back.
+                        deleteKeyCode={null}
+                        proOptions={{ hideAttribution: true }}
+                    >
+                        <Background />
+                        <Controls />
+                        {/* Docked left rather than in React Flow's default corner: the
                         panel is a full-height right column, and `onBuilt` always
                         resolves a selection, so a right-docked minimap would be
                         hidden in every state the user lands in. */}
-                    <MiniMap
-                        pannable
-                        position='bottom-left'
-                    />
-                </ReactFlow>
+                        <MiniMap
+                            pannable
+                            position='bottom-left'
+                        />
+                    </ReactFlow>
+                </OpGraphBlockExpansionContext.Provider>
             </OpGraphExpansionContext.Provider>
             <div className='op-graph-bottom-band'>
                 {isCriticalPathActive && hasCriticalPath && !isBuilding ? (

--- a/src/components/operation-graph/OperationGraphReactFlow.tsx
+++ b/src/components/operation-graph/OperationGraphReactFlow.tsx
@@ -451,6 +451,7 @@ const OperationGraphInner = ({
                         operationId: node.data.operationId,
                         name: node.data.filterString,
                         memberNames: node.data.memberNames,
+                        memberOperationIds: node.data.memberOperationIds,
                     });
                     if (node.data.memberOperationIds !== undefined) {
                         for (const memberId of node.data.memberOperationIds) {
@@ -471,7 +472,13 @@ const OperationGraphInner = ({
             // An op can drop out between builds (isolated, or filtered as a
             // deallocate), so selection falls back rather than point at nothing.
             const desired = selectedOperationIdRef.current;
-            const isPresent = desired !== null && graph.nodes.some((node) => node.data.operationId === desired);
+            const isPresent =
+                desired !== null &&
+                graph.nodes.some(
+                    (node) =>
+                        node.data.operationId === desired ||
+                        (node.data.memberOperationIds !== undefined && node.data.memberOperationIds.includes(desired)),
+                );
             const target = isPresent ? desired : (graph.nodes[0]?.data.operationId ?? null);
             if (target !== desired) {
                 setSelectedOperationId(target);
@@ -641,6 +648,7 @@ const OperationGraphInner = ({
     const handleHideDeallocateChange = useCallback((next: boolean) => {
         setHideDeallocate(next);
         setExpandedBlockIds(NOTHING_EXPANDED_BLOCKS);
+        setExpandedOperationIds(NOTHING_EXPANDED);
     }, []);
 
     if (operationId !== undefined && revealedOperationId !== operationId && detectedBlocks.length > 0) {
@@ -880,7 +888,17 @@ const OperationGraphInner = ({
         return { selectedId, relationByNodeId, relationByEdgeId };
     }, [selectedOperationId, edgesBySource, edgesByTarget, nodeIdByOperationId]);
 
-    const graphOperationIds = useMemo(() => nodeIndex.map((entry) => entry.operationId), [nodeIndex]);
+    const graphOperationIds = useMemo(() => {
+        const ids: number[] = [];
+        for (const entry of nodeIndex) {
+            if (entry.memberOperationIds !== undefined) {
+                ids.push(...entry.memberOperationIds);
+            } else {
+                ids.push(entry.operationId);
+            }
+        }
+        return ids;
+    }, [nodeIndex]);
 
     const perfOverlay = useMemo(
         () => buildOpGraphPerfOverlay(perfRows, isPerfReportLoaded, graphOperationIds),
@@ -963,8 +981,8 @@ const OperationGraphInner = ({
     // Built once per score change so the styling pass reuses these identities
     // instead of allocating one per node on every drag frame.
     const perfStyleByNodeId = useMemo(
-        () => buildPerfNodeStyleByNodeId(perfOverlay, isPerfOverlayActive),
-        [isPerfOverlayActive, perfOverlay],
+        () => buildPerfNodeStyleByNodeId(perfOverlay, isPerfOverlayActive, nodeIndex),
+        [isPerfOverlayActive, perfOverlay, nodeIndex],
     );
 
     const styledNodes = useMemo(() => {
@@ -1085,9 +1103,16 @@ const OperationGraphInner = ({
         (_event: ReactMouseEvent, node: OpGraphFlowNode) => {
             if (node.data.blockInstanceId !== undefined) {
                 toggleBlockExpansion(node.data.blockInstanceId);
+                return;
+            }
+            const instance = detectedBlocks.find(
+                (block) => expandedBlockIds.has(block.instanceId) && block.operationIds.includes(node.data.operationId),
+            );
+            if (instance !== undefined) {
+                toggleBlockExpansion(instance.instanceId);
             }
         },
-        [toggleBlockExpansion],
+        [detectedBlocks, expandedBlockIds, toggleBlockExpansion],
     );
 
     const handlePaneClick = useCallback(() => {
@@ -1289,7 +1314,7 @@ const OperationGraphInner = ({
             <div className='op-graph-bottom-band'>
                 {isCriticalPathActive && hasCriticalPath && !isBuilding ? (
                     <CriticalPathAnnotation
-                        opCount={criticalPath.opIds.length}
+                        opCount={criticalPath.opCount}
                         totalNs={criticalPath.totalNs}
                         measuredNs={perfOverlay.totalNs}
                         isPartial={criticalPath.hasCycle}
@@ -1318,7 +1343,7 @@ const OperationGraphInner = ({
             {isPanelOpen ? (
                 <OpGraphInfoPanel
                     operationId={selectedOperationId}
-                    operationList={operationList}
+                    operationById={operationById}
                     operationNamesById={operationNamesById}
                     onLocateOperation={focusOperation}
                     isPerfOverlayActive={isPerfOverlayActive}

--- a/src/components/operation-graph/opGraphBlockBoundary.ts
+++ b/src/components/operation-graph/opGraphBlockBoundary.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { NodeRelation } from '../../definitions/NodeRelation';
+import type { OperationDescription, Tensor } from '../../model/APIData';
+
+/**
+ * @description Rewrite a tensor's endpoints to only those outside the block, so a
+ * boundary tensor names what it actually connects the block to rather than listing
+ * members the panel is already showing.
+ *
+ * Ids and names are two arrays aligned by index, so they are filtered as pairs and
+ * rebuilt together; filtering the ids alone would shift every name by one and
+ * attribute a boundary tensor to the wrong operation. A missing name becomes '',
+ * which keeps the pairing rather than collapsing the list.
+ */
+export const withExternalEndpoints = (
+    tensor: Tensor,
+    memberIds: ReadonlySet<number>,
+    direction: NodeRelation,
+): Tensor => {
+    if (direction === NodeRelation.Input) {
+        const producers = tensor.producers ?? [];
+        const producerNames = tensor.producerNames ?? [];
+        const keep = producers
+            .map((id, index) => ({ id, name: producerNames[index] ?? '' }))
+            .filter((entry) => !memberIds.has(entry.id));
+        return { ...tensor, producers: keep.map((entry) => entry.id), producerNames: keep.map((entry) => entry.name) };
+    }
+    const consumers = tensor.consumers ?? [];
+    const consumerNames = tensor.consumerNames ?? [];
+    const keep = consumers
+        .map((id, index) => ({ id, name: consumerNames[index] ?? '' }))
+        .filter((entry) => !memberIds.has(entry.id));
+    return { ...tensor, consumers: keep.map((entry) => entry.id), consumerNames: keep.map((entry) => entry.name) };
+};
+
+/**
+ * @description The block's I/O in one direction: tensors that cross its boundary,
+ * deduplicated by tensor id and with their endpoints narrowed to the outside.
+ *
+ * A tensor with no counterparts at all is kept — it is a graph input or output, not
+ * an internal edge — while one whose every counterpart is a member is dropped as
+ * internal to the block.
+ */
+export const getBlockBoundaryTensors = (
+    members: OperationDescription[],
+    memberIds: ReadonlySet<number>,
+    direction: NodeRelation,
+): Tensor[] => {
+    const tensors: Tensor[] = [];
+    const seenIds = new Set<number>();
+    for (const member of members) {
+        const list = (direction === NodeRelation.Input ? member.inputs : member.outputs) ?? [];
+        for (const tensor of list) {
+            if (!seenIds.has(tensor.id)) {
+                const counterparts = (direction === NodeRelation.Input ? tensor.producers : tensor.consumers) ?? [];
+                if (counterparts.length === 0 || counterparts.some((id) => !memberIds.has(id))) {
+                    seenIds.add(tensor.id);
+                    tensors.push(withExternalEndpoints(tensor, memberIds, direction));
+                }
+            }
+        }
+    }
+    return tensors;
+};

--- a/src/components/operation-graph/opGraphBlockMeta.ts
+++ b/src/components/operation-graph/opGraphBlockMeta.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { formatMemorySize, formatSize } from '../../functions/math';
+
+/**
+ * @description The block node's second line — op count, then duration and memory
+ * delta when there is any to report. Shared by the node and the block panel, which
+ * are on screen together: two derivations of the same numbers would show up as the
+ * two of them disagreeing about one block. #1944
+ */
+export function formatBlockMeta(opCount: number, durationSeconds: number, memoryDeltaBytes: number): string {
+    const parts = [`${opCount} ops`];
+    if (durationSeconds > 0) {
+        parts.push(`${formatSize(durationSeconds, 2)} s`);
+    }
+    if (memoryDeltaBytes !== 0) {
+        const sign = memoryDeltaBytes > 0 ? '+' : '-';
+        parts.push(`${sign}${formatMemorySize(Math.abs(memoryDeltaBytes), 0)}`);
+    }
+    return parts.join(' · ');
+}

--- a/src/components/operation-graph/opGraphBuilder.ts
+++ b/src/components/operation-graph/opGraphBuilder.ts
@@ -7,11 +7,12 @@ import {
     type LayoutInputEdge,
     estimateBlockNodeSize,
     estimateOpNodeSize,
-    formatBlockMeta,
     layoutDeviceSubgraph,
     layoutOpGraph,
 } from './opGraphLayout';
-import { detectRepeatBlocks, sumOptional } from './opGraphRepeatBlocks';
+import { detectRepeatBlocks } from './opGraphRepeatBlocks';
+import { formatBlockMeta } from './opGraphBlockMeta';
+import { sumOptional } from '../../functions/math';
 import {
     type OpGraphBlockSummary,
     type OpGraphBuildOptions,
@@ -288,14 +289,21 @@ export function buildOpGraph(
         layoutEdges,
     );
 
-    const blocks: OpGraphBlockSummary[] = detectedBlocks.map((instance) => ({
-        instanceId: instance.instanceId,
-        operationIds: instance.operationIds,
-        label: instance.label,
-        patternLabel: instance.patternLabel,
-        instanceIndex: instance.instanceIndex,
-        instanceCount: instance.instanceCount,
-    }));
+    const blocks: OpGraphBlockSummary[] = detectedBlocks.map((instance) => {
+        const members = instance.operationIds
+            .map((id) => operationById.get(id))
+            .filter((member): member is OpGraphSourceOperation => member !== undefined);
+        return {
+            instanceId: instance.instanceId,
+            operationIds: instance.operationIds,
+            label: instance.label,
+            patternLabel: instance.patternLabel,
+            instanceIndex: instance.instanceIndex,
+            instanceCount: instance.instanceCount,
+            durationSeconds: sumOptional(members.map((member) => member.durationSeconds)),
+            memoryDeltaBytes: sumOptional(members.map((member) => member.memoryDeltaBytes)),
+        };
+    });
 
     return {
         // Children last: React Flow resolves `parentId` against the nodes it has

--- a/src/components/operation-graph/opGraphBuilder.ts
+++ b/src/components/operation-graph/opGraphBuilder.ts
@@ -274,6 +274,9 @@ export function buildOpGraph(
         instanceId: instance.instanceId,
         operationIds: instance.operationIds,
         label: instance.label,
+        patternLabel: instance.patternLabel,
+        instanceIndex: instance.instanceIndex,
+        instanceCount: instance.instanceCount,
     }));
 
     return {

--- a/src/components/operation-graph/opGraphBuilder.ts
+++ b/src/components/operation-graph/opGraphBuilder.ts
@@ -3,8 +3,16 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { DEALLOCATE_OP_NAME_LIST } from '../../definitions/Deallocate';
-import { type LayoutInputEdge, estimateOpNodeSize, layoutDeviceSubgraph, layoutOpGraph } from './opGraphLayout';
 import {
+    type LayoutInputEdge,
+    estimateBlockNodeSize,
+    estimateOpNodeSize,
+    layoutDeviceSubgraph,
+    layoutOpGraph,
+} from './opGraphLayout';
+import { detectRepeatBlocks, sumOptional } from './opGraphRepeatBlocks';
+import {
+    type OpGraphBlockSummary,
     type OpGraphBuildOptions,
     type OpGraphBuiltGraph,
     type OpGraphDeviceSubgraph,
@@ -42,9 +50,11 @@ function collectCandidateEdges(operations: OpGraphSourceOperation[]): CandidateE
     return candidates;
 }
 
+const BLOCK_META_WIDTH_SAMPLE = '00 ops · 00.00 s · 00.00 MiB';
+
 export function buildOpGraph(
     operations: OpGraphSourceOperation[],
-    { hideDeallocate, deviceSubgraphs }: OpGraphBuildOptions,
+    { hideDeallocate, deviceSubgraphs, expandedBlockIds = [] }: OpGraphBuildOptions,
 ): OpGraphBuiltGraph {
     const candidates = collectCandidateEdges(operations);
 
@@ -73,13 +83,70 @@ export function buildOpGraph(
         return subgraph?.entryNodeIdByTensorId[tensorId] ?? subgraph?.entryFallbackNodeId ?? String(operationId);
     };
 
+    const keptOperations: OpGraphSourceOperation[] = [];
     const kept = new Set<number>();
-    const nodes: OpGraphFlowNode[] = [];
-    const deviceOpNodes: OpGraphFlowNode[] = [];
-    const deviceOpEdges: OpGraphFlowEdge[] = [];
     for (const operation of operations) {
         if (connected.has(operation.id) && !(hideDeallocate && isDeallocate(operation.name))) {
             kept.add(operation.id);
+            keptOperations.push(operation);
+        }
+    }
+
+    const operationById = new Map<number, OpGraphSourceOperation>(
+        keptOperations.map((operation) => [operation.id, operation]),
+    );
+    const detectedBlocks = detectRepeatBlocks(keptOperations);
+    const expandedBlocks = new Set<string>(expandedBlockIds);
+    const collapsedInstanceByOpId = new Map<string, (typeof detectedBlocks)[number]>();
+    for (const instance of detectedBlocks) {
+        if (!expandedBlocks.has(instance.instanceId)) {
+            for (const operationId of instance.operationIds) {
+                collapsedInstanceByOpId.set(String(operationId), instance);
+            }
+        }
+    }
+
+    const renderedNodeIdOf = (operationId: number): string =>
+        collapsedInstanceByOpId.get(String(operationId))?.instanceId ?? String(operationId);
+
+    const nodes: OpGraphFlowNode[] = [];
+    const deviceOpNodes: OpGraphFlowNode[] = [];
+    const deviceOpEdges: OpGraphFlowEdge[] = [];
+    const emittedBlockIds = new Set<string>();
+
+    for (const operation of keptOperations) {
+        const collapsedInstance = collapsedInstanceByOpId.get(String(operation.id));
+        if (collapsedInstance !== undefined) {
+            if (!emittedBlockIds.has(collapsedInstance.instanceId)) {
+                emittedBlockIds.add(collapsedInstance.instanceId);
+                const members = collapsedInstance.operationIds
+                    .map((id) => operationById.get(id))
+                    .filter((member): member is OpGraphSourceOperation => member !== undefined);
+                const opCount = collapsedInstance.operationIds.length;
+                const durationSeconds = sumOptional(members.map((member) => member.durationSeconds));
+                const memoryDeltaBytes = sumOptional(members.map((member) => member.memoryDeltaBytes));
+                const size = estimateBlockNodeSize(collapsedInstance.label, BLOCK_META_WIDTH_SAMPLE);
+                nodes.push({
+                    id: collapsedInstance.instanceId,
+                    type: OpGraphNodeType.BLOCK,
+                    position: { x: 0, y: 0 },
+                    ...size,
+                    data: {
+                        operationId: collapsedInstance.operationIds[0],
+                        label: collapsedInstance.label,
+                        fileIdentifier: '',
+                        filterString: collapsedInstance.label,
+                        deviceOperationCount: 0,
+                        blockInstanceId: collapsedInstance.instanceId,
+                        memberNames: members.map((member) => member.name),
+                        memberOperationIds: collapsedInstance.operationIds,
+                        opCount,
+                        durationSeconds,
+                        memoryDeltaBytes,
+                    },
+                });
+            }
+        } else {
             const label = `${operation.id} ${operation.name}`;
             const collapsedSize = estimateOpNodeSize(
                 label,
@@ -173,22 +240,28 @@ export function buildOpGraph(
     const layoutEdges: LayoutInputEdge[] = [];
     for (const candidate of candidates) {
         if (kept.has(candidate.source) && kept.has(candidate.target)) {
-            const pair = `${candidate.source}-${candidate.target}`;
-            const parallelIndex = parallelCountByPair.get(pair) ?? 0;
-            parallelCountByPair.set(pair, parallelIndex + 1);
-            edges.push({
-                id: `${pair}-${parallelIndex}`,
-                source: exitNodeIdOf(candidate.source, candidate.tensorId),
-                target: entryNodeIdOf(candidate.target, candidate.tensorId),
-                type: OpGraphEdgeType.OP,
-                label: candidate.label,
-                data: {
-                    parallelIndex,
-                    sourceOperationId: candidate.source,
-                    targetOperationId: candidate.target,
-                },
-            });
-            layoutEdges.push({ source: String(candidate.source), target: String(candidate.target) });
+            const renderedSource = renderedNodeIdOf(candidate.source);
+            const renderedTarget = renderedNodeIdOf(candidate.target);
+            if (renderedSource !== renderedTarget) {
+                const pair = `${candidate.source}-${candidate.target}`;
+                const parallelIndex = parallelCountByPair.get(pair) ?? 0;
+                parallelCountByPair.set(pair, parallelIndex + 1);
+                const sourceIsCollapsed = collapsedInstanceByOpId.has(String(candidate.source));
+                const targetIsCollapsed = collapsedInstanceByOpId.has(String(candidate.target));
+                edges.push({
+                    id: `${pair}-${parallelIndex}`,
+                    source: sourceIsCollapsed ? renderedSource : exitNodeIdOf(candidate.source, candidate.tensorId),
+                    target: targetIsCollapsed ? renderedTarget : entryNodeIdOf(candidate.target, candidate.tensorId),
+                    type: OpGraphEdgeType.OP,
+                    label: candidate.label,
+                    data: {
+                        parallelIndex,
+                        sourceOperationId: candidate.source,
+                        targetOperationId: candidate.target,
+                    },
+                });
+                layoutEdges.push({ source: renderedSource, target: renderedTarget });
+            }
         }
     }
 
@@ -196,6 +269,12 @@ export function buildOpGraph(
         nodes.map((node) => ({ id: node.id, width: node.width ?? 0, height: node.height ?? 0 })),
         layoutEdges,
     );
+
+    const blocks: OpGraphBlockSummary[] = detectedBlocks.map((instance) => ({
+        instanceId: instance.instanceId,
+        operationIds: instance.operationIds,
+        label: instance.label,
+    }));
 
     return {
         // Children last: React Flow resolves `parentId` against the nodes it has
@@ -205,5 +284,6 @@ export function buildOpGraph(
             ...deviceOpNodes,
         ],
         edges: [...edges, ...deviceOpEdges],
+        blocks,
     };
 }

--- a/src/components/operation-graph/opGraphBuilder.ts
+++ b/src/components/operation-graph/opGraphBuilder.ts
@@ -142,15 +142,17 @@ export function buildOpGraph(
                     data: {
                         operationId: collapsedInstance.operationIds[0],
                         label: collapsedInstance.label,
-                        fileIdentifier: meta,
+                        // Not `fileIdentifier`: a block has no source file, and the
+                        // stats line was being smuggled through the field that names
+                        // one. The sums it is formatted from live on the summary.
+                        fileIdentifier: '',
+                        metaLine: meta,
                         filterString: collapsedInstance.label,
                         deviceOperationCount: 0,
                         blockInstanceId: collapsedInstance.instanceId,
                         memberNames: members.map((member) => member.name),
                         memberOperationIds: collapsedInstance.operationIds,
                         opCount,
-                        durationSeconds,
-                        memoryDeltaBytes,
                     },
                 });
             }

--- a/src/components/operation-graph/opGraphBuilder.ts
+++ b/src/components/operation-graph/opGraphBuilder.ts
@@ -26,7 +26,7 @@ import {
     isExpandableOperation,
 } from './opGraphTypes';
 
-interface CandidateEdge {
+export interface CandidateEdge {
     source: number;
     target: number;
     label: string;
@@ -35,7 +35,7 @@ interface CandidateEdge {
 
 const isDeallocate = (name: string): boolean => DEALLOCATE_OP_NAME_LIST.includes(name.toLowerCase());
 
-function collectCandidateEdges(operations: OpGraphSourceOperation[]): CandidateEdge[] {
+export function collectCandidateEdges(operations: OpGraphSourceOperation[]): CandidateEdge[] {
     const candidates: CandidateEdge[] = [];
     for (const operation of operations) {
         for (const output of operation.outputs) {
@@ -55,10 +55,13 @@ function collectCandidateEdges(operations: OpGraphSourceOperation[]): CandidateE
 export function getKeptOperations(
     operations: OpGraphSourceOperation[],
     hideDeallocate: boolean,
-): OpGraphSourceOperation[] {
     // Connectivity is decided before the deallocate filter so hiding deallocate
     // ops cannot drop their neighbours or pull in ops that were always isolated.
-    const candidates = collectCandidateEdges(operations);
+    // Callers that already hold the candidate pass supply it: this is an
+    // ops x outputs x consumers walk on the build hot path, and `buildOpGraph` and
+    // the worker's detection step both used to pay for it again here.
+    candidates: readonly CandidateEdge[] = collectCandidateEdges(operations),
+): OpGraphSourceOperation[] {
     const connected = new Set<number>();
     for (const candidate of candidates) {
         connected.add(candidate.source);
@@ -92,7 +95,7 @@ export function buildOpGraph(
         return subgraph?.entryNodeIdByTensorId[tensorId] ?? subgraph?.entryFallbackNodeId ?? String(operationId);
     };
 
-    const keptOperations = getKeptOperations(operations, hideDeallocate);
+    const keptOperations = getKeptOperations(operations, hideDeallocate, candidates);
     const kept = new Set<number>(keptOperations.map((operation) => operation.id));
 
     const operationById = new Map<number, OpGraphSourceOperation>(

--- a/src/components/operation-graph/opGraphBuilder.ts
+++ b/src/components/operation-graph/opGraphBuilder.ts
@@ -7,6 +7,7 @@ import {
     type LayoutInputEdge,
     estimateBlockNodeSize,
     estimateOpNodeSize,
+    formatBlockMeta,
     layoutDeviceSubgraph,
     layoutOpGraph,
 } from './opGraphLayout';
@@ -21,6 +22,7 @@ import {
     type OpGraphFlowNode,
     OpGraphNodeType,
     type OpGraphSourceOperation,
+    type RepeatBlockInstance,
     isExpandableOperation,
 } from './opGraphTypes';
 
@@ -50,21 +52,28 @@ function collectCandidateEdges(operations: OpGraphSourceOperation[]): CandidateE
     return candidates;
 }
 
-const BLOCK_META_WIDTH_SAMPLE = '00 ops · 00.00 s · 00.00 MiB';
-
-export function buildOpGraph(
+export function getKeptOperations(
     operations: OpGraphSourceOperation[],
-    { hideDeallocate, deviceSubgraphs, expandedBlockIds = [] }: OpGraphBuildOptions,
-): OpGraphBuiltGraph {
-    const candidates = collectCandidateEdges(operations);
-
+    hideDeallocate: boolean,
+): OpGraphSourceOperation[] {
     // Connectivity is decided before the deallocate filter so hiding deallocate
     // ops cannot drop their neighbours or pull in ops that were always isolated.
+    const candidates = collectCandidateEdges(operations);
     const connected = new Set<number>();
     for (const candidate of candidates) {
         connected.add(candidate.source);
         connected.add(candidate.target);
     }
+    return operations.filter(
+        (operation) => connected.has(operation.id) && !(hideDeallocate && isDeallocate(operation.name)),
+    );
+}
+
+export function buildOpGraph(
+    operations: OpGraphSourceOperation[],
+    { hideDeallocate, deviceSubgraphs, expandedBlockIds = [], detectedBlocks: providedBlocks }: OpGraphBuildOptions,
+): OpGraphBuiltGraph {
+    const candidates = collectCandidateEdges(operations);
 
     const subgraphByOperationId = new Map<number, OpGraphDeviceSubgraph>(
         deviceSubgraphs.map((subgraph) => [subgraph.operationId, subgraph]),
@@ -83,31 +92,25 @@ export function buildOpGraph(
         return subgraph?.entryNodeIdByTensorId[tensorId] ?? subgraph?.entryFallbackNodeId ?? String(operationId);
     };
 
-    const keptOperations: OpGraphSourceOperation[] = [];
-    const kept = new Set<number>();
-    for (const operation of operations) {
-        if (connected.has(operation.id) && !(hideDeallocate && isDeallocate(operation.name))) {
-            kept.add(operation.id);
-            keptOperations.push(operation);
-        }
-    }
+    const keptOperations = getKeptOperations(operations, hideDeallocate);
+    const kept = new Set<number>(keptOperations.map((operation) => operation.id));
 
     const operationById = new Map<number, OpGraphSourceOperation>(
         keptOperations.map((operation) => [operation.id, operation]),
     );
-    const detectedBlocks = detectRepeatBlocks(keptOperations);
+    const detectedBlocks = providedBlocks ?? detectRepeatBlocks(keptOperations);
     const expandedBlocks = new Set<string>(expandedBlockIds);
-    const collapsedInstanceByOpId = new Map<string, (typeof detectedBlocks)[number]>();
+    const collapsedInstanceByOpId = new Map<number, RepeatBlockInstance>();
     for (const instance of detectedBlocks) {
         if (!expandedBlocks.has(instance.instanceId)) {
             for (const operationId of instance.operationIds) {
-                collapsedInstanceByOpId.set(String(operationId), instance);
+                collapsedInstanceByOpId.set(operationId, instance);
             }
         }
     }
 
     const renderedNodeIdOf = (operationId: number): string =>
-        collapsedInstanceByOpId.get(String(operationId))?.instanceId ?? String(operationId);
+        collapsedInstanceByOpId.get(operationId)?.instanceId ?? String(operationId);
 
     const nodes: OpGraphFlowNode[] = [];
     const deviceOpNodes: OpGraphFlowNode[] = [];
@@ -115,7 +118,7 @@ export function buildOpGraph(
     const emittedBlockIds = new Set<string>();
 
     for (const operation of keptOperations) {
-        const collapsedInstance = collapsedInstanceByOpId.get(String(operation.id));
+        const collapsedInstance = collapsedInstanceByOpId.get(operation.id);
         if (collapsedInstance !== undefined) {
             if (!emittedBlockIds.has(collapsedInstance.instanceId)) {
                 emittedBlockIds.add(collapsedInstance.instanceId);
@@ -125,7 +128,8 @@ export function buildOpGraph(
                 const opCount = collapsedInstance.operationIds.length;
                 const durationSeconds = sumOptional(members.map((member) => member.durationSeconds));
                 const memoryDeltaBytes = sumOptional(members.map((member) => member.memoryDeltaBytes));
-                const size = estimateBlockNodeSize(collapsedInstance.label, BLOCK_META_WIDTH_SAMPLE);
+                const meta = formatBlockMeta(opCount, durationSeconds, memoryDeltaBytes);
+                const size = estimateBlockNodeSize(collapsedInstance.label, meta);
                 nodes.push({
                     id: collapsedInstance.instanceId,
                     type: OpGraphNodeType.BLOCK,
@@ -134,7 +138,7 @@ export function buildOpGraph(
                     data: {
                         operationId: collapsedInstance.operationIds[0],
                         label: collapsedInstance.label,
-                        fileIdentifier: '',
+                        fileIdentifier: meta,
                         filterString: collapsedInstance.label,
                         deviceOperationCount: 0,
                         blockInstanceId: collapsedInstance.instanceId,
@@ -232,6 +236,7 @@ export function buildOpGraph(
     }
 
     const parallelCountByPair = new Map<string, number>();
+    const layoutPairSeen = new Set<string>();
     const edges: OpGraphFlowEdge[] = [];
     // Ranking is between operations, so an edge that renders into an expanded node
     // still has to be handed to Dagre as reaching the node itself. Dagre drops edges
@@ -243,24 +248,34 @@ export function buildOpGraph(
             const renderedSource = renderedNodeIdOf(candidate.source);
             const renderedTarget = renderedNodeIdOf(candidate.target);
             if (renderedSource !== renderedTarget) {
-                const pair = `${candidate.source}-${candidate.target}`;
-                const parallelIndex = parallelCountByPair.get(pair) ?? 0;
-                parallelCountByPair.set(pair, parallelIndex + 1);
-                const sourceIsCollapsed = collapsedInstanceByOpId.has(String(candidate.source));
-                const targetIsCollapsed = collapsedInstanceByOpId.has(String(candidate.target));
-                edges.push({
-                    id: `${pair}-${parallelIndex}`,
-                    source: sourceIsCollapsed ? renderedSource : exitNodeIdOf(candidate.source, candidate.tensorId),
-                    target: targetIsCollapsed ? renderedTarget : entryNodeIdOf(candidate.target, candidate.tensorId),
-                    type: OpGraphEdgeType.OP,
-                    label: candidate.label,
-                    data: {
-                        parallelIndex,
-                        sourceOperationId: candidate.source,
-                        targetOperationId: candidate.target,
-                    },
-                });
-                layoutEdges.push({ source: renderedSource, target: renderedTarget });
+                const pair = `${renderedSource}->${renderedTarget}`;
+                const sourceIsCollapsed = collapsedInstanceByOpId.has(candidate.source);
+                const targetIsCollapsed = collapsedInstanceByOpId.has(candidate.target);
+                // A folded block's boundary is the pair, not the tensors: N shapes
+                // between the same two nodes are one dependency drawn N times.
+                const isCollapsedBoundary = sourceIsCollapsed || targetIsCollapsed;
+                if (!(isCollapsedBoundary && layoutPairSeen.has(pair))) {
+                    const parallelIndex = parallelCountByPair.get(pair) ?? 0;
+                    parallelCountByPair.set(pair, parallelIndex + 1);
+                    edges.push({
+                        id: `${candidate.source}-${candidate.target}-${parallelIndex}`,
+                        source: sourceIsCollapsed ? renderedSource : exitNodeIdOf(candidate.source, candidate.tensorId),
+                        target: targetIsCollapsed
+                            ? renderedTarget
+                            : entryNodeIdOf(candidate.target, candidate.tensorId),
+                        type: OpGraphEdgeType.OP,
+                        label: isCollapsedBoundary ? undefined : candidate.label,
+                        data: {
+                            parallelIndex,
+                            sourceOperationId: candidate.source,
+                            targetOperationId: candidate.target,
+                        },
+                    });
+                    if (!layoutPairSeen.has(pair)) {
+                        layoutPairSeen.add(pair);
+                        layoutEdges.push({ source: renderedSource, target: renderedTarget });
+                    }
+                }
             }
         }
     }

--- a/src/components/operation-graph/opGraphCriticalPath.ts
+++ b/src/components/operation-graph/opGraphCriticalPath.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import { memberOperationIdsOf, sumDeviceTimeNs } from './opGraphMemberTime';
+
 interface CriticalPathNode {
     id: string;
     operationId: number;
@@ -88,26 +90,23 @@ export const findCriticalPath = (
         }
     }
 
-    const membersByNodeId = new Map<string, number[]>();
-    for (const node of nodes) {
-        membersByNodeId.set(node.id, node.memberOperationIds ?? [node.operationId]);
-    }
-
-    const weightOf = (nodeId: string) => {
-        let total = 0;
-        for (const operationId of membersByNodeId.get(nodeId) ?? []) {
-            total += deviceTimeNsByOpId.get(operationId) ?? 0;
-        }
-        return total;
-    };
-
+    // A node's own weight and member count, kept apart from the running chain
+    // totals below because relaxation overwrites those. `weightOf` used to be
+    // called from inside the edge loop, so a node's member sum was recomputed once
+    // per incoming edge rather than once per node.
+    const weightByNodeId = new Map<string, number>();
+    const memberCountByNodeId = new Map<string, number>();
     const costByNodeId = new Map<string, number>();
     const opCountByNodeId = new Map<string, number>();
     const predecessorByNodeId = new Map<string, string>();
     const predecessorEdgeByNodeId = new Map<string, string>();
     for (const node of nodes) {
-        costByNodeId.set(node.id, weightOf(node.id));
-        opCountByNodeId.set(node.id, membersByNodeId.get(node.id)?.length ?? 1);
+        const members = memberOperationIdsOf(node);
+        const weight = sumDeviceTimeNs(members, (operationId) => deviceTimeNsByOpId.get(operationId));
+        weightByNodeId.set(node.id, weight);
+        memberCountByNodeId.set(node.id, members.length);
+        costByNodeId.set(node.id, weight);
+        opCountByNodeId.set(node.id, members.length);
     }
 
     const byOpId = (left: string, right: string) =>
@@ -124,8 +123,8 @@ export const findCriticalPath = (
         const nodeOpCount = opCountByNodeId.get(nodeId) ?? 1;
 
         for (const edge of outgoingByNodeId.get(nodeId) ?? []) {
-            const candidateCost = nodeCost + weightOf(edge.target);
-            const candidateOpCount = nodeOpCount + (membersByNodeId.get(edge.target)?.length ?? 1);
+            const candidateCost = nodeCost + (weightByNodeId.get(edge.target) ?? 0);
+            const candidateOpCount = nodeOpCount + (memberCountByNodeId.get(edge.target) ?? 1);
             const currentPredecessor = predecessorByNodeId.get(edge.target);
             const isBetter = isPreferredChain(
                 candidateCost - (costByNodeId.get(edge.target) ?? 0),

--- a/src/components/operation-graph/opGraphCriticalPath.ts
+++ b/src/components/operation-graph/opGraphCriticalPath.ts
@@ -5,6 +5,7 @@
 interface CriticalPathNode {
     id: string;
     operationId: number;
+    memberOperationIds?: number[];
 }
 
 interface CriticalPathEdge {
@@ -20,6 +21,8 @@ const UNKNOWN_OP_ID = -1;
 export interface CriticalPath {
     /** Source to sink. */
     opIds: number[];
+    /** Member ops along the path; a folded block counts every member. */
+    opCount: number;
     nodeIds: ReadonlySet<string>;
     edgeIds: ReadonlySet<string>;
     totalNs: number;
@@ -32,6 +35,7 @@ export interface CriticalPath {
 
 export const EMPTY_CRITICAL_PATH: CriticalPath = {
     opIds: [],
+    opCount: 0,
     nodeIds: new Set<string>(),
     edgeIds: new Set<string>(),
     totalNs: 0,
@@ -84,7 +88,18 @@ export const findCriticalPath = (
         }
     }
 
-    const weightOf = (nodeId: string) => deviceTimeNsByOpId.get(opIdByNodeId.get(nodeId) ?? UNKNOWN_OP_ID) ?? 0;
+    const membersByNodeId = new Map<string, number[]>();
+    for (const node of nodes) {
+        membersByNodeId.set(node.id, node.memberOperationIds ?? [node.operationId]);
+    }
+
+    const weightOf = (nodeId: string) => {
+        let total = 0;
+        for (const operationId of membersByNodeId.get(nodeId) ?? []) {
+            total += deviceTimeNsByOpId.get(operationId) ?? 0;
+        }
+        return total;
+    };
 
     const costByNodeId = new Map<string, number>();
     const opCountByNodeId = new Map<string, number>();
@@ -92,7 +107,7 @@ export const findCriticalPath = (
     const predecessorEdgeByNodeId = new Map<string, string>();
     for (const node of nodes) {
         costByNodeId.set(node.id, weightOf(node.id));
-        opCountByNodeId.set(node.id, 1);
+        opCountByNodeId.set(node.id, membersByNodeId.get(node.id)?.length ?? 1);
     }
 
     const byOpId = (left: string, right: string) =>
@@ -110,7 +125,7 @@ export const findCriticalPath = (
 
         for (const edge of outgoingByNodeId.get(nodeId) ?? []) {
             const candidateCost = nodeCost + weightOf(edge.target);
-            const candidateOpCount = nodeOpCount + 1;
+            const candidateOpCount = nodeOpCount + (membersByNodeId.get(edge.target)?.length ?? 1);
             const currentPredecessor = predecessorByNodeId.get(edge.target);
             const isBetter = isPreferredChain(
                 candidateCost - (costByNodeId.get(edge.target) ?? 0),
@@ -169,6 +184,7 @@ export const findCriticalPath = (
 
     return {
         opIds,
+        opCount: opCountByNodeId.get(endNodeId) ?? opIds.length,
         nodeIds,
         edgeIds,
         totalNs: costByNodeId.get(endNodeId) ?? 0,

--- a/src/components/operation-graph/opGraphExpansionContext.ts
+++ b/src/components/operation-graph/opGraphExpansionContext.ts
@@ -13,3 +13,5 @@ import { createContext } from 'react';
  * is a wiring mistake, not a reason to blank the canvas.
  */
 export const OpGraphExpansionContext = createContext<(operationId: number) => void>(() => {});
+
+export const OpGraphBlockExpansionContext = createContext<(instanceId: string) => void>(() => {});

--- a/src/components/operation-graph/opGraphLayout.ts
+++ b/src/components/operation-graph/opGraphLayout.ts
@@ -11,9 +11,11 @@ const NODE_MIN_WIDTH = 108;
 const NODE_MAX_WIDTH = 560;
 const NODE_HEIGHT = 32;
 const NODE_HEIGHT_WITH_FILE = 46;
-const BLOCK_NODE_HEIGHT = 56;
+const BLOCK_NODE_HEIGHT = 58;
 // The device-operation badge, kept in step with `.op-graph-node-expander`.
-const EXPANDER_WIDTH = 30;
+const EXPANDER_WIDTH = 32;
+// Pill chip (`▾ 336`) is wider than the device-op badge.
+const BLOCK_EXPANDER_WIDTH = 52;
 // Wide enough for an edge to carry its shape label between two ranks without
 // colliding with the neighbouring column.
 const NODE_SEP = 30;
@@ -65,7 +67,7 @@ export function estimateOpNodeSize(
 export function estimateBlockNodeSize(label: string, meta: string): { width: number; height: number } {
     const widestLine = Math.max(label.length * CHAR_WIDTH, meta.length * FILE_CHAR_WIDTH);
     const labelWidth = Math.min(NODE_MAX_WIDTH, Math.max(NODE_MIN_WIDTH, widestLine + NODE_PADDING_X));
-    return { width: Math.ceil(labelWidth + EXPANDER_WIDTH), height: BLOCK_NODE_HEIGHT };
+    return { width: Math.ceil(labelWidth + BLOCK_EXPANDER_WIDTH), height: BLOCK_NODE_HEIGHT };
 }
 
 function runDagre(nodes: LayoutInputNode[], edges: LayoutInputEdge[], ranker: string): Map<string, LayoutPosition> {

--- a/src/components/operation-graph/opGraphLayout.ts
+++ b/src/components/operation-graph/opGraphLayout.ts
@@ -11,6 +11,7 @@ const NODE_MIN_WIDTH = 108;
 const NODE_MAX_WIDTH = 560;
 const NODE_HEIGHT = 32;
 const NODE_HEIGHT_WITH_FILE = 46;
+const BLOCK_NODE_HEIGHT = 56;
 // The device-operation badge, kept in step with `.op-graph-node-expander`.
 const EXPANDER_WIDTH = 30;
 // Wide enough for an edge to carry its shape label between two ranks without
@@ -59,6 +60,12 @@ export function estimateOpNodeSize(
     const labelWidth = Math.min(NODE_MAX_WIDTH, Math.max(NODE_MIN_WIDTH, widestLine + NODE_PADDING_X));
     const width = Math.ceil(labelWidth + (hasExpander ? EXPANDER_WIDTH : 0));
     return { width, height: fileIdentifier ? NODE_HEIGHT_WITH_FILE : NODE_HEIGHT };
+}
+
+export function estimateBlockNodeSize(label: string, meta: string): { width: number; height: number } {
+    const widestLine = Math.max(label.length * CHAR_WIDTH, meta.length * FILE_CHAR_WIDTH);
+    const labelWidth = Math.min(NODE_MAX_WIDTH, Math.max(NODE_MIN_WIDTH, widestLine + NODE_PADDING_X));
+    return { width: Math.ceil(labelWidth + EXPANDER_WIDTH), height: BLOCK_NODE_HEIGHT };
 }
 
 function runDagre(nodes: LayoutInputNode[], edges: LayoutInputEdge[], ranker: string): Map<string, LayoutPosition> {

--- a/src/components/operation-graph/opGraphLayout.ts
+++ b/src/components/operation-graph/opGraphLayout.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import dagre from '@dagrejs/dagre';
+import { formatMemorySize, formatSize } from '../../functions/math';
 
 const CHAR_WIDTH = 6.8;
 const FILE_CHAR_WIDTH = 6.2;
@@ -62,6 +63,18 @@ export function estimateOpNodeSize(
     const labelWidth = Math.min(NODE_MAX_WIDTH, Math.max(NODE_MIN_WIDTH, widestLine + NODE_PADDING_X));
     const width = Math.ceil(labelWidth + (hasExpander ? EXPANDER_WIDTH : 0));
     return { width, height: fileIdentifier ? NODE_HEIGHT_WITH_FILE : NODE_HEIGHT };
+}
+
+export function formatBlockMeta(opCount: number, durationSeconds: number, memoryDeltaBytes: number): string {
+    const parts = [`${opCount} ops`];
+    if (durationSeconds > 0) {
+        parts.push(`${formatSize(durationSeconds, 2)} s`);
+    }
+    if (memoryDeltaBytes !== 0) {
+        const sign = memoryDeltaBytes > 0 ? '+' : '-';
+        parts.push(`${sign}${formatMemorySize(Math.abs(memoryDeltaBytes), 0)}`);
+    }
+    return parts.join(' · ');
 }
 
 export function estimateBlockNodeSize(label: string, meta: string): { width: number; height: number } {

--- a/src/components/operation-graph/opGraphLayout.ts
+++ b/src/components/operation-graph/opGraphLayout.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import dagre from '@dagrejs/dagre';
-import { formatMemorySize, formatSize } from '../../functions/math';
 
 const CHAR_WIDTH = 6.8;
 const FILE_CHAR_WIDTH = 6.2;
@@ -63,18 +62,6 @@ export function estimateOpNodeSize(
     const labelWidth = Math.min(NODE_MAX_WIDTH, Math.max(NODE_MIN_WIDTH, widestLine + NODE_PADDING_X));
     const width = Math.ceil(labelWidth + (hasExpander ? EXPANDER_WIDTH : 0));
     return { width, height: fileIdentifier ? NODE_HEIGHT_WITH_FILE : NODE_HEIGHT };
-}
-
-export function formatBlockMeta(opCount: number, durationSeconds: number, memoryDeltaBytes: number): string {
-    const parts = [`${opCount} ops`];
-    if (durationSeconds > 0) {
-        parts.push(`${formatSize(durationSeconds, 2)} s`);
-    }
-    if (memoryDeltaBytes !== 0) {
-        const sign = memoryDeltaBytes > 0 ? '+' : '-';
-        parts.push(`${sign}${formatMemorySize(Math.abs(memoryDeltaBytes), 0)}`);
-    }
-    return parts.join(' · ');
 }
 
 export function estimateBlockNodeSize(label: string, meta: string): { width: number; height: number } {

--- a/src/components/operation-graph/opGraphLayoutWorker.ts
+++ b/src/components/operation-graph/opGraphLayoutWorker.ts
@@ -36,12 +36,18 @@ let operations: OpGraphSourceOperation[] = [];
 //
 // Expanded ids are sorted so the key describes the set rather than the order it
 // was clicked in: opening A then B is the same graph as opening B then A.
-const cacheKeyOf = (version: number, hideDeallocate: boolean, deviceSubgraphs: OpGraphDeviceSubgraph[]): string => {
+const cacheKeyOf = (
+    version: number,
+    hideDeallocate: boolean,
+    deviceSubgraphs: OpGraphDeviceSubgraph[],
+    expandedBlockIds: readonly string[],
+): string => {
     const expanded = deviceSubgraphs
         .map((subgraph) => subgraph.operationId)
         .sort((left, right) => left - right)
         .join(',');
-    return `${version}:${hideDeallocate}:${expanded}`;
+    const blocks = [...expandedBlockIds].sort().join(',');
+    return `${version}:${hideDeallocate}:${expanded}:${blocks}`;
 };
 
 const postError = (requestId: number, error: unknown): void => {
@@ -68,7 +74,12 @@ const drainPendingBuild = (): void => {
         return;
     }
 
-    const cacheKey = cacheKeyOf(request.sourceVersion, request.hideDeallocate, request.deviceSubgraphs);
+    const cacheKey = cacheKeyOf(
+        request.sourceVersion,
+        request.hideDeallocate,
+        request.deviceSubgraphs,
+        request.expandedBlockIds ?? [],
+    );
     const cached = layoutCache.get(cacheKey);
     if (cached) {
         touchLruCache(layoutCache, cacheKey, cached, LAYOUT_CACHE_LIMIT);
@@ -85,6 +96,7 @@ const drainPendingBuild = (): void => {
         const graph = buildOpGraph(operations, {
             hideDeallocate: request.hideDeallocate,
             deviceSubgraphs: request.deviceSubgraphs,
+            expandedBlockIds: request.expandedBlockIds,
         });
         touchLruCache(layoutCache, cacheKey, graph, LAYOUT_CACHE_LIMIT);
         postMessage({
@@ -116,6 +128,7 @@ onmessage = (event: MessageEvent<OpGraphWorkerInboundMessage>) => {
         sourceVersion: message.sourceVersion,
         hideDeallocate: message.hideDeallocate,
         deviceSubgraphs: message.deviceSubgraphs,
+        expandedBlockIds: message.expandedBlockIds,
     };
 
     if (!isDrainScheduled) {

--- a/src/components/operation-graph/opGraphLayoutWorker.ts
+++ b/src/components/operation-graph/opGraphLayoutWorker.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { touchLruCache } from '../../functions/touchLruCache';
-import { buildOpGraph, getKeptOperations } from './opGraphBuilder';
+import { type CandidateEdge, buildOpGraph, collectCandidateEdges, getKeptOperations } from './opGraphBuilder';
 import { detectRepeatBlocks } from './opGraphRepeatBlocks';
 import {
     type OpGraphBuildOptions,
@@ -25,13 +25,36 @@ let isDrainScheduled = false;
 
 // Expansion makes the option space combinatorial rather than a single boolean, so
 // the cache now earns its keep on the walk back out of a subgraph. Each entry
-// holds a fully laid-out graph, which is what keeps this in the tens.
-const LAYOUT_CACHE_LIMIT = 16;
+// holds a fully laid-out graph — every node with its `memberNames`, every edge, and
+// its own copy of `graph.blocks`.
+//
+// Sized down from 16 because block folding added a third independently-toggleable
+// key dimension: every detected instance folds and unrolls on its own, so exploring
+// a handful of blocks mints a distinct key per toggle where this was previously
+// rarely full. On an 8k-op report a full cache is retained for the whole session,
+// freed only on `SET_GRAPH`.
+const LAYOUT_CACHE_LIMIT = 8;
 const layoutCache = new Map<string, OpGraphBuiltGraph>();
 
 let sourceVersion = -1;
 let operations: OpGraphSourceOperation[] = [];
-const detectionByDeallocate = new Map<boolean, RepeatBlockInstance[]>();
+
+// Keyed on the source version for the same reason the layout cache is: the
+// `SET_GRAPH` clear is what frees the previous report, but without the version a
+// clear that is ever moved or missed would fold report B using report A's block
+// instances, whose member op ids exist in B but mean unrelated operations.
+const detectionByDeallocate = new Map<string, RepeatBlockInstance[]>();
+
+// One candidate-edge pass per source. It is an ops x outputs x consumers walk, and
+// detection and the build both need it.
+let candidateCache: { version: number; candidates: CandidateEdge[] } | null = null;
+
+const candidatesOf = (): CandidateEdge[] => {
+    if (candidateCache?.version !== sourceVersion) {
+        candidateCache = { version: sourceVersion, candidates: collectCandidateEdges(operations) };
+    }
+    return candidateCache.candidates;
+};
 
 // Keyed on the source version as well as the options. The `SET_GRAPH` clear is
 // what frees the previous report's graphs, but keying on the version too means a
@@ -54,12 +77,13 @@ const cacheKeyOf = (
 };
 
 const detectedBlocksOf = (hideDeallocate: boolean): RepeatBlockInstance[] => {
-    const cached = detectionByDeallocate.get(hideDeallocate);
+    const key = `${sourceVersion}:${hideDeallocate}`;
+    const cached = detectionByDeallocate.get(key);
     if (cached !== undefined) {
         return cached;
     }
-    const blocks = detectRepeatBlocks(getKeptOperations(operations, hideDeallocate));
-    detectionByDeallocate.set(hideDeallocate, blocks);
+    const blocks = detectRepeatBlocks(getKeptOperations(operations, hideDeallocate, candidatesOf()));
+    detectionByDeallocate.set(key, blocks);
     return blocks;
 };
 
@@ -132,6 +156,7 @@ onmessage = (event: MessageEvent<OpGraphWorkerInboundMessage>) => {
         operations = message.operations;
         layoutCache.clear();
         detectionByDeallocate.clear();
+        candidateCache = null;
         // A build queued against the previous source is moot; the view reissues
         // one for the new source as part of the same change.
         pendingBuild = null;

--- a/src/components/operation-graph/opGraphLayoutWorker.ts
+++ b/src/components/operation-graph/opGraphLayoutWorker.ts
@@ -3,7 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { touchLruCache } from '../../functions/touchLruCache';
-import { buildOpGraph } from './opGraphBuilder';
+import { buildOpGraph, getKeptOperations } from './opGraphBuilder';
+import { detectRepeatBlocks } from './opGraphRepeatBlocks';
 import {
     type OpGraphBuildOptions,
     type OpGraphBuiltGraph,
@@ -11,6 +12,7 @@ import {
     type OpGraphSourceOperation,
     type OpGraphWorkerInboundMessage,
     OpGraphWorkerMessageType,
+    type RepeatBlockInstance,
 } from './opGraphTypes';
 
 // The op-range slider drives builds from Blueprint's continuous `onChange`, so
@@ -29,6 +31,7 @@ const layoutCache = new Map<string, OpGraphBuiltGraph>();
 
 let sourceVersion = -1;
 let operations: OpGraphSourceOperation[] = [];
+const detectionByDeallocate = new Map<boolean, RepeatBlockInstance[]>();
 
 // Keyed on the source version as well as the options. The `SET_GRAPH` clear is
 // what frees the previous report's graphs, but keying on the version too means a
@@ -48,6 +51,16 @@ const cacheKeyOf = (
         .join(',');
     const blocks = [...expandedBlockIds].sort().join(',');
     return `${version}:${hideDeallocate}:${expanded}:${blocks}`;
+};
+
+const detectedBlocksOf = (hideDeallocate: boolean): RepeatBlockInstance[] => {
+    const cached = detectionByDeallocate.get(hideDeallocate);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const blocks = detectRepeatBlocks(getKeptOperations(operations, hideDeallocate));
+    detectionByDeallocate.set(hideDeallocate, blocks);
+    return blocks;
 };
 
 const postError = (requestId: number, error: unknown): void => {
@@ -97,6 +110,7 @@ const drainPendingBuild = (): void => {
             hideDeallocate: request.hideDeallocate,
             deviceSubgraphs: request.deviceSubgraphs,
             expandedBlockIds: request.expandedBlockIds,
+            detectedBlocks: detectedBlocksOf(request.hideDeallocate),
         });
         touchLruCache(layoutCache, cacheKey, graph, LAYOUT_CACHE_LIMIT);
         postMessage({
@@ -117,6 +131,7 @@ onmessage = (event: MessageEvent<OpGraphWorkerInboundMessage>) => {
         sourceVersion = message.sourceVersion;
         operations = message.operations;
         layoutCache.clear();
+        detectionByDeallocate.clear();
         // A build queued against the previous source is moot; the view reissues
         // one for the new source as part of the same change.
         pendingBuild = null;

--- a/src/components/operation-graph/opGraphMemberTime.ts
+++ b/src/components/operation-graph/opGraphMemberTime.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * The operations a rendered node stands for: a folded block's members, or the
+ * node's own operation. Three call sites shared this `?? [operationId]` shape and
+ * the sum built on it — the perf overlay's bars, the critical path's weights, and
+ * the panel's selected-block total. #1944
+ */
+export interface MemberBearingNode {
+    operationId: number;
+    memberOperationIds?: number[];
+}
+
+export const memberOperationIdsOf = (node: MemberBearingNode): readonly number[] =>
+    node.memberOperationIds ?? [node.operationId];
+
+/** Device time across the given operations, counting an unlinked one as zero. */
+export const sumDeviceTimeNs = (
+    operationIds: readonly number[],
+    deviceTimeNsOf: (operationId: number) => number | undefined,
+): number => {
+    let total = 0;
+    for (const operationId of operationIds) {
+        total += deviceTimeNsOf(operationId) ?? 0;
+    }
+    return total;
+};

--- a/src/components/operation-graph/opGraphNavigation.ts
+++ b/src/components/operation-graph/opGraphNavigation.ts
@@ -18,19 +18,33 @@ export interface AdjacentOperationIds {
  * exact-id lookup therefore missed the entry and `next` restarted from the
  * graph's first node, so a block matches on its members too. #1944
  */
+/**
+ * @description Render position of every operation the index can be selected by:
+ * an entry's own id, plus each member id a folded block stands in for. Built once
+ * per index rather than scanned per stepper render.
+ */
+export const buildPositionByOperationId = (nodeIndex: readonly OpGraphNodeIndexEntry[]): Map<number, number> => {
+    const positionByOperationId = new Map<number, number>();
+    nodeIndex.forEach((entry, position) => {
+        // First-wins throughout, matching the `findIndex` this replaces.
+        if (!positionByOperationId.has(entry.operationId)) {
+            positionByOperationId.set(entry.operationId, position);
+        }
+        for (const memberOperationId of entry.memberOperationIds ?? []) {
+            if (!positionByOperationId.has(memberOperationId)) {
+                positionByOperationId.set(memberOperationId, position);
+            }
+        }
+    });
+    return positionByOperationId;
+};
+
 export const getAdjacentOperationIds = (
     nodeIndex: readonly OpGraphNodeIndexEntry[],
     selectedOperationId: number | null,
+    positionByOperationId: ReadonlyMap<number, number> = buildPositionByOperationId(nodeIndex),
 ): AdjacentOperationIds => {
-    const position =
-        selectedOperationId === null
-            ? -1
-            : nodeIndex.findIndex(
-                  (entry) =>
-                      entry.operationId === selectedOperationId ||
-                      (entry.memberOperationIds !== undefined &&
-                          entry.memberOperationIds.includes(selectedOperationId)),
-              );
+    const position = selectedOperationId === null ? -1 : (positionByOperationId.get(selectedOperationId) ?? -1);
 
     if (position === -1) {
         return { previousOperationId: null, nextOperationId: nodeIndex[0]?.operationId ?? null };

--- a/src/components/operation-graph/opGraphNavigation.ts
+++ b/src/components/operation-graph/opGraphNavigation.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { OpGraphNodeIndexEntry } from './opGraphTypes';
+
+export interface AdjacentOperationIds {
+    previousOperationId: number | null;
+    nextOperationId: number | null;
+}
+
+/**
+ * @description The operations either side of the selection in render order, for
+ * the toolbar's prev/next steppers. Both are `null` past the respective end.
+ *
+ * A folded block is indexed under its first member, but the selection may sit on
+ * any member — the rebuild keeps a selected op when a block closes over it. An
+ * exact-id lookup therefore missed the entry and `next` restarted from the
+ * graph's first node, so a block matches on its members too. #1944
+ */
+export const getAdjacentOperationIds = (
+    nodeIndex: readonly OpGraphNodeIndexEntry[],
+    selectedOperationId: number | null,
+): AdjacentOperationIds => {
+    const position =
+        selectedOperationId === null
+            ? -1
+            : nodeIndex.findIndex(
+                  (entry) =>
+                      entry.operationId === selectedOperationId ||
+                      (entry.memberOperationIds !== undefined &&
+                          entry.memberOperationIds.includes(selectedOperationId)),
+              );
+
+    if (position === -1) {
+        return { previousOperationId: null, nextOperationId: nodeIndex[0]?.operationId ?? null };
+    }
+
+    return {
+        previousOperationId: nodeIndex[position - 1]?.operationId ?? null,
+        nextOperationId: nodeIndex[position + 1]?.operationId ?? null,
+    };
+};

--- a/src/components/operation-graph/opGraphPerfOverlay.ts
+++ b/src/components/operation-graph/opGraphPerfOverlay.ts
@@ -139,17 +139,54 @@ export const buildOpGraphPerfOverlay = (
 export const buildPerfNodeStyleByNodeId = (
     overlay: OpGraphPerfOverlay,
     isActive: boolean,
+    nodes?: readonly { id: string; operationId: number; memberOperationIds?: number[] }[],
 ): Map<string, CSSProperties> | null => {
     if (!isActive) {
         return null;
     }
+    const tOfNs = (ns: number): number | null => {
+        if (ns <= 0) {
+            return null;
+        }
+        if (overlay.minNs === overlay.maxNs) {
+            return 0;
+        }
+        const logMin = Math.log10(overlay.minNs);
+        const range = Math.log10(overlay.maxNs) - logMin;
+        return Math.min(1, Math.max(0, (Math.log10(ns) - logMin) / range));
+    };
+
     const styleByNodeId = new Map<string, CSSProperties>();
-    for (const [opId, score] of overlay.scoreByOpId) {
-        // `CSSProperties` has no index signature for custom properties.
-        styleByNodeId.set(String(opId), {
-            [PERF_BAR_SCALE_VAR]: score.t,
-            [PERF_BAR_COLOR_VAR]: perfColorScale(score.t),
-        } as CSSProperties);
+    if (nodes === undefined) {
+        for (const [opId, score] of overlay.scoreByOpId) {
+            styleByNodeId.set(String(opId), {
+                [PERF_BAR_SCALE_VAR]: score.t,
+                [PERF_BAR_COLOR_VAR]: perfColorScale(score.t),
+            } as CSSProperties);
+        }
+        return styleByNodeId;
+    }
+
+    for (const node of nodes) {
+        const memberIds = node.memberOperationIds ?? [node.operationId];
+        let ns = 0;
+        let hasRow = false;
+        for (const operationId of memberIds) {
+            const aggregate = overlay.aggregatesByOpId.get(operationId);
+            if (aggregate !== undefined) {
+                ns += aggregate.deviceTimeNs;
+                hasRow = true;
+            }
+        }
+        if (hasRow) {
+            const t = tOfNs(ns);
+            if (t !== null) {
+                styleByNodeId.set(node.id, {
+                    [PERF_BAR_SCALE_VAR]: t,
+                    [PERF_BAR_COLOR_VAR]: perfColorScale(t),
+                } as CSSProperties);
+            }
+        }
     }
     return styleByNodeId;
 };

--- a/src/components/operation-graph/opGraphPerfOverlay.ts
+++ b/src/components/operation-graph/opGraphPerfOverlay.ts
@@ -131,6 +131,71 @@ export const buildOpGraphPerfOverlay = (
     };
 };
 
+interface RenderedPerfNode {
+    id: string;
+    operationId: number;
+    memberOperationIds?: number[];
+}
+
+/**
+ * Device time per rendered node, a folded block summing its members. Nodes with
+ * no linked row — or only zero-duration ones — are absent rather than zero, so
+ * they neither take a bar nor drag the scale's floor down to nothing.
+ */
+const sumNsByRenderedNode = (overlay: OpGraphPerfOverlay, nodes: readonly RenderedPerfNode[]): Map<string, number> => {
+    const nsByNodeId = new Map<string, number>();
+    for (const node of nodes) {
+        const memberIds = node.memberOperationIds ?? [node.operationId];
+        let ns = 0;
+        for (const operationId of memberIds) {
+            ns += overlay.aggregatesByOpId.get(operationId)?.deviceTimeNs ?? 0;
+        }
+        if (ns > 0) {
+            nsByNodeId.set(node.id, ns);
+        }
+    }
+    return nsByNodeId;
+};
+
+/**
+ * The duration range the node bars are actually drawn against, which the legend
+ * is the key for. A folded block's bar stands for the sum of its members, so
+ * that sum — not the per-operation range on the overlay — is what the ramp has
+ * to span: scored against the per-operation range a block outruns the slowest
+ * single op and every block clamped to 1, and when the member rows all shared a
+ * duration `minNs === maxNs` forced every block to 0. #1944
+ */
+const spanOfTotals = (
+    nsByNodeId: Map<string, number>,
+    fallback: { minNs: number; maxNs: number },
+): { minNs: number; maxNs: number } => {
+    if (nsByNodeId.size === 0) {
+        return fallback;
+    }
+    let minNs = Infinity;
+    let maxNs = -Infinity;
+    for (const ns of nsByNodeId.values()) {
+        if (ns < minNs) {
+            minNs = ns;
+        }
+        if (ns > maxNs) {
+            maxNs = ns;
+        }
+    }
+    return { minNs, maxNs };
+};
+
+export const getRenderedPerfRange = (
+    overlay: OpGraphPerfOverlay,
+    nodes?: readonly RenderedPerfNode[],
+): { minNs: number; maxNs: number } => {
+    const perOperationRange = { minNs: overlay.minNs, maxNs: overlay.maxNs };
+    if (nodes === undefined) {
+        return perOperationRange;
+    }
+    return spanOfTotals(sumNsByRenderedNode(overlay, nodes), perOperationRange);
+};
+
 /**
  * Style patch by node id, or `null` when the overlay is off so the caller can
  * skip the styling pass. Custom properties only: `className` already carries
@@ -139,22 +204,11 @@ export const buildOpGraphPerfOverlay = (
 export const buildPerfNodeStyleByNodeId = (
     overlay: OpGraphPerfOverlay,
     isActive: boolean,
-    nodes?: readonly { id: string; operationId: number; memberOperationIds?: number[] }[],
+    nodes?: readonly RenderedPerfNode[],
 ): Map<string, CSSProperties> | null => {
     if (!isActive) {
         return null;
     }
-    const tOfNs = (ns: number): number | null => {
-        if (ns <= 0) {
-            return null;
-        }
-        if (overlay.minNs === overlay.maxNs) {
-            return 0;
-        }
-        const logMin = Math.log10(overlay.minNs);
-        const range = Math.log10(overlay.maxNs) - logMin;
-        return Math.min(1, Math.max(0, (Math.log10(ns) - logMin) / range));
-    };
 
     const styleByNodeId = new Map<string, CSSProperties>();
     if (nodes === undefined) {
@@ -167,26 +221,19 @@ export const buildPerfNodeStyleByNodeId = (
         return styleByNodeId;
     }
 
-    for (const node of nodes) {
-        const memberIds = node.memberOperationIds ?? [node.operationId];
-        let ns = 0;
-        let hasRow = false;
-        for (const operationId of memberIds) {
-            const aggregate = overlay.aggregatesByOpId.get(operationId);
-            if (aggregate !== undefined) {
-                ns += aggregate.deviceTimeNs;
-                hasRow = true;
-            }
-        }
-        if (hasRow) {
-            const t = tOfNs(ns);
-            if (t !== null) {
-                styleByNodeId.set(node.id, {
-                    [PERF_BAR_SCALE_VAR]: t,
-                    [PERF_BAR_COLOR_VAR]: perfColorScale(t),
-                } as CSSProperties);
-            }
-        }
+    const nsByNodeId = sumNsByRenderedNode(overlay, nodes);
+    const { minNs, maxNs } = spanOfTotals(nsByNodeId, { minNs: overlay.minNs, maxNs: overlay.maxNs });
+    const logMin = Math.log10(minNs);
+    const range = Math.log10(maxNs) - logMin;
+
+    for (const [nodeId, ns] of nsByNodeId) {
+        // As in `scoreOps`: one distinct total across the graph carries no
+        // ranking signal, so nothing is heated rather than everything.
+        const t = minNs === maxNs ? 0 : Math.min(1, Math.max(0, (Math.log10(ns) - logMin) / range));
+        styleByNodeId.set(nodeId, {
+            [PERF_BAR_SCALE_VAR]: t,
+            [PERF_BAR_COLOR_VAR]: perfColorScale(t),
+        } as CSSProperties);
     }
     return styleByNodeId;
 };

--- a/src/components/operation-graph/opGraphPerfOverlay.ts
+++ b/src/components/operation-graph/opGraphPerfOverlay.ts
@@ -4,6 +4,8 @@
 
 import type { CSSProperties } from 'react';
 
+import { type MemberBearingNode, memberOperationIdsOf, sumDeviceTimeNs } from './opGraphMemberTime';
+
 import { NO_PERF_DATA_LABEL, PerfOverlayStatus } from '../../definitions/PerfOverlayStatus';
 import { formatDuration } from '../../functions/formatting';
 import {
@@ -131,10 +133,8 @@ export const buildOpGraphPerfOverlay = (
     };
 };
 
-interface RenderedPerfNode {
+interface RenderedPerfNode extends MemberBearingNode {
     id: string;
-    operationId: number;
-    memberOperationIds?: number[];
 }
 
 /**
@@ -144,12 +144,9 @@ interface RenderedPerfNode {
  */
 const sumNsByRenderedNode = (overlay: OpGraphPerfOverlay, nodes: readonly RenderedPerfNode[]): Map<string, number> => {
     const nsByNodeId = new Map<string, number>();
+    const deviceTimeNsOf = (operationId: number) => overlay.aggregatesByOpId.get(operationId)?.deviceTimeNs;
     for (const node of nodes) {
-        const memberIds = node.memberOperationIds ?? [node.operationId];
-        let ns = 0;
-        for (const operationId of memberIds) {
-            ns += overlay.aggregatesByOpId.get(operationId)?.deviceTimeNs ?? 0;
-        }
+        const ns = sumDeviceTimeNs(memberOperationIdsOf(node), deviceTimeNsOf);
         if (ns > 0) {
             nsByNodeId.set(node.id, ns);
         }
@@ -185,57 +182,55 @@ const spanOfTotals = (
     return { minNs, maxNs };
 };
 
-export const getRenderedPerfRange = (
-    overlay: OpGraphPerfOverlay,
-    nodes?: readonly RenderedPerfNode[],
-): { minNs: number; maxNs: number } => {
-    const perOperationRange = { minNs: overlay.minNs, maxNs: overlay.maxNs };
-    if (nodes === undefined) {
-        return perOperationRange;
+/**
+ * Position on the log ramp, matching `scoreOps`. One distinct duration across the
+ * graph carries no ranking signal, so nothing is heated rather than everything.
+ */
+const logScore = (ns: number, minNs: number, maxNs: number): number => {
+    if (minNs === maxNs) {
+        return 0;
     }
-    return spanOfTotals(sumNsByRenderedNode(overlay, nodes), perOperationRange);
+    const logMin = Math.log10(minNs);
+    return Math.min(1, Math.max(0, (Math.log10(ns) - logMin) / (Math.log10(maxNs) - logMin)));
 };
+
+export interface RenderedPerfStyling {
+    styleByNodeId: Map<string, CSSProperties>;
+    /**
+     * The range the node bars are actually drawn against, which the legend is the
+     * key for. Returned alongside the styles because both come from one pass over
+     * the node set — they were two, from two memos with the same dependencies.
+     */
+    minNs: number;
+    maxNs: number;
+}
 
 /**
  * Style patch by node id, or `null` when the overlay is off so the caller can
  * skip the styling pass. Custom properties only: `className` already carries
  * selection and the I/O highlight, and the filter dim is inherited.
  */
-export const buildPerfNodeStyleByNodeId = (
+export const buildRenderedPerfStyling = (
     overlay: OpGraphPerfOverlay,
     isActive: boolean,
-    nodes?: readonly RenderedPerfNode[],
-): Map<string, CSSProperties> | null => {
+    nodes: readonly RenderedPerfNode[],
+): RenderedPerfStyling | null => {
     if (!isActive) {
         return null;
     }
 
-    const styleByNodeId = new Map<string, CSSProperties>();
-    if (nodes === undefined) {
-        for (const [opId, score] of overlay.scoreByOpId) {
-            styleByNodeId.set(String(opId), {
-                [PERF_BAR_SCALE_VAR]: score.t,
-                [PERF_BAR_COLOR_VAR]: perfColorScale(score.t),
-            } as CSSProperties);
-        }
-        return styleByNodeId;
-    }
-
     const nsByNodeId = sumNsByRenderedNode(overlay, nodes);
     const { minNs, maxNs } = spanOfTotals(nsByNodeId, { minNs: overlay.minNs, maxNs: overlay.maxNs });
-    const logMin = Math.log10(minNs);
-    const range = Math.log10(maxNs) - logMin;
 
+    const styleByNodeId = new Map<string, CSSProperties>();
     for (const [nodeId, ns] of nsByNodeId) {
-        // As in `scoreOps`: one distinct total across the graph carries no
-        // ranking signal, so nothing is heated rather than everything.
-        const t = minNs === maxNs ? 0 : Math.min(1, Math.max(0, (Math.log10(ns) - logMin) / range));
+        const t = logScore(ns, minNs, maxNs);
         styleByNodeId.set(nodeId, {
             [PERF_BAR_SCALE_VAR]: t,
             [PERF_BAR_COLOR_VAR]: perfColorScale(t),
         } as CSSProperties);
     }
-    return styleByNodeId;
+    return { styleByNodeId, minNs, maxNs };
 };
 
 /** Duration, rank among the linked ops, and share of their total. #1610 */

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -22,6 +22,9 @@ const OUTSIDE_KEPT = -1;
 // layer. Keep them only when every member is plumbing.
 const PLUMBING_FILE_STEMS = new Set(['lazy_weight']);
 const MAX_PATTERN_NAME_PARTS = 4;
+// A file on most of the graph is the model (ttnn_functional_resnet50), not the
+// tile. Drop it and name from ops. Module files stay under this.
+const GLOBAL_FILE_FRACTION = 0.75;
 
 interface OutgoingEdge {
     targetIndex: number;
@@ -139,21 +142,45 @@ const joinCapped = (parts: readonly string[]): string => {
     return `${parts.slice(0, MAX_PATTERN_NAME_PARTS).join(' + ')} + …`;
 };
 
-export function formatRepeatPatternLabel(members: readonly OpGraphSourceOperation[]): string {
-    const withoutPlumbing = uniqueFileStems(members, true);
-    if (withoutPlumbing.length > 0) {
-        return joinCapped(withoutPlumbing);
+const globalFileStems = (operations: readonly OpGraphSourceOperation[]): Set<string> => {
+    const counts = new Map<string, number>();
+    for (const operation of operations) {
+        const stem = fileStemOf(operation.fileIdentifier);
+        if (!stem || PLUMBING_FILE_STEMS.has(stem)) {
+            continue;
+        }
+        counts.set(stem, (counts.get(stem) ?? 0) + 1);
     }
-    const allStems = uniqueFileStems(members, false);
-    if (allStems.length > 0) {
-        return joinCapped(allStems);
+    const threshold = operations.length * GLOBAL_FILE_FRACTION;
+    const stems = new Set<string>();
+    for (const [stem, count] of counts) {
+        if (count > threshold) {
+            stems.add(stem);
+        }
     }
-    return joinCapped(uniqueShortOpNames(members));
+    return stems;
+};
+
+export function formatRepeatPatternLabel(
+    members: readonly OpGraphSourceOperation[],
+    graphOperations: readonly OpGraphSourceOperation[] = members,
+): string {
+    const globalStems = globalFileStems(graphOperations);
+    const moduleStems = uniqueFileStems(members, true).filter((stem) => !globalStems.has(stem));
+    if (moduleStems.length > 0) {
+        return joinCapped(moduleStems);
+    }
+    const opNames = uniqueShortOpNames(members);
+    if (opNames.length > 0) {
+        return joinCapped(opNames);
+    }
+    return joinCapped(uniqueFileStems(members, false));
 }
 
 const labelForPattern = (
     patternId: string,
     members: readonly OpGraphSourceOperation[],
+    graphOperations: readonly OpGraphSourceOperation[],
     labelByPatternId: Map<string, string>,
     collisionCountBySummary: Map<string, number>,
     anonymousCount: { value: number },
@@ -163,7 +190,7 @@ const labelForPattern = (
         return existing;
     }
 
-    const summary = formatRepeatPatternLabel(members);
+    const summary = formatRepeatPatternLabel(members, graphOperations);
     if (!summary) {
         const label = `Block ${blockLetter(anonymousCount.value)}`;
         anonymousCount.value += 1;
@@ -273,6 +300,7 @@ export function detectRepeatBlocks(keptOperations: readonly OpGraphSourceOperati
         const patternLabel = labelForPattern(
             patternId,
             members,
+            keptOperations,
             labelByPatternId,
             collisionCountBySummary,
             anonymousCount,

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -364,13 +364,3 @@ export function detectRepeatBlocks(keptOperations: readonly OpGraphSourceOperati
 
     return instances;
 }
-
-export function sumOptional(values: readonly (number | undefined)[]): number {
-    let total = 0;
-    for (const value of values) {
-        if (value !== undefined && Number.isFinite(value)) {
-            total += value;
-        }
-    }
-    return total;
-}

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -165,12 +165,20 @@ export function formatRepeatPatternLabel(
     members: readonly OpGraphSourceOperation[],
     graphOperations: readonly OpGraphSourceOperation[] = members,
 ): string {
+    const opNames = uniqueShortOpNames(members);
+    // One operation type is named by that operation, not by the file it came from.
+    // A module stem earns the label when it *summarises* several distinct
+    // operations — `norm + attention + encoder + mlp` beats listing eight op
+    // names. When there is only one, the stem says where the operation lives
+    // while the name says what it is, and the name is what the node is for.
+    if (opNames.length === 1) {
+        return opNames[0];
+    }
     const globalStems = globalFileStems(graphOperations);
     const moduleStems = uniqueFileStems(members, true).filter((stem) => !globalStems.has(stem));
     if (moduleStems.length > 0) {
         return joinCapped(moduleStems);
     }
-    const opNames = uniqueShortOpNames(members);
     if (opNames.length > 0) {
         return joinCapped(opNames);
     }

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -135,6 +135,40 @@ const uniqueShortOpNames = (operations: readonly OpGraphSourceOperation[]): stri
     return names;
 };
 
+// Module files from one model share a framework-and-model prefix: the four
+// SentenceBERT files behind one block named it in 124 characters, 72 of which were
+// `ttnn_sentencebert_` four times over, so the node showed three of the four parts
+// and clipped the rest. A prefix every part carries is context, not distinction.
+// #1944
+const MIN_DISTINGUISHING_STEM_LENGTH = 3;
+
+// `> index + 1` leaves every stem at least one segment of its own, so a set where
+// one stem is a prefix of the others keeps that stem whole.
+const isSegmentShared = (segmented: readonly string[][], index: number): boolean =>
+    segmented.every((segments) => segments.length > index + 1 && segments[index] === segmented[0][index]);
+
+const dropSharedStemPrefix = (stems: readonly string[]): string[] => {
+    if (stems.length < 2) {
+        return [...stems];
+    }
+    const segmented = stems.map((stem) => stem.split('_'));
+    let shared = 0;
+    while (isSegmentShared(segmented, shared)) {
+        shared += 1;
+    }
+    if (shared === 0) {
+        return [...stems];
+    }
+    const trimmed = segmented.map((segments) => segments.slice(shared).join('_'));
+    // A remainder of a letter or two names nothing on its own — `mlp_up + mlp_down`
+    // is worth its length in a way `up + down` is not — so keep the prefix rather
+    // than reduce the label to initials.
+    if (trimmed.some((stem) => stem.length < MIN_DISTINGUISHING_STEM_LENGTH)) {
+        return [...stems];
+    }
+    return trimmed;
+};
+
 const joinCapped = (parts: readonly string[]): string => {
     if (parts.length <= MAX_PATTERN_NAME_PARTS) {
         return parts.join(' + ');
@@ -177,12 +211,12 @@ export function formatRepeatPatternLabel(
     const globalStems = globalFileStems(graphOperations);
     const moduleStems = uniqueFileStems(members, true).filter((stem) => !globalStems.has(stem));
     if (moduleStems.length > 0) {
-        return joinCapped(moduleStems);
+        return joinCapped(dropSharedStemPrefix(moduleStems));
     }
     if (opNames.length > 0) {
         return joinCapped(opNames);
     }
-    return joinCapped(uniqueFileStems(members, false));
+    return joinCapped(dropSharedStemPrefix(uniqueFileStems(members, false)));
 }
 
 const labelForPattern = (

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -4,23 +4,27 @@
 
 /* eslint-disable no-continue -- window scan skips consumed spans instead of nesting four levels */
 
-import type { OpGraphSourceOperation } from './opGraphTypes';
+import type { OpGraphSourceOperation, RepeatBlockInstance } from './opGraphTypes';
 
 export const MIN_REPEAT_WINDOW = 2;
 export const MIN_REPEAT_COUNT = 2;
+// A repeated subgraph is a layer, not half the graph. Descending from ⌊N/2⌋
+// made the no-repeat case — the common one — O(N³) and folded 12 layers into
+// two half-model blocks. #1583
+export const MAX_REPEAT_WINDOW = 64;
+// 4k–8k op graphs are real (#1809). Past this the scan is skipped rather than
+// competing with Dagre; the main-thread fallback calls the same detector.
+export const MAX_DETECT_OPS = 10_000;
+// Consumer not in the kept list still counts as a leaving edge so hide-deallocate
+// cannot erase the first copy's outgoing tensor and miss the run.
+const OUTSIDE_KEPT = -1;
+// Weight-dump helpers share one file and drown the modules that identify the
+// layer. Keep them only when every member is plumbing.
+const PLUMBING_FILE_STEMS = new Set(['lazy_weight']);
+const MAX_PATTERN_NAME_PARTS = 4;
 
-export interface RepeatBlockInstance {
-    instanceId: string;
-    patternId: string;
-    label: string;
-    patternLabel: string;
-    operationIds: number[];
-    instanceIndex: number;
-    instanceCount: number;
-}
-
-interface InternalEdge {
-    target: number;
+interface OutgoingEdge {
+    targetIndex: number;
     label: string;
 }
 
@@ -30,20 +34,41 @@ const fingerprintOf = (operation: OpGraphSourceOperation): string => {
     return `${operation.name}|${inputs}|${outputs}`;
 };
 
-const windowKey = (fingerprints: string[], start: number, length: number): string =>
-    fingerprints.slice(start, start + length).join(';');
+const internFingerprints = (fingerprints: readonly string[]): number[] => {
+    const idByFingerprint = new Map<string, number>();
+    const ids: number[] = [];
+    for (const fingerprint of fingerprints) {
+        let id = idByFingerprint.get(fingerprint);
+        if (id === undefined) {
+            id = idByFingerprint.size + 1;
+            idByFingerprint.set(fingerprint, id);
+        }
+        ids.push(id);
+    }
+    return ids;
+};
 
-const internalEdgeSignature = (
-    operationIds: number[],
-    edgesBySource: ReadonlyMap<number, readonly InternalEdge[]>,
-): string => {
-    const indexById = new Map<number, number>(operationIds.map((id, index) => [id, index]));
+const idsEqual = (ids: readonly number[], left: number, right: number, length: number): boolean => {
+    for (let offset = 0; offset < length; offset++) {
+        if (ids[left + offset] !== ids[right + offset]) {
+            return false;
+        }
+    }
+    return true;
+};
+
+// Internal edges as `i->j:label`; edges that leave the window as `i->out:label`.
+// The out-edges are what keep a terminal copy from joining when its last op no
+// longer feeds the next copy — fingerprint equality only sees output labels.
+const windowStructure = (start: number, length: number, outgoing: readonly (readonly OutgoingEdge[])[]): string => {
+    const end = start + length;
     const parts: string[] = [];
-    for (let index = 0; index < operationIds.length; index++) {
-        for (const edge of edgesBySource.get(operationIds[index]) ?? []) {
-            const targetIndex = indexById.get(edge.target);
-            if (targetIndex !== undefined) {
-                parts.push(`${index}->${targetIndex}:${edge.label}`);
+    for (let offset = 0; offset < length; offset++) {
+        for (const edge of outgoing[start + offset]) {
+            if (edge.targetIndex >= start && edge.targetIndex < end) {
+                parts.push(`${offset}->${edge.targetIndex - start}:${edge.label}`);
+            } else {
+                parts.push(`${offset}->out:${edge.label}`);
             }
         }
     }
@@ -61,6 +86,98 @@ const blockLetter = (index: number): string => {
     return label;
 };
 
+const fileStemOf = (fileIdentifier: string): string => {
+    if (!fileIdentifier) {
+        return '';
+    }
+    const withoutLine = fileIdentifier.replace(/:\d+$/, '');
+    const base = withoutLine.split('/').pop() ?? withoutLine;
+    return base.replace(/\.py$/i, '');
+};
+
+const uniqueFileStems = (operations: readonly OpGraphSourceOperation[], dropPlumbing: boolean): string[] => {
+    const stems: string[] = [];
+    const seen = new Set<string>();
+    for (const operation of operations) {
+        const stem = fileStemOf(operation.fileIdentifier);
+        if (!stem || seen.has(stem) || (dropPlumbing && PLUMBING_FILE_STEMS.has(stem))) {
+            continue;
+        }
+        seen.add(stem);
+        stems.push(stem);
+    }
+    return stems;
+};
+
+const shortOperationName = (name: string): string => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+        return '';
+    }
+    const parts = trimmed.split(/::|\./);
+    return parts[parts.length - 1] || trimmed;
+};
+
+const uniqueShortOpNames = (operations: readonly OpGraphSourceOperation[]): string[] => {
+    const names: string[] = [];
+    const seen = new Set<string>();
+    for (const operation of operations) {
+        const short = shortOperationName(operation.name);
+        if (!short || seen.has(short)) {
+            continue;
+        }
+        seen.add(short);
+        names.push(short);
+    }
+    return names;
+};
+
+const joinCapped = (parts: readonly string[]): string => {
+    if (parts.length <= MAX_PATTERN_NAME_PARTS) {
+        return parts.join(' + ');
+    }
+    return `${parts.slice(0, MAX_PATTERN_NAME_PARTS).join(' + ')} + …`;
+};
+
+export function formatRepeatPatternLabel(members: readonly OpGraphSourceOperation[]): string {
+    const withoutPlumbing = uniqueFileStems(members, true);
+    if (withoutPlumbing.length > 0) {
+        return joinCapped(withoutPlumbing);
+    }
+    const allStems = uniqueFileStems(members, false);
+    if (allStems.length > 0) {
+        return joinCapped(allStems);
+    }
+    return joinCapped(uniqueShortOpNames(members));
+}
+
+const labelForPattern = (
+    patternId: string,
+    members: readonly OpGraphSourceOperation[],
+    labelByPatternId: Map<string, string>,
+    collisionCountBySummary: Map<string, number>,
+    anonymousCount: { value: number },
+): string => {
+    const existing = labelByPatternId.get(patternId);
+    if (existing !== undefined) {
+        return existing;
+    }
+
+    const summary = formatRepeatPatternLabel(members);
+    if (!summary) {
+        const label = `Block ${blockLetter(anonymousCount.value)}`;
+        anonymousCount.value += 1;
+        labelByPatternId.set(patternId, label);
+        return label;
+    }
+
+    const prior = collisionCountBySummary.get(summary) ?? 0;
+    collisionCountBySummary.set(summary, prior + 1);
+    const label = prior === 0 ? summary : `${summary} · ${blockLetter(prior)}`;
+    labelByPatternId.set(patternId, label);
+    return label;
+};
+
 const isRangeConsumed = (consumed: Uint8Array, start: number, length: number): boolean => {
     for (let offset = 0; offset < length; offset++) {
         if (consumed[start + offset]) {
@@ -75,35 +192,34 @@ const markConsumed = (consumed: Uint8Array, start: number, length: number): void
 };
 
 /**
- * Longest contiguous, structurally equal windows first. A 1-op run is the
- * common "same name twice" case and is too noisy to collapse.
+ * Smallest window that repeats, extended as far as it matches. A 1-op run is
+ * the common "same name twice" case and is too noisy to collapse.
  */
 export function detectRepeatBlocks(keptOperations: readonly OpGraphSourceOperation[]): RepeatBlockInstance[] {
     const count = keptOperations.length;
-    if (count < MIN_REPEAT_WINDOW * MIN_REPEAT_COUNT) {
+    if (count < MIN_REPEAT_WINDOW * MIN_REPEAT_COUNT || count > MAX_DETECT_OPS) {
         return [];
     }
 
     const fingerprints = keptOperations.map(fingerprintOf);
+    const ids = internFingerprints(fingerprints);
     const operationIds = keptOperations.map((operation) => operation.id);
-    const keptIds = new Set<number>(operationIds);
-    const edgesBySource = new Map<number, InternalEdge[]>();
-    for (const operation of keptOperations) {
-        const outgoing: InternalEdge[] = [];
-        for (const output of operation.outputs) {
+    const indexById = new Map<number, number>(operationIds.map((id, index) => [id, index]));
+    const outgoing: OutgoingEdge[][] = operationIds.map(() => []);
+    for (let sourceIndex = 0; sourceIndex < count; sourceIndex++) {
+        for (const output of keptOperations[sourceIndex].outputs) {
             for (const consumer of output.consumers) {
-                if (keptIds.has(consumer)) {
-                    outgoing.push({ target: consumer, label: output.edgeLabel });
-                }
+                const targetIndex = indexById.get(consumer) ?? OUTSIDE_KEPT;
+                outgoing[sourceIndex].push({ targetIndex, label: output.edgeLabel });
             }
         }
-        edgesBySource.set(operation.id, outgoing);
     }
 
     const consumed = new Uint8Array(count);
     const runs: { start: number; length: number; repeatCount: number }[] = [];
+    const maxLength = Math.min(MAX_REPEAT_WINDOW, Math.floor(count / MIN_REPEAT_COUNT));
 
-    for (let length = Math.floor(count / MIN_REPEAT_COUNT); length >= MIN_REPEAT_WINDOW; length--) {
+    for (let length = MIN_REPEAT_WINDOW; length <= maxLength; length++) {
         let start = 0;
         while (start <= count - length * MIN_REPEAT_COUNT) {
             if (consumed[start] || isRangeConsumed(consumed, start, length)) {
@@ -111,52 +227,65 @@ export function detectRepeatBlocks(keptOperations: readonly OpGraphSourceOperati
                 continue;
             }
 
-            const key = windowKey(fingerprints, start, length);
-            const structure = internalEdgeSignature(operationIds.slice(start, start + length), edgesBySource);
-            let repeatCount = 1;
+            const nextStart = start + length;
+            if (isRangeConsumed(consumed, nextStart, length) || !idsEqual(ids, start, nextStart, length)) {
+                start += 1;
+                continue;
+            }
+
+            const structure = windowStructure(start, length, outgoing);
+            if (windowStructure(nextStart, length, outgoing) !== structure) {
+                start += 1;
+                continue;
+            }
+
+            let repeatCount = 2;
             while (start + (repeatCount + 1) * length <= count) {
-                const nextStart = start + repeatCount * length;
-                if (isRangeConsumed(consumed, nextStart, length)) {
+                const following = start + repeatCount * length;
+                if (isRangeConsumed(consumed, following, length)) {
                     break;
                 }
-                if (windowKey(fingerprints, nextStart, length) !== key) {
+                if (!idsEqual(ids, start, following, length)) {
                     break;
                 }
-                const nextIds = operationIds.slice(nextStart, nextStart + length);
-                if (internalEdgeSignature(nextIds, edgesBySource) !== structure) {
+                if (windowStructure(following, length, outgoing) !== structure) {
                     break;
                 }
                 repeatCount += 1;
             }
 
-            if (repeatCount >= MIN_REPEAT_COUNT) {
-                const span = repeatCount * length;
-                runs.push({ start, length, repeatCount });
-                markConsumed(consumed, start, span);
-                start += span;
-                continue;
-            }
-
-            start += 1;
+            const span = repeatCount * length;
+            runs.push({ start, length, repeatCount });
+            markConsumed(consumed, start, span);
+            start += span;
         }
     }
 
     runs.sort((left, right) => left.start - right.start);
 
+    const labelByPatternId = new Map<string, string>();
+    const collisionCountBySummary = new Map<string, number>();
+    const anonymousCount = { value: 0 };
     const instances: RepeatBlockInstance[] = [];
-    runs.forEach((run, patternIndex) => {
-        const patternLabel = `Block ${blockLetter(patternIndex)}`;
-        const firstIds = operationIds.slice(run.start, run.start + run.length);
-        const patternId = `${windowKey(fingerprints, run.start, run.length)}#${internalEdgeSignature(firstIds, edgesBySource)}`;
+    runs.forEach((run, runIndex) => {
+        const patternId = `${ids.slice(run.start, run.start + run.length).join(',')}#${windowStructure(run.start, run.length, outgoing)}`;
+        const members = keptOperations.slice(run.start, run.start + run.length);
+        const patternLabel = labelForPattern(
+            patternId,
+            members,
+            labelByPatternId,
+            collisionCountBySummary,
+            anonymousCount,
+        );
         for (let instanceIndex = 0; instanceIndex < run.repeatCount; instanceIndex++) {
             const instanceStart = run.start + instanceIndex * run.length;
-            const ids = operationIds.slice(instanceStart, instanceStart + run.length);
+            const memberIds = operationIds.slice(instanceStart, instanceStart + run.length);
             instances.push({
-                instanceId: `block:${patternIndex}:${ids[0]}`,
+                instanceId: `block:${runIndex}:${memberIds[0]}`,
                 patternId,
                 label: `${patternLabel} × ${run.repeatCount}`,
                 patternLabel,
-                operationIds: ids,
+                operationIds: memberIds,
                 instanceIndex,
                 instanceCount: run.repeatCount,
             });

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/* eslint-disable no-continue -- window scan skips consumed spans instead of nesting four levels */
+
+import type { OpGraphSourceOperation } from './opGraphTypes';
+
+export const MIN_REPEAT_WINDOW = 2;
+export const MIN_REPEAT_COUNT = 2;
+
+export interface RepeatBlockInstance {
+    instanceId: string;
+    patternId: string;
+    label: string;
+    patternLabel: string;
+    operationIds: number[];
+    instanceIndex: number;
+    instanceCount: number;
+}
+
+interface InternalEdge {
+    target: number;
+    label: string;
+}
+
+const fingerprintOf = (operation: OpGraphSourceOperation): string => {
+    const inputs = (operation.inputShapes ?? []).join(',');
+    const outputs = operation.outputs.map((output) => output.edgeLabel).join(',');
+    return `${operation.name}|${inputs}|${outputs}`;
+};
+
+const windowKey = (fingerprints: string[], start: number, length: number): string =>
+    fingerprints.slice(start, start + length).join(';');
+
+const internalEdgeSignature = (
+    operationIds: number[],
+    edgesBySource: ReadonlyMap<number, readonly InternalEdge[]>,
+): string => {
+    const indexById = new Map<number, number>(operationIds.map((id, index) => [id, index]));
+    const parts: string[] = [];
+    for (let index = 0; index < operationIds.length; index++) {
+        for (const edge of edgesBySource.get(operationIds[index]) ?? []) {
+            const targetIndex = indexById.get(edge.target);
+            if (targetIndex !== undefined) {
+                parts.push(`${index}->${targetIndex}:${edge.label}`);
+            }
+        }
+    }
+    return parts.sort().join('|');
+};
+
+const blockLetter = (index: number): string => {
+    let remaining = index + 1;
+    let label = '';
+    while (remaining > 0) {
+        remaining -= 1;
+        label = String.fromCharCode(65 + (remaining % 26)) + label;
+        remaining = Math.floor(remaining / 26);
+    }
+    return label;
+};
+
+const isRangeConsumed = (consumed: Uint8Array, start: number, length: number): boolean => {
+    for (let offset = 0; offset < length; offset++) {
+        if (consumed[start + offset]) {
+            return true;
+        }
+    }
+    return false;
+};
+
+const markConsumed = (consumed: Uint8Array, start: number, length: number): void => {
+    consumed.fill(1, start, start + length);
+};
+
+/**
+ * Longest contiguous, structurally equal windows first. A 1-op run is the
+ * common "same name twice" case and is too noisy to collapse.
+ */
+export function detectRepeatBlocks(keptOperations: readonly OpGraphSourceOperation[]): RepeatBlockInstance[] {
+    const count = keptOperations.length;
+    if (count < MIN_REPEAT_WINDOW * MIN_REPEAT_COUNT) {
+        return [];
+    }
+
+    const fingerprints = keptOperations.map(fingerprintOf);
+    const operationIds = keptOperations.map((operation) => operation.id);
+    const keptIds = new Set<number>(operationIds);
+    const edgesBySource = new Map<number, InternalEdge[]>();
+    for (const operation of keptOperations) {
+        const outgoing: InternalEdge[] = [];
+        for (const output of operation.outputs) {
+            for (const consumer of output.consumers) {
+                if (keptIds.has(consumer)) {
+                    outgoing.push({ target: consumer, label: output.edgeLabel });
+                }
+            }
+        }
+        edgesBySource.set(operation.id, outgoing);
+    }
+
+    const consumed = new Uint8Array(count);
+    const runs: { start: number; length: number; repeatCount: number }[] = [];
+
+    for (let length = Math.floor(count / MIN_REPEAT_COUNT); length >= MIN_REPEAT_WINDOW; length--) {
+        let start = 0;
+        while (start <= count - length * MIN_REPEAT_COUNT) {
+            if (consumed[start] || isRangeConsumed(consumed, start, length)) {
+                start += 1;
+                continue;
+            }
+
+            const key = windowKey(fingerprints, start, length);
+            const structure = internalEdgeSignature(operationIds.slice(start, start + length), edgesBySource);
+            let repeatCount = 1;
+            while (start + (repeatCount + 1) * length <= count) {
+                const nextStart = start + repeatCount * length;
+                if (isRangeConsumed(consumed, nextStart, length)) {
+                    break;
+                }
+                if (windowKey(fingerprints, nextStart, length) !== key) {
+                    break;
+                }
+                const nextIds = operationIds.slice(nextStart, nextStart + length);
+                if (internalEdgeSignature(nextIds, edgesBySource) !== structure) {
+                    break;
+                }
+                repeatCount += 1;
+            }
+
+            if (repeatCount >= MIN_REPEAT_COUNT) {
+                const span = repeatCount * length;
+                runs.push({ start, length, repeatCount });
+                markConsumed(consumed, start, span);
+                start += span;
+                continue;
+            }
+
+            start += 1;
+        }
+    }
+
+    runs.sort((left, right) => left.start - right.start);
+
+    const instances: RepeatBlockInstance[] = [];
+    runs.forEach((run, patternIndex) => {
+        const patternLabel = `Block ${blockLetter(patternIndex)}`;
+        const firstIds = operationIds.slice(run.start, run.start + run.length);
+        const patternId = `${windowKey(fingerprints, run.start, run.length)}#${internalEdgeSignature(firstIds, edgesBySource)}`;
+        for (let instanceIndex = 0; instanceIndex < run.repeatCount; instanceIndex++) {
+            const instanceStart = run.start + instanceIndex * run.length;
+            const ids = operationIds.slice(instanceStart, instanceStart + run.length);
+            instances.push({
+                instanceId: `block:${patternIndex}:${ids[0]}`,
+                patternId,
+                label: `${patternLabel} × ${run.repeatCount}`,
+                patternLabel,
+                operationIds: ids,
+                instanceIndex,
+                instanceCount: run.repeatCount,
+            });
+        }
+    });
+
+    return instances;
+}
+
+export function sumOptional(values: readonly (number | undefined)[]): number {
+    let total = 0;
+    for (const value of values) {
+        if (value !== undefined && Number.isFinite(value)) {
+            total += value;
+        }
+    }
+    return total;
+}

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -291,13 +291,21 @@ export function detectRepeatBlocks(keptOperations: readonly OpGraphSourceOperati
     for (let length = MIN_REPEAT_WINDOW; length <= maxLength; length++) {
         let start = 0;
         while (start <= count - length * MIN_REPEAT_COUNT) {
-            if (consumed[start] || isRangeConsumed(consumed, start, length)) {
+            const nextStart = start + length;
+            // O(1) and necessary for the window to repeat at all, so it goes ahead
+            // of the two O(length) consumed walks rather than behind them. The
+            // while condition keeps `nextStart` in bounds. Same control flow —
+            // every rejected `start` still advances by one.
+            if (consumed[start] || ids[start] !== ids[nextStart]) {
                 start += 1;
                 continue;
             }
 
-            const nextStart = start + length;
-            if (isRangeConsumed(consumed, nextStart, length) || !idsEqual(ids, start, nextStart, length)) {
+            if (
+                isRangeConsumed(consumed, start, length) ||
+                isRangeConsumed(consumed, nextStart, length) ||
+                !idsEqual(ids, start, nextStart, length)
+            ) {
                 start += 1;
                 continue;
             }

--- a/src/components/operation-graph/opGraphRepeatBlocks.ts
+++ b/src/components/operation-graph/opGraphRepeatBlocks.ts
@@ -8,9 +8,14 @@ import type { OpGraphSourceOperation, RepeatBlockInstance } from './opGraphTypes
 
 export const MIN_REPEAT_WINDOW = 2;
 export const MIN_REPEAT_COUNT = 2;
-// A repeated subgraph is a layer, not half the graph. Descending from ⌊N/2⌋
-// made the no-repeat case — the common one — O(N³) and folded 12 layers into
-// two half-model blocks. #1583
+// A repeated subgraph is a layer, not half the graph. Descending from ⌊N/2⌋ made
+// the no-repeat case — the common one — O(N³) and folded 12 layers into two
+// half-model blocks.
+//
+// This is an unmet part of #1583, which asks for no bound: a tile of more than 64
+// kept ops never folds, and a transformer layer can exceed that. Tracked in #1956
+// — the scan is ~10x faster than when 64 was chosen, so what is left to settle is
+// the half-model-block case rather than the time.
 export const MAX_REPEAT_WINDOW = 64;
 // 4k–8k op graphs are real (#1809). Past this the scan is skipped rather than
 // competing with Dagre; the main-thread fallback calls the same detector.

--- a/src/components/operation-graph/opGraphRevealPan.ts
+++ b/src/components/operation-graph/opGraphRevealPan.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Marks the nodes a structural toggle just produced, so an expand or fold is
+// visibly *something appearing* rather than the graph rearranging itself. Cleared
+// on a timer: it answers "where did it go", which stops being a question once the
+// user has seen the answer. #1944
+export const REVEALED_NODE_CLASS = 'op-graph-node-revealed';
+export const REVEAL_HIGHLIGHT_MS = 2600;
+// Keeps a revealed node off the very edge of the pane, where it reads as clipped.
+const REVEAL_MARGIN_PX = 48;
+
+/**
+ * The smallest pan that brings `bounds` inside the pane, or no pan when it
+ * already fits.
+ *
+ * Minimal on purpose: `fitView` would answer "is it in view" while destroying
+ * "did I lose my place", which is the same complaint. When the revealed set is
+ * taller than the pane its top edge wins — that is where the expansion started
+ * and where the user was looking.
+ */
+export const revealPanShift = (
+    bounds: { minX: number; minY: number; maxX: number; maxY: number },
+    viewport: { x: number; y: number; zoom: number },
+    pane: { width: number; height: number },
+): { dx: number; dy: number } => {
+    const left = bounds.minX * viewport.zoom + viewport.x;
+    const top = bounds.minY * viewport.zoom + viewport.y;
+    const right = bounds.maxX * viewport.zoom + viewport.x;
+    const bottom = bounds.maxY * viewport.zoom + viewport.y;
+
+    const axis = (nearEdge: number, farEdge: number, extent: number): number => {
+        const lowLimit = REVEAL_MARGIN_PX;
+        const highLimit = extent - REVEAL_MARGIN_PX;
+        if (farEdge - nearEdge > highLimit - lowLimit) {
+            // Too large to fit: align the near edge and let the rest run off.
+            return lowLimit - nearEdge;
+        }
+        if (nearEdge < lowLimit) {
+            return lowLimit - nearEdge;
+        }
+        if (farEdge > highLimit) {
+            return highLimit - farEdge;
+        }
+        return 0;
+    };
+
+    return { dx: axis(left, right, pane.width), dy: axis(top, bottom, pane.height) };
+};

--- a/src/components/operation-graph/opGraphRevealPan.ts
+++ b/src/components/operation-graph/opGraphRevealPan.ts
@@ -3,11 +3,13 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 // Marks the nodes a structural toggle just produced, so an expand or fold is
-// visibly *something appearing* rather than the graph rearranging itself. Cleared
-// on a timer: it answers "where did it go", which stops being a question once the
-// user has seen the answer. #1944
+// visibly *something appearing* rather than the graph rearranging itself.
+//
+// Held rather than timed out: the ring pulses for attention and then rests faint,
+// and the faint state answers "which ones did I just open", which stays useful for
+// as long as they are open. The next toggle replaces the set, so exactly one group
+// is ever marked. #1944
 export const REVEALED_NODE_CLASS = 'op-graph-node-revealed';
-export const REVEAL_HIGHLIGHT_MS = 2600;
 // Keeps a revealed node off the very edge of the pane, where it reads as clipped.
 const REVEAL_MARGIN_PX = 48;
 

--- a/src/components/operation-graph/opGraphTypes.ts
+++ b/src/components/operation-graph/opGraphTypes.ts
@@ -130,6 +130,9 @@ export interface OpGraphBlockSummary {
     instanceId: string;
     operationIds: number[];
     label: string;
+    patternLabel: string;
+    instanceIndex: number;
+    instanceCount: number;
 }
 
 export interface OpGraphBuiltGraph {

--- a/src/components/operation-graph/opGraphTypes.ts
+++ b/src/components/operation-graph/opGraphTypes.ts
@@ -77,8 +77,8 @@ export type OpGraphNodeData = {
     memberNames?: string[];
     memberOperationIds?: number[];
     opCount?: number;
-    durationSeconds?: number;
-    memoryDeltaBytes?: number;
+    /** A block's stats line. Its sums live on `OpGraphBlockSummary`. */
+    metaLine?: string;
     buriedMatchCount?: number;
 };
 

--- a/src/components/operation-graph/opGraphTypes.ts
+++ b/src/components/operation-graph/opGraphTypes.ts
@@ -126,6 +126,16 @@ export interface OpGraphDeviceSubgraph {
     exitFallbackNodeId: string | null;
 }
 
+export interface RepeatBlockInstance {
+    instanceId: string;
+    patternId: string;
+    label: string;
+    patternLabel: string;
+    operationIds: number[];
+    instanceIndex: number;
+    instanceCount: number;
+}
+
 export interface OpGraphBlockSummary {
     instanceId: string;
     operationIds: number[];
@@ -149,6 +159,7 @@ export interface OpGraphNodeIndexEntry {
     operationId: number;
     name: string;
     memberNames?: string[];
+    memberOperationIds?: number[];
 }
 
 export interface OpGraphBuildOptions {
@@ -157,6 +168,8 @@ export interface OpGraphBuildOptions {
     deviceSubgraphs: OpGraphDeviceSubgraph[];
     /** Empty means every detected instance is collapsed. #1583 */
     expandedBlockIds?: readonly string[];
+    /** Worker-only: detection is invariant under fold / device-op expand. */
+    detectedBlocks?: RepeatBlockInstance[];
 }
 
 export type OpGraphWorkerInboundMessage =

--- a/src/components/operation-graph/opGraphTypes.ts
+++ b/src/components/operation-graph/opGraphTypes.ts
@@ -11,6 +11,8 @@ export enum OpGraphNodeType {
     DEVICE_GROUP = 'deviceGroupNode',
     /** One device operation, parented to the operation it belongs to. */
     DEVICE_OP = 'deviceOpNode',
+    /** A collapsed repeat-window instance. #1583 */
+    BLOCK = 'blockNode',
 }
 
 export enum OpGraphEdgeType {
@@ -38,6 +40,10 @@ export interface OpGraphSourceOperation {
      * built through `isDeviceOperation`, a deliberately narrower predicate.
      */
     deviceOperationCount: number;
+    /** Fingerprint inputs for repeat detection. Absent in older test fixtures. */
+    inputShapes?: string[];
+    durationSeconds?: number;
+    memoryDeltaBytes?: number;
 }
 
 // A single device operation expands into one node with no edges, which says
@@ -67,6 +73,13 @@ export type OpGraphNodeData = {
     /** 0 when the operation decomposes into nothing the graph would draw. */
     deviceOperationCount: number;
     highlight?: NodeRelation;
+    blockInstanceId?: string;
+    memberNames?: string[];
+    memberOperationIds?: number[];
+    opCount?: number;
+    durationSeconds?: number;
+    memoryDeltaBytes?: number;
+    buriedMatchCount?: number;
 };
 
 export type OpGraphEdgeData = {
@@ -113,9 +126,16 @@ export interface OpGraphDeviceSubgraph {
     exitFallbackNodeId: string | null;
 }
 
+export interface OpGraphBlockSummary {
+    instanceId: string;
+    operationIds: number[];
+    label: string;
+}
+
 export interface OpGraphBuiltGraph {
     nodes: OpGraphFlowNode[];
     edges: OpGraphFlowEdge[];
+    blocks?: OpGraphBlockSummary[];
 }
 
 // Rebuilt only when the worker delivers a graph, in canvas order. The filter and
@@ -125,12 +145,15 @@ export interface OpGraphNodeIndexEntry {
     id: string;
     operationId: number;
     name: string;
+    memberNames?: string[];
 }
 
 export interface OpGraphBuildOptions {
     hideDeallocate: boolean;
     /** Only the expanded operations, so a collapsed graph carries no payload. */
     deviceSubgraphs: OpGraphDeviceSubgraph[];
+    /** Empty means every detected instance is collapsed. #1583 */
+    expandedBlockIds?: readonly string[];
 }
 
 export type OpGraphWorkerInboundMessage =

--- a/src/components/operation-graph/opGraphTypes.ts
+++ b/src/components/operation-graph/opGraphTypes.ts
@@ -143,6 +143,11 @@ export interface OpGraphBlockSummary {
     patternLabel: string;
     instanceIndex: number;
     instanceCount: number;
+    // Summed once here rather than re-derived by the panel: the node's meta line
+    // and the panel's stats are on screen together, so two derivations show up as
+    // the two of them disagreeing about one block. #1944
+    durationSeconds: number;
+    memoryDeltaBytes: number;
 }
 
 export interface OpGraphBuiltGraph {

--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -225,3 +225,22 @@ export const getMemoryAddress = (address: number | null, showHex: boolean): stri
 
     return showHex ? toHex(address) : address.toString();
 };
+
+/**
+ * @description Sum values that may be absent or non-finite, treating both as
+ * nothing rather than propagating NaN. Report fields are optional per row, so a
+ * plain reduce poisons the total for the whole set.
+ */
+export const sumOptional = (values: readonly (number | undefined)[]): number => {
+    let total = 0;
+    for (const value of values) {
+        if (value !== undefined && Number.isFinite(value)) {
+            total += value;
+        }
+    }
+    return total;
+};
+
+/** @description Total bytes across tensors, counting an unknown size as zero. */
+export const tensorBytes = (tensors: readonly { size: number | null }[]): number =>
+    tensors.reduce((total, tensor) => total + (tensor.size ?? 0), 0);

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -27,6 +27,11 @@
      * the colour legend (see GRAPH_COLORS). */
     --graph-op-node: #f5f5f5;
     --graph-group: #7d7d7d;
+
+    /* Cool tint + ink so a collapsed block does not read as another grey op.
+     * `--graph-group` is mid-grey on `--graph-normal` and vanishes at graph zoom. */
+    --graph-block: #{$tt-blue-tint-2};
+    --graph-block-border: #{$tt-blue};
     --graph-section-group: #9b59b6;
     --graph-selected: #{$tt-blue-accent};
 

--- a/src/scss/components/OpGraphToolbar.scss
+++ b/src/scss/components/OpGraphToolbar.scss
@@ -44,3 +44,10 @@
     font-size: 12px;
     white-space: nowrap;
 }
+
+.op-graph-toolbar-group-label {
+    padding: 0 4px;
+    color: $tt-grey-7;
+    font-size: 12px;
+    white-space: nowrap;
+}

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -327,7 +327,8 @@ $minimap-width: 200px;
         white-space: nowrap;
     }
 
-    .op-graph-node-file {
+    .op-graph-node-file,
+    .op-graph-node-meta {
         overflow: hidden;
         color: $tt-grey-2;
         font-size: 11px;
@@ -395,7 +396,7 @@ $minimap-width: 200px;
     // inputs and outputs would fade half of them. Critical path and "dim
     // unrelated edges" ask for the same fade, so they share the rule.
     &.op-graph-critical-path:not(.op-graph-filtering),
-    &.op-graph-focus-edges:not(.op-graph-filtering) {
+    &.op-graph-dim-unrelated-edges:not(.op-graph-filtering) {
         .react-flow__edge:not(.op-graph-edge-critical-path, .op-graph-edge-input, .op-graph-edge-output) {
             opacity: 0.35;
         }

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -45,7 +45,8 @@ $minimap-width: 200px;
     // perf bar all belong to the operation, not to whether it is showing its
     // device operations. #1195
     .react-flow__node-opNode,
-    .react-flow__node-deviceGroupNode {
+    .react-flow__node-deviceGroupNode,
+    .react-flow__node-blockNode {
         display: flex;
         flex-direction: column;
         gap: 2px;
@@ -105,12 +106,18 @@ $minimap-width: 200px;
     // A collapsed operation is a filled box, so the I/O relation reads as its
     // fill. An expanded one is a field its device operations sit on, where the
     // same fill would bury them — see the group's border highlight below.
-    .react-flow__node-opNode.op-graph-node-input {
+    .react-flow__node-opNode.op-graph-node-input,
+    .react-flow__node-blockNode.op-graph-node-input {
         background-color: var(--graph-input-node);
     }
 
-    .react-flow__node-opNode.op-graph-node-output {
+    .react-flow__node-opNode.op-graph-node-output,
+    .react-flow__node-blockNode.op-graph-node-output {
         background-color: var(--graph-output-node);
+    }
+
+    .react-flow__node-blockNode {
+        border: 2px dashed var(--graph-group);
     }
 
     // The MLIR graph's group: a translucent field inside a dashed border. That is
@@ -237,10 +244,26 @@ $minimap-width: 200px;
     // and a badge hung off the corner was clipped by the boundary and easy to
     // miss. Absolute so it can't become a flex item and grow the node past the
     // height the layout measured.
-    .react-flow__node-opNode > .op-graph-node-expander {
+    .react-flow__node-opNode > .op-graph-node-expander,
+    .react-flow__node-blockNode > .op-graph-node-expander {
         position: absolute;
         top: 3px;
         right: 3px;
+    }
+
+    .op-graph-node-buried-badge {
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        padding: 1px 5px;
+        border-radius: 8px;
+        background: $tt-yellow;
+        color: $tt-black;
+        font-size: 10px;
+        font-weight: 600;
+        line-height: 1.1;
+        pointer-events: none;
+        user-select: none;
     }
 
     // On the bottom band beside the minimap, reading against the nodes it

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -403,26 +403,29 @@ $minimap-width: 200px;
 
     // What a structural toggle just produced. Its own channel again — box-shadow,
     // since selection owns the border, the I/O highlight the fill and the critical
-    // path the outline — so a revealed node that is also selected shows both. Two
-    // pulses then hold, long enough to catch the eye without becoming decoration;
-    // the class is removed on a timer. #1944
+    // path the outline — so a revealed node that is also selected shows both.
+    //
+    // Three slow pulses to catch the eye, then it rests on the rule's own faint
+    // ring, which is where the animation leaves it. That resting state is not a
+    // leftover: it marks the group you last opened for as long as it is open, and
+    // is faint enough not to compete with selection. #1944
     .react-flow__node.op-graph-node-revealed {
-        animation: op-graph-reveal 0.65s ease-out 2;
-        box-shadow: 0 0 0 3px rgb(116 197 223 / 55%);
+        animation: op-graph-reveal 0.9s ease-out 3;
+        box-shadow: 0 0 0 2px rgb(116 197 223 / 32%);
         z-index: 3;
     }
 
     @keyframes op-graph-reveal {
         0% {
-            box-shadow: 0 0 0 2px rgb(116 197 223 / 90%);
+            box-shadow: 0 0 0 2px rgb(116 197 223 / 95%);
         }
 
-        50% {
-            box-shadow: 0 0 0 9px rgb(116 197 223 / 0%);
+        45% {
+            box-shadow: 0 0 0 10px rgb(116 197 223 / 0%);
         }
 
         100% {
-            box-shadow: 0 0 0 3px rgb(116 197 223 / 55%);
+            box-shadow: 0 0 0 2px rgb(116 197 223 / 32%);
         }
     }
 

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -401,6 +401,39 @@ $minimap-width: 200px;
         }
     }
 
+    // What a structural toggle just produced. Its own channel again — box-shadow,
+    // since selection owns the border, the I/O highlight the fill and the critical
+    // path the outline — so a revealed node that is also selected shows both. Two
+    // pulses then hold, long enough to catch the eye without becoming decoration;
+    // the class is removed on a timer. #1944
+    .react-flow__node.op-graph-node-revealed {
+        animation: op-graph-reveal 0.65s ease-out 2;
+        box-shadow: 0 0 0 3px rgb(116 197 223 / 55%);
+        z-index: 3;
+    }
+
+    @keyframes op-graph-reveal {
+        0% {
+            box-shadow: 0 0 0 2px rgb(116 197 223 / 90%);
+        }
+
+        50% {
+            box-shadow: 0 0 0 9px rgb(116 197 223 / 0%);
+        }
+
+        100% {
+            box-shadow: 0 0 0 3px rgb(116 197 223 / 55%);
+        }
+    }
+
+    // Reduced motion still needs the *answer* to "where did it go", so the ring
+    // stays and only the pulse goes.
+    @media (prefers-reduced-motion: reduce) {
+        .react-flow__node.op-graph-node-revealed {
+            animation: none;
+        }
+    }
+
     // Outline, not border or fill: selection owns the border and the I/O
     // highlight the fill, so the path stacks with either. Offset clears the 3px
     // selection ring, which an outline would otherwise paint over.

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -117,7 +117,18 @@ $minimap-width: 200px;
     }
 
     .react-flow__node-blockNode {
-        border: 2px dashed var(--graph-group);
+        // 4px dash + matching inset ring: at 0.1–0.3 zoom a 2px grey dash
+        // collapses to the same hairline the ops already have.
+        border: 4px dashed var(--graph-block-border);
+        border-radius: 8px;
+        background-color: var(--graph-block);
+        box-shadow: inset 0 0 0 2px var(--graph-block-border);
+
+        &.op-graph-node-selected {
+            border-style: solid;
+            border-color: var(--graph-selected);
+            box-shadow: 0 0 0 3px var(--graph-selected);
+        }
     }
 
     // The MLIR graph's group: a translucent field inside a dashed border. That is
@@ -208,23 +219,19 @@ $minimap-width: 200px;
         display: inline-flex;
         gap: 2px;
         align-items: center;
-        padding: 1px 4px;
-
-        // Separates the chip from the expanded group's dark field, where a
-        // borderless dark chip disappears. Invisible on a light collapsed node,
-        // which needs no help.
-        border: 1px solid rgba($tt-white, 0.14);
+        padding: 2px 5px;
+        border: 1px solid $tt-grey-2;
         border-radius: 3px;
-        background-color: rgba($tt-black, 0.88);
-        color: $tt-grey-7;
+        background-color: $tt-black;
+        color: $tt-white;
         font-family: inherit;
-        font-size: 10px;
-        font-weight: 600;
-        line-height: 1.4;
+        font-size: 11px;
+        font-weight: 700;
+        line-height: 1.3;
         cursor: pointer;
 
         &:hover {
-            background-color: $tt-black;
+            background-color: $tt-grey-2;
             color: $tt-white;
         }
 
@@ -249,6 +256,22 @@ $minimap-width: 200px;
         position: absolute;
         top: 3px;
         right: 3px;
+    }
+
+    // Pill + the block ink, so `▾ 336` is not the same black chip as a
+    // device-op expander sitting on a grey op.
+    .react-flow__node-blockNode > .op-graph-node-expander {
+        top: 6px;
+        right: 6px;
+        padding: 3px 8px;
+        border: 2px solid $tt-white;
+        border-radius: 999px;
+        background-color: var(--graph-block-border);
+        font-size: 12px;
+
+        &:hover {
+            background-color: var(--graph-selected);
+        }
     }
 
     .op-graph-node-buried-badge {

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -520,6 +520,26 @@ $minimap-width: 200px;
         border-bottom: 1px solid rgba($tt-white, 0.06);
     }
 
+    .op-graph-panel-stats {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 2px 12px;
+        margin: 0;
+        padding: 8px 12px;
+        border-bottom: 1px solid rgba($tt-white, 0.06);
+        font-size: 12px;
+
+        dt {
+            color: $tt-grey-6;
+        }
+
+        dd {
+            margin: 0;
+            color: $tt-grey-7;
+            font-variant-numeric: tabular-nums;
+        }
+    }
+
     .op-graph-panel-section {
         border-bottom: 1px solid rgba($tt-white, 0.06);
 

--- a/src/scss/components/OperationGraphReactFlow.scss
+++ b/src/scss/components/OperationGraphReactFlow.scss
@@ -392,8 +392,10 @@ $minimap-width: 200px;
     // Skipped while a search runs: the filter dim is the narrower intent and
     // would otherwise lose to this rule's extra `:not()` specificity. The
     // selected node's own edges are exempt too, or clicking a node to inspect its
-    // inputs and outputs would fade half of them.
-    &.op-graph-critical-path:not(.op-graph-filtering) {
+    // inputs and outputs would fade half of them. Critical path and "dim
+    // unrelated edges" ask for the same fade, so they share the rule.
+    &.op-graph-critical-path:not(.op-graph-filtering),
+    &.op-graph-focus-edges:not(.op-graph-filtering) {
         .react-flow__edge:not(.op-graph-edge-critical-path, .op-graph-edge-input, .op-graph-edge-output) {
             opacity: 0.35;
         }

--- a/tests/OpGraphBlockPanelStats.spec.tsx
+++ b/tests/OpGraphBlockPanelStats.spec.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import OpGraphInfoPanel from '../src/components/operation-graph/OpGraphInfoPanel';
+import type { OpGraphBlockSummary } from '../src/components/operation-graph/opGraphTypes';
+import type { OperationDescription } from '../src/model/APIData';
+
+const operation = (id: number): OperationDescription =>
+    ({
+        id,
+        name: 'ttnn.matmul',
+        operationFileIdentifier: 'layer.py:1',
+        inputs: [],
+        outputs: [],
+        arguments: [],
+        deviceOperationNameList: [],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+    }) as unknown as OperationDescription;
+
+const block = (durationSeconds: number, memoryDeltaBytes: number): OpGraphBlockSummary => ({
+    instanceId: 'block:0:2',
+    operationIds: [2, 3],
+    label: 'layer_a + layer_b',
+    patternLabel: 'layer_a + layer_b',
+    instanceIndex: 0,
+    instanceCount: 4,
+    durationSeconds,
+    memoryDeltaBytes,
+});
+
+const renderBlockPanel = (summary: OpGraphBlockSummary) => {
+    const ops = summary.operationIds.map(operation);
+    return render(
+        <MemoryRouter>
+            <OpGraphInfoPanel
+                operationId={ops[0].id}
+                operationById={new Map(ops.map((op) => [op.id, op]))}
+                operationNamesById={new Map(ops.map((op) => [op.id, op.name]))}
+                onLocateOperation={vi.fn()}
+                isPerfOverlayActive={false}
+                block={summary}
+            />
+        </MemoryRouter>,
+    );
+};
+
+afterEach(cleanup);
+
+// Both gates and the sign branch were uncovered, and these numbers are also
+// formatted onto the block node, which is on screen at the same time. #1944
+describe('block panel stats', () => {
+    it('shows the operation count unconditionally', () => {
+        renderBlockPanel(block(0, 0));
+
+        expect(screen.getByText('Operations')).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('omits duration and memory rows when there is nothing to report', () => {
+        renderBlockPanel(block(0, 0));
+
+        expect(screen.queryByText('Python duration')).not.toBeInTheDocument();
+        expect(screen.queryByText('Memory delta')).not.toBeInTheDocument();
+    });
+
+    it('shows a duration once there is one', () => {
+        renderBlockPanel(block(2, 0));
+
+        expect(screen.getByText('Python duration')).toBeInTheDocument();
+        expect(screen.getByText('2 s')).toBeInTheDocument();
+    });
+
+    it('signs a positive memory delta', () => {
+        renderBlockPanel(block(0, 2048));
+
+        expect(screen.getByText(/^\+2 KiB$/)).toBeInTheDocument();
+    });
+
+    it('signs a negative memory delta', () => {
+        // The absolute value is formatted and the sign prepended, so a bare
+        // formatMemorySize of a negative number would read wrong here.
+        renderBlockPanel(block(0, -2048));
+
+        expect(screen.getByText(/^-2 KiB$/)).toBeInTheDocument();
+    });
+});

--- a/tests/OpGraphPanelLabelTooltip.spec.tsx
+++ b/tests/OpGraphPanelLabelTooltip.spec.tsx
@@ -59,6 +59,8 @@ describe('op graph panel heading tooltips', () => {
             patternLabel: label,
             instanceIndex: 1,
             instanceCount: 11,
+            durationSeconds: 0,
+            memoryDeltaBytes: 0,
         });
 
         expect(screen.getByRole('heading', { level: 2 })).toHaveAttribute('title', label);

--- a/tests/OpGraphPanelLabelTooltip.spec.tsx
+++ b/tests/OpGraphPanelLabelTooltip.spec.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import OpGraphInfoPanel from '../src/components/operation-graph/OpGraphInfoPanel';
+import type { OpGraphBlockSummary } from '../src/components/operation-graph/opGraphTypes';
+import type { OperationDescription } from '../src/model/APIData';
+
+// No stack trace, so `SourceFileButton` never mounts and the panel stays a pure
+// render — as in OpGraphPanelPerfMetric.spec.tsx.
+const operation = (id: number, name: string): OperationDescription =>
+    ({
+        id,
+        name,
+        operationFileIdentifier: 'ttnn_sentencebert_self_attention.py:31',
+        inputs: [],
+        outputs: [],
+        arguments: [],
+        deviceOperationNameList: [],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+    }) as unknown as OperationDescription;
+
+const renderPanel = (block?: OpGraphBlockSummary) => {
+    const ops = (block?.operationIds ?? [187]).map((id) =>
+        operation(id, 'ttnn.experimental.split_query_key_value_and_split_heads'),
+    );
+    return render(
+        <MemoryRouter>
+            <OpGraphInfoPanel
+                operationId={ops[0].id}
+                operationById={new Map(ops.map((op) => [op.id, op]))}
+                operationNamesById={new Map(ops.map((op) => [op.id, op.name]))}
+                onLocateOperation={vi.fn()}
+                isPerfOverlayActive={false}
+                block={block}
+            />
+        </MemoryRouter>,
+    );
+};
+
+afterEach(cleanup);
+
+// Both headings are `text-overflow: ellipsis`, and the label is the one thing the
+// panel exists to show — without a tooltip a four-module block name is readable
+// nowhere in the app, on the node or in the panel. #1944
+describe('op graph panel heading tooltips', () => {
+    it('carries the whole block label as a tooltip', () => {
+        const label = 'self_attention + self_output + intermediate + output';
+        renderPanel({
+            instanceId: 'block:0:187',
+            operationIds: [187, 188],
+            label,
+            patternLabel: label,
+            instanceIndex: 1,
+            instanceCount: 11,
+        });
+
+        expect(screen.getByRole('heading', { level: 2 })).toHaveAttribute('title', label);
+    });
+
+    it('carries the whole operation label as a tooltip', () => {
+        renderPanel();
+
+        expect(screen.getByRole('heading', { level: 2 })).toHaveAttribute(
+            'title',
+            '187 ttnn.experimental.split_query_key_value_and_split_heads',
+        );
+    });
+});

--- a/tests/OpGraphPanelPerfMetric.spec.tsx
+++ b/tests/OpGraphPanelPerfMetric.spec.tsx
@@ -38,7 +38,7 @@ const renderPanel = ({ isPerfOverlayActive, perfDeviceTimeNs, perfColor }: Rende
         <MemoryRouter>
             <OpGraphInfoPanel
                 operationId={OPERATION.id}
-                operationList={[OPERATION]}
+                operationById={new Map<number, OperationDescription>([[OPERATION.id, OPERATION]])}
                 operationNamesById={new Map<number, string>([[OPERATION.id, OPERATION.name]])}
                 onLocateOperation={vi.fn()}
                 isPerfOverlayActive={isPerfOverlayActive}

--- a/tests/OpGraphToolbarSwitches.spec.tsx
+++ b/tests/OpGraphToolbarSwitches.spec.tsx
@@ -14,16 +14,26 @@ interface RenderToolbarOptions {
     status: PerfOverlayStatus;
     onPerfOverlayChange?: (next: boolean) => void;
     onCriticalPathChange?: (next: boolean) => void;
-    onFocusUnrelatedEdgesChange?: (next: boolean) => void;
+    onDimUnrelatedEdgesChange?: (next: boolean) => void;
     isDisabled?: boolean;
+    hasBlocks?: boolean;
+    areAllBlocksExpanded?: boolean;
+    areAllBlocksCollapsed?: boolean;
+    onExpandAllBlocks?: () => void;
+    onCollapseAllBlocks?: () => void;
 }
 
 const renderToolbar = ({
     status,
     onPerfOverlayChange = vi.fn(),
     onCriticalPathChange = vi.fn(),
-    onFocusUnrelatedEdgesChange = vi.fn(),
+    onDimUnrelatedEdgesChange = vi.fn(),
     isDisabled = false,
+    hasBlocks = false,
+    areAllBlocksExpanded = false,
+    areAllBlocksCollapsed = true,
+    onExpandAllBlocks = vi.fn(),
+    onCollapseAllBlocks = vi.fn(),
 }: RenderToolbarOptions) => {
     render(
         <OpGraphToolbar
@@ -43,8 +53,8 @@ const renderToolbar = ({
             onGoToOperation={vi.fn()}
             hideDeallocate
             onHideDeallocateChange={vi.fn()}
-            focusUnrelatedEdges={false}
-            onFocusUnrelatedEdgesChange={onFocusUnrelatedEdgesChange}
+            isDimUnrelatedEdges={false}
+            onDimUnrelatedEdgesChange={onDimUnrelatedEdgesChange}
             isPerfOverlayActive={false}
             onPerfOverlayChange={onPerfOverlayChange}
             isCriticalPathActive={false}
@@ -53,6 +63,11 @@ const renderToolbar = ({
             linkedOpCount={180}
             totalOpCount={302}
             isDisabled={isDisabled}
+            hasBlocks={hasBlocks}
+            areAllBlocksExpanded={areAllBlocksExpanded}
+            areAllBlocksCollapsed={areAllBlocksCollapsed}
+            onExpandAllBlocks={onExpandAllBlocks}
+            onCollapseAllBlocks={onCollapseAllBlocks}
         />,
     );
 };
@@ -154,12 +169,12 @@ describe('critical path switch', () => {
 
 describe('dim unrelated edges switch', () => {
     it('turns on when toggled', () => {
-        const onFocusUnrelatedEdgesChange = vi.fn();
-        renderToolbar({ status: PerfOverlayStatus.READY, onFocusUnrelatedEdgesChange });
+        const onDimUnrelatedEdgesChange = vi.fn();
+        renderToolbar({ status: PerfOverlayStatus.READY, onDimUnrelatedEdgesChange });
 
         fireEvent.click(switchNamed(/^Dim unrelated edges/).input);
 
-        expect(onFocusUnrelatedEdgesChange).toHaveBeenCalledWith(true);
+        expect(onDimUnrelatedEdgesChange).toHaveBeenCalledWith(true);
     });
 
     it('is disabled while the graph is being laid out', () => {
@@ -194,5 +209,62 @@ describe('switch tooltips', () => {
         fireEvent.mouseEnter(criticalPathSwitch().label);
 
         await waitFor(() => expect(screen.getByText(CRITICAL_PATH_TOOLTIP[status])).toBeInTheDocument());
+    });
+});
+
+// Each Repeats button has two independent disable reasons; only the
+// all-expanded / all-collapsed one was covered. Mid-build is the one that matters,
+// where an unroll would be queued against a node set about to be replaced. #1944
+describe('repeats controls', () => {
+    const repeatsButtons = () => ({
+        unroll: screen.getByRole('button', { name: 'Unroll all repeats' }),
+        fold: screen.getByRole('button', { name: 'Fold all repeats' }),
+    });
+
+    it('stays out of the toolbar when the report has no repeats', () => {
+        renderToolbar({ status: PerfOverlayStatus.READY, hasBlocks: false });
+
+        expect(screen.queryByRole('button', { name: 'Unroll all repeats' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Fold all repeats' })).not.toBeInTheDocument();
+    });
+
+    it('offers both directions when some blocks are unrolled and some are not', () => {
+        renderToolbar({
+            status: PerfOverlayStatus.READY,
+            hasBlocks: true,
+            areAllBlocksExpanded: false,
+            areAllBlocksCollapsed: false,
+        });
+
+        const { unroll, fold } = repeatsButtons();
+        expect(unroll).toBeEnabled();
+        expect(fold).toBeEnabled();
+    });
+
+    it('disables both mid-build, whatever the fold state', () => {
+        renderToolbar({
+            status: PerfOverlayStatus.READY,
+            isDisabled: true,
+            hasBlocks: true,
+            areAllBlocksExpanded: false,
+            areAllBlocksCollapsed: false,
+        });
+
+        const { unroll, fold } = repeatsButtons();
+        expect(unroll).toBeDisabled();
+        expect(fold).toBeDisabled();
+    });
+
+    it('disables only the direction that would do nothing', () => {
+        renderToolbar({
+            status: PerfOverlayStatus.READY,
+            hasBlocks: true,
+            areAllBlocksExpanded: true,
+            areAllBlocksCollapsed: false,
+        });
+
+        const { unroll, fold } = repeatsButtons();
+        expect(unroll).toBeDisabled();
+        expect(fold).toBeEnabled();
     });
 });

--- a/tests/OpGraphToolbarSwitches.spec.tsx
+++ b/tests/OpGraphToolbarSwitches.spec.tsx
@@ -14,6 +14,7 @@ interface RenderToolbarOptions {
     status: PerfOverlayStatus;
     onPerfOverlayChange?: (next: boolean) => void;
     onCriticalPathChange?: (next: boolean) => void;
+    onFocusUnrelatedEdgesChange?: (next: boolean) => void;
     isDisabled?: boolean;
 }
 
@@ -21,6 +22,7 @@ const renderToolbar = ({
     status,
     onPerfOverlayChange = vi.fn(),
     onCriticalPathChange = vi.fn(),
+    onFocusUnrelatedEdgesChange = vi.fn(),
     isDisabled = false,
 }: RenderToolbarOptions) => {
     render(
@@ -41,6 +43,8 @@ const renderToolbar = ({
             onGoToOperation={vi.fn()}
             hideDeallocate
             onHideDeallocateChange={vi.fn()}
+            focusUnrelatedEdges={false}
+            onFocusUnrelatedEdgesChange={onFocusUnrelatedEdgesChange}
             isPerfOverlayActive={false}
             onPerfOverlayChange={onPerfOverlayChange}
             isCriticalPathActive={false}
@@ -145,6 +149,23 @@ describe('critical path switch', () => {
 
         expect(onCriticalPathChange).toHaveBeenCalledWith(true);
         expect(onPerfOverlayChange).not.toHaveBeenCalled();
+    });
+});
+
+describe('dim unrelated edges switch', () => {
+    it('turns on when toggled', () => {
+        const onFocusUnrelatedEdgesChange = vi.fn();
+        renderToolbar({ status: PerfOverlayStatus.READY, onFocusUnrelatedEdgesChange });
+
+        fireEvent.click(switchNamed(/^Dim unrelated edges/).input);
+
+        expect(onFocusUnrelatedEdgesChange).toHaveBeenCalledWith(true);
+    });
+
+    it('is disabled while the graph is being laid out', () => {
+        renderToolbar({ status: PerfOverlayStatus.READY, isDisabled: true });
+
+        expect(switchNamed(/^Dim unrelated edges/).input).toBeDisabled();
     });
 });
 

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -1218,3 +1218,136 @@ describe('OperationGraphReactFlow device operation expansion', () => {
         expect(hasClass(nodeById(lastFlowRender().nodes, '3'), 'op-graph-node-selected')).toBe(true);
     });
 });
+
+describe('OperationGraphReactFlow repeat blocks', () => {
+    // prefix → (layer_a → layer_b) × 2 → suffix. Two instances of one pattern.
+    const REPEAT_OPERATION_LIST: OperationDescription[] = [
+        operation(1, 'prefix', [2]),
+        operation(2, 'layer_a', [3]),
+        operation(3, 'layer_b', [4]),
+        operation(4, 'layer_a', [5]),
+        operation(5, 'layer_b', [6]),
+        operation(6, 'suffix', []),
+    ];
+
+    const FIRST_BLOCK_ID = 'block:0:2';
+    const SECOND_BLOCK_ID = 'block:0:4';
+
+    const deliver = (operations: OperationDescription[], options: Partial<OpGraphBuildOptions> = {}) => {
+        act(() => {
+            harness.onBuilt?.(
+                buildOpGraph(sourceFor(operations), {
+                    hideDeallocate: true,
+                    deviceSubgraphs: [],
+                    ...options,
+                }),
+            );
+        });
+    };
+
+    it('collapses repeats on first layout and offers Unroll / Fold', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+
+        expect(lastFlowRender().nodes.map((node) => node.id)).toEqual(['1', FIRST_BLOCK_ID, SECOND_BLOCK_ID, '6']);
+        expect(screen.getByRole('button', { name: 'Unroll all repeats' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Fold all repeats' })).toBeDisabled();
+        expect(screen.getAllByRole('button', { name: 'Unroll 2 operations' })).toHaveLength(2);
+    });
+
+    it('does not show the Repeats row when nothing was detected', () => {
+        renderGraph();
+
+        expect(screen.queryByRole('button', { name: 'Unroll all repeats' })).toBeNull();
+    });
+
+    it('unrolls every instance from the toolbar and folds them back', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+        runBuild.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unroll all repeats' }));
+        const unrolled = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+        expect(unrolled.expandedBlockIds).toEqual(expect.arrayContaining([FIRST_BLOCK_ID, SECOND_BLOCK_ID]));
+        expect(unrolled.expandedBlockIds).toHaveLength(2);
+
+        deliver(REPEAT_OPERATION_LIST, { expandedBlockIds: unrolled.expandedBlockIds });
+        expect(lastFlowRender().nodes.map((node) => node.id)).toEqual(['1', '2', '3', '4', '5', '6']);
+        expect(screen.getByRole('button', { name: 'Unroll all repeats' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Fold all repeats' })).toBeEnabled();
+
+        runBuild.mockClear();
+        fireEvent.click(screen.getByRole('button', { name: 'Fold all repeats' }));
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ expandedBlockIds: [] }));
+    });
+
+    it('unrolls one instance from its chip', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+        runBuild.mockClear();
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Unroll 2 operations' })[0]);
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(
+            expect.objectContaining({ expandedBlockIds: [FIRST_BLOCK_ID] }),
+        );
+    });
+
+    it('counts buried filter matches on the collapsed node and in the counter', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+        typeFilter('layer_a');
+
+        expect(screen.getByText('2 matches (+2 inside)')).toBeInTheDocument();
+        expect(screen.getAllByTitle('1 filter match inside')).toHaveLength(2);
+        expect(screen.getAllByText('+1')).toHaveLength(2);
+    });
+
+    it('opens the block panel instead of the first member when a collapsed block is selected', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+
+        act(() => {
+            harness.onNodeClick?.(null, nodeById(lastFlowRender().nodes, FIRST_BLOCK_ID));
+        });
+
+        const panel = screen.getByLabelText('Selected block details');
+        expect(panel).toHaveTextContent('Block A × 2');
+        expect(panel).toHaveTextContent('ops 2–3 · instance 1 of 2');
+        expect(screen.queryByRole('button', { name: /Memory Details/ })).toBeNull();
+        expect(screen.queryByLabelText('Selected operation details')).toBeNull();
+    });
+
+    it('does not rebuild when the worker repeats the same block detections', () => {
+        const operations = REPEAT_OPERATION_LIST.map((op) =>
+            op.id === 1 ? withDeviceOperations(op, ['AlphaDeviceOperation', 'BetaDeviceOperation']) : op,
+        );
+        renderGraph(operations);
+        fireEvent.click(screen.getByRole('button', { name: 'Show 2 device operations' }));
+        const expandedOptions = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+
+        deliver(operations, { deviceSubgraphs: expandedOptions.deviceSubgraphs });
+        runBuild.mockClear();
+        deliver(operations, { deviceSubgraphs: expandedOptions.deviceSubgraphs });
+
+        expect(runBuild).not.toHaveBeenCalled();
+    });
+
+    it('drops a member device-op expansion when that instance is folded', () => {
+        const operations = REPEAT_OPERATION_LIST.map((op) =>
+            op.id === 2
+                ? withDeviceOperations(op, ['AlphaDeviceOperation', 'BetaDeviceOperation', 'GammaDeviceOperation'])
+                : op,
+        );
+        renderGraph(operations);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unroll all repeats' }));
+        const unrolled = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+        deliver(operations, { expandedBlockIds: unrolled.expandedBlockIds });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show 3 device operations' }));
+        const withSubgraph = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+        expect(withSubgraph.deviceSubgraphs).toHaveLength(1);
+        expect(withSubgraph.deviceSubgraphs[0].operationId).toBe(2);
+
+        runBuild.mockClear();
+        fireEvent.click(screen.getByRole('button', { name: 'Fold all repeats' }));
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(
+            expect.objectContaining({ deviceSubgraphs: [], expandedBlockIds: [] }),
+        );
+    });
+});

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -34,6 +34,7 @@ const harness: {
     setNodes: ((updater: (previous: OpGraphFlowNode[]) => OpGraphFlowNode[]) => void) | null;
     setEdges: ((updater: (previous: OpGraphFlowEdge[]) => OpGraphFlowEdge[]) => void) | null;
     onNodeClick: ((event: unknown, node: OpGraphFlowNode) => void) | null;
+    onNodeDoubleClick: ((event: unknown, node: OpGraphFlowNode) => void) | null;
     onNodesChange: ((changes: NodeChange<OpGraphFlowNode>[]) => void) | null;
     // Left as `undefined` by the view when the overlay is off, which is the gating
     // a test can only see by reading the prop React Flow was actually handed.
@@ -44,6 +45,7 @@ const harness: {
     setNodes: null,
     setEdges: null,
     onNodeClick: null,
+    onNodeDoubleClick: null,
     onNodesChange: null,
     onNodeMouseEnter: undefined,
     onNodeMouseLeave: undefined,
@@ -86,6 +88,7 @@ vi.mock('@xyflow/react', async () => {
             edges,
             nodeTypes,
             onNodeClick,
+            onNodeDoubleClick,
             onNodesChange,
             onNodeMouseEnter,
             onNodeMouseLeave,
@@ -98,6 +101,7 @@ vi.mock('@xyflow/react', async () => {
                 (props: { id: string; data: OpGraphFlowNode['data']; type?: string }) => ReactNode
             >;
             onNodeClick: (event: unknown, node: OpGraphFlowNode) => void;
+            onNodeDoubleClick?: (event: unknown, node: OpGraphFlowNode) => void;
             onNodesChange: (changes: NodeChange<OpGraphFlowNode>[]) => void;
             onNodeMouseEnter?: (event: unknown, node: OpGraphFlowNode) => void;
             onNodeMouseLeave?: () => void;
@@ -105,6 +109,7 @@ vi.mock('@xyflow/react', async () => {
         }) => {
             flowRenders.push({ nodes, edges });
             harness.onNodeClick = onNodeClick;
+            harness.onNodeDoubleClick = onNodeDoubleClick ?? null;
             harness.onNodesChange = onNodesChange;
             harness.onNodeMouseEnter = onNodeMouseEnter;
             harness.onNodeMouseLeave = onNodeMouseLeave;
@@ -413,6 +418,7 @@ beforeEach(() => {
     harness.setNodes = null;
     harness.setEdges = null;
     harness.onNodeClick = null;
+    harness.onNodeDoubleClick = null;
     harness.onNodesChange = null;
     harness.onNodeMouseEnter = undefined;
     harness.onNodeMouseLeave = undefined;
@@ -1306,7 +1312,7 @@ describe('OperationGraphReactFlow repeat blocks', () => {
         });
 
         const panel = screen.getByLabelText('Selected block details');
-        expect(panel).toHaveTextContent('Block A × 2');
+        expect(panel).toHaveTextContent('model × 2');
         expect(panel).toHaveTextContent('ops 2–3 · instance 1 of 2');
         expect(screen.queryByRole('button', { name: /Memory Details/ })).toBeNull();
         expect(screen.queryByLabelText('Selected operation details')).toBeNull();
@@ -1349,5 +1355,97 @@ describe('OperationGraphReactFlow repeat blocks', () => {
         expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(
             expect.objectContaining({ deviceSubgraphs: [], expandedBlockIds: [] }),
         );
+    });
+
+    it('folds that instance when an unrolled member is double-clicked', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+        fireEvent.click(screen.getAllByRole('button', { name: 'Unroll 2 operations' })[0]);
+        const unrolled = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+        deliver(REPEAT_OPERATION_LIST, { expandedBlockIds: unrolled.expandedBlockIds });
+
+        runBuild.mockClear();
+        act(() => {
+            harness.onNodeDoubleClick?.(null, nodeById(lastFlowRender().nodes, '3'));
+        });
+
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ expandedBlockIds: [] }));
+    });
+
+    it('folds every instance and drops member device-op expansion when deallocate hiding changes', () => {
+        const operations = REPEAT_OPERATION_LIST.map((op) =>
+            op.id === 2
+                ? withDeviceOperations(op, ['AlphaDeviceOperation', 'BetaDeviceOperation', 'GammaDeviceOperation'])
+                : op,
+        );
+        renderGraph(operations);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unroll all repeats' }));
+        const unrolled = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+        deliver(operations, { expandedBlockIds: unrolled.expandedBlockIds });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show 3 device operations' }));
+        expect((runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions).deviceSubgraphs).toHaveLength(1);
+
+        runBuild.mockClear();
+        fireEvent.click(screen.getByLabelText('Hide deallocate ops'));
+
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(
+            expect.objectContaining({ hideDeallocate: false, deviceSubgraphs: [], expandedBlockIds: [] }),
+        );
+    });
+
+    it('unrolls the instance that contains the operation the URL names', () => {
+        const { rerender } = renderGraph(REPEAT_OPERATION_LIST);
+        runBuild.mockClear();
+
+        rerender(
+            <MemoryRouter>
+                <OperationGraphReactFlow
+                    operationList={REPEAT_OPERATION_LIST}
+                    operationId={3}
+                />
+            </MemoryRouter>,
+        );
+
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(
+            expect.objectContaining({ expandedBlockIds: [FIRST_BLOCK_ID] }),
+        );
+    });
+
+    it('forgets unrolled instances when the profiler report changes', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+        fireEvent.click(screen.getByRole('button', { name: 'Unroll all repeats' }));
+        expect((runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions).expandedBlockIds).toHaveLength(2);
+
+        runBuild.mockClear();
+        act(() => {
+            getDefaultStore().set(activeProfilerReportAtom, {
+                path: '/reports/resnet50',
+                reportName: 'resnet50',
+            } as ReportFolder);
+        });
+
+        expect(runBuild.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ expandedBlockIds: [] }));
+    });
+
+    it('keeps the selection on a folded block when the selected op is a non-first member', () => {
+        renderGraph(REPEAT_OPERATION_LIST);
+        fireEvent.click(screen.getAllByRole('button', { name: 'Unroll 2 operations' })[0]);
+        const unrolled = runBuild.mock.calls.at(-1)?.[0] as OpGraphBuildOptions;
+        deliver(REPEAT_OPERATION_LIST, { expandedBlockIds: unrolled.expandedBlockIds });
+
+        act(() => {
+            harness.onNodeClick?.(null, nodeById(lastFlowRender().nodes, '3'));
+        });
+        expect(screen.getByLabelText('Selected operation details')).toHaveTextContent('layer_b');
+
+        act(() => {
+            harness.onNodeDoubleClick?.(null, nodeById(lastFlowRender().nodes, '3'));
+        });
+        deliver(REPEAT_OPERATION_LIST, { expandedBlockIds: [] });
+
+        expect(screen.getByLabelText('Selected block details')).toHaveTextContent('model × 2');
+        expect(hasClass(nodeById(lastFlowRender().nodes, FIRST_BLOCK_ID), 'op-graph-node-selected')).toBe(true);
+        expect(hasClass(nodeById(lastFlowRender().nodes, '1'), 'op-graph-node-selected')).toBe(false);
     });
 });

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -491,7 +491,11 @@ describe('OperationGraphReactFlow rebuild triggers', () => {
         fireEvent.click(screen.getByLabelText('Hide deallocate ops'));
 
         expect(runBuild).toHaveBeenCalledTimes(1);
-        expect(runBuild).toHaveBeenLastCalledWith({ hideDeallocate: false, deviceSubgraphs: [] });
+        expect(runBuild).toHaveBeenLastCalledWith({
+            hideDeallocate: false,
+            deviceSubgraphs: [],
+            expandedBlockIds: [],
+        });
     });
 
     it('relayouts when the report changes', () => {

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -18,6 +18,7 @@ import type {
     OpGraphDeviceSubgraph,
     OpGraphFlowEdge,
     OpGraphFlowNode,
+    OpGraphSourceOperation,
 } from '../src/components/operation-graph/opGraphTypes';
 
 // A layout is the most expensive thing this view can do, and every cheap
@@ -41,8 +42,13 @@ const harness: {
     onNodeMouseEnter: ((event: unknown, node: OpGraphFlowNode) => void) | undefined;
     onNodeMouseLeave: (() => void) | undefined;
     onPaneClick: (() => void) | null;
+    // What the view actually derived from `operationList`. Builds run against this
+    // rather than a reimplementation, so a field the mapping stops carrying fails
+    // here instead of silently changing what detection fingerprints on.
+    sourceOperations: OpGraphSourceOperation[] | null;
 } = {
     onBuilt: null,
+    sourceOperations: null,
     setNodes: null,
     setEdges: null,
     onNodeClick: null,
@@ -61,6 +67,16 @@ const applyNodeChanges = vi.fn();
 // the store publishes, so a `subscribe` that never invoked its callback left both
 // the initial write and the subscription itself impossible to falsify.
 const flowTransform: { current: [number, number, number] } = { current: [0, 0, 1] };
+
+// Real spies rather than inert stubs: the viewport anchor is the mechanism this
+// branch extends, and it was unobservable. `knownNodeIds` is populated by every
+// delivered graph so `getNode` can tell a live id from a stale one. Hoisted
+// because the `@xyflow/react` factory below is, and it reads them eagerly.
+const { setCenter, setViewport, knownNodeIds } = vi.hoisted(() => ({
+    setCenter: vi.fn(() => Promise.resolve()),
+    setViewport: vi.fn(() => Promise.resolve()),
+    knownNodeIds: new Set<string>(),
+}));
 const flowStoreListeners = new Set<(state: { transform: [number, number, number] }) => void>();
 
 vi.mock('@xyflow/react', async () => {
@@ -70,10 +86,15 @@ vi.mock('@xyflow/react', async () => {
     // and an unstable one here would invalidate the callbacks whose stability the
     // rebuild effect depends on, quietly weakening every assertion below.
     const flowApi = {
-        setCenter: () => Promise.resolve(),
-        getNode: (id: string) => ({ id, position: { x: 0, y: 0 }, width: 100, height: 40 }),
+        setCenter,
+        // `undefined` for an id the graph does not hold, which is the whole point
+        // of the `nodeId ?? fallbackNodeId` fallback: the anchor id flips between a
+        // block id and its first member id across a fold, and a getNode that
+        // answered for any id at all made that fallback unfalsifiable.
+        getNode: (id: string) =>
+            knownNodeIds.has(id) ? { id, position: { x: 0, y: 0 }, width: 100, height: 40 } : undefined,
         getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
-        setViewport: () => Promise.resolve(),
+        setViewport,
     };
     // Stable like `flowApi`: the zoom effect lists the store as a dependency, so
     // a fresh object per render would resubscribe on every pass.
@@ -161,8 +182,15 @@ vi.mock('@xyflow/react', async () => {
 });
 
 vi.mock('../src/components/operation-graph/useOpGraphLayoutWorker', () => ({
-    useOpGraphLayoutWorker: (_operations: unknown, onBuilt: (graph: OpGraphBuiltGraph) => void) => {
-        harness.onBuilt = onBuilt;
+    useOpGraphLayoutWorker: (operations: OpGraphSourceOperation[], onBuilt: (graph: OpGraphBuiltGraph) => void) => {
+        harness.sourceOperations = operations;
+        harness.onBuilt = (graph) => {
+            knownNodeIds.clear();
+            for (const node of graph.nodes) {
+                knownNodeIds.add(node.id);
+            }
+            onBuilt(graph);
+        };
         return { runBuild, isBuilding: false };
     },
 }));
@@ -255,7 +283,12 @@ const renderGraph = (operations = OPERATION_LIST, perfRows?: PerfOverlaySource[]
     // The worker is stubbed, so the view only receives a graph when a test says
     // so; this is the reply the mount's own `runBuild` would have produced.
     act(() => {
-        harness.onBuilt?.(buildOpGraph(sourceFor(operations), { hideDeallocate: true, deviceSubgraphs: [] }));
+        harness.onBuilt?.(
+            buildOpGraph(harness.sourceOperations ?? sourceFor(operations), {
+                hideDeallocate: true,
+                deviceSubgraphs: [],
+            }),
+        );
     });
     return view;
 };
@@ -348,7 +381,12 @@ const deviceSubgraphFor = (operationId: number, producerId: number): OpGraphDevi
 // inject the graph this way so they don't depend on the click path.
 const rebuildWith = (operations: OperationDescription[], deviceSubgraphs: OpGraphDeviceSubgraph[]) => {
     act(() => {
-        harness.onBuilt?.(buildOpGraph(sourceFor(operations), { hideDeallocate: true, deviceSubgraphs }));
+        harness.onBuilt?.(
+            buildOpGraph(harness.sourceOperations ?? sourceFor(operations), {
+                hideDeallocate: true,
+                deviceSubgraphs,
+            }),
+        );
     });
 };
 
@@ -425,6 +463,10 @@ beforeEach(() => {
     vi.mocked(findCriticalPath).mockClear();
     flowRenders.length = 0;
     harness.onBuilt = null;
+    harness.sourceOperations = null;
+    setCenter.mockClear();
+    setViewport.mockClear();
+    knownNodeIds.clear();
     harness.setNodes = null;
     harness.setEdges = null;
     harness.onNodeClick = null;
@@ -1276,7 +1318,7 @@ describe('OperationGraphReactFlow repeat blocks', () => {
     const deliver = (operations: OperationDescription[], options: Partial<OpGraphBuildOptions> = {}) => {
         act(() => {
             harness.onBuilt?.(
-                buildOpGraph(sourceFor(operations), {
+                buildOpGraph(harness.sourceOperations ?? sourceFor(operations), {
                     hideDeallocate: true,
                     deviceSubgraphs: [],
                     ...options,
@@ -1284,6 +1326,39 @@ describe('OperationGraphReactFlow repeat blocks', () => {
             );
         });
     };
+
+    it('hands the worker every field detection fingerprints on', () => {
+        // The fixture used to reimplement this mapping and drop three of its
+        // fields, `inputShapes` among them — so every folding assertion in this
+        // file ran against a source shape production never emits, and deleting
+        // `inputShapes` from the real mapping would have over-folded live graphs
+        // with the suite green.
+        renderGraph(REPEAT_OPERATION_LIST);
+
+        const mapped = harness.sourceOperations;
+        expect(mapped).not.toBeNull();
+        expect(mapped).toHaveLength(REPEAT_OPERATION_LIST.length);
+        for (const mappedOperation of mapped ?? []) {
+            expect(mappedOperation.inputShapes).toBeDefined();
+            expect(mappedOperation).toHaveProperty('durationSeconds');
+            expect(mappedOperation).toHaveProperty('memoryDeltaBytes');
+        }
+    });
+
+    it('holds the viewport on an unroll instead of recentring on the selection', () => {
+        // The anchor and the selection tween fight for the viewport; the anchor
+        // has to win, or the graph jumps to whatever the selection fell back to.
+        // Both stubs were inert, so neither half of this was observable. #1944
+        renderGraph(REPEAT_OPERATION_LIST);
+        setCenter.mockClear();
+        setViewport.mockClear();
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Unroll 2 operations' })[0]);
+        deliver(REPEAT_OPERATION_LIST, { expandedBlockIds: [FIRST_BLOCK_ID] });
+
+        expect(setViewport).toHaveBeenCalledTimes(1);
+        expect(setCenter).not.toHaveBeenCalled();
+    });
 
     it('collapses repeats on first layout and offers Unroll / Fold', () => {
         renderGraph(REPEAT_OPERATION_LIST);

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -1096,23 +1096,23 @@ describe('OperationGraphReactFlow critical path rendering', () => {
 describe('OperationGraphReactFlow dim unrelated edges', () => {
     it('flags the container so the stylesheet can dim edges off the selection', () => {
         const { container } = renderGraph();
-        expect(container.querySelector('.op-graph-focus-edges')).toBeNull();
+        expect(container.querySelector('.op-graph-dim-unrelated-edges')).toBeNull();
 
         fireEvent.click(screen.getByLabelText('Dim unrelated edges'));
 
-        expect(container.querySelector('.op-graph-focus-edges')).not.toBeNull();
+        expect(container.querySelector('.op-graph-dim-unrelated-edges')).not.toBeNull();
     });
 
     it('drops the flag when nothing is selected', () => {
         const { container } = renderGraph();
         fireEvent.click(screen.getByLabelText('Dim unrelated edges'));
-        expect(container.querySelector('.op-graph-focus-edges')).not.toBeNull();
+        expect(container.querySelector('.op-graph-dim-unrelated-edges')).not.toBeNull();
 
         act(() => {
             harness.onPaneClick?.();
         });
 
-        expect(container.querySelector('.op-graph-focus-edges')).toBeNull();
+        expect(container.querySelector('.op-graph-dim-unrelated-edges')).toBeNull();
     });
 });
 

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -197,11 +197,16 @@ import type { ReportFolder } from '../src/definitions/Reports';
 
 const FILTER_DEBOUNCE_MS = 120;
 
-const operation = (id: number, name: string, consumers: number[]): OperationDescription =>
+const operation = (
+    id: number,
+    name: string,
+    consumers: number[],
+    fileIdentifier = `model.py:${id}`,
+): OperationDescription =>
     ({
         id,
         name,
-        operationFileIdentifier: `model.py:${id}`,
+        operationFileIdentifier: fileIdentifier,
         // Tensor ids matter once an operation expands: they are how an edge finds
         // the device operation at the far end of the boundary.
         outputs: [{ id: id * 10, shape: 'Shape([1, 32])', consumers }],
@@ -1295,8 +1300,24 @@ describe('OperationGraphReactFlow repeat blocks', () => {
         );
     });
 
-    it('counts buried filter matches on the collapsed node and in the counter', () => {
+    it('counts a folded block as a visible match when the query hits its label', () => {
         renderGraph(REPEAT_OPERATION_LIST);
+        typeFilter('layer_a');
+
+        expect(screen.getByText('2 matches')).toBeInTheDocument();
+        expect(screen.queryByText(/\+2 inside/)).toBeNull();
+    });
+
+    it('counts buried filter matches when the query hits a member but not the label', () => {
+        const operations: OperationDescription[] = [
+            operation(1, 'prefix', [2]),
+            operation(2, 'layer_a', [3], 'attention.py:1'),
+            operation(3, 'layer_b', [4], 'mlp.py:1'),
+            operation(4, 'layer_a', [5], 'attention.py:2'),
+            operation(5, 'layer_b', [6], 'mlp.py:2'),
+            operation(6, 'suffix', []),
+        ];
+        renderGraph(operations);
         typeFilter('layer_a');
 
         expect(screen.getByText('2 matches (+2 inside)')).toBeInTheDocument();
@@ -1312,7 +1333,7 @@ describe('OperationGraphReactFlow repeat blocks', () => {
         });
 
         const panel = screen.getByLabelText('Selected block details');
-        expect(panel).toHaveTextContent('model × 2');
+        expect(panel).toHaveTextContent('layer_a + layer_b × 2');
         expect(panel).toHaveTextContent('ops 2–3 · instance 1 of 2');
         expect(screen.queryByRole('button', { name: /Memory Details/ })).toBeNull();
         expect(screen.queryByLabelText('Selected operation details')).toBeNull();
@@ -1444,7 +1465,7 @@ describe('OperationGraphReactFlow repeat blocks', () => {
         });
         deliver(REPEAT_OPERATION_LIST, { expandedBlockIds: [] });
 
-        expect(screen.getByLabelText('Selected block details')).toHaveTextContent('model × 2');
+        expect(screen.getByLabelText('Selected block details')).toHaveTextContent('layer_a + layer_b × 2');
         expect(hasClass(nodeById(lastFlowRender().nodes, FIRST_BLOCK_ID), 'op-graph-node-selected')).toBe(true);
         expect(hasClass(nodeById(lastFlowRender().nodes, '1'), 'op-graph-node-selected')).toBe(false);
     });

--- a/tests/OperationGraphRebuildDiscipline.spec.tsx
+++ b/tests/OperationGraphRebuildDiscipline.spec.tsx
@@ -40,6 +40,7 @@ const harness: {
     // a test can only see by reading the prop React Flow was actually handed.
     onNodeMouseEnter: ((event: unknown, node: OpGraphFlowNode) => void) | undefined;
     onNodeMouseLeave: (() => void) | undefined;
+    onPaneClick: (() => void) | null;
 } = {
     onBuilt: null,
     setNodes: null,
@@ -49,6 +50,7 @@ const harness: {
     onNodesChange: null,
     onNodeMouseEnter: undefined,
     onNodeMouseLeave: undefined,
+    onPaneClick: null,
 };
 
 // What `useNodesState` hands the view as its change applier. Stable, because the
@@ -92,6 +94,7 @@ vi.mock('@xyflow/react', async () => {
             onNodesChange,
             onNodeMouseEnter,
             onNodeMouseLeave,
+            onPaneClick,
             children,
         }: {
             nodes: OpGraphFlowNode[];
@@ -105,6 +108,7 @@ vi.mock('@xyflow/react', async () => {
             onNodesChange: (changes: NodeChange<OpGraphFlowNode>[]) => void;
             onNodeMouseEnter?: (event: unknown, node: OpGraphFlowNode) => void;
             onNodeMouseLeave?: () => void;
+            onPaneClick?: () => void;
             children?: ReactNode;
         }) => {
             flowRenders.push({ nodes, edges });
@@ -113,6 +117,7 @@ vi.mock('@xyflow/react', async () => {
             harness.onNodesChange = onNodesChange;
             harness.onNodeMouseEnter = onNodeMouseEnter;
             harness.onNodeMouseLeave = onNodeMouseLeave;
+            harness.onPaneClick = onPaneClick ?? null;
             return createElement(
                 Fragment,
                 null,
@@ -427,6 +432,7 @@ beforeEach(() => {
     harness.onNodesChange = null;
     harness.onNodeMouseEnter = undefined;
     harness.onNodeMouseLeave = undefined;
+    harness.onPaneClick = null;
     flowTransform.current = [0, 0, 1];
     flowStoreListeners.clear();
     sessionStorage.clear();
@@ -1084,6 +1090,29 @@ describe('OperationGraphReactFlow critical path rendering', () => {
         expect(vi.mocked(findCriticalPath)).not.toHaveBeenCalled();
         // Still drawn: the point is that the answer was reused, not dropped.
         expect(hasClass(edgeBetween(lastFlowRender().edges, '1', '3'), 'op-graph-edge-critical-path')).toBe(true);
+    });
+});
+
+describe('OperationGraphReactFlow dim unrelated edges', () => {
+    it('flags the container so the stylesheet can dim edges off the selection', () => {
+        const { container } = renderGraph();
+        expect(container.querySelector('.op-graph-focus-edges')).toBeNull();
+
+        fireEvent.click(screen.getByLabelText('Dim unrelated edges'));
+
+        expect(container.querySelector('.op-graph-focus-edges')).not.toBeNull();
+    });
+
+    it('drops the flag when nothing is selected', () => {
+        const { container } = renderGraph();
+        fireEvent.click(screen.getByLabelText('Dim unrelated edges'));
+        expect(container.querySelector('.op-graph-focus-edges')).not.toBeNull();
+
+        act(() => {
+            harness.onPaneClick?.();
+        });
+
+        expect(container.querySelector('.op-graph-focus-edges')).toBeNull();
     });
 });
 

--- a/tests/math.spec.ts
+++ b/tests/math.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { nsToUs } from '../src/functions/math';
+import { nsToUs, sumOptional, tensorBytes } from '../src/functions/math';
 
 describe('nsToUs', () => {
     it('converts a nanosecond string to microseconds', () => {
@@ -25,5 +25,19 @@ describe('nsToUs', () => {
     it('returns null for non-numeric input instead of propagating NaN', () => {
         expect(nsToUs('   ')).toBeNull();
         expect(nsToUs('n/a')).toBeNull();
+    });
+});
+
+describe('sumOptional', () => {
+    it('adds finite numbers and skips the rest', () => {
+        expect(sumOptional([1, undefined, 2.5, Number.NaN, Number.POSITIVE_INFINITY])).toBe(3.5);
+        expect(sumOptional([])).toBe(0);
+    });
+});
+
+describe('tensorBytes', () => {
+    it('totals tensor sizes and counts an unknown size as zero', () => {
+        expect(tensorBytes([{ size: 512 }, { size: null }, { size: 1536 }])).toBe(2048);
+        expect(tensorBytes([])).toBe(0);
     });
 });

--- a/tests/opGraphBlockBoundary.spec.ts
+++ b/tests/opGraphBlockBoundary.spec.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { getBlockBoundaryTensors, withExternalEndpoints } from '../src/components/operation-graph/opGraphBlockBoundary';
+import { NodeRelation } from '../src/definitions/NodeRelation';
+import type { OperationDescription, Tensor } from '../src/model/APIData';
+
+const tensor = (overrides: Partial<Tensor> & { id: number }): Tensor =>
+    ({ shape: '[1, 32]', size: 128, ...overrides }) as unknown as Tensor;
+
+const member = (id: number, inputs: Tensor[], outputs: Tensor[]): OperationDescription =>
+    ({ id, name: `op_${id}`, inputs, outputs }) as unknown as OperationDescription;
+
+const MEMBERS = new Set([10, 11]);
+
+describe('withExternalEndpoints', () => {
+    it('keeps ids and names aligned when it drops an interior producer', () => {
+        // The pair is filtered together; filtering ids alone would shift every
+        // name by one and credit the tensor to the wrong operation.
+        const result = withExternalEndpoints(
+            tensor({ id: 1, producers: [10, 7, 11, 8], producerNames: ['m_a', 'outside_x', 'm_b', 'outside_y'] }),
+            MEMBERS,
+            NodeRelation.Input,
+        );
+
+        expect(result.producers).toEqual([7, 8]);
+        expect(result.producerNames).toEqual(['outside_x', 'outside_y']);
+    });
+
+    it('keeps ids and names aligned on the consumer side too', () => {
+        const result = withExternalEndpoints(
+            tensor({ id: 2, consumers: [10, 9, 11], consumerNames: ['m_a', 'outside_z', 'm_b'] }),
+            MEMBERS,
+            NodeRelation.Output,
+        );
+
+        expect(result.consumers).toEqual([9]);
+        expect(result.consumerNames).toEqual(['outside_z']);
+    });
+
+    it('substitutes an empty name rather than dropping an unnamed endpoint', () => {
+        // A short names array must not shorten the id list, or the two stop
+        // corresponding for every entry after the gap.
+        const result = withExternalEndpoints(
+            tensor({ id: 3, producers: [7, 8], producerNames: ['outside_x'] }),
+            MEMBERS,
+            NodeRelation.Input,
+        );
+
+        expect(result.producers).toEqual([7, 8]);
+        expect(result.producerNames).toEqual(['outside_x', '']);
+    });
+
+    it('tolerates a tensor with no endpoint arrays at all', () => {
+        const result = withExternalEndpoints(tensor({ id: 4 }), MEMBERS, NodeRelation.Input);
+
+        expect(result.producers).toEqual([]);
+        expect(result.producerNames).toEqual([]);
+    });
+
+    it('leaves the source tensor untouched', () => {
+        const source = tensor({ id: 5, producers: [10, 7], producerNames: ['m_a', 'outside_x'] });
+
+        withExternalEndpoints(source, MEMBERS, NodeRelation.Input);
+
+        expect(source.producers).toEqual([10, 7]);
+    });
+});
+
+describe('getBlockBoundaryTensors', () => {
+    it('drops a tensor whose every producer is inside the block', () => {
+        const internal = tensor({ id: 100, producers: [10], producerNames: ['m_a'] });
+        const crossing = tensor({ id: 101, producers: [7], producerNames: ['outside_x'] });
+
+        const result = getBlockBoundaryTensors(
+            [member(10, [internal], []), member(11, [crossing], [])],
+            MEMBERS,
+            NodeRelation.Input,
+        );
+
+        expect(result.map((entry) => entry.id)).toEqual([101]);
+    });
+
+    it('keeps a tensor with no producers at all as a graph input', () => {
+        const result = getBlockBoundaryTensors(
+            [member(10, [tensor({ id: 102, producers: [] })], [])],
+            MEMBERS,
+            NodeRelation.Input,
+        );
+
+        expect(result.map((entry) => entry.id)).toEqual([102]);
+    });
+
+    it('deduplicates a tensor two members both consume', () => {
+        const shared = tensor({ id: 103, producers: [7], producerNames: ['outside_x'] });
+
+        const result = getBlockBoundaryTensors(
+            [member(10, [shared], []), member(11, [shared], [])],
+            MEMBERS,
+            NodeRelation.Input,
+        );
+
+        expect(result).toHaveLength(1);
+    });
+
+    it('narrows the endpoints of what it keeps', () => {
+        const crossing = tensor({ id: 104, consumers: [10, 9], consumerNames: ['m_a', 'outside_z'] });
+
+        const result = getBlockBoundaryTensors([member(10, [], [crossing])], MEMBERS, NodeRelation.Output);
+
+        expect(result[0].consumers).toEqual([9]);
+        expect(result[0].consumerNames).toEqual(['outside_z']);
+    });
+
+    it('reads outputs rather than inputs in the output direction', () => {
+        const asInput = tensor({ id: 105, producers: [7], producerNames: ['outside_x'] });
+        const asOutput = tensor({ id: 106, consumers: [9], consumerNames: ['outside_z'] });
+
+        const result = getBlockBoundaryTensors([member(10, [asInput], [asOutput])], MEMBERS, NodeRelation.Output);
+
+        expect(result.map((entry) => entry.id)).toEqual([106]);
+    });
+});

--- a/tests/opGraphBlockMeta.spec.ts
+++ b/tests/opGraphBlockMeta.spec.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { formatBlockMeta } from '../src/components/operation-graph/opGraphBlockMeta';
+
+describe('formatBlockMeta', () => {
+    it('omits duration and memory when they are zero', () => {
+        expect(formatBlockMeta(3, 0, 0)).toBe('3 ops');
+    });
+
+    it('includes a signed memory delta when it is not zero', () => {
+        expect(formatBlockMeta(2, 1.5, 1024)).toContain('+');
+        expect(formatBlockMeta(2, 1.5, -1024)).toContain('-');
+    });
+});

--- a/tests/opGraphBuilder.spec.ts
+++ b/tests/opGraphBuilder.spec.ts
@@ -457,7 +457,7 @@ describe('buildOpGraph', () => {
             expect(summary).toBeDefined();
             expect(summary?.durationSeconds).toBe(2);
             expect(summary?.memoryDeltaBytes).toBe(1280);
-            expect(node.data.fileIdentifier).toBe(
+            expect(node.data.metaLine).toBe(
                 formatBlockMeta(
                     summary?.operationIds.length ?? 0,
                     summary?.durationSeconds ?? 0,
@@ -471,8 +471,10 @@ describe('buildOpGraph', () => {
             const first = nodeById(graph, FIRST_BLOCK_ID);
 
             expect(first.data.opCount).toBe(2);
-            expect(first.data.durationSeconds).toBe(2);
-            expect(first.data.memoryDeltaBytes).toBe(1280);
+            // The sums themselves are asserted on the block summary, which is now
+            // the single place they are derived; the node carries the formatted line.
+            expect(first.data.metaLine).toBe(formatBlockMeta(2, 2, 1280));
+            expect(first.data.fileIdentifier).toBe('');
             expect(first.data.memberNames).toEqual(['layer_a', 'layer_b']);
             expect(first.data.memberOperationIds).toEqual([2, 3]);
         });

--- a/tests/opGraphBuilder.spec.ts
+++ b/tests/opGraphBuilder.spec.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { getDeviceEdgeId, getDeviceNodeId } from '../src/components/operation-graph/opGraphDeviceSubgraph';
+import { formatBlockMeta } from '../src/components/operation-graph/opGraphBlockMeta';
 import { buildOpGraph } from '../src/components/operation-graph/opGraphBuilder';
 import {
     type OpGraphDeviceSubgraph,
@@ -443,6 +444,26 @@ describe('buildOpGraph', () => {
                 { id: '6', type: OpGraphNodeType.OP, operationId: 6 },
             ]);
             expect(graph.blocks?.map((block) => block.instanceId)).toEqual([FIRST_BLOCK_ID, SECOND_BLOCK_ID]);
+        });
+
+        it('gives the node and the block summary the same sums', () => {
+            // The node's meta line and the panel's stats rows are on screen at the
+            // same time; they were derived twice, by independent paths, so drift
+            // would have shown as the two disagreeing about one block.
+            const graph = build(REPEAT_CHAIN, false);
+            const node = nodeById(graph, FIRST_BLOCK_ID);
+            const summary = graph.blocks?.find((block) => block.instanceId === FIRST_BLOCK_ID);
+
+            expect(summary).toBeDefined();
+            expect(summary?.durationSeconds).toBe(2);
+            expect(summary?.memoryDeltaBytes).toBe(1280);
+            expect(node.data.fileIdentifier).toBe(
+                formatBlockMeta(
+                    summary?.operationIds.length ?? 0,
+                    summary?.durationSeconds ?? 0,
+                    summary?.memoryDeltaBytes ?? 0,
+                ),
+            );
         });
 
         it('sums duration and memory onto the collapsed node', () => {

--- a/tests/opGraphBuilder.spec.ts
+++ b/tests/opGraphBuilder.spec.ts
@@ -16,6 +16,8 @@ interface OperationSpec {
     name?: string;
     outputs?: { label?: string; consumers: number[]; tensorId?: number }[];
     deviceOperationCount?: number;
+    durationSeconds?: number;
+    memoryDeltaBytes?: number;
 }
 
 const operation = ({
@@ -23,6 +25,8 @@ const operation = ({
     name = `ttnn.op${id}`,
     outputs = [],
     deviceOperationCount = 0,
+    durationSeconds,
+    memoryDeltaBytes,
 }: OperationSpec): OpGraphSourceOperation => ({
     id,
     name,
@@ -33,6 +37,8 @@ const operation = ({
         tensorId: tensorId + index,
     })),
     deviceOperationCount,
+    durationSeconds,
+    memoryDeltaBytes,
 });
 
 const build = (operations: OpGraphSourceOperation[], hideDeallocate: boolean) =>
@@ -396,6 +402,121 @@ describe('buildOpGraph', () => {
             const none = build([operation({ id: 1, outputs: [{ consumers: [2] }] })], false).nodes[0];
 
             expect(single.width).toBe(none.width);
+        });
+    });
+
+    describe('repeat blocks', () => {
+        const REPEAT_CHAIN = [
+            operation({ id: 1, name: 'prefix', outputs: [{ consumers: [2] }] }),
+            operation({
+                id: 2,
+                name: 'layer_a',
+                outputs: [{ consumers: [3] }],
+                durationSeconds: 1.5,
+                memoryDeltaBytes: 1024,
+            }),
+            operation({
+                id: 3,
+                name: 'layer_b',
+                outputs: [{ consumers: [4] }],
+                durationSeconds: 0.5,
+                memoryDeltaBytes: 256,
+            }),
+            operation({ id: 4, name: 'layer_a', outputs: [{ consumers: [5] }] }),
+            operation({ id: 5, name: 'layer_b', outputs: [{ consumers: [6] }] }),
+            operation({ id: 6, name: 'suffix' }),
+        ];
+
+        const FIRST_BLOCK_ID = 'block:0:2';
+        const SECOND_BLOCK_ID = 'block:0:4';
+
+        const typesOf = (graph: ReturnType<typeof buildOpGraph>) =>
+            graph.nodes.map((node) => ({ id: node.id, type: node.type, operationId: node.data.operationId }));
+
+        it('replaces each collapsed copy with a block node and hides the members', () => {
+            const graph = build(REPEAT_CHAIN, false);
+
+            expect(typesOf(graph)).toEqual([
+                { id: '1', type: OpGraphNodeType.OP, operationId: 1 },
+                { id: FIRST_BLOCK_ID, type: OpGraphNodeType.BLOCK, operationId: 2 },
+                { id: SECOND_BLOCK_ID, type: OpGraphNodeType.BLOCK, operationId: 4 },
+                { id: '6', type: OpGraphNodeType.OP, operationId: 6 },
+            ]);
+            expect(graph.blocks?.map((block) => block.instanceId)).toEqual([FIRST_BLOCK_ID, SECOND_BLOCK_ID]);
+        });
+
+        it('sums duration and memory onto the collapsed node', () => {
+            const graph = build(REPEAT_CHAIN, false);
+            const first = nodeById(graph, FIRST_BLOCK_ID);
+
+            expect(first.data.opCount).toBe(2);
+            expect(first.data.durationSeconds).toBe(2);
+            expect(first.data.memoryDeltaBytes).toBe(1280);
+            expect(first.data.memberNames).toEqual(['layer_a', 'layer_b']);
+            expect(first.data.memberOperationIds).toEqual([2, 3]);
+        });
+
+        it('reroutes crossing edges onto the block and drops edges inside it', () => {
+            const graph = build(REPEAT_CHAIN, false);
+
+            expect(edgeBetweenOperations(graph, 1, 2).source).toBe('1');
+            expect(edgeBetweenOperations(graph, 1, 2).target).toBe(FIRST_BLOCK_ID);
+            expect(edgeBetweenOperations(graph, 3, 4).source).toBe(FIRST_BLOCK_ID);
+            expect(edgeBetweenOperations(graph, 3, 4).target).toBe(SECOND_BLOCK_ID);
+            expect(edgeBetweenOperations(graph, 5, 6).source).toBe(SECOND_BLOCK_ID);
+            expect(
+                graph.edges.find((edge) => edge.data?.sourceOperationId === 2 && edge.data?.targetOperationId === 3),
+            ).toBeUndefined();
+        });
+
+        it('restores the members when that instance is unrolled', () => {
+            const graph = buildOpGraph(REPEAT_CHAIN, {
+                hideDeallocate: false,
+                deviceSubgraphs: [],
+                expandedBlockIds: [FIRST_BLOCK_ID],
+            });
+
+            expect(typesOf(graph)).toEqual([
+                { id: '1', type: OpGraphNodeType.OP, operationId: 1 },
+                { id: '2', type: OpGraphNodeType.OP, operationId: 2 },
+                { id: '3', type: OpGraphNodeType.OP, operationId: 3 },
+                { id: SECOND_BLOCK_ID, type: OpGraphNodeType.BLOCK, operationId: 4 },
+                { id: '6', type: OpGraphNodeType.OP, operationId: 6 },
+            ]);
+            expect(edgeBetweenOperations(graph, 1, 2).target).toBe('2');
+            expect(edgeBetweenOperations(graph, 3, 4).target).toBe(SECOND_BLOCK_ID);
+        });
+
+        it('does not expand device operations for a member still inside a collapsed block', () => {
+            const graph = buildOpGraph(REPEAT_CHAIN, {
+                hideDeallocate: false,
+                deviceSubgraphs: [deviceSubgraph({ operationId: 2 })],
+            });
+
+            expect(graph.nodes.some((node) => node.type === OpGraphNodeType.DEVICE_GROUP)).toBe(false);
+            expect(graph.nodes.some((node) => node.type === OpGraphNodeType.DEVICE_OP)).toBe(false);
+            expect(nodeById(graph, FIRST_BLOCK_ID).type).toBe(OpGraphNodeType.BLOCK);
+        });
+
+        it('detects a repeat that only becomes contiguous once deallocate ops are hidden', () => {
+            const withDeallocate = [
+                operation({ id: 1, name: 'layer_a', outputs: [{ consumers: [2] }] }),
+                operation({ id: 2, name: 'layer_b', outputs: [{ consumers: [3] }] }),
+                operation({
+                    id: 3,
+                    name: 'ttnn.deallocate',
+                    outputs: [{ consumers: [4] }],
+                }),
+                operation({ id: 4, name: 'layer_a', outputs: [{ consumers: [5] }] }),
+                operation({ id: 5, name: 'layer_b', outputs: [{ consumers: [6] }] }),
+                operation({ id: 6, name: 'suffix' }),
+            ];
+
+            expect(build(withDeallocate, false).nodes.every((node) => node.type === OpGraphNodeType.OP)).toBe(true);
+
+            const hidden = build(withDeallocate, true);
+            expect(hidden.nodes.filter((node) => node.type === OpGraphNodeType.BLOCK)).toHaveLength(2);
+            expect(hidden.nodes.some((node) => node.data.filterString === 'ttnn.deallocate')).toBe(false);
         });
     });
 });

--- a/tests/opGraphBuilder.spec.ts
+++ b/tests/opGraphBuilder.spec.ts
@@ -487,6 +487,44 @@ describe('buildOpGraph', () => {
             expect(edgeBetweenOperations(graph, 3, 4).target).toBe(SECOND_BLOCK_ID);
         });
 
+        it('draws one unlabelled edge between a folded pair, regardless of tensor count', () => {
+            const twoTensors = [
+                operation({
+                    id: 1,
+                    name: 'layer_a',
+                    outputs: [
+                        { label: '[1, 32]', consumers: [2, 3] },
+                        { label: '[1, 64]', consumers: [3] },
+                    ],
+                }),
+                operation({
+                    id: 2,
+                    name: 'layer_b',
+                    outputs: [{ consumers: [3] }],
+                }),
+                operation({
+                    id: 3,
+                    name: 'layer_a',
+                    outputs: [
+                        { label: '[1, 32]', consumers: [4, 5] },
+                        { label: '[1, 64]', consumers: [5] },
+                    ],
+                }),
+                operation({
+                    id: 4,
+                    name: 'layer_b',
+                    outputs: [{ consumers: [5] }],
+                }),
+                operation({ id: 5, name: 'suffix' }),
+            ];
+            const graph = build(twoTensors, false);
+            const between = graph.edges.filter((edge) => edge.source === 'block:0:1' && edge.target === 'block:0:3');
+
+            expect(between).toHaveLength(1);
+            expect(between[0].label).toBeUndefined();
+            expect(between[0].data?.parallelIndex).toBe(0);
+        });
+
         it('does not expand device operations for a member still inside a collapsed block', () => {
             const graph = buildOpGraph(REPEAT_CHAIN, {
                 hideDeallocate: false,

--- a/tests/opGraphCriticalPath.spec.ts
+++ b/tests/opGraphCriticalPath.spec.ts
@@ -22,6 +22,7 @@ describe('findCriticalPath', () => {
         const path = findCriticalPath(nodes(1, 2, 3), edges([1, 2], [2, 3]), weights([1, 100], [2, 200], [3, 300]));
 
         expect(path.opIds).toEqual([1, 2, 3]);
+        expect(path.opCount).toBe(3);
         expect(path.totalNs).toBe(600);
         expect([...path.edgeIds]).toEqual(expect.arrayContaining([edgeId(1, 2), edgeId(2, 3)]));
         expect(path.hasCycle).toBe(false);
@@ -169,5 +170,25 @@ describe('findCriticalPath', () => {
         expect(path.edgeIds.size).toBe(0);
         expect(path.totalNs).toBe(0);
         expect(path.hasCycle).toBe(false);
+        expect(path.opCount).toBe(0);
+    });
+
+    it('weights a folded block by the sum of its members', () => {
+        const path = findCriticalPath(
+            [
+                { id: '1', operationId: 1 },
+                { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3, 4] },
+                { id: '5', operationId: 5 },
+            ],
+            [
+                { id: '1-2-0', source: '1', target: 'block:0:2' },
+                { id: '2-5-0', source: 'block:0:2', target: '5' },
+            ],
+            weights([1, 10], [2, 100], [3, 100], [4, 100], [5, 10]),
+        );
+
+        expect(path.nodeIds.has('block:0:2')).toBe(true);
+        expect(path.totalNs).toBe(320);
+        expect(path.opCount).toBe(5);
     });
 });

--- a/tests/opGraphLayout.spec.ts
+++ b/tests/opGraphLayout.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
     type LayoutInputEdge,
     type LayoutInputNode,
+    estimateBlockNodeSize,
     estimateOpNodeSize,
     layoutOpGraph,
 } from '../src/components/operation-graph/opGraphLayout';
@@ -73,6 +74,19 @@ describe('estimateOpNodeSize', () => {
 
     it('keeps the height independent of how long either line is', () => {
         expect(estimateOpNodeSize(LONG, LONG).height).toBe(estimateOpNodeSize('op', 'a.py:1').height);
+    });
+});
+
+describe('estimateBlockNodeSize', () => {
+    it('is taller than an op node so the meta line has a row of its own', () => {
+        expect(estimateBlockNodeSize('Block A × 2', '2 ops').height).toBeGreaterThan(
+            estimateOpNodeSize('Block A × 2', '2 ops').height,
+        );
+    });
+
+    it('reserves the fold chip after the label hits the maximum width', () => {
+        const label = 'x'.repeat(400);
+        expect(estimateBlockNodeSize(label, '2 ops').width).toBeGreaterThan(estimateOpNodeSize(label, '2 ops').width);
     });
 });
 

--- a/tests/opGraphLayout.spec.ts
+++ b/tests/opGraphLayout.spec.ts
@@ -8,7 +8,6 @@ import {
     type LayoutInputNode,
     estimateBlockNodeSize,
     estimateOpNodeSize,
-    formatBlockMeta,
     layoutOpGraph,
 } from '../src/components/operation-graph/opGraphLayout';
 
@@ -90,17 +89,6 @@ describe('estimateBlockNodeSize', () => {
         expect(estimateBlockNodeSize(label, '2 ops').width).toBeGreaterThan(
             estimateOpNodeSize(label, '2 ops', true).width,
         );
-    });
-});
-
-describe('formatBlockMeta', () => {
-    it('omits duration and memory when they are zero', () => {
-        expect(formatBlockMeta(3, 0, 0)).toBe('3 ops');
-    });
-
-    it('includes a signed memory delta when it is not zero', () => {
-        expect(formatBlockMeta(2, 1.5, 1024)).toContain('+');
-        expect(formatBlockMeta(2, 1.5, -1024)).toContain('-');
     });
 });
 

--- a/tests/opGraphLayout.spec.ts
+++ b/tests/opGraphLayout.spec.ts
@@ -8,6 +8,7 @@ import {
     type LayoutInputNode,
     estimateBlockNodeSize,
     estimateOpNodeSize,
+    formatBlockMeta,
     layoutOpGraph,
 } from '../src/components/operation-graph/opGraphLayout';
 
@@ -84,9 +85,22 @@ describe('estimateBlockNodeSize', () => {
         );
     });
 
-    it('reserves the fold chip after the label hits the maximum width', () => {
+    it('reserves a wider chip than the device-op badge after the label hits the cap', () => {
         const label = 'x'.repeat(400);
-        expect(estimateBlockNodeSize(label, '2 ops').width).toBeGreaterThan(estimateOpNodeSize(label, '2 ops').width);
+        expect(estimateBlockNodeSize(label, '2 ops').width).toBeGreaterThan(
+            estimateOpNodeSize(label, '2 ops', true).width,
+        );
+    });
+});
+
+describe('formatBlockMeta', () => {
+    it('omits duration and memory when they are zero', () => {
+        expect(formatBlockMeta(3, 0, 0)).toBe('3 ops');
+    });
+
+    it('includes a signed memory delta when it is not zero', () => {
+        expect(formatBlockMeta(2, 1.5, 1024)).toContain('+');
+        expect(formatBlockMeta(2, 1.5, -1024)).toContain('-');
     });
 });
 

--- a/tests/opGraphLayoutWorker.spec.ts
+++ b/tests/opGraphLayoutWorker.spec.ts
@@ -78,12 +78,14 @@ const build = (
     hideDeallocate: boolean,
     sourceVersion = 1,
     deviceSubgraphs: OpGraphDeviceSubgraph[] = [],
+    expandedBlockIds: readonly string[] = [],
 ): OpGraphWorkerInboundMessage => ({
     type: OpGraphWorkerMessageType.BUILD,
     sourceVersion,
     requestId,
     hideDeallocate,
     deviceSubgraphs,
+    expandedBlockIds,
 });
 
 const builtReplies = () => posted.filter((message) => message.type === OpGraphWorkerMessageType.BUILT);
@@ -251,6 +253,60 @@ describe('opGraphLayoutWorker', () => {
             drain();
 
             expect(buildOpGraph).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not serve a folded layout to an unrolled graph', async () => {
+            const send = await loadWorker();
+            send(setGraph(1));
+
+            send(build(1, true));
+            drain();
+            send(build(2, true, 1, [], ['block:0:2']));
+            drain();
+
+            expect(buildOpGraph).toHaveBeenCalledTimes(2);
+            const replies = builtReplies();
+            expect(replies[1].graph).not.toBe(replies[0].graph);
+        });
+
+        it('tells one unrolled set from another', async () => {
+            const send = await loadWorker();
+            send(setGraph(1));
+
+            send(build(1, true, 1, [], ['block:0:2']));
+            drain();
+            send(build(2, true, 1, [], ['block:0:2', 'block:0:4']));
+            drain();
+
+            expect(buildOpGraph).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not lay out again because two block ids arrived in a different order', async () => {
+            const send = await loadWorker();
+            send(setGraph(1));
+
+            send(build(1, true, 1, [], ['block:0:2', 'block:0:4']));
+            drain();
+            send(build(2, true, 1, [], ['block:0:4', 'block:0:2']));
+            drain();
+
+            expect(buildOpGraph).toHaveBeenCalledTimes(1);
+        });
+
+        it('serves a fold back to a set it has already laid out', async () => {
+            const send = await loadWorker();
+            send(setGraph(1));
+
+            send(build(1, true, 1, [], ['block:0:2']));
+            drain();
+            send(build(2, true, 1, [], ['block:0:4']));
+            drain();
+            send(build(3, true, 1, [], ['block:0:2']));
+            drain();
+
+            expect(buildOpGraph).toHaveBeenCalledTimes(2);
+            const replies = builtReplies();
+            expect(replies[2].graph).toBe(replies[0].graph);
         });
 
         it('does not serve one report\u2019s layout for another', async () => {

--- a/tests/opGraphLayoutWorker.spec.ts
+++ b/tests/opGraphLayoutWorker.spec.ts
@@ -20,8 +20,13 @@ const buildOpGraph = vi.hoisted(() =>
     vi.fn<(operations: OpGraphSourceOperation[], options: OpGraphBuildOptions) => OpGraphBuiltGraph>(),
 );
 
+// `collectCandidateEdges` is counted, not stubbed away: the worker is supposed to
+// run it once per source and share the result between detection and the build.
+const collectCandidateEdges = vi.fn(() => []);
+
 vi.mock('../src/components/operation-graph/opGraphBuilder', () => ({
     buildOpGraph,
+    collectCandidateEdges,
     getKeptOperations: (operations: OpGraphSourceOperation[]) => operations,
 }));
 
@@ -98,6 +103,7 @@ const drain = () => vi.advanceTimersByTime(0);
 beforeEach(() => {
     posted.length = 0;
     buildOpGraph.mockReset();
+    collectCandidateEdges.mockClear();
     // A fresh object per layout, so object identity distinguishes a cache hit
     // from a rebuild that happens to produce an equal graph.
     buildOpGraph.mockImplementation(() => ({ nodes: [], edges: [] }));
@@ -322,6 +328,43 @@ describe('opGraphLayoutWorker', () => {
             expect(buildOpGraph).toHaveBeenCalledTimes(2);
             const replies = builtReplies();
             expect(replies[2].graph).toBe(replies[0].graph);
+        });
+
+        it('does not reuse one report’s detection for another', async () => {
+            // The detection cache was keyed on `hideDeallocate` alone and relied
+            // entirely on the SET_GRAPH clear. If that clear is ever moved or
+            // missed, report B folds using report A’s instances, whose member op
+            // ids exist in B but mean unrelated operations.
+            const send = await loadWorker();
+            send(setGraph(1));
+            send(build(1, true));
+            drain();
+
+            send(setGraph(2));
+            send(build(2, true, 2));
+            drain();
+
+            expect(buildOpGraph.mock.calls[1][1].detectedBlocks).not.toBe(buildOpGraph.mock.calls[0][1].detectedBlocks);
+        });
+
+        it('collects candidate edges once per source, not once per build', async () => {
+            // An ops x outputs x consumers walk that detection and the build both
+            // need; it ran two to three times per build before.
+            const send = await loadWorker();
+            send(setGraph(1));
+
+            send(build(1, true));
+            drain();
+            send(build(2, true, 1, [], ['block:0:2']));
+            drain();
+
+            expect(collectCandidateEdges).toHaveBeenCalledTimes(1);
+
+            send(setGraph(2));
+            send(build(3, true, 2));
+            drain();
+
+            expect(collectCandidateEdges).toHaveBeenCalledTimes(2);
         });
 
         it('does not serve one report\u2019s layout for another', async () => {

--- a/tests/opGraphLayoutWorker.spec.ts
+++ b/tests/opGraphLayoutWorker.spec.ts
@@ -20,7 +20,10 @@ const buildOpGraph = vi.hoisted(() =>
     vi.fn<(operations: OpGraphSourceOperation[], options: OpGraphBuildOptions) => OpGraphBuiltGraph>(),
 );
 
-vi.mock('../src/components/operation-graph/opGraphBuilder', () => ({ buildOpGraph }));
+vi.mock('../src/components/operation-graph/opGraphBuilder', () => ({
+    buildOpGraph,
+    getKeptOperations: (operations: OpGraphSourceOperation[]) => operations,
+}));
 
 const OPERATIONS: OpGraphSourceOperation[] = [
     {
@@ -291,6 +294,18 @@ describe('opGraphLayoutWorker', () => {
             drain();
 
             expect(buildOpGraph).toHaveBeenCalledTimes(1);
+        });
+
+        it('reuses the same detection across fold and unroll', async () => {
+            const send = await loadWorker();
+            send(setGraph(1));
+
+            send(build(1, true));
+            drain();
+            send(build(2, true, 1, [], ['block:0:2']));
+            drain();
+
+            expect(buildOpGraph.mock.calls[0][1].detectedBlocks).toBe(buildOpGraph.mock.calls[1][1].detectedBlocks);
         });
 
         it('serves a fold back to a set it has already laid out', async () => {

--- a/tests/opGraphNavigation.spec.ts
+++ b/tests/opGraphNavigation.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+
+import { getAdjacentOperationIds } from '../src/components/operation-graph/opGraphNavigation';
+import type { OpGraphNodeIndexEntry } from '../src/components/operation-graph/opGraphTypes';
+
+const entry = (operationId: number, memberOperationIds?: number[]): OpGraphNodeIndexEntry => ({
+    id: memberOperationIds ? `block:0:${operationId}` : String(operationId),
+    operationId,
+    name: `op ${operationId}`,
+    memberOperationIds,
+});
+
+describe('getAdjacentOperationIds', () => {
+    it('steps either side of a plain operation', () => {
+        const nodeIndex = [entry(1), entry(2), entry(3)];
+
+        expect(getAdjacentOperationIds(nodeIndex, 2)).toEqual({ previousOperationId: 1, nextOperationId: 3 });
+    });
+
+    it('returns null past each end rather than wrapping', () => {
+        const nodeIndex = [entry(1), entry(2)];
+
+        expect(getAdjacentOperationIds(nodeIndex, 1).previousOperationId).toBeNull();
+        expect(getAdjacentOperationIds(nodeIndex, 2).nextOperationId).toBeNull();
+    });
+
+    it('finds a folded block by a member that is not its representative (#1944)', () => {
+        // Selecting op 3 and folding [2, 3] keeps the selection on 3, but the
+        // block indexes under 2 — an exact-id lookup missed it and `next` jumped
+        // back to the graph's first node.
+        const nodeIndex = [entry(1), entry(2, [2, 3]), entry(4)];
+
+        expect(getAdjacentOperationIds(nodeIndex, 3)).toEqual({ previousOperationId: 1, nextOperationId: 4 });
+    });
+
+    it('treats the block representative and its members alike', () => {
+        const nodeIndex = [entry(1), entry(2, [2, 3, 4]), entry(5)];
+
+        expect(getAdjacentOperationIds(nodeIndex, 2)).toEqual(getAdjacentOperationIds(nodeIndex, 4));
+    });
+
+    it('offers the first node when the selection is absent or empty', () => {
+        const nodeIndex = [entry(7), entry(8)];
+
+        expect(getAdjacentOperationIds(nodeIndex, 99)).toEqual({ previousOperationId: null, nextOperationId: 7 });
+        expect(getAdjacentOperationIds(nodeIndex, null)).toEqual({ previousOperationId: null, nextOperationId: 7 });
+        expect(getAdjacentOperationIds([], 1)).toEqual({ previousOperationId: null, nextOperationId: null });
+    });
+});

--- a/tests/opGraphNodeStyles.spec.ts
+++ b/tests/opGraphNodeStyles.spec.ts
@@ -140,3 +140,17 @@ describe('op graph critical path styling', () => {
         expect(outlineOffset).toBeGreaterThan(ringWidth);
     });
 });
+
+describe('block meta line styling', () => {
+    it('shares the file line’s declarations so moving off fileIdentifier changed nothing visible', () => {
+        // A block has no source file, so its stats line moved off `fileIdentifier`
+        // and onto `metaLine` with a class of its own. The two must stay styled
+        // together or that rename becomes a visual change. #1944
+        const body = ruleBody('.op-graph-node-file,\n    .op-graph-node-meta');
+
+        expect(body).toMatch(/text-overflow:\s*ellipsis/);
+        expect(body).toMatch(/white-space:\s*nowrap/);
+        expect(body).toMatch(/overflow:\s*hidden/);
+        expect(body).toMatch(/font-size:\s*11px/);
+    });
+});

--- a/tests/opGraphNodeStyles.spec.ts
+++ b/tests/opGraphNodeStyles.spec.ts
@@ -95,6 +95,11 @@ describe('op graph critical path styling', () => {
         expect(STYLESHEET).toContain(OFF_PATH_DIM_SELECTOR);
     });
 
+    it('shares the off-path dim with dim-unrelated-edges', () => {
+        expect(STYLESHEET).toContain('&.op-graph-focus-edges:not(.op-graph-filtering)');
+        expect(ruleBody(OFF_PATH_DIM_SELECTOR)).toMatch(/opacity:\s*0\.35/);
+    });
+
     it('exempts the selected node′s own edges from the off-path dim', () => {
         // Clicking a node to read its inputs and outputs would otherwise fade
         // whichever of them sit off the path. Read out of the `:not()` arguments
@@ -105,8 +110,7 @@ describe('op graph critical path styling', () => {
             .map((selector) => selector.trim());
 
         // The path's own edges first: dropping this member dims the feature's
-        // central visual to 0.35 along with everything it was meant to stand out
-        // from.
+        // central visual along with everything it was meant to stand out from.
         expect(exclusions).toContain('.op-graph-edge-critical-path');
         expect(exclusions).toContain('.op-graph-edge-input');
         expect(exclusions).toContain('.op-graph-edge-output');

--- a/tests/opGraphNodeStyles.spec.ts
+++ b/tests/opGraphNodeStyles.spec.ts
@@ -96,7 +96,7 @@ describe('op graph critical path styling', () => {
     });
 
     it('shares the off-path dim with dim-unrelated-edges', () => {
-        expect(STYLESHEET).toContain('&.op-graph-focus-edges:not(.op-graph-filtering)');
+        expect(STYLESHEET).toContain('&.op-graph-dim-unrelated-edges:not(.op-graph-filtering)');
         expect(ruleBody(OFF_PATH_DIM_SELECTOR)).toMatch(/opacity:\s*0\.35/);
     });
 

--- a/tests/opGraphPerfOverlay.spec.ts
+++ b/tests/opGraphPerfOverlay.spec.ts
@@ -173,6 +173,18 @@ describe('buildPerfNodeStyleByNodeId', () => {
         expect(customProps(styleByNodeId?.get('1'))[PERF_BAR_SCALE_VAR]).toBe(0);
     });
 
+    it('keys a folded block by its node id using the summed member times', () => {
+        const blockOverlay = buildOpGraphPerfOverlay(rows([1, 10], [2, 1_000], [3, 1_000]), true, [1, 2, 3]);
+        const styleByNodeId = buildPerfNodeStyleByNodeId(blockOverlay, true, [
+            { id: '1', operationId: 1 },
+            { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3] },
+        ]);
+
+        expect(styleByNodeId?.has('block:0:2')).toBe(true);
+        expect(styleByNodeId?.has('2')).toBe(false);
+        expect(customProps(styleByNodeId?.get('block:0:2'))[PERF_BAR_SCALE_VAR]).toBe(1);
+    });
+
     it('colours the bar with the same ramp the side panel swatch uses', () => {
         // The panel swatch is `perfColorScale(score.t)` too, so a divergence
         // shows up as a node and its own detail panel disagreeing.

--- a/tests/opGraphPerfOverlay.spec.ts
+++ b/tests/opGraphPerfOverlay.spec.ts
@@ -9,9 +9,8 @@ import {
     PERF_BAR_COLOR_VAR,
     PERF_BAR_SCALE_VAR,
     buildOpGraphPerfOverlay,
-    buildPerfNodeStyleByNodeId,
+    buildRenderedPerfStyling,
     getPerfHoverLabel,
-    getRenderedPerfRange,
 } from '../src/components/operation-graph/opGraphPerfOverlay';
 import { NO_PERF_DATA_LABEL, PerfOverlayStatus } from '../src/definitions/PerfOverlayStatus';
 import { formatDuration } from '../src/functions/formatting';
@@ -133,8 +132,17 @@ describe('buildOpGraphPerfOverlay ranking', () => {
     });
 });
 
-describe('buildPerfNodeStyleByNodeId', () => {
+describe('buildRenderedPerfStyling', () => {
     const overlay = buildOpGraphPerfOverlay(rows([1, 10], [2, 1_000]), true, [1, 2, 3]);
+
+    // The graph always renders one node per unfolded op, so these stand in for what
+    // the component actually passes. The no-nodes overload this spec used to lean
+    // on was unreachable in production. #1944
+    const PLAIN_NODES = [
+        { id: '1', operationId: 1 },
+        { id: '2', operationId: 2 },
+        { id: '3', operationId: 3 },
+    ];
 
     // `CSSProperties` has no index signature for custom properties.
     const customProps = (style: CSSProperties | undefined): Record<string, unknown> =>
@@ -143,19 +151,19 @@ describe('buildPerfNodeStyleByNodeId', () => {
     it('produces nothing at all when the overlay is off', () => {
         // `null`, not an empty map, so the styling pass can return the node
         // array by identity instead of rebuilding it.
-        expect(buildPerfNodeStyleByNodeId(overlay, false)).toBeNull();
+        expect(buildRenderedPerfStyling(overlay, false, PLAIN_NODES)).toBeNull();
     });
 
     it('writes only the two custom properties, leaving fill and border alone', () => {
         // Background is the I/O highlight and border/box-shadow are selection,
         // so perf must not reach for a single standard property. #1880
-        const style = buildPerfNodeStyleByNodeId(overlay, true)?.get('2');
+        const style = buildRenderedPerfStyling(overlay, true, PLAIN_NODES)?.styleByNodeId.get('2');
 
         expect(Object.keys(style ?? {})).toEqual([PERF_BAR_SCALE_VAR, PERF_BAR_COLOR_VAR]);
     });
 
     it('keys by node id so the styling pass can look up without a conversion', () => {
-        const styleByNodeId = buildPerfNodeStyleByNodeId(overlay, true);
+        const styleByNodeId = buildRenderedPerfStyling(overlay, true, PLAIN_NODES)?.styleByNodeId;
 
         expect(styleByNodeId?.has('1')).toBe(true);
         expect(styleByNodeId?.has('2')).toBe(true);
@@ -164,11 +172,11 @@ describe('buildPerfNodeStyleByNodeId', () => {
     it('skips an op with no perf row, leaving its bar transparent', () => {
         // Op 3 is on the canvas but absent from the report, so the CSS fallback
         // paints nothing — which is what separates it from the fastest op.
-        expect(buildPerfNodeStyleByNodeId(overlay, true)?.has('3')).toBe(false);
+        expect(buildRenderedPerfStyling(overlay, true, PLAIN_NODES)?.styleByNodeId.has('3')).toBe(false);
     });
 
     it('puts the slowest visible op at the hot end of the ramp', () => {
-        const styleByNodeId = buildPerfNodeStyleByNodeId(overlay, true);
+        const styleByNodeId = buildRenderedPerfStyling(overlay, true, PLAIN_NODES)?.styleByNodeId;
 
         expect(customProps(styleByNodeId?.get('2'))[PERF_BAR_SCALE_VAR]).toBe(1);
         expect(customProps(styleByNodeId?.get('1'))[PERF_BAR_SCALE_VAR]).toBe(0);
@@ -176,12 +184,12 @@ describe('buildPerfNodeStyleByNodeId', () => {
 
     it('keys a folded block by its node id using the summed member times', () => {
         const blockOverlay = buildOpGraphPerfOverlay(rows([1, 10], [2, 1_000], [3, 1_000]), true, [1, 2, 3]);
-        const styleByNodeId = buildPerfNodeStyleByNodeId(blockOverlay, true, [
+        const { styleByNodeId } = buildRenderedPerfStyling(blockOverlay, true, [
             { id: '1', operationId: 1 },
             { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3] },
-        ]);
+        ])!;
 
-        expect(styleByNodeId?.has('block:0:2')).toBe(true);
+        expect(styleByNodeId.has('block:0:2')).toBe(true);
         expect(styleByNodeId?.has('2')).toBe(false);
         expect(customProps(styleByNodeId?.get('block:0:2'))[PERF_BAR_SCALE_VAR]).toBe(1);
     });
@@ -195,10 +203,10 @@ describe('buildPerfNodeStyleByNodeId', () => {
             true,
             [1, 2, 3, 4, 5, 6, 7, 8, 9],
         );
-        const styleByNodeId = buildPerfNodeStyleByNodeId(blockOverlay, true, [
+        const { styleByNodeId } = buildRenderedPerfStyling(blockOverlay, true, [
             { id: 'block:0:1', operationId: 1, memberOperationIds: [1, 2, 3] },
             { id: 'block:1:4', operationId: 4, memberOperationIds: [4, 5, 6, 7, 8, 9] },
-        ]);
+        ])!;
 
         const small = customProps(styleByNodeId?.get('block:0:1'))[PERF_BAR_SCALE_VAR] as number;
         const large = customProps(styleByNodeId?.get('block:1:4'))[PERF_BAR_SCALE_VAR] as number;
@@ -210,45 +218,50 @@ describe('buildPerfNodeStyleByNodeId', () => {
         // The per-operation range collapses to a point here, which used to force
         // `t = 0` on everything — including a block worth three times any node.
         const blockOverlay = buildOpGraphPerfOverlay(rows([1, 100], [2, 100], [3, 100], [4, 100]), true, [1, 2, 3, 4]);
-        const styleByNodeId = buildPerfNodeStyleByNodeId(blockOverlay, true, [
+        const { styleByNodeId } = buildRenderedPerfStyling(blockOverlay, true, [
             { id: '1', operationId: 1 },
             { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3, 4] },
-        ]);
+        ])!;
 
-        expect(customProps(styleByNodeId?.get('1'))[PERF_BAR_SCALE_VAR]).toBe(0);
+        expect(customProps(styleByNodeId.get('1'))[PERF_BAR_SCALE_VAR]).toBe(0);
         expect(customProps(styleByNodeId?.get('block:0:2'))[PERF_BAR_SCALE_VAR]).toBe(1);
     });
 
     it('colours the bar with the same ramp the side panel swatch uses', () => {
         // The panel swatch is `perfColorScale(score.t)` too, so a divergence
         // shows up as a node and its own detail panel disagreeing.
-        const styleByNodeId = buildPerfNodeStyleByNodeId(overlay, true);
+        const styleByNodeId = buildRenderedPerfStyling(overlay, true, PLAIN_NODES)?.styleByNodeId;
 
         expect(customProps(styleByNodeId?.get('2'))[PERF_BAR_COLOR_VAR]).toBe(perfColorScale(1));
     });
 });
 
-describe('getRenderedPerfRange', () => {
+describe('buildRenderedPerfStyling range', () => {
     it('spans the summed block totals the bars are drawn against, which the legend keys (#1944)', () => {
         const overlay = buildOpGraphPerfOverlay(rows([1, 100], [2, 100], [3, 100]), true, [1, 2, 3]);
 
-        const range = getRenderedPerfRange(overlay, [
+        const styling = buildRenderedPerfStyling(overlay, true, [
             { id: '1', operationId: 1 },
             { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3] },
-        ]);
+        ])!;
 
-        expect(range.minNs).toBe(100 * 1_000);
-        expect(range.maxNs).toBe(200 * 1_000);
+        expect(styling.minNs).toBe(100 * 1_000);
+        expect(styling.maxNs).toBe(200 * 1_000);
     });
 
-    it('falls back to the per-operation range when nothing is rendered with a row', () => {
+    it('falls back to the per-operation range when nothing rendered carries a row', () => {
         const overlay = buildOpGraphPerfOverlay(rows([1, 10], [2, 1_000]), true, [1, 2]);
 
-        expect(getRenderedPerfRange(overlay)).toEqual({ minNs: overlay.minNs, maxNs: overlay.maxNs });
-        expect(getRenderedPerfRange(overlay, [{ id: '9', operationId: 9 }])).toEqual({
-            minNs: overlay.minNs,
-            maxNs: overlay.maxNs,
-        });
+        const styling = buildRenderedPerfStyling(overlay, true, [{ id: '9', operationId: 9 }])!;
+
+        expect(styling.minNs).toBe(overlay.minNs);
+        expect(styling.maxNs).toBe(overlay.maxNs);
+    });
+
+    it('does no work at all while the overlay is off, when the legend is not rendered', () => {
+        const overlay = buildOpGraphPerfOverlay(rows([1, 10], [2, 1_000]), true, [1, 2]);
+
+        expect(buildRenderedPerfStyling(overlay, false, [{ id: '1', operationId: 1 }])).toBeNull();
     });
 });
 

--- a/tests/opGraphPerfOverlay.spec.ts
+++ b/tests/opGraphPerfOverlay.spec.ts
@@ -11,6 +11,7 @@ import {
     buildOpGraphPerfOverlay,
     buildPerfNodeStyleByNodeId,
     getPerfHoverLabel,
+    getRenderedPerfRange,
 } from '../src/components/operation-graph/opGraphPerfOverlay';
 import { NO_PERF_DATA_LABEL, PerfOverlayStatus } from '../src/definitions/PerfOverlayStatus';
 import { formatDuration } from '../src/functions/formatting';
@@ -185,12 +186,69 @@ describe('buildPerfNodeStyleByNodeId', () => {
         expect(customProps(styleByNodeId?.get('block:0:2'))[PERF_BAR_SCALE_VAR]).toBe(1);
     });
 
+    it('ranks folded blocks against each other rather than clamping them all hot (#1944)', () => {
+        // Both blocks outrun the slowest single op, so scoring their totals
+        // against the per-operation range pinned each of them to 1 and a slow
+        // layer was indistinguishable from a fast one.
+        const blockOverlay = buildOpGraphPerfOverlay(
+            rows([1, 100], [2, 100], [3, 100], [4, 100], [5, 100], [6, 100], [7, 100], [8, 100], [9, 100]),
+            true,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        );
+        const styleByNodeId = buildPerfNodeStyleByNodeId(blockOverlay, true, [
+            { id: 'block:0:1', operationId: 1, memberOperationIds: [1, 2, 3] },
+            { id: 'block:1:4', operationId: 4, memberOperationIds: [4, 5, 6, 7, 8, 9] },
+        ]);
+
+        const small = customProps(styleByNodeId?.get('block:0:1'))[PERF_BAR_SCALE_VAR] as number;
+        const large = customProps(styleByNodeId?.get('block:1:4'))[PERF_BAR_SCALE_VAR] as number;
+        expect(small).toBe(0);
+        expect(large).toBe(1);
+    });
+
+    it('still separates a block from an ordinary node when every row shares a duration (#1944)', () => {
+        // The per-operation range collapses to a point here, which used to force
+        // `t = 0` on everything — including a block worth three times any node.
+        const blockOverlay = buildOpGraphPerfOverlay(rows([1, 100], [2, 100], [3, 100], [4, 100]), true, [1, 2, 3, 4]);
+        const styleByNodeId = buildPerfNodeStyleByNodeId(blockOverlay, true, [
+            { id: '1', operationId: 1 },
+            { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3, 4] },
+        ]);
+
+        expect(customProps(styleByNodeId?.get('1'))[PERF_BAR_SCALE_VAR]).toBe(0);
+        expect(customProps(styleByNodeId?.get('block:0:2'))[PERF_BAR_SCALE_VAR]).toBe(1);
+    });
+
     it('colours the bar with the same ramp the side panel swatch uses', () => {
         // The panel swatch is `perfColorScale(score.t)` too, so a divergence
         // shows up as a node and its own detail panel disagreeing.
         const styleByNodeId = buildPerfNodeStyleByNodeId(overlay, true);
 
         expect(customProps(styleByNodeId?.get('2'))[PERF_BAR_COLOR_VAR]).toBe(perfColorScale(1));
+    });
+});
+
+describe('getRenderedPerfRange', () => {
+    it('spans the summed block totals the bars are drawn against, which the legend keys (#1944)', () => {
+        const overlay = buildOpGraphPerfOverlay(rows([1, 100], [2, 100], [3, 100]), true, [1, 2, 3]);
+
+        const range = getRenderedPerfRange(overlay, [
+            { id: '1', operationId: 1 },
+            { id: 'block:0:2', operationId: 2, memberOperationIds: [2, 3] },
+        ]);
+
+        expect(range.minNs).toBe(100 * 1_000);
+        expect(range.maxNs).toBe(200 * 1_000);
+    });
+
+    it('falls back to the per-operation range when nothing is rendered with a row', () => {
+        const overlay = buildOpGraphPerfOverlay(rows([1, 10], [2, 1_000]), true, [1, 2]);
+
+        expect(getRenderedPerfRange(overlay)).toEqual({ minNs: overlay.minNs, maxNs: overlay.maxNs });
+        expect(getRenderedPerfRange(overlay, [{ id: '9', operationId: 9 }])).toEqual({
+            minNs: overlay.minNs,
+            maxNs: overlay.maxNs,
+        });
     });
 });
 

--- a/tests/opGraphRepeatBlocks.spec.ts
+++ b/tests/opGraphRepeatBlocks.spec.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { detectRepeatBlocks, sumOptional } from '../src/components/operation-graph/opGraphRepeatBlocks';
+import type { OpGraphSourceOperation } from '../src/components/operation-graph/opGraphTypes';
+
+interface OperationSpec {
+    id: number;
+    name: string;
+    consumers?: number[];
+    inputShapes?: string[];
+    edgeLabel?: string;
+}
+
+const op = ({
+    id,
+    name,
+    consumers = [],
+    inputShapes,
+    edgeLabel = '[1, 32]',
+}: OperationSpec): OpGraphSourceOperation => ({
+    id,
+    name,
+    fileIdentifier: `model.py:${id}`,
+    outputs: consumers.length === 0 ? [] : [{ edgeLabel, consumers, tensorId: id * 100 }],
+    deviceOperationCount: 0,
+    inputShapes,
+});
+
+const chain = (specs: { id: number; name: string; inputShapes?: string[] }[]): OpGraphSourceOperation[] =>
+    specs.map((spec, index) =>
+        op({
+            ...spec,
+            consumers: index < specs.length - 1 ? [specs[index + 1].id] : [],
+        }),
+    );
+
+const idsOf = (instances: ReturnType<typeof detectRepeatBlocks>) => instances.map((instance) => instance.operationIds);
+
+describe('detectRepeatBlocks', () => {
+    it('returns nothing when the graph is too short to hold two windows', () => {
+        expect(
+            detectRepeatBlocks(
+                chain([
+                    { id: 1, name: 'a' },
+                    { id: 2, name: 'b' },
+                    { id: 3, name: 'a' },
+                ]),
+            ),
+        ).toEqual([]);
+    });
+
+    it('does not collapse a 1-op run, including two identical neighbours', () => {
+        expect(
+            detectRepeatBlocks(
+                chain([
+                    { id: 1, name: 'a' },
+                    { id: 2, name: 'a' },
+                ]),
+            ),
+        ).toEqual([]);
+    });
+
+    it('collapses two contiguous copies of a 2-op window', () => {
+        const instances = detectRepeatBlocks(
+            chain([
+                { id: 1, name: 'prefix' },
+                { id: 2, name: 'layer_a' },
+                { id: 3, name: 'layer_b' },
+                { id: 4, name: 'layer_a' },
+                { id: 5, name: 'layer_b' },
+                { id: 6, name: 'suffix' },
+            ]),
+        );
+
+        expect(idsOf(instances)).toEqual([
+            [2, 3],
+            [4, 5],
+        ]);
+        expect(instances[0].label).toBe('Block A × 2');
+        expect(instances[0].patternLabel).toBe('Block A');
+        expect(instances.map((instance) => instance.instanceIndex)).toEqual([0, 1]);
+        expect(instances[0].instanceCount).toBe(2);
+        expect(instances[0].patternId).toBe(instances[1].patternId);
+        expect(instances[0].instanceId).toBe('block:0:2');
+        expect(instances[1].instanceId).toBe('block:0:4');
+    });
+
+    it('does not collapse the same window when a different op sits between the copies', () => {
+        expect(
+            detectRepeatBlocks(
+                chain([
+                    { id: 1, name: 'layer_a' },
+                    { id: 2, name: 'layer_b' },
+                    { id: 3, name: 'other' },
+                    { id: 4, name: 'layer_a' },
+                    { id: 5, name: 'layer_b' },
+                ]),
+            ),
+        ).toEqual([]);
+    });
+
+    it('prefers the longest matching window over more copies of a shorter one', () => {
+        // Suffix so the last copy still emits the same outgoing tensor the fingerprint keys on.
+        const instances = detectRepeatBlocks(
+            chain([
+                { id: 1, name: 'a' },
+                { id: 2, name: 'b' },
+                { id: 3, name: 'a' },
+                { id: 4, name: 'b' },
+                { id: 5, name: 'a' },
+                { id: 6, name: 'b' },
+                { id: 7, name: 'a' },
+                { id: 8, name: 'b' },
+                { id: 9, name: 'suffix' },
+            ]),
+        );
+
+        expect(idsOf(instances)).toEqual([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+        ]);
+        expect(instances[0].label).toBe('Block A × 2');
+    });
+
+    it('still takes three copies when no longer window matches', () => {
+        const instances = detectRepeatBlocks(
+            chain([
+                { id: 1, name: 'a' },
+                { id: 2, name: 'b' },
+                { id: 3, name: 'a' },
+                { id: 4, name: 'b' },
+                { id: 5, name: 'a' },
+                { id: 6, name: 'b' },
+                { id: 7, name: 'suffix' },
+            ]),
+        );
+
+        expect(idsOf(instances)).toEqual([
+            [1, 2],
+            [3, 4],
+            [5, 6],
+        ]);
+        expect(instances[0].label).toBe('Block A × 3');
+        expect(instances[0].instanceCount).toBe(3);
+    });
+
+    it('assigns a new letter to a second pattern', () => {
+        const instances = detectRepeatBlocks(
+            chain([
+                { id: 1, name: 'a' },
+                { id: 2, name: 'b' },
+                { id: 3, name: 'a' },
+                { id: 4, name: 'b' },
+                { id: 5, name: 'c' },
+                { id: 6, name: 'd' },
+                { id: 7, name: 'c' },
+                { id: 8, name: 'd' },
+                { id: 9, name: 'suffix' },
+            ]),
+        );
+
+        expect(instances.map((instance) => instance.patternLabel)).toEqual([
+            'Block A',
+            'Block A',
+            'Block B',
+            'Block B',
+        ]);
+        expect(instances[2].label).toBe('Block B × 2');
+        expect(instances[2].patternId).not.toBe(instances[0].patternId);
+    });
+
+    it('does not treat matching fingerprints as a repeat when the internal edges differ', () => {
+        // Same names and output labels, but only the first copy connects a → b.
+        const operations = [
+            op({ id: 1, name: 'a', consumers: [2] }),
+            op({ id: 2, name: 'b', consumers: [3] }),
+            op({ id: 3, name: 'a', consumers: [5] }),
+            op({ id: 4, name: 'b', consumers: [5] }),
+            op({ id: 5, name: 'sink' }),
+        ];
+
+        expect(detectRepeatBlocks(operations)).toEqual([]);
+    });
+
+    it('does not match windows whose input shapes differ', () => {
+        expect(
+            detectRepeatBlocks(
+                chain([
+                    { id: 1, name: 'a', inputShapes: ['[1, 32]'] },
+                    { id: 2, name: 'b' },
+                    { id: 3, name: 'a', inputShapes: ['[1, 64]'] },
+                    { id: 4, name: 'b' },
+                ]),
+            ),
+        ).toEqual([]);
+    });
+});
+
+describe('sumOptional', () => {
+    it('adds finite numbers and skips the rest', () => {
+        expect(sumOptional([1, undefined, 2.5, Number.NaN, Number.POSITIVE_INFINITY])).toBe(3.5);
+        expect(sumOptional([])).toBe(0);
+    });
+});

--- a/tests/opGraphRepeatBlocks.spec.ts
+++ b/tests/opGraphRepeatBlocks.spec.ts
@@ -94,8 +94,8 @@ describe('detectRepeatBlocks', () => {
             [2, 3],
             [4, 5],
         ]);
-        expect(instances[0].label).toBe('model × 2');
-        expect(instances[0].patternLabel).toBe('model');
+        expect(instances[0].label).toBe('layer_a + layer_b × 2');
+        expect(instances[0].patternLabel).toBe('layer_a + layer_b');
         expect(instances.map((instance) => instance.instanceIndex)).toEqual([0, 1]);
         expect(instances[0].instanceCount).toBe(2);
         expect(instances[0].patternId).toBe(instances[1].patternId);
@@ -138,7 +138,7 @@ describe('detectRepeatBlocks', () => {
             [5, 6],
             [7, 8],
         ]);
-        expect(instances[0].label).toBe('model × 4');
+        expect(instances[0].label).toBe('a + b × 4');
     });
 
     it('reports per-layer copies rather than two half-model blocks', () => {
@@ -160,7 +160,7 @@ describe('detectRepeatBlocks', () => {
         );
 
         expect(instances).toHaveLength(6);
-        expect(instances[0].label).toBe('model × 6');
+        expect(instances[0].label).toBe('attn + mlp + norm × 6');
         expect(instances[0].operationIds).toHaveLength(3);
     });
 
@@ -180,7 +180,7 @@ describe('detectRepeatBlocks', () => {
             [1, 2],
             [3, 4],
         ]);
-        expect(instances[0].label).toBe('model × 2');
+        expect(instances[0].label).toBe('a + b × 2');
     });
 
     it("still matches when a dropped op sits on the first copy's outgoing edge", () => {
@@ -198,7 +198,7 @@ describe('detectRepeatBlocks', () => {
         ]);
     });
 
-    it('assigns a new letter to a second pattern', () => {
+    it('names a second pattern from its own ops', () => {
         const instances = detectRepeatBlocks(
             chain([
                 { id: 1, name: 'a' },
@@ -213,13 +213,8 @@ describe('detectRepeatBlocks', () => {
             ]),
         );
 
-        expect(instances.map((instance) => instance.patternLabel)).toEqual([
-            'model',
-            'model',
-            'model · B',
-            'model · B',
-        ]);
-        expect(instances[2].label).toBe('model · B × 2');
+        expect(instances.map((instance) => instance.patternLabel)).toEqual(['a + b', 'a + b', 'c + d', 'c + d']);
+        expect(instances[2].label).toBe('c + d × 2');
         expect(instances[2].patternId).not.toBe(instances[0].patternId);
     });
 
@@ -239,7 +234,7 @@ describe('detectRepeatBlocks', () => {
             ]),
         );
 
-        expect(instances.map((instance) => instance.patternLabel)).toEqual(['model', 'model', 'model', 'model']);
+        expect(instances.map((instance) => instance.patternLabel)).toEqual(['a + b', 'a + b', 'a + b', 'a + b']);
     });
 
     it('does not treat matching fingerprints as a repeat when the internal edges differ', () => {
@@ -320,22 +315,44 @@ describe('formatRepeatPatternLabel', () => {
         ).toBe('norm + attention + encoder + mlp');
     });
 
-    it('keeps a plumbing-only window instead of inventing a name', () => {
+    it('names a plumbing-only window from its ops', () => {
         expect(
             formatRepeatPatternLabel([
                 op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'lazy_weight.py:10' }),
                 op({ id: 2, name: 'ttnn.from_torch', fileIdentifier: 'lazy_weight.py:11' }),
             ]),
-        ).toBe('lazy_weight');
+        ).toBe('as_tensor + from_torch');
     });
 
-    it('uses the single user file when every member shares it', () => {
+    it('keeps a module file that is not most of the graph', () => {
+        const members = [
+            op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'tt_routed_expert.py:132' }),
+            op({ id: 2, name: 'ttnn.squeeze', fileIdentifier: 'tt_routed_expert.py:163' }),
+        ];
         expect(
-            formatRepeatPatternLabel([
-                op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'tt_routed_expert.py:132' }),
-                op({ id: 2, name: 'ttnn.squeeze', fileIdentifier: 'tt_routed_expert.py:163' }),
+            formatRepeatPatternLabel(members, [
+                ...members,
+                op({ id: 10, name: 'ttnn.matmul', fileIdentifier: 'tt_moe.py:1' }),
+                op({ id: 11, name: 'ttnn.add', fileIdentifier: 'tt_moe_gate_prefill.py:1' }),
             ]),
         ).toBe('tt_routed_expert');
+    });
+
+    it('names from ops when the only file is the whole model', () => {
+        const members = [
+            op({ id: 1, name: 'ttnn.add_', fileIdentifier: 'ttnn_functional_resnet50.py:260' }),
+            op({ id: 2, name: 'ttnn.conv2d', fileIdentifier: 'ttnn_functional_resnet50.py:196' }),
+            op({ id: 3, name: 'ttnn.conv2d', fileIdentifier: 'ttnn_functional_resnet50.py:196' }),
+            op({ id: 4, name: 'ttnn.conv2d', fileIdentifier: 'ttnn_functional_resnet50.py:196' }),
+        ];
+        const rest = Array.from({ length: 20 }, (_, index) =>
+            op({
+                id: 10 + index,
+                name: 'ttnn.conv2d',
+                fileIdentifier: 'ttnn_functional_resnet50.py:100',
+            }),
+        );
+        expect(formatRepeatPatternLabel(members, [...members, ...rest])).toBe('add_ + conv2d');
     });
 
     it('falls back to short op names when no file identifier is present', () => {

--- a/tests/opGraphRepeatBlocks.spec.ts
+++ b/tests/opGraphRepeatBlocks.spec.ts
@@ -353,6 +353,44 @@ describe('formatRepeatPatternLabel', () => {
         expect(formatRepeatPatternLabel(members)).toBe('norm + attention + encoder + mlp');
     });
 
+    it('drops the framework-and-model prefix the module stems all share', () => {
+        // Reported from the SentenceBERT graph: three module files whose names are
+        // 60% one repeated prefix, clipped by the node it had to fit in.
+        const members = [
+            op({ id: 187, name: 'ttnn.layer_norm', fileIdentifier: 'ttnn_sentencebert_self_attention.py:31' }),
+            op({ id: 188, name: 'ttnn.matmul', fileIdentifier: 'ttnn_sentencebert_self_output.py:44' }),
+            op({ id: 189, name: 'ttnn.linear', fileIdentifier: 'ttnn_sentencebert_intermediate.py:19' }),
+        ];
+        expect(formatRepeatPatternLabel(members)).toBe('self_attention + self_output + intermediate');
+    });
+
+    it('leaves every stem a segment of its own when one is a prefix of the rest', () => {
+        const members = [
+            op({ id: 1, name: 'ttnn.linear', fileIdentifier: 'tt_llama_attention.py:1' }),
+            op({ id: 2, name: 'ttnn.gelu', fileIdentifier: 'tt_llama_mlp.py:2' }),
+            op({ id: 3, name: 'ttnn.add', fileIdentifier: 'tt_llama.py:3' }),
+        ];
+        // `tt` is shared but stripping it would leave `tt_llama` as the empty
+        // string, so the prefix stays.
+        expect(formatRepeatPatternLabel(members)).toBe('llama_attention + llama_mlp + llama');
+    });
+
+    it('keeps a shared prefix when stripping it would leave initials', () => {
+        const members = [
+            op({ id: 1, name: 'ttnn.linear', fileIdentifier: 'mlp_up.py:1' }),
+            op({ id: 2, name: 'ttnn.gelu', fileIdentifier: 'mlp_down.py:2' }),
+        ];
+        expect(formatRepeatPatternLabel(members)).toBe('mlp_up + mlp_down');
+    });
+
+    it('leaves stems that share no leading segment alone', () => {
+        const members = [
+            op({ id: 1, name: 'ttnn.layer_norm', fileIdentifier: 'norm.py:86' }),
+            op({ id: 2, name: 'ttnn.linear', fileIdentifier: 'attention.py:193' }),
+        ];
+        expect(formatRepeatPatternLabel(members)).toBe('norm + attention');
+    });
+
     it('keeps a module file that is not most of the graph', () => {
         const members = [
             op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'tt_routed_expert.py:132' }),

--- a/tests/opGraphRepeatBlocks.spec.ts
+++ b/tests/opGraphRepeatBlocks.spec.ts
@@ -3,7 +3,14 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { detectRepeatBlocks, sumOptional } from '../src/components/operation-graph/opGraphRepeatBlocks';
+import {
+    MAX_DETECT_OPS,
+    MIN_REPEAT_COUNT,
+    MIN_REPEAT_WINDOW,
+    detectRepeatBlocks,
+    formatRepeatPatternLabel,
+    sumOptional,
+} from '../src/components/operation-graph/opGraphRepeatBlocks';
 import type { OpGraphSourceOperation } from '../src/components/operation-graph/opGraphTypes';
 
 interface OperationSpec {
@@ -12,6 +19,7 @@ interface OperationSpec {
     consumers?: number[];
     inputShapes?: string[];
     edgeLabel?: string;
+    fileIdentifier?: string;
 }
 
 const op = ({
@@ -20,16 +28,19 @@ const op = ({
     consumers = [],
     inputShapes,
     edgeLabel = '[1, 32]',
+    fileIdentifier = `model.py:${id}`,
 }: OperationSpec): OpGraphSourceOperation => ({
     id,
     name,
-    fileIdentifier: `model.py:${id}`,
-    outputs: consumers.length === 0 ? [] : [{ edgeLabel, consumers, tensorId: id * 100 }],
+    fileIdentifier,
+    outputs: [{ edgeLabel, consumers, tensorId: id * 100 }],
     deviceOperationCount: 0,
     inputShapes,
 });
 
-const chain = (specs: { id: number; name: string; inputShapes?: string[] }[]): OpGraphSourceOperation[] =>
+const chain = (
+    specs: { id: number; name: string; inputShapes?: string[]; fileIdentifier?: string }[],
+): OpGraphSourceOperation[] =>
     specs.map((spec, index) =>
         op({
             ...spec,
@@ -52,15 +63,19 @@ describe('detectRepeatBlocks', () => {
         ).toEqual([]);
     });
 
-    it('does not collapse a 1-op run, including two identical neighbours', () => {
+    it('does not collapse a 1-op run of identical neighbours', () => {
         expect(
             detectRepeatBlocks(
                 chain([
-                    { id: 1, name: 'a' },
-                    { id: 2, name: 'a' },
+                    { id: 1, name: 'prefix' },
+                    { id: 2, name: 'add' },
+                    { id: 3, name: 'add' },
+                    { id: 4, name: 'suffix' },
                 ]),
             ),
         ).toEqual([]);
+        expect(MIN_REPEAT_WINDOW).toBe(2);
+        expect(MIN_REPEAT_COUNT).toBe(2);
     });
 
     it('collapses two contiguous copies of a 2-op window', () => {
@@ -79,8 +94,8 @@ describe('detectRepeatBlocks', () => {
             [2, 3],
             [4, 5],
         ]);
-        expect(instances[0].label).toBe('Block A × 2');
-        expect(instances[0].patternLabel).toBe('Block A');
+        expect(instances[0].label).toBe('model × 2');
+        expect(instances[0].patternLabel).toBe('model');
         expect(instances.map((instance) => instance.instanceIndex)).toEqual([0, 1]);
         expect(instances[0].instanceCount).toBe(2);
         expect(instances[0].patternId).toBe(instances[1].patternId);
@@ -102,8 +117,7 @@ describe('detectRepeatBlocks', () => {
         ).toEqual([]);
     });
 
-    it('prefers the longest matching window over more copies of a shorter one', () => {
-        // Suffix so the last copy still emits the same outgoing tensor the fingerprint keys on.
+    it('takes the smallest window that repeats, extended maximally', () => {
         const instances = detectRepeatBlocks(
             chain([
                 { id: 1, name: 'a' },
@@ -119,13 +133,38 @@ describe('detectRepeatBlocks', () => {
         );
 
         expect(idsOf(instances)).toEqual([
-            [1, 2, 3, 4],
-            [5, 6, 7, 8],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+            [7, 8],
         ]);
-        expect(instances[0].label).toBe('Block A × 2');
+        expect(instances[0].label).toBe('model × 4');
     });
 
-    it('still takes three copies when no longer window matches', () => {
+    it('reports per-layer copies rather than two half-model blocks', () => {
+        const layer = (start: number): { id: number; name: string }[] => [
+            { id: start, name: 'attn' },
+            { id: start + 1, name: 'mlp' },
+            { id: start + 2, name: 'norm' },
+        ];
+        const instances = detectRepeatBlocks(
+            chain([
+                ...layer(1),
+                ...layer(4),
+                ...layer(7),
+                ...layer(10),
+                ...layer(13),
+                ...layer(16),
+                { id: 19, name: 'suffix' },
+            ]),
+        );
+
+        expect(instances).toHaveLength(6);
+        expect(instances[0].label).toBe('model × 6');
+        expect(instances[0].operationIds).toHaveLength(3);
+    });
+
+    it('does not join the last copy when its leaving tensors differ', () => {
         const instances = detectRepeatBlocks(
             chain([
                 { id: 1, name: 'a' },
@@ -134,17 +173,29 @@ describe('detectRepeatBlocks', () => {
                 { id: 4, name: 'b' },
                 { id: 5, name: 'a' },
                 { id: 6, name: 'b' },
-                { id: 7, name: 'suffix' },
             ]),
         );
 
         expect(idsOf(instances)).toEqual([
             [1, 2],
             [3, 4],
-            [5, 6],
         ]);
-        expect(instances[0].label).toBe('Block A × 3');
-        expect(instances[0].instanceCount).toBe(3);
+        expect(instances[0].label).toBe('model × 2');
+    });
+
+    it("still matches when a dropped op sits on the first copy's outgoing edge", () => {
+        const instances = detectRepeatBlocks([
+            op({ id: 1, name: 'layer_a', consumers: [2] }),
+            op({ id: 2, name: 'layer_b', consumers: [99] }),
+            op({ id: 4, name: 'layer_a', consumers: [5] }),
+            op({ id: 5, name: 'layer_b', consumers: [6] }),
+            op({ id: 6, name: 'suffix' }),
+        ]);
+
+        expect(idsOf(instances)).toEqual([
+            [1, 2],
+            [4, 5],
+        ]);
     });
 
     it('assigns a new letter to a second pattern', () => {
@@ -163,17 +214,35 @@ describe('detectRepeatBlocks', () => {
         );
 
         expect(instances.map((instance) => instance.patternLabel)).toEqual([
-            'Block A',
-            'Block A',
-            'Block B',
-            'Block B',
+            'model',
+            'model',
+            'model · B',
+            'model · B',
         ]);
-        expect(instances[2].label).toBe('Block B × 2');
+        expect(instances[2].label).toBe('model · B × 2');
         expect(instances[2].patternId).not.toBe(instances[0].patternId);
     });
 
+    it('reuses the letter when the same pattern recurs after a gap', () => {
+        const instances = detectRepeatBlocks(
+            chain([
+                { id: 1, name: 'a' },
+                { id: 2, name: 'b' },
+                { id: 3, name: 'a' },
+                { id: 4, name: 'b' },
+                { id: 5, name: 'other' },
+                { id: 6, name: 'a' },
+                { id: 7, name: 'b' },
+                { id: 8, name: 'a' },
+                { id: 9, name: 'b' },
+                { id: 10, name: 'suffix' },
+            ]),
+        );
+
+        expect(instances.map((instance) => instance.patternLabel)).toEqual(['model', 'model', 'model', 'model']);
+    });
+
     it('does not treat matching fingerprints as a repeat when the internal edges differ', () => {
-        // Same names and output labels, but only the first copy connects a → b.
         const operations = [
             op({ id: 1, name: 'a', consumers: [2] }),
             op({ id: 2, name: 'b', consumers: [3] }),
@@ -193,9 +262,101 @@ describe('detectRepeatBlocks', () => {
                     { id: 2, name: 'b' },
                     { id: 3, name: 'a', inputShapes: ['[1, 64]'] },
                     { id: 4, name: 'b' },
+                    { id: 5, name: 'suffix' },
                 ]),
             ),
         ).toEqual([]);
+    });
+
+    it('names a pattern from distinct member files and keeps that name across a gap', () => {
+        const instances = detectRepeatBlocks(
+            chain([
+                { id: 1, name: 'q', fileIdentifier: 'attention.py:1' },
+                { id: 2, name: 'ff', fileIdentifier: 'mlp.py:1' },
+                { id: 3, name: 'q', fileIdentifier: 'attention.py:2' },
+                { id: 4, name: 'ff', fileIdentifier: 'mlp.py:2' },
+                { id: 5, name: 'other', fileIdentifier: 'other.py:1' },
+                { id: 6, name: 'q', fileIdentifier: 'attention.py:3' },
+                { id: 7, name: 'ff', fileIdentifier: 'mlp.py:3' },
+                { id: 8, name: 'q', fileIdentifier: 'attention.py:4' },
+                { id: 9, name: 'ff', fileIdentifier: 'mlp.py:4' },
+                { id: 10, name: 'suffix', fileIdentifier: 'tail.py:1' },
+            ]),
+        );
+
+        expect(instances.map((instance) => instance.patternLabel)).toEqual([
+            'attention + mlp',
+            'attention + mlp',
+            'attention + mlp',
+            'attention + mlp',
+        ]);
+        expect(instances[0].label).toBe('attention + mlp × 2');
+    });
+
+    it('returns nothing above MAX_DETECT_OPS rather than scanning', () => {
+        const operations = Array.from({ length: MAX_DETECT_OPS + 1 }, (_, index) =>
+            op({
+                id: index + 1,
+                name: index % 2 === 0 ? 'a' : 'b',
+                consumers: index < MAX_DETECT_OPS ? [index + 2] : [],
+            }),
+        );
+
+        expect(detectRepeatBlocks(operations)).toEqual([]);
+    });
+});
+
+describe('formatRepeatPatternLabel', () => {
+    it('joins unique file stems and drops lazy_weight when anything else remains', () => {
+        expect(
+            formatRepeatPatternLabel([
+                op({ id: 1, name: 'ttnn.from_torch', fileIdentifier: 'lazy_weight.py:315' }),
+                op({ id: 2, name: 'ttnn.layer_norm', fileIdentifier: 'norm.py:86' }),
+                op({ id: 3, name: 'ttnn.linear', fileIdentifier: 'attention.py:193' }),
+                op({ id: 4, name: 'ttnn.add', fileIdentifier: 'encoder.py:72' }),
+                op({ id: 5, name: 'ttnn.gelu', fileIdentifier: 'mlp.py:112' }),
+                op({ id: 6, name: 'ttnn.add', fileIdentifier: 'encoder.py:78' }),
+            ]),
+        ).toBe('norm + attention + encoder + mlp');
+    });
+
+    it('keeps a plumbing-only window instead of inventing a name', () => {
+        expect(
+            formatRepeatPatternLabel([
+                op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'lazy_weight.py:10' }),
+                op({ id: 2, name: 'ttnn.from_torch', fileIdentifier: 'lazy_weight.py:11' }),
+            ]),
+        ).toBe('lazy_weight');
+    });
+
+    it('uses the single user file when every member shares it', () => {
+        expect(
+            formatRepeatPatternLabel([
+                op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'tt_routed_expert.py:132' }),
+                op({ id: 2, name: 'ttnn.squeeze', fileIdentifier: 'tt_routed_expert.py:163' }),
+            ]),
+        ).toBe('tt_routed_expert');
+    });
+
+    it('falls back to short op names when no file identifier is present', () => {
+        expect(
+            formatRepeatPatternLabel([
+                op({ id: 1, name: 'ttnn.matmul', fileIdentifier: '' }),
+                op({ id: 2, name: 'ttnn.add', fileIdentifier: '' }),
+            ]),
+        ).toBe('matmul + add');
+    });
+
+    it('caps a long file list', () => {
+        expect(
+            formatRepeatPatternLabel([
+                op({ id: 1, name: 'a', fileIdentifier: 'one.py:1' }),
+                op({ id: 2, name: 'b', fileIdentifier: 'two.py:1' }),
+                op({ id: 3, name: 'c', fileIdentifier: 'three.py:1' }),
+                op({ id: 4, name: 'd', fileIdentifier: 'four.py:1' }),
+                op({ id: 5, name: 'e', fileIdentifier: 'five.py:1' }),
+            ]),
+        ).toBe('one + two + three + four + …');
     });
 });
 

--- a/tests/opGraphRepeatBlocks.spec.ts
+++ b/tests/opGraphRepeatBlocks.spec.ts
@@ -9,7 +9,6 @@ import {
     MIN_REPEAT_WINDOW,
     detectRepeatBlocks,
     formatRepeatPatternLabel,
-    sumOptional,
 } from '../src/components/operation-graph/opGraphRepeatBlocks';
 import type { OpGraphSourceOperation } from '../src/components/operation-graph/opGraphTypes';
 
@@ -441,12 +440,5 @@ describe('formatRepeatPatternLabel', () => {
                 op({ id: 5, name: 'e', fileIdentifier: 'five.py:1' }),
             ]),
         ).toBe('one + two + three + four + …');
-    });
-});
-
-describe('sumOptional', () => {
-    it('adds finite numbers and skips the rest', () => {
-        expect(sumOptional([1, undefined, 2.5, Number.NaN, Number.POSITIVE_INFINITY])).toBe(3.5);
-        expect(sumOptional([])).toBe(0);
     });
 });

--- a/tests/opGraphRepeatBlocks.spec.ts
+++ b/tests/opGraphRepeatBlocks.spec.ts
@@ -324,6 +324,35 @@ describe('formatRepeatPatternLabel', () => {
         ).toBe('as_tensor + from_torch');
     });
 
+    it('names a single-operation-type block from the operation, not its file', () => {
+        // Reported from the DeepSeek MoE graph: a block of two `ttnn.squeeze`
+        // rendered as `tt_routed_expert`, which says where they live rather than
+        // what the node is. The file only earns the label when it stands in for
+        // several distinct operations.
+        const members = [
+            op({ id: 35, name: 'ttnn.squeeze', fileIdentifier: 'tt_routed_expert.py:165' }),
+            op({ id: 36, name: 'ttnn.squeeze', fileIdentifier: 'tt_routed_expert.py:165' }),
+        ];
+        expect(
+            formatRepeatPatternLabel(members, [
+                ...members,
+                op({ id: 10, name: 'ttnn.matmul', fileIdentifier: 'tt_moe.py:1' }),
+            ]),
+        ).toBe('squeeze');
+    });
+
+    it('still prefers the module when the block spans several operation types', () => {
+        // The counterpart, and why the rule is narrow: four distinct operations
+        // across four module files read better as the modules.
+        const members = [
+            op({ id: 1, name: 'ttnn.layer_norm', fileIdentifier: 'norm.py:86' }),
+            op({ id: 2, name: 'ttnn.linear', fileIdentifier: 'attention.py:193' }),
+            op({ id: 3, name: 'ttnn.add', fileIdentifier: 'encoder.py:72' }),
+            op({ id: 4, name: 'ttnn.gelu', fileIdentifier: 'mlp.py:112' }),
+        ];
+        expect(formatRepeatPatternLabel(members)).toBe('norm + attention + encoder + mlp');
+    });
+
     it('keeps a module file that is not most of the graph', () => {
         const members = [
             op({ id: 1, name: 'ttnn.as_tensor', fileIdentifier: 'tt_routed_expert.py:132' }),

--- a/tests/opGraphRevealPan.spec.ts
+++ b/tests/opGraphRevealPan.spec.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+
+import { revealPanShift } from '../src/components/operation-graph/opGraphRevealPan';
+
+const PANE = { width: 1000, height: 700 };
+const AT_ORIGIN = { x: 0, y: 0, zoom: 1 };
+// Matches REVEAL_MARGIN_PX; asserted against rather than imported so a change to
+// the constant has to be a deliberate change to these expectations too.
+const MARGIN = 48;
+
+describe('revealPanShift', () => {
+    it('does not move a set already comfortably in view', () => {
+        const shift = revealPanShift({ minX: 200, minY: 200, maxX: 400, maxY: 400 }, AT_ORIGIN, PANE);
+
+        expect(shift).toEqual({ dx: 0, dy: 0 });
+    });
+
+    it('pans down by the minimum when the set starts above the pane', () => {
+        // Expanding upward is the case a top-edge anchor misses.
+        const shift = revealPanShift({ minX: 200, minY: -120, maxX: 400, maxY: 100 }, AT_ORIGIN, PANE);
+
+        expect(shift.dy).toBe(MARGIN + 120);
+        expect(shift.dx).toBe(0);
+    });
+
+    it('pans up by the minimum when the set runs off the bottom', () => {
+        // The reported case: a block low in the pane unrolls into 28 operations.
+        const shift = revealPanShift({ minX: 100, minY: 500, maxX: 300, maxY: 900 }, AT_ORIGIN, PANE);
+
+        expect(shift.dy).toBe(PANE.height - MARGIN - 900);
+        expect(shift.dy).toBeLessThan(0);
+    });
+
+    it('aligns the near edge when the set is taller than the pane', () => {
+        // Nothing can bring it all in, so it keeps the end the expansion started
+        // from rather than scrolling past it.
+        const shift = revealPanShift({ minX: 100, minY: 300, maxX: 300, maxY: 2000 }, AT_ORIGIN, PANE);
+
+        expect(shift.dy).toBe(MARGIN - 300);
+        // The top edge lands on the margin, not off-screen.
+        expect(300 + shift.dy).toBe(MARGIN);
+    });
+
+    it('moves both axes when the set is off two edges at once', () => {
+        const shift = revealPanShift({ minX: -200, minY: -50, maxX: 100, maxY: 200 }, AT_ORIGIN, PANE);
+
+        expect(shift.dx).toBeGreaterThan(0);
+        expect(shift.dy).toBeGreaterThan(0);
+    });
+
+    it('accounts for the live zoom and pan rather than raw graph coordinates', () => {
+        // Same bounds, but already scrolled into view by the viewport: no pan.
+        const bounds = { minX: 1000, minY: 1000, maxX: 1100, maxY: 1100 };
+        const scrolled = { x: -900, y: -900, zoom: 1 };
+
+        expect(revealPanShift(bounds, scrolled, PANE)).toEqual({ dx: 0, dy: 0 });
+        // Unscrolled, the same bounds are far off the bottom-right.
+        const unscrolled = revealPanShift(bounds, AT_ORIGIN, PANE);
+        expect(unscrolled.dx).toBeLessThan(0);
+        expect(unscrolled.dy).toBeLessThan(0);
+    });
+
+    it('scales the offsets by zoom, so a zoomed-out graph pans less', () => {
+        const bounds = { minX: 200, minY: 1000, maxX: 400, maxY: 1200 };
+        const near = revealPanShift(bounds, { x: 0, y: 0, zoom: 1 }, PANE);
+        const far = revealPanShift(bounds, { x: 0, y: 0, zoom: 0.25 }, PANE);
+
+        expect(Math.abs(far.dy)).toBeLessThan(Math.abs(near.dy));
+    });
+});


### PR DESCRIPTION

<img width="1481" height="1106" alt="image" src="https://github.com/user-attachments/assets/68f0f917-fd3d-4600-afee-04a577d8de58" />

## Summary

A 12-layer model is hundreds of near-identical ops on the graph. This detects strict contiguous repeated subgraphs, folds each copy into a block, and names the block from the modules (or ops) that identify the tile.

Closes #1583

### Frontend
- `opGraphRepeatBlocks.ts` — smallest window that repeats (`L ≥ 2`), structural check including leaving edges, skip above `MAX_DETECT_OPS`. Labels from unique source-file stems; a file that covers most of the graph (e.g. `ttnn_functional_resnet50.py`) is dropped so the name becomes `add_ + conv2d` rather than the model file. `lazy_weight` is plumbing. A block of a single operation type is named by that operation rather than its file (two `ttnn.squeeze` read `squeeze`, not `tt_routed_expert`), and a leading prefix every stem shares is dropped — one SentenceBERT block spans four modules and was named in 124 characters, 72 of them `ttnn_sentencebert_` four times over, so it now reads `self_attention + self_output + intermediate + output`. Stripping stops while every stem keeps a segment of its own, and is abandoned if a remainder would fall under three characters, so `mlp_up + mlp_down` does not become `up + down`.
- `opGraphBuilder.ts` / layout worker — collapsed `blockNode`s, one unlabelled edge per rendered pair, detection cached per deallocate filter, layout cache keyed on the unrolled-instance set.
- `OperationGraphReactFlow.tsx` — folded by default; Unroll/Fold on the toolbar and per-block chip; double-click a block to unroll, double-click a member to fold that instance. Selecting a block opens the block panel (aggregates, types, boundary I/O), not the first member. Filter treats a member-name hit as a match (`+N inside`). Device-op expand is dropped when that instance is folded.
- Perf overlay and critical path sum member weights; critical path counts member ops.
- **Dim unrelated edges** toolbar switch (off by default): with a node selected, non-I/O edges fade to 0.35 via a container class, same rule as critical-path off-path dim. Filter still wins. No-op with nothing selected.

### Keeping your place when a block opens
Unrolling repacks the layout, which moved the graph under the reader — the reported symptom was "I opened one and I can't even see it on the screen anymore."

- A structural toggle holds the viewport anchor, and pans the revealed ops back into view when the repack put them outside it.
- Those ops are ringed: three slow pulses for attention, then a faint ring that **rests until the next toggle**, so "which ones did I just open" stays answerable while they are open. Exactly one group is ever marked; the ring clears on a report swap or a deallocate-filter repack.
- Labels are the other half of not losing your place, hence the naming rules above. Node labels cap at `NODE_MAX_WIDTH` and both panel headings ellipsise, so all three now carry the full string as a native tooltip — the file identifier beside them already did.

## Known limitations (out of scope, tracked separately)
- Repeated windows longer than `MAX_REPEAT_WINDOW` (64 ops) are not detected — a layer above that stays unfolded — #1956. Descending from ⌊N/2⌋ made the no-repeat case O(N³) and folded 12 layers into two half-model blocks. The time half is now largely gone: hoisting the O(1) window discriminator ahead of the two O(length) consumed walks takes detection on a 10k-op no-repeat graph from 40.4ms to 4.0ms. What is left to settle is the half-model-block case, which is why the cap stays here
- No keyboard-accessible way to fold a single unrolled instance; the toolbar folds all. #1942 covers the cramped chrome rather than this, so the a11y gap needs its own issue — adding a fold affordance to unrolled members is new UI and was out of scope for a behaviour-preserving pass
- Toolbar chrome is cramped after the new switch — #1942
- No fuzzy match, no user rename (`Transformer layer`), no shared identity on the op list / perf table (as in #1583)

## Test plan
- [ ] Frontend: `pnpm test tests/opGraphRepeatBlocks.spec.ts tests/opGraphBuilder.spec.ts tests/opGraphLayoutWorker.spec.ts tests/OperationGraphRebuildDiscipline.spec.tsx tests/OpGraphToolbarSwitches.spec.tsx tests/opGraphNodeStyles.spec.ts tests/opGraphRevealPan.spec.ts tests/opGraphNavigation.spec.ts tests/OpGraphPanelLabelTooltip.spec.tsx tests/OpGraphBlockPanelStats.spec.tsx tests/opGraphBlockBoundary.spec.ts tests/opGraphBlockMeta.spec.ts`
- [ ] `pnpm lint` clean on touched files
- [ ] Manual — bge_m3: 24 copies named `norm + attention + encoder + mlp × 24`; unroll one instance; filter a member name; double-click to fold
- [ ] Manual — resnet50: blocks named `add_ + conv2d` (not `ttnn_functional_resnet50`); Dim unrelated edges on/off with a node selected
- [ ] Manual — MoE setup loop: blocks read `squeeze × 2` (they read `tt_routed_expert × 2` before the label fix)
- [ ] Manual — sentence_bert: the block reads `self_attention + self_output + intermediate + output`; hover a truncated label for the full name
- [ ] Manual — unroll a block low in the viewport: it stays in view, pulses, and holds a faint ring until the next unroll

## Review pass

David's review (4 Must fix, 21 Should fix) is addressed in `3fc7a5b2`..`884e6762`, constrained to changes that alter neither behaviour nor UX. Summary in the PR comment; the two deliberate exceptions are #1956 (raising the window cap changes what folds) and the keyboard fold affordance (new UI). Suite went 2285 → 2318.

## Follow-ups
- #1942 — tidy the filter and toggle chrome
- #1191 — graph illegible at scale (this is the collapse half)
- #1192 — identifying groups of operations



