### PR TITLE
Link memory and performance reports across signposts

### DIFF
--- a/backend/ttnn_visualizer/tests/test_perf_report.py
+++ b/backend/ttnn_visualizer/tests/test_perf_report.py
@@ -184,5 +184,67 @@ class TestPerfReportKernelDurationSchemaCompatibility(unittest.TestCase):
             self.assertEqual(report[0][key], value)
 
 
+class TestPerfReportSignpostOpType(unittest.TestCase):
+    """A signpost row must reach the report as ``op_type == "signpost"``.
+
+    The frontend drops exactly that value before it aligns device operations to
+    perf rows (#1943), so this spelling is a contract rather than an incidental
+    detail. `TestPerfReportKernelDurations.test_signpost_rows_have_no_kernel_durations`
+    cannot stand in for it: it filters for the value and loops the result, and
+    the n300-llama fixture contains no signpost rows at all, so it holds
+    vacuously. Driven from a synthetic CSV so it does not depend on a fixture
+    happening to carry one.
+    """
+
+    def test_signpost_row_reaches_the_report_with_its_op_type(self):
+        raw_csv = "\n".join(
+            [
+                "OP TYPE,OP CODE,DEVICE KERNEL DURATION [ns]",
+                "signpost,tt_forward_START,",
+                "tt_dnn_device,Matmul,1200",
+                "",
+            ]
+        )
+
+        def _fake_generate_perf_report(*args, **kwargs):
+            output_csv_path = args[8]
+
+            def row(row_id, op_code):
+                values = ["" for _ in REPORT_HEADER]
+                values[REPORT_HEADER.index("id")] = row_id
+                values[REPORT_HEADER.index("op_code")] = op_code
+                values[REPORT_HEADER.index("raw_op_code")] = op_code
+                return ",".join(values)
+
+            with open(
+                output_csv_path, "w", encoding="utf-8", newline=""
+            ) as output_file:
+                output_file.write(",".join(REPORT_HEADER) + "\n")
+                # Ids are row numbers in the raw CSV, which the report indexes
+                # back into as `id - 2`.
+                output_file.write(row("2", "tt_forward_START") + "\n")
+                output_file.write(row("3", "Matmul") + "\n")
+
+        instance = Instance(instance_id="test", performance_path="/tmp")
+
+        with (
+            mock.patch(
+                "ttnn_visualizer.csv_queries.OpsPerformanceQueries.get_raw_csv",
+                return_value=raw_csv,
+            ),
+            mock.patch(
+                "ttnn_visualizer.csv_queries.perf_report.generate_perf_report",
+                side_effect=_fake_generate_perf_report,
+            ),
+        ):
+            report = OpsPerformanceReportQueries.generate_report(instance)["report"]
+
+        op_types = {row["raw_op_code"]: row["op_type"] for row in report}
+        self.assertEqual(op_types.get("tt_forward_START"), "signpost")
+        # The device row alongside it must not be tarred with the same value, or
+        # the frontend filter would drop real operations.
+        self.assertEqual(op_types.get("Matmul"), "tt_dnn_device")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/functions/deviceOperationMatching.ts
+++ b/src/functions/deviceOperationMatching.ts
@@ -4,6 +4,7 @@
 
 import { PerfTableRow } from '../model/PerfTable';
 import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
