### PR TITLE
Treat a lone unsuffixed cluster descriptor as one host

### DIFF
--- a/backend/ttnn_visualizer/tests/test_utils.py
+++ b/backend/ttnn_visualizer/tests/test_utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import os
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -693,6 +694,128 @@ def test_pick_mesh_descriptor_rank_out_of_range(tmp_path):
     path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=2)
     assert path is None
     assert err == "rank_out_of_range"
+
+
+def _write(path: Path, text: str, mtime_ns: int | None = None) -> Path:
+    path.write_text(text, encoding="utf-8")
+    if mtime_ns is not None:
+        os.utime(path, ns=(mtime_ns, mtime_ns))
+    return path
+
+
+# The producer reuses the output directory and writes each descriptor only
+# `if not path.exists()`, so the import that runs first owns its filenames and a
+# later import of a different world size adds the other family. Which family is
+# stale therefore depends on import order, and both orders are reachable. #1947
+OLD_NS = 1_600_000_000_000_000_000
+NEW_NS = 1_700_000_000_000_000_000
+
+
+def _cluster_families(tmp_path, single_ns, ranked_ns, world=2):
+    _write(tmp_path / "cluster_descriptor.yaml", "chips: []\n", single_ns)
+    for index in range(1, world + 1):
+        _write(
+            tmp_path / f"cluster_descriptor_{index}_of_{world}.yaml",
+            f"chips: [{index}]\n",
+            ranked_ns,
+        )
+
+
+def _mesh_families(tmp_path, single_ns, ranked_ns, world=2):
+    _write(
+        tmp_path / "physical_chip_mesh_coordinate_mapping.yaml",
+        "chips: []\n",
+        single_ns,
+    )
+    for index in range(1, world + 1):
+        _write(
+            tmp_path / f"physical_chip_mesh_coordinate_mapping_{index}_of_{world}.yaml",
+            f"chips: [{index}]\n",
+            ranked_ns,
+        )
+
+
+def test_ranked_family_wins_when_it_is_the_newer_import(tmp_path):
+    # world-1 imported first, then world-2: the unsuffixed file is the leftover.
+    _cluster_families(tmp_path, single_ns=OLD_NS, ranked_ns=NEW_NS)
+
+    for rank, expected in (
+        (0, "cluster_descriptor_1_of_2.yaml"),
+        (1, "cluster_descriptor_2_of_2.yaml"),
+    ):
+        path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=rank)
+        assert err is None
+        assert path is not None and path.name == expected
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=2)
+    assert path is None and err == "rank_out_of_range"
+
+
+def test_unsuffixed_wins_when_it_is_the_newer_import(tmp_path):
+    # The reverse order, which the producer permits just as readily: world-2
+    # imported first, then world-1, so the ranked family is the leftover.
+    _cluster_families(tmp_path, single_ns=NEW_NS, ranked_ns=OLD_NS)
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None and path.name == "cluster_descriptor.yaml"
+
+    # One host, so nothing past rank 0 — not the stale ranked family's world.
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=1)
+    assert path is None and err == "rank_out_of_range"
+
+
+def test_a_partial_ranked_family_does_not_mask_an_unsuffixed_descriptor(tmp_path):
+    # `ranked_report_basenames` calls a lone `_1_of_2` a consistent group, which
+    # made rank 1 fail with `missing_rank_file` while a usable descriptor sat
+    # beside it. An incomplete family is not eligible to win, whatever its mtime.
+    _write(tmp_path / "cluster_descriptor.yaml", "chips: []\n", OLD_NS)
+    _write(tmp_path / "cluster_descriptor_1_of_2.yaml", "chips: [1]\n", NEW_NS)
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None and path.name == "cluster_descriptor.yaml"
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=1)
+    assert path is None and err == "rank_out_of_range"
+
+
+def test_a_partial_ranked_family_is_still_used_when_it_is_all_there_is(tmp_path):
+    # Completeness governs precedence, not usability: with no unsuffixed file to
+    # defer to, rank 0 is still serviceable and only the absent rank errors.
+    _write(tmp_path / "cluster_descriptor_1_of_2.yaml", "chips: [1]\n")
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None and path.name == "cluster_descriptor_1_of_2.yaml"
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=1)
+    assert path is None and err == "missing_rank_file"
+
+
+@pytest.mark.parametrize(
+    "single_ns,ranked_ns,expect_ranked",
+    [(OLD_NS, NEW_NS, True), (NEW_NS, OLD_NS, False)],
+)
+def test_cluster_and_mesh_choose_the_same_generation(
+    tmp_path, single_ns, ranked_ns, expect_ranked
+):
+    # The failure this guards: cluster selecting the current ranked descriptors
+    # while mesh returned the stale unsuffixed mapping, which then overrode
+    # `descriptor.chips` for every host. Family selection is shared, so the two
+    # cannot disagree; only the per-rank rule differs. #1947
+    _cluster_families(tmp_path, single_ns, ranked_ns)
+    _mesh_families(tmp_path, single_ns, ranked_ns)
+
+    cluster, cluster_err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+    mesh, mesh_err = pick_mesh_descriptor_path(tmp_path, logical_rank=0)
+
+    assert cluster_err is None and mesh_err is None
+    assert cluster is not None and mesh is not None
+    assert ("_1_of_2" in cluster.name) is expect_ranked
+    assert (
+        "_1_of_2" in mesh.name
+    ) is expect_ranked, "mesh chose a different generation"
 
 
 def test_pick_cluster_descriptor_ranked_set_outranks_a_stale_unsuffixed_file(tmp_path):