+import { OpType } from '../definitions/Performance';
 
 /**
  * TODO: remove once memory and performance reports carry a shared run id (#1800)
@@ -72,6 +73,17 @@ const alignToPerfRows = (
 };
 
 /**
+ * @description Drop the signpost rows a model emits with `signpost()`. They are
+ * markers rather than operations, so the memory report has no device operation
+ * to pair them with, and they are their own op type rather than a host op — so
+ * the pinned `hideHostOps` filter leaves them in place. Alignment is positional,
+ * so one signpost anywhere but the tail shifts every later row out of position
+ * and fails the whole report. See #1943.
+ */
+const alignableRowsOf = (perfRows: PerfTableRow[]): PerfTableRow[] =>
+    perfRows.filter((perfRow) => perfRow.op_type !== OpType.SIGNPOST);
+
+/**
  * @description Match a memory report's device operations against a performance
  * report's rows, returning the mappings when the two sequences describe the same
  * run and [] when they don't (the report-link UNLINKED signal).
@@ -85,7 +97,8 @@ export const matchDeviceOperationsToPerf = (
     perfRows: PerfTableRow[],
     numDevices: number,
 ): DeviceOperationMapping[] => {
-    const directMatch = alignToPerfRows(deviceOperations, perfRows);
+    const alignableRows = alignableRowsOf(perfRows);
+    const directMatch = alignToPerfRows(deviceOperations, alignableRows);
 
     if (directMatch.length > 0) {
         return directMatch;
@@ -97,5 +110,5 @@ export const matchDeviceOperationsToPerf = (
         return [];
     }
 
-    return alignToPerfRows(collapseMultideviceOperations(deviceOperations, numDevices), perfRows);
+    return alignToPerfRows(collapseMultideviceOperations(deviceOperations, numDevices), alignableRows);
 };

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { collapseMultideviceOperations, matchDeviceOperationsToPerf } from '../src/functions/deviceOperationMatching';
 import { PerfTableRow } from '../src/model/PerfTable';
 import { DeviceOperationMapping } from '../src/model/DeviceOperationMapping';
+import { OpType } from '../src/definitions/Performance';
 
 const mapping = (name: string, id: number): DeviceOperationMapping => ({
     name,
@@ -17,6 +18,10 @@ const perfRow = (rawOpCode: string, id: number): PerfTableRow =>
     ({ id: String(id), raw_op_code: rawOpCode, device_time: '1' }) as unknown as PerfTableRow;
 
 const perfRowsFor = (names: string[]): PerfTableRow[] => names.map((name, index) => perfRow(name, index));
+
+/** A row for a `signpost()` marker, which no device operation corresponds to. */
+const signpostRow = (label: string, id: number): PerfTableRow =>
+    ({ id: String(id), raw_op_code: label, op_type: OpType.SIGNPOST }) as unknown as PerfTableRow;
 
 /** Each op recorded once per device, as `numDevices` consecutive entries. */
 const duplicatedPerDevice = (names: string[], numDevices: number): DeviceOperationMapping[] =>
@@ -47,6 +52,44 @@ describe('matchDeviceOperationsToPerf', () => {
         // The collapse heuristic alone keeps only the twice-seen `Pad` key, so
         // this report only links via the direct pass.
         expect(collapseMultideviceOperations(deviceOperations, 2)).toHaveLength(1);
+    });
+
+    it('links a report whose perf rows carry signposts (#1943)', () => {
+        // Shape of test_ttnn_moe_aug26_2217: a model that calls `signpost()` gets
+        // marker rows leading, interleaved and trailing. Only the leading and
+        // interleaved ones shift the alignment, but all are dropped.
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2), mapping('Gamma', 3)];
+        const perfRows = [
+            signpostRow('tt_forward_START', 0),
+            perfRow('Alpha', 1),
+            signpostRow('phase_start', 2),
+            perfRow('Beta', 3),
+            perfRow('Gamma', 4),
+            signpostRow('phase_end', 5),
+            signpostRow('tt_forward_END', 6),
+        ];
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRows, 1);
+
+        expect(matched).toHaveLength(3);
+        // The ids are the rows' own, so consumers still join against the unfiltered report.
+        expect(matched.map((deviceOperation) => deviceOperation.perfData?.id)).toEqual(['1', '3', '4']);
+    });
+
+    it('ignores signposts on the collapsed fallback too', () => {
+        const deviceOperations = duplicatedPerDevice(['Alpha', 'Beta'], 32);
+        const perfRows = [signpostRow('MoE_START', 0), perfRow('Alpha', 1), perfRow('Beta', 2)];
+
+        const matched = matchDeviceOperationsToPerf(deviceOperations, perfRows, 32);
+
+        expect(matched.map((deviceOperation) => deviceOperation.perfData?.id)).toEqual(['1', '2']);
+    });
+
+    it('still rejects a report that disagrees once its signposts are dropped', () => {
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2)];
+        const perfRows = [signpostRow('start', 0), perfRow('Alpha', 1), perfRow('Gamma', 2)];
+
+        expect(matchDeviceOperationsToPerf(deviceOperations, perfRows, 1)).toEqual([]);
     });
 
     it('falls back to collapsing when the report records each device op once per device', () => {

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -14,14 +14,17 @@ const mapping = (name: string, id: number): DeviceOperationMapping => ({
     operationName: `ttnn.${name.toLowerCase()}`,
 });
 
-const perfRow = (rawOpCode: string, id: number): PerfTableRow =>
-    ({ id: String(id), raw_op_code: rawOpCode, device_time: '1' }) as unknown as PerfTableRow;
+// Rows carry an `op_type` because the model has it non-nullable and the backend
+// always writes one. Defaulting it here is what makes every other case in this
+// file pin that a real device row is *retained* by the signpost filter, rather
+// than only exercising it against a shape the backend never emits.
+const perfRow = (rawOpCode: string, id: number, opType: OpType | null = OpType.DEVICE_OP): PerfTableRow =>
+    ({ id: String(id), raw_op_code: rawOpCode, device_time: '1', op_type: opType }) as unknown as PerfTableRow;
 
 const perfRowsFor = (names: string[]): PerfTableRow[] => names.map((name, index) => perfRow(name, index));
 
 /** A row for a `signpost()` marker, which no device operation corresponds to. */
-const signpostRow = (label: string, id: number): PerfTableRow =>
-    ({ id: String(id), raw_op_code: label, op_type: OpType.SIGNPOST }) as unknown as PerfTableRow;
+const signpostRow = (label: string, id: number): PerfTableRow => perfRow(label, id, OpType.SIGNPOST);
 
 /** Each op recorded once per device, as `numDevices` consecutive entries. */
 const duplicatedPerDevice = (names: string[], numDevices: number): DeviceOperationMapping[] =>
@@ -83,6 +86,16 @@ describe('matchDeviceOperationsToPerf', () => {
         const matched = matchDeviceOperationsToPerf(deviceOperations, perfRows, 32);
 
         expect(matched.map((deviceOperation) => deviceOperation.perfData?.id)).toEqual(['1', '2']);
+    });
+
+    it('keeps a row whose op type the backend could not resolve', () => {
+        // `set_op_type_from_results` writes `op_type = None` when a row id falls
+        // outside the ops perf CSV, so null reaches the frontend as a real shape
+        // and must pass the filter rather than being mistaken for a marker.
+        const deviceOperations = [mapping('Alpha', 1), mapping('Beta', 2)];
+        const perfRows = [perfRow('Alpha', 0, null), perfRow('Beta', 1, null)];
+
+        expect(matchDeviceOperationsToPerf(deviceOperations, perfRows, 1)).toHaveLength(2);
     });
 
     it('still rejects a report that disagrees once its signposts are dropped', () => {


### PR DESCRIPTION
Closes #1943. Targets `dev`.

## Summary

A memory report and a performance report from the same run would not link if the model called `signpost()`.

Device operations are matched to perf rows by strict positional alignment, all-or-nothing. A signpost row is a marker, not an operation, so the memory report has no device operation to pair it with — and because signposts are their own op type rather than a host op, the pinned `hideHostOps` filter never removed them. One signpost anywhere but the tail shifted every later row out of position and rejected the whole report.

Signpost rows are now dropped before alignment. The alignment logic itself is unchanged.

This only ever affected models that emit signposts — which is precisely the instrumented bring-up work most likely to need the link. A model whose signposts all sit at the end was already linking, since trailing extra rows were tolerated.

The filtering happens inside the matcher rather than at fetch time on purpose: the performance tab still wants its signpost rows, and the matcher is the only consumer that aligns positionally. Every other consumer reads the matcher's output and inherits the fix.

## Test plan

Verified against a real pair that reproduced the bug — memory report `test_ttnn_moe_aug26_2217` with profiler run `2026_08_26_22_21_37`, a DeepSeek-V3 MoE prefill on a 32-chip Blackhole mesh, whose perf report is 25 device ops plus 8 signposts:

| | perf rows | matched | result |
|---|---|---|---|
| before | 33 | 0 | UNLINKED |
| after | 33 | 25 | **LINKED** |

Perf row ids are the unfiltered report's own (`23, 51, 86, … 782`), so consumers still join against the full perf table.

New cases in `deviceOperationMatching.spec.ts` cover signposts leading, interleaved and trailing; signposts on the collapsed multi-device path; and a negative case confirming a genuinely mismatched report is still rejected once its signposts are dropped.

`pnpm test` green (2212 tests, 199 files), `tsc --noEmit` and eslint clean.

## Follow-ups

Not addressed here, both filed separately: #1940 (surface the subdevice fields tt-perf-report drops) and #1941 (the device log reader breaks on current profiler CSVs).