--- a/backend/ttnn_visualizer/tests/test_utils.py
+++ b/backend/ttnn_visualizer/tests/test_utils.py
@@ -695,15 +695,33 @@ def test_pick_mesh_descriptor_rank_out_of_range(tmp_path):
     assert err == "rank_out_of_range"
 
 
-def test_pick_cluster_descriptor_prefers_unsuffixed_file(tmp_path):
+def test_pick_cluster_descriptor_ranked_set_outranks_a_stale_unsuffixed_file(tmp_path):
+    # tt-metal reuses the output directory and writes each descriptor only
+    # `if not path.exists()`, so a world-1 import followed by a world-2 import into
+    # the same directory leaves the unsuffixed file beside the ranked pair. Serving
+    # that leftover for every rank reproduced #1939 bounded by the world size, so
+    # the ranked set wins and its bound applies. #1947
     (tmp_path / "cluster_descriptor.yaml").write_text("chips: []\n", encoding="utf-8")
     (tmp_path / "cluster_descriptor_1_of_2.yaml").write_text(
         "chips: [1]\n", encoding="utf-8"
     )
+    (tmp_path / "cluster_descriptor_2_of_2.yaml").write_text(
+        "chips: [2]\n", encoding="utf-8"
+    )
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None and path.name == "cluster_descriptor_1_of_2.yaml"
+
     path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=1)
     assert err is None
-    assert path is not None
-    assert path.name == "cluster_descriptor.yaml"
+    assert path is not None and path.name == "cluster_descriptor_2_of_2.yaml"
+
+    # The probe stops at the world bound instead of walking to its cap.
+    for rank in (2, 3, 31):
+        path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=rank)
+        assert path is None, f"rank {rank} resolved to {path}"
+        assert err == "rank_out_of_range"
 
 
 def test_pick_cluster_descriptor_single_file_answers_rank_zero_only(tmp_path):
@@ -723,18 +741,20 @@ def test_pick_cluster_descriptor_single_file_answers_rank_zero_only(tmp_path):
         assert err == "rank_out_of_range", f"rank {rank} returned {err!r}"
 
 
-def test_pick_mesh_descriptor_single_file_answers_rank_zero_only(tmp_path):
+def test_pick_mesh_descriptor_single_file_serves_every_rank(tmp_path):
+    # Deliberately unlike the cluster rule: one unsuffixed mesh mapping covers the
+    # whole world, either reused as a legacy single doc or holding one `chips:`
+    # document per rank that the frontend selects from. Applying the cluster
+    # rank-0-only rule here left later hosts with no mesh data. #1947
     (tmp_path / "physical_chip_mesh_coordinate_mapping.yaml").write_text(
         "chips: []\n", encoding="utf-8"
     )
 
-    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=0)
-    assert err is None
-    assert path is not None
-
-    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=1)
-    assert path is None
-    assert err == "rank_out_of_range"
+    for rank in (0, 1, 5, 31):
+        path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=rank)
+        assert err is None, f"rank {rank} returned {err!r}"
+        assert path is not None
+        assert path.name == "physical_chip_mesh_coordinate_mapping.yaml"
 
 
 def test_pick_cluster_descriptor_ranked_files(tmp_path):

--- a/backend/ttnn_visualizer/tests/test_utils.py
+++ b/backend/ttnn_visualizer/tests/test_utils.py
@@ -706,6 +706,37 @@ def test_pick_cluster_descriptor_prefers_unsuffixed_file(tmp_path):
     assert path.name == "cluster_descriptor.yaml"
 
 
+def test_pick_cluster_descriptor_single_file_answers_rank_zero_only(tmp_path):
+    # A report shipping one unsuffixed descriptor is a single host. Answering
+    # rank 1..N with the same file made the topology probe clone that host once
+    # per probed rank (#1939), so every rank past 0 is out of range.
+    (tmp_path / "cluster_descriptor.yaml").write_text("chips: []\n", encoding="utf-8")
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None
+    assert path.name == "cluster_descriptor.yaml"
+
+    for rank in (1, 2, 31, 99):
+        path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=rank)
+        assert path is None, f"rank {rank} should not resolve to a file"
+        assert err == "rank_out_of_range", f"rank {rank} returned {err!r}"
+
+
+def test_pick_mesh_descriptor_single_file_answers_rank_zero_only(tmp_path):
+    (tmp_path / "physical_chip_mesh_coordinate_mapping.yaml").write_text(
+        "chips: []\n", encoding="utf-8"
+    )
+
+    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=0)
+    assert err is None
+    assert path is not None
+
+    path, err = pick_mesh_descriptor_path(tmp_path, logical_rank=1)
+    assert path is None
+    assert err == "rank_out_of_range"
+
+
 def test_pick_cluster_descriptor_ranked_files(tmp_path):
     (tmp_path / "cluster_descriptor_2_of_2.yaml").write_text(
         "chips: [2]\n", encoding="utf-8"

--- a/backend/ttnn_visualizer/tests/test_utils.py
+++ b/backend/ttnn_visualizer/tests/test_utils.py
@@ -10,12 +10,14 @@ import pytest
 from ttnn_visualizer.models import RemoteConnection
 from ttnn_visualizer.utils import (
     FALSE_VALUES,
+    MAX_RANKED_WORLD_SIZE,
     TRUE_VALUES,
     find_gunicorn_path,
     get_app_data_directory,
     get_mlir_path,
     get_report_data_directory,
     is_running_in_container,
+    is_valid_profiler_ranked_entry,
     parse_bool,
     pick_cluster_descriptor_path,
     pick_mesh_descriptor_path,
@@ -891,3 +893,46 @@ def test_pick_cluster_descriptor_ranked_files(tmp_path):
     assert err is None
     assert path is not None
     assert path.name == "cluster_descriptor_2_of_2.yaml"
+
+
+def test_ranked_world_size_is_bounded_against_a_hostile_filename(tmp_path):
+    """
+    ``world_size`` is parsed straight out of a filename, and the local upload path
+    preserves client basenames. Completeness used to be decided by comparing
+    against ``set(range(1, world_size + 1))``, so an 11-digit world size asked for
+    a multi-terabyte allocation inside the shared Flask process. #1947
+    """
+    assert is_valid_profiler_ranked_entry(1, MAX_RANKED_WORLD_SIZE) is True
+    assert is_valid_profiler_ranked_entry(1, MAX_RANKED_WORLD_SIZE + 1) is False
+    assert is_valid_profiler_ranked_entry(1, 99_999_999_999) is False
+
+    # End to end: an over-cap name is skipped, so a usable unsuffixed descriptor
+    # still answers rather than the request dying on the allocation.
+    (tmp_path / "cluster_descriptor.yaml").write_text("chips: []\n", encoding="utf-8")
+    (tmp_path / "cluster_descriptor_1_of_99999999999.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+
+    assert err is None
+    assert path is not None
+    assert path.name == "cluster_descriptor.yaml"
+
+
+def test_ranked_family_completeness_counts_rather_than_enumerating(tmp_path):
+    # The count settles completeness because the indices are unique and already
+    # bounded to 1..world; an incomplete family must not outrank the unsuffixed file.
+    (tmp_path / "cluster_descriptor.yaml").write_text("chips: []\n", encoding="utf-8")
+    (tmp_path / "cluster_descriptor_1_of_3.yaml").write_text(
+        "chips: [1]\n", encoding="utf-8"
+    )
+    (tmp_path / "cluster_descriptor_2_of_3.yaml").write_text(
+        "chips: [2]\n", encoding="utf-8"
+    )
+
+    path, err = pick_cluster_descriptor_path(tmp_path, logical_rank=0)
+
+    assert err is None
+    assert path is not None
+    assert path.name == "cluster_descriptor.yaml"

--- a/backend/ttnn_visualizer/tests/views/test_descriptor_endpoints.py
+++ b/backend/ttnn_visualizer/tests/views/test_descriptor_endpoints.py
@@ -146,3 +146,34 @@ def test_mesh_descriptor_returns_empty_chips_shape_when_yaml_has_no_dict_docs(
         assert response.status_code == 200
         data = response.get_json()
         assert data == {"chips": {}}
+
+
+def test_cluster_descriptor_rejects_a_rank_a_lone_descriptor_cannot_answer(app, client):
+    """
+    The fix for #1939 only reaches the frontend as an HTTP status: the probe loop
+    stops when a rank 400s. Nothing asserted that mapping, so remapping
+    ``rank_out_of_range`` to 200 or 500 would have passed the suite while
+    restoring the 32-host clone.
+    """
+    instance_id = "test-cluster-lone-descriptor-rank"
+    with tempfile.TemporaryDirectory() as tmp:
+        report_dir = Path(tmp)
+        (report_dir / "cluster_descriptor.yaml").write_text(
+            "chips: []\n", encoding="utf-8"
+        )
+        _register_profiler_instance_with_dir(app, instance_id, report_dir)
+
+        # Rank 0 is the one host this report describes.
+        rank_zero = client.get(
+            "/api/cluster-descriptor",
+            query_string={"instanceId": instance_id, "rank": 0},
+        )
+        assert rank_zero.status_code == 200
+
+        # Every rank past it is out of range, not another copy of the same host.
+        for rank in (1, 2, 31):
+            response = client.get(
+                "/api/cluster-descriptor",
+                query_string={"instanceId": instance_id, "rank": rank},
+            )
+            assert response.status_code == 400, f"rank {rank}"

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -119,11 +119,17 @@ def _pick_single_or_ranked_report_path(
     Prefer ``single_basename`` when present; otherwise pick the ranked file for
     ``logical_rank``. Returns ``(path, None)`` or ``(None, error)`` where error
     is ``rank_out_of_range``, ``missing_rank_file``, or ``None`` when absent.
+
+    An unsuffixed file with no ranked siblings answers rank 0 only: world size is
+    encoded in the ranked filenames, so a report that ships one unsuffixed
+    descriptor is a single host whatever chips it lists. See ``logical_rank``
+    handling below and #1939.
     """
     if not report_dir.is_dir():
         return None, None
     single = report_dir / single_basename
-    if single.is_file():
+    single_exists = single.is_file()
+    if single_exists and logical_rank == 0:
         return single, None
 
     ranked_names = ranked_report_basenames(
@@ -131,6 +137,15 @@ def _pick_single_or_ranked_report_path(
         ranked_re,
         malformed_label,
     )
+    if single_exists:
+        # Ranked siblings present: the unsuffixed file keeps precedence over them
+        # for every rank, as it always has.
+        if ranked_names:
+            return single, None
+        # Otherwise this is the only descriptor in the report. Serving it for
+        # rank 1..N too made the topology probe read a single host as a whole
+        # world and clone it once per probed rank. #1939
+        return None, "rank_out_of_range"
     if not ranked_names:
         return None, None
 

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -114,22 +114,29 @@ def _pick_single_or_ranked_report_path(
     ranked_basename_for: Callable[[int, int], str],
     malformed_label: str,
     logical_rank: int = 0,
+    single_is_one_rank: bool = False,
 ) -> tuple[Optional[Path], Optional[str]]:
     """
-    Prefer ``single_basename`` when present; otherwise pick the ranked file for
-    ``logical_rank``. Returns ``(path, None)`` or ``(None, error)`` where error
-    is ``rank_out_of_range``, ``missing_rank_file``, or ``None`` when absent.
+    Pick the descriptor file for ``logical_rank``. Returns ``(path, None)`` or
+    ``(None, error)`` where error is ``rank_out_of_range``, ``missing_rank_file``,
+    or ``None`` when nothing is present.
 
-    An unsuffixed file with no ranked siblings answers rank 0 only: world size is
-    encoded in the ranked filenames, so a report that ships one unsuffixed
-    descriptor is a single host whatever chips it lists. See ``logical_rank``
-    handling below and #1939.
+    ``single_is_one_rank`` declares that an unsuffixed file describes exactly one
+    rank. A consistent ranked set then outranks it, and with no ranked set it
+    answers rank 0 only. Cluster descriptors set it: world size lives in the
+    ranked filenames, so serving one unsuffixed descriptor for every rank made the
+    topology probe read a single host as a whole world and clone it once per
+    probed rank. #1939
+
+    Left ``False`` for mesh mappings, where one unsuffixed file legitimately
+    covers every rank — reused as a legacy single doc, or holding one ``chips:``
+    document per rank that the frontend selects from by rank. #1947
     """
     if not report_dir.is_dir():
         return None, None
     single = report_dir / single_basename
     single_exists = single.is_file()
-    if single_exists and logical_rank == 0:
+    if single_exists and not single_is_one_rank:
         return single, None
 
     ranked_names = ranked_report_basenames(
@@ -137,18 +144,21 @@ def _pick_single_or_ranked_report_path(
         ranked_re,
         malformed_label,
     )
-    if single_exists:
-        # Ranked siblings present: the unsuffixed file keeps precedence over them
-        # for every rank, as it always has.
-        if ranked_names:
-            return single, None
-        # Otherwise this is the only descriptor in the report. Serving it for
-        # rank 1..N too made the topology probe read a single host as a whole
-        # world and clone it once per probed rank. #1939
-        return None, "rank_out_of_range"
     if not ranked_names:
+        if single_exists:
+            # The only descriptor in the report, and it stands for a single rank.
+            if logical_rank == 0:
+                return single, None
+            return None, "rank_out_of_range"
         return None, None
 
+    # A consistent ranked set is authoritative even when an unsuffixed file sits
+    # beside it. That pairing is reachable from the producer rather than exotic:
+    # `import_report` reuses the output directory and writes each descriptor only
+    # `if not path.exists()`, so a world-1 import followed by a world-N import into
+    # the same directory leaves both. Serving the stale unsuffixed file for every
+    # rank reproduced #1939, bounded by the ranked world size rather than the
+    # probe cap. #1947
     parsed0 = parse_ranked_basename(ranked_names[0], ranked_re)
     if not parsed0:
         return None, None
@@ -1057,6 +1067,8 @@ def pick_cluster_descriptor_path(
         ),
         malformed_label="cluster_descriptor_<n>_of_<world>.yaml with 1 <= n <= world",
         logical_rank=logical_rank,
+        # One unsuffixed cluster descriptor is one host. Mesh mappings differ. #1939
+        single_is_one_rank=True,
     )
 
 

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -106,6 +106,71 @@ def ranked_profiler_config_basenames(file_names: Iterable[str]) -> List[str]:
     )
 
 
+def _ranked_family(
+    report_dir: Path, ranked_re: Pattern[str], malformed_label: str
+) -> tuple[List[str], int, bool]:
+    """
+    The ranked files in ``report_dir``: their names, world size, and completeness.
+
+    ``ranked_report_basenames`` calls any non-empty same-world group consistent, so
+    a lone ``_1_of_2`` left behind by an earlier import looks like a family. It is
+    reported as incomplete here instead, because such a group must not outrank a
+    usable unsuffixed descriptor. #1947
+    """
+    names = ranked_report_basenames(
+        (p.name for p in report_dir.iterdir() if p.is_file()),
+        ranked_re,
+        malformed_label,
+    )
+    if not names:
+        return [], 0, False
+    parsed = parse_ranked_basename(names[0], ranked_re)
+    if not parsed:
+        return [], 0, False
+    _, world_size = parsed
+    indices = {
+        parse_ranked_basename(name, ranked_re)[0]  # type: ignore[index]
+        for name in names
+        if parse_ranked_basename(name, ranked_re)
+    }
+    return names, world_size, indices == set(range(1, world_size + 1))
+
+
+def _newest_mtime_ns(paths: Iterable[Path]) -> int:
+    """Newest mtime among ``paths``; -1 when none of them can be stat'd."""
+    stamps = []
+    for path in paths:
+        try:
+            stamps.append(path.stat().st_mtime_ns)
+        except OSError:
+            continue
+    return max(stamps) if stamps else -1
+
+
+def _prefer_ranked_family(
+    report_dir: Path, single: Path, ranked_names: List[str], ranked_is_complete: bool
+) -> bool:
+    """
+    Whether the ranked family wins over an unsuffixed descriptor beside it.
+
+    Both can exist: ``import_report`` reuses the output directory and writes each
+    descriptor only ``if not path.exists()``, so whichever import ran first owns
+    its filenames and the other import adds the second family. Which one is stale
+    therefore depends on import order, and both orders are reachable — a world-1
+    import then a world-N one leaves the unsuffixed file stale, and the reverse
+    leaves the ranked family stale.
+
+    Nothing in the filenames records that, so recency decides, and only a complete
+    family is eligible to win. Ties go to the ranked family, which carries per-rank
+    detail. Note that mtimes do not survive every copy — an archive extract can
+    flatten them all — in which case the tie-break is what applies. #1947
+    """
+    if not ranked_is_complete:
+        return False
+    ranked_mtime = _newest_mtime_ns(report_dir / name for name in ranked_names)
+    return ranked_mtime >= _newest_mtime_ns([single])
+
+
 def _pick_single_or_ranked_report_path(
     report_dir: Path,
     *,
@@ -131,44 +196,43 @@ def _pick_single_or_ranked_report_path(
     Left ``False`` for mesh mappings, where one unsuffixed file legitimately
     covers every rank — reused as a legacy single doc, or holding one ``chips:``
     document per rank that the frontend selects from by rank. #1947
+
+    Which *family* is used — the unsuffixed file or the ranked set — is decided
+    identically for both, so cluster and mesh cannot end up reading different
+    generations of the same report. Only the per-rank question above differs.
     """
     if not report_dir.is_dir():
         return None, None
+
     single = report_dir / single_basename
     single_exists = single.is_file()
-    if single_exists and not single_is_one_rank:
-        return single, None
-
-    ranked_names = ranked_report_basenames(
-        (p.name for p in report_dir.iterdir() if p.is_file()),
-        ranked_re,
-        malformed_label,
+    ranked_names, world_size, ranked_is_complete = _ranked_family(
+        report_dir, ranked_re, malformed_label
     )
-    if not ranked_names:
-        if single_exists:
-            # The only descriptor in the report, and it stands for a single rank.
-            if logical_rank == 0:
-                return single, None
-            return None, "rank_out_of_range"
-        return None, None
 
-    # A consistent ranked set is authoritative even when an unsuffixed file sits
-    # beside it. That pairing is reachable from the producer rather than exotic:
-    # `import_report` reuses the output directory and writes each descriptor only
-    # `if not path.exists()`, so a world-1 import followed by a world-N import into
-    # the same directory leaves both. Serving the stale unsuffixed file for every
-    # rank reproduced #1939, bounded by the ranked world size rather than the
-    # probe cap. #1947
-    parsed0 = parse_ranked_basename(ranked_names[0], ranked_re)
-    if not parsed0:
-        return None, None
-    _, world_size = parsed0
+    if single_exists and ranked_names:
+        use_ranked = _prefer_ranked_family(
+            report_dir, single, ranked_names, ranked_is_complete
+        )
+    else:
+        use_ranked = bool(ranked_names)
+
+    if not use_ranked:
+        if not single_exists:
+            return None, None
+        # A whole-world mapping answers every rank; a single-host descriptor
+        # answers rank 0 and nothing beyond it.
+        if single_is_one_rank and logical_rank != 0:
+            return None, "rank_out_of_range"
+        return single, None
 
     if logical_rank < 0 or logical_rank >= world_size:
         return None, "rank_out_of_range"
 
     path = report_dir / ranked_basename_for(logical_rank + 1, world_size)
     if not path.is_file():
+        # Only reachable for an incomplete family that had no unsuffixed file to
+        # defer to, or a file removed since the directory was listed.
         return None, "missing_rank_file"
     return path, None
 

--- a/backend/ttnn_visualizer/utils.py
+++ b/backend/ttnn_visualizer/utils.py
@@ -54,9 +54,17 @@ def parse_ranked_profiler_config_basename(
     return parse_ranked_basename(filename, PROFILER_CONFIG_RANKED_RE)
 
 
+# A world size is parsed straight out of a filename, and filenames on the local
+# upload path are client-controlled. Anything past this is not a run we could
+# render anyway — the largest cluster the app has seen is in the hundreds — and
+# without a bound an 11-digit name asks for a multi-terabyte allocation in the
+# shared Flask process. Well above _MAX_RANK's use as a query-param bound.
+MAX_RANKED_WORLD_SIZE = 4096
+
+
 def is_valid_profiler_ranked_entry(index_one_based: int, world: int) -> bool:
     """True when the filename indices match TTNN output (1..world inclusive)."""
-    return 1 <= index_one_based <= world
+    return 1 <= world <= MAX_RANKED_WORLD_SIZE and 1 <= index_one_based <= world
 
 
 def ranked_report_basenames(
@@ -124,16 +132,18 @@ def _ranked_family(
     )
     if not names:
         return [], 0, False
-    parsed = parse_ranked_basename(names[0], ranked_re)
-    if not parsed:
+    # Parsed once per name: this ran the regex three times per filename, and the
+    # hoist is also what removes the `type: ignore[index]` the comprehension needed.
+    parsed = [parse_ranked_basename(name, ranked_re) for name in names]
+    if not parsed[0]:
         return [], 0, False
-    _, world_size = parsed
-    indices = {
-        parse_ranked_basename(name, ranked_re)[0]  # type: ignore[index]
-        for name in names
-        if parse_ranked_basename(name, ranked_re)
-    }
-    return names, world_size, indices == set(range(1, world_size + 1))
+    _, world_size = parsed[0]
+    indices = {entry[0] for entry in parsed if entry}
+    # Counted, not compared against `set(range(1, world_size + 1))`: the indices are
+    # already unique and `ranked_report_basenames` has bounded them to 1..world, so
+    # the count settles completeness without allocating a set sized by a number that
+    # came out of a filename.
+    return names, world_size, len(indices) == world_size
 
 
 def _newest_mtime_ns(paths: Iterable[Path]) -> int:

--- a/src/functions/clusterTopology.ts
+++ b/src/functions/clusterTopology.ts
@@ -151,10 +151,17 @@ export const hostHasTwoDimensionalMesh = (host: ClusterHost): boolean => {
 };
 
 /**
- * True iff this descriptor looks like a per-rank slice of a multi-host report.
+ * True iff this descriptor *might* be a per-rank slice of a multi-host report.
  * Requires BOTH `ethernet_connections_to_remote_devices` and `chip_unique_ids`
- * to be non-empty — single-host reports omit these and a more permissive check
- * would trigger spurious world-size probes against the unranked descriptor.
+ * to be non-empty.
+ *
+ * It is a hint, not a decision. The premise that single-host reports omit these
+ * fields is false: a UBB with scale-out links populates both while describing one
+ * host, and this check cannot separate it from a genuine rank-0 slice — which is
+ * the mechanism behind #1939, where a lone descriptor was cloned once per probed
+ * rank. What bounds the probe is the backend, which answers 400 for any rank a
+ * report's descriptor family cannot cover, so a false positive here costs one
+ * rejected request rather than a fabricated host.
  */
 export const looksLikeRankedDescriptor = (descriptor: ClusterModel): boolean => {
     const remoteConnections = descriptor.ethernet_connections_to_remote_devices;

--- a/tests/clusterTopology.spec.ts
+++ b/tests/clusterTopology.spec.ts
@@ -376,8 +376,47 @@ describe('looksLikeRankedDescriptor', () => {
             chip_unique_ids: { 0: 1234 },
         } as unknown as ClusterModel;
         // An empty remote-connections array means there are no cross-host links,
-        // which we treat as single-host (galaxy can't trigger a 32-rank probe).
+        // which we treat as single-host. Note this does not cover every galaxy:
+        // a UBB with scale-out links populates the field — see the UBB case below.
         expect(looksLikeRankedDescriptor(desc)).toBe(false);
+    });
+
+    it('cannot tell a single UBB from a rank slice, so the backend gates the probe (#1939)', () => {
+        // Shape of test_ttnn_moe_aug26_2217: one unsuffixed descriptor, 32 Blackhole
+        // chips on a single `ubb_blackhole` board, no mesh coords, and remote-eth
+        // links to fabric chips that are not in this capture.
+        // Unique ids are stand-ins: the real ones are 64-bit and exceed
+        // Number.MAX_SAFE_INTEGER, so they arrive here already rounded by
+        // JSON.parse. Only the off-capture property matters for this test.
+        const ubb = {
+            ...baseDescriptor,
+            arch: Object.fromEntries(Array.from({ length: 32 }, (_, chip) => [chip, 'blackhole'])),
+            boards: [
+                {
+                    board_id: 4892798423057,
+                    board_type: 'ubb_blackhole',
+                    chips: Array.from({ length: 32 }, (_, chip) => chip),
+                },
+            ],
+            chip_unique_ids: Object.fromEntries(Array.from({ length: 32 }, (_, chip) => [chip, 1000 + chip])),
+            ethernet_connections_to_remote_devices: [
+                [
+                    { chip: 25, chan: 9 },
+                    // Off-capture: absent from `chip_unique_ids` above.
+                    { remote_chip_id: 9001, chan: 9 },
+                ],
+            ],
+        } as unknown as ClusterModel;
+
+        // Deliberately true. A genuine rank-0 slice also points its remotes at
+        // chips it does not own, so no property of a lone descriptor separates
+        // the two — see the two-host case at the top of this file, where rank 0's
+        // remote id 200 is likewise absent from its own chip_unique_ids.
+        expect(looksLikeRankedDescriptor(ubb)).toBe(true);
+        // World size lives in the ranked filenames instead, so the backend answers
+        // rank 1+ with `rank_out_of_range` when the unsuffixed file is the only
+        // descriptor and the probe stops after rank 0. Covered by
+        // `test_pick_cluster_descriptor_single_file_answers_rank_zero_only`.
     });
 
     it('returns false when chip_unique_ids is missing or empty', () => {


### PR DESCRIPTION
Closes #1939. Targets `dev`.

## Summary

Opening `test_ttnn_moe_aug26_2217` in Topology rendered 32 boards instead of the one 32-chip UBB the descriptor describes.

The topology probe walks ranks until the backend refuses one, but `_pick_single_or_ranked_report_path` returned the unsuffixed `cluster_descriptor.yaml` for **every** rank — including ranks past the world, verified up to 99. The probe's break condition was unreachable, so it collected `MAX_PROBE_RANKS` copies of one descriptor and stitched 32 hosts out of them.

World size is encoded in the ranked filenames, so a report shipping only the unsuffixed descriptor now answers rank 0 and reports `rank_out_of_range` beyond it. The probe stops after rank 0 and gets one host.

Reports that ship `cluster_descriptor_<n>_of_<world>.yaml` are untouched, and the existing precedence of an unsuffixed file over ranked siblings is preserved for every rank — no report on disk mixes the two, and the two tests pinning that precedence still pass unchanged.

### Why the backend rather than `looksLikeRankedDescriptor`

The issue offered tightening the frontend heuristic as an alternative: treat remote unique ids absent from this descriptor's own `chip_unique_ids` as fabric rather than another rank. That does not discriminate. A genuine rank-0 slice also points its remotes at chips it does not own — in the two-host fixture at the top of `clusterTopology.spec.ts`, rank 0's `remote_chip_id: 200` is likewise absent from its own `chip_unique_ids`. Adopting it would have classified real multi-host rank slices as single-host and broken stitching, failing the issue's own second acceptance criterion.

No property of a lone descriptor separates a single UBB from a rank slice, so the filename is the only authority. `looksLikeRankedDescriptor` is left as-is and a spec case now records that it returns `true` for this shape deliberately, with the backend gating the probe.

## Test plan

Verified against both real reports through the running backend, driving the same probe loop the frontend runs and stitching the result with the shipped `stitchClusterTopology`:

| report | rank slices collected | hosts | worldSize | isMultiHost | interHostLinks |
|---|---|---|---|---|---|
| `test_ttnn_moe_aug26_2217` (one unsuffixed) | 1 | **1** | 1 | **false** | 0 |
| `multihost_poc_jun24_2321` (`1_of_2`, `2_of_2`) | 2 | 2 | 2 | true | 6 |

Before the change the MoE report produced 32 hosts with `unresolvedRemoteCount: 1248` (39 remote links × 32 clones). It is now 1 host with 39 — the genuine off-capture fabric links, which #1939 puts out of scope.

Endpoint behaviour, single-descriptor report: rank 0 → 200, ranks 1/2/31 → 400. Ranked report: ranks 0 and 1 → 200 with *different* descriptors, rank 2 → 400.

New coverage:
- `test_pick_cluster_descriptor_single_file_answers_rank_zero_only` — rank 0 resolves, ranks 1/2/31/99 all return `rank_out_of_range`.
- `test_pick_mesh_descriptor_single_file_answers_rank_zero_only` — same for the mesh descriptor, which shares the picker.
- A `clusterTopology.spec.ts` fixture shaped like this report (32 Blackhole chips, one `ubb_blackhole` board, no mesh coords, off-capture remote-eth), recording why the heuristic cannot decide it.

Also corrected a spec comment that claimed a galaxy "can't trigger a 32-rank probe" — this UBB is the counterexample.

Backend 1135 passing, frontend 2210 passing, `tsc`, eslint, isort and black all clean.

## Follow-ups

Not addressed here:

- #1241 remains the durable fix — take world size from report metadata instead of probing YAML shape. This stops the clone without it.
- Real `remote_chip_id` values are 64-bit and exceed `Number.MAX_SAFE_INTEGER`, so they are already rounded by `JSON.parse` before any matching happens. Noted in the new fixture; worth its own issue if remote-id matching is ever tightened.
