### PR TITLE
Group condensed cluster chips by board slot

### DIFF
--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -13,6 +13,7 @@ import { useGetClusterTopology } from '../../hooks/useAPI';
 import { getChipDesign } from '../../functions/getChipDesign';
 import {
     FALLBACK_PER_HOST_COLS,
+    getAsicLocationGroups,
     hostHasMeshCoords,
     sortHostsByConnectionProximity,
 } from '../../functions/clusterTopology';
@@ -47,6 +48,10 @@ const CLUSTER_CHIP_SIZE_SMALL = 150;
 // stays in sync). Used as a fallback when no mesh coords are present, or as
 // a user-selectable alternative to the literal mesh layout. #1510
 const FALLBACK_HOST_GUTTER_ROWS = 1;
+// Blank row between board groups in the condensed fallback, so a group-to-group
+// link visibly crosses a boundary and chips either side of one are not drawn
+// touching. #1948
+const FALLBACK_GROUP_GUTTER_ROWS = 1;
 // Top padding gives outward-edge curves from the topmost host room to arc
 // without colliding with the cluster panel chrome.
 const FALLBACK_TOP_PAD_ROWS = 2;
@@ -219,6 +224,21 @@ function buildClusterRenderModel(
 
         let usedFallback = false;
 
+        // Fallback tier between mesh coords and raw id order: group the chips by
+        // board slot so the grid can separate groups. `null` keeps id order. #1948
+        const fallbackGroups = useMeshCoords ? null : getAsicLocationGroups(host.descriptor, chipIdsForHost);
+        const fallbackRowsPerGroup = fallbackGroups ? Math.ceil(fallbackGroups[0].length / FALLBACK_PER_HOST_COLS) : 0;
+        const fallbackPositionByChip = new Map<number, readonly [number, number]>();
+        fallbackGroups?.forEach((group, groupIndex) => {
+            const groupTop = groupIndex * (fallbackRowsPerGroup + FALLBACK_GROUP_GUTTER_ROWS);
+            group.forEach((groupedChipId, slotIndex) => {
+                fallbackPositionByChip.set(groupedChipId, [
+                    slotIndex % FALLBACK_PER_HOST_COLS,
+                    groupTop + Math.floor(slotIndex / FALLBACK_PER_HOST_COLS),
+                ]);
+            });
+        });
+
         // Plain `for` to keep mutable counters out of a closure (no-loop-func).
         for (let localIndex = 0; localIndex < chipIdsForHost.length; localIndex += 1) {
             const chipId = chipIdsForHost[localIndex];
@@ -229,8 +249,14 @@ function buildClusterRenderModel(
                 [x, y] = meshCoord;
             } else {
                 usedFallback = true;
-                x = localIndex % FALLBACK_PER_HOST_COLS;
-                y = nextHostOffsetY + Math.floor(localIndex / FALLBACK_PER_HOST_COLS);
+                const grouped = fallbackPositionByChip.get(chipId);
+                if (grouped) {
+                    [x] = grouped;
+                    y = nextHostOffsetY + grouped[1];
+                } else {
+                    x = localIndex % FALLBACK_PER_HOST_COLS;
+                    y = nextHostOffsetY + Math.floor(localIndex / FALLBACK_PER_HOST_COLS);
+                }
             }
             totalCols = Math.max(totalCols, x + 1);
             totalRows = Math.max(totalRows, y + 1);
@@ -249,7 +275,12 @@ function buildClusterRenderModel(
         }
 
         if (usedFallback) {
-            const hostRows = Math.ceil(chipIdsForHost.length / FALLBACK_PER_HOST_COLS);
+            // Grouped layouts are taller by one gutter row per boundary; the last
+            // group does not get a trailing one.
+            const hostRows = fallbackGroups
+                ? fallbackGroups.length * (fallbackRowsPerGroup + FALLBACK_GROUP_GUTTER_ROWS) -
+                  FALLBACK_GROUP_GUTTER_ROWS
+                : Math.ceil(chipIdsForHost.length / FALLBACK_PER_HOST_COLS);
             nextHostOffsetY += hostRows + FALLBACK_HOST_GUTTER_ROWS;
         }
     }
@@ -837,6 +868,11 @@ function ClusterRenderer() {
                         />
                     </Tooltip>
                 </ButtonGroup>
+                {!isMeshAvailable && (
+                    <Tooltip content='This report carries no mesh coordinates, so chips are tiled by board slot rather than placed at their physical positions. Links are accurate; positions are not.'>
+                        <span className='cluster-view-layout-note'>Positions not to scale</span>
+                    </Tooltip>
+                )}
                 {isMultiHost && isMeshAvailable && (
                     <Tooltip content='Switch between honouring the report mesh coordinates and a condensed 4-wide grid'>
                         <Switch

--- a/src/components/cluster/ClusterRenderer.tsx
+++ b/src/components/cluster/ClusterRenderer.tsx
@@ -13,7 +13,7 @@ import { useGetClusterTopology } from '../../hooks/useAPI';
 import { getChipDesign } from '../../functions/getChipDesign';
 import {
     FALLBACK_PER_HOST_COLS,
-    getAsicLocationGroups,
+    getCondensedHostLayout,
     hostHasMeshCoords,
     sortHostsByConnectionProximity,
 } from '../../functions/clusterTopology';
@@ -48,10 +48,6 @@ const CLUSTER_CHIP_SIZE_SMALL = 150;
 // stays in sync). Used as a fallback when no mesh coords are present, or as
 // a user-selectable alternative to the literal mesh layout. #1510
 const FALLBACK_HOST_GUTTER_ROWS = 1;
-// Blank row between board groups in the condensed fallback, so a group-to-group
-// link visibly crosses a boundary and chips either side of one are not drawn
-// touching. #1948
-const FALLBACK_GROUP_GUTTER_ROWS = 1;
 // Top padding gives outward-edge curves from the topmost host room to arc
 // without colliding with the cluster panel chrome.
 const FALLBACK_TOP_PAD_ROWS = 2;
@@ -114,6 +110,8 @@ interface ClusterRenderModel {
     layoutMode: ClusterLayoutMode;
     // Mesh layout is viable for this topology (drives the UI toggle's visibility).
     isMeshAvailable: boolean;
+    /** True when at least one host's condensed layout fell through to chip id order. */
+    anyHostFellToIdOrder: boolean;
 }
 
 type ClusterRenderResult = { status: 'ready'; model: ClusterRenderModel } | { status: 'unsupported' };
@@ -200,6 +198,10 @@ function buildClusterRenderModel(
 
     const renderChips: RenderChip[] = [];
     let nextHostOffsetY = useMeshCoords ? 0 : FALLBACK_TOP_PAD_ROWS;
+    // Which condensed tier the layout actually reached. The caveat copy has to name
+    // the tier it got: board-slot grouping needs the descriptor to support it, and
+    // plenty of reports — the 2-chip n300 among them — fall through to chip id order.
+    let anyHostFellToIdOrder = false;
     let totalCols = 0;
     let totalRows = 0;
 
@@ -224,20 +226,12 @@ function buildClusterRenderModel(
 
         let usedFallback = false;
 
-        // Fallback tier between mesh coords and raw id order: group the chips by
-        // board slot so the grid can separate groups. `null` keeps id order. #1948
-        const fallbackGroups = useMeshCoords ? null : getAsicLocationGroups(host.descriptor, chipIdsForHost);
-        const fallbackRowsPerGroup = fallbackGroups ? Math.ceil(fallbackGroups[0].length / FALLBACK_PER_HOST_COLS) : 0;
-        const fallbackPositionByChip = new Map<number, readonly [number, number]>();
-        fallbackGroups?.forEach((group, groupIndex) => {
-            const groupTop = groupIndex * (fallbackRowsPerGroup + FALLBACK_GROUP_GUTTER_ROWS);
-            group.forEach((groupedChipId, slotIndex) => {
-                fallbackPositionByChip.set(groupedChipId, [
-                    slotIndex % FALLBACK_PER_HOST_COLS,
-                    groupTop + Math.floor(slotIndex / FALLBACK_PER_HOST_COLS),
-                ]);
-            });
-        });
+        // Fallback tier between mesh coords and raw id order: board slots when the
+        // descriptor supports them, id order when it does not. #1948
+        const condensed = useMeshCoords ? null : getCondensedHostLayout(host.descriptor, chipIdsForHost);
+        if (condensed && !condensed.isGrouped) {
+            anyHostFellToIdOrder = true;
+        }
 
         // Plain `for` to keep mutable counters out of a closure (no-loop-func).
         for (let localIndex = 0; localIndex < chipIdsForHost.length; localIndex += 1) {
@@ -249,14 +243,12 @@ function buildClusterRenderModel(
                 [x, y] = meshCoord;
             } else {
                 usedFallback = true;
-                const grouped = fallbackPositionByChip.get(chipId);
-                if (grouped) {
-                    [x] = grouped;
-                    y = nextHostOffsetY + grouped[1];
-                } else {
-                    x = localIndex % FALLBACK_PER_HOST_COLS;
-                    y = nextHostOffsetY + Math.floor(localIndex / FALLBACK_PER_HOST_COLS);
-                }
+                const placed = condensed?.positionByChip.get(chipId) ?? [
+                    localIndex % FALLBACK_PER_HOST_COLS,
+                    Math.floor(localIndex / FALLBACK_PER_HOST_COLS),
+                ];
+                [x] = placed;
+                y = nextHostOffsetY + placed[1];
             }
             totalCols = Math.max(totalCols, x + 1);
             totalRows = Math.max(totalRows, y + 1);
@@ -275,12 +267,7 @@ function buildClusterRenderModel(
         }
 
         if (usedFallback) {
-            // Grouped layouts are taller by one gutter row per boundary; the last
-            // group does not get a trailing one.
-            const hostRows = fallbackGroups
-                ? fallbackGroups.length * (fallbackRowsPerGroup + FALLBACK_GROUP_GUTTER_ROWS) -
-                  FALLBACK_GROUP_GUTTER_ROWS
-                : Math.ceil(chipIdsForHost.length / FALLBACK_PER_HOST_COLS);
+            const hostRows = condensed?.rows ?? Math.ceil(chipIdsForHost.length / FALLBACK_PER_HOST_COLS);
             nextHostOffsetY += hostRows + FALLBACK_HOST_GUTTER_ROWS;
         }
     }
@@ -643,6 +630,7 @@ function buildClusterRenderModel(
             svgPad: Math.round(stride),
             layoutMode,
             isMeshAvailable,
+            anyHostFellToIdOrder,
         },
     };
 }
@@ -830,7 +818,15 @@ function ClusterRenderer() {
         worldSize,
         layoutMode: activeLayoutMode,
         isMeshAvailable,
+        anyHostFellToIdOrder,
     } = renderResult.model;
+
+    // Named per tier: board-slot grouping needs the descriptor to carry slots that
+    // repeat in equal runs, and reports that miss that — the 2-chip n300 among them
+    // — get chip id order instead. Claiming a slot-driven layout on those was wrong.
+    const condensedCaveat = anyHostFellToIdOrder
+        ? 'Chips are tiled in id order, not placed at their physical positions: this report carries no usable board-slot information. Links are accurate; positions carry no physical meaning.'
+        : 'Chips are tiled by board slot rather than placed at their physical positions. Links are accurate; positions carry no physical meaning.';
 
     const isChipActive = (key: string) => {
         if (hoveredChip === null) {
@@ -868,9 +864,19 @@ function ClusterRenderer() {
                         />
                     </Tooltip>
                 </ButtonGroup>
-                {!isMeshAvailable && (
-                    <Tooltip content='This report carries no mesh coordinates, so chips are tiled by board slot rather than placed at their physical positions. Links are accurate; positions are not.'>
-                        <span className='cluster-view-layout-note'>Positions not to scale</span>
+                {activeLayoutMode === 'condensed' && (
+                    <Tooltip content={condensedCaveat}>
+                        {/* The accessible name is the whole caveat, not the three
+                            visible words: the tooltip is hover-only, so without
+                            this a screen reader gets the summary and never the
+                            sentence that explains it. */}
+                        <span
+                            className='cluster-view-layout-note'
+                            role='note'
+                            aria-label={condensedCaveat}
+                        >
+                            Positions not physical
+                        </span>
                     </Tooltip>
                 )}
                 {isMultiHost && isMeshAvailable && (

--- a/src/functions/clusterTopology.ts
+++ b/src/functions/clusterTopology.ts
@@ -18,6 +18,50 @@ import {
 export const FALLBACK_PER_HOST_COLS = 4;
 
 /**
+ * @description Chip ids split into board groups using `asic_locations`, each
+ * group ordered by slot, or `null` when the field carries no grouping.
+ *
+ * A layout fallback only, one tier below mesh coordinates and one above raw id
+ * order. Without it the condensed grid tiled chips by id, which on a 32-chip UBB
+ * drew 41% of the links between non-adjacent cells and made 12 unconnected pairs
+ * look adjacent. Grouping lets the renderer put a gutter between board groups so
+ * the group-to-group links read as such. #1948
+ *
+ * Requires the slots to repeat in equal consecutive runs that each cover every
+ * slot exactly once. Anything else is not a grouping we can trust: a descriptor
+ * that gives every chip the same slot, or a distinct slot per chip, returns
+ * `null` and the caller keeps id order.
+ */
+export const getAsicLocationGroups = (descriptor: ClusterModel, chipIds: number[]): number[][] | null => {
+    const locations = descriptor.asic_locations;
+    if (!locations || chipIds.length === 0) {
+        return null;
+    }
+
+    const slots = chipIds.map((id) => locations[id]);
+    if (slots.some((slot) => typeof slot !== 'number' || !Number.isFinite(slot))) {
+        return null;
+    }
+
+    const groupSize = new Set(slots).size;
+    // One slot for every chip carries no grouping; one slot shared by all of them
+    // is not a position either.
+    if (groupSize <= 1 || groupSize >= chipIds.length || chipIds.length % groupSize !== 0) {
+        return null;
+    }
+
+    const groups: number[][] = [];
+    for (let start = 0; start < chipIds.length; start += groupSize) {
+        const run = chipIds.slice(start, start + groupSize);
+        if (new Set(run.map((id) => locations[id])).size !== groupSize) {
+            return null;
+        }
+        groups.push([...run].sort((a, b) => locations[a] - locations[b]));
+    }
+    return groups;
+};
+
+/**
  * Stitch per-rank cluster descriptors and mesh-coordinate mappings into a unified
  * topology. Pure; single-host reports pass a 1-element array. #1510
  */

--- a/src/functions/clusterTopology.ts
+++ b/src/functions/clusterTopology.ts
@@ -61,6 +61,55 @@ export const getAsicLocationGroups = (descriptor: ClusterModel, chipIds: number[
     return groups;
 };
 
+// Blank row between board groups, so a group-to-group link reads as crossing a
+// boundary rather than as another intra-group hop. Lives beside
+// `FALLBACK_PER_HOST_COLS` so the renderer and the adjacency heuristic below stay
+// in lockstep. #1948
+export const FALLBACK_GROUP_GUTTER_ROWS = 1;
+
+export interface CondensedHostLayout {
+    /** Local grid position per chip, `[x, y]`, y relative to the host's own top. */
+    positionByChip: Map<number, readonly [number, number]>;
+    /** Rows the host occupies, gutters between groups included. */
+    rows: number;
+    /** Whether board slots drove the layout, or it fell through to chip id order. */
+    isGrouped: boolean;
+}
+
+/**
+ * @description One host's condensed placement: chips tiled `FALLBACK_PER_HOST_COLS`
+ * wide, grouped by board slot when the descriptor supports it and in id order when
+ * it does not.
+ *
+ * The two cases are one computation — ungrouped is the grouped case with a single
+ * group, where `groupTop` is 0, the slot index is the local index, and
+ * `1 * (rows + gutter) - gutter` is `ceil(n / cols)`. They were two
+ * implementations, as were the two row-count formulas beside them.
+ */
+export const getCondensedHostLayout = (descriptor: ClusterModel, chipIds: number[]): CondensedHostLayout => {
+    const slotGroups = getAsicLocationGroups(descriptor, chipIds);
+    const groups = slotGroups ?? [chipIds];
+    const rowsPerGroup = Math.ceil(groups[0].length / FALLBACK_PER_HOST_COLS);
+
+    const positionByChip = new Map<number, readonly [number, number]>();
+    groups.forEach((group, groupIndex) => {
+        const groupTop = groupIndex * (rowsPerGroup + FALLBACK_GROUP_GUTTER_ROWS);
+        group.forEach((chipId, slotIndex) => {
+            positionByChip.set(chipId, [
+                slotIndex % FALLBACK_PER_HOST_COLS,
+                groupTop + Math.floor(slotIndex / FALLBACK_PER_HOST_COLS),
+            ]);
+        });
+    });
+
+    return {
+        positionByChip,
+        // The last group gets no trailing gutter.
+        rows: groups.length * (rowsPerGroup + FALLBACK_GROUP_GUTTER_ROWS) - FALLBACK_GROUP_GUTTER_ROWS,
+        isGrouped: slotGroups !== null,
+    };
+};
+
 /**
  * Stitch per-rank cluster descriptors and mesh-coordinate mappings into a unified
  * topology. Pure; single-host reports pass a 1-element array. #1510

--- a/src/model/ClusterModel.ts
+++ b/src/model/ClusterModel.ts
@@ -86,6 +86,11 @@ export interface ClusterModel {
     chip_to_bus_id: Record<ChipId, number>;
     chip_unique_ids: Record<ChipId, number>;
     boards: ClusterBoard[];
+
+    // Slot each chip occupies within its board group, 1-based. A 32-chip UBB
+    // repeats 1..8 four times, one run per group. Only a layout fallback: mesh
+    // coordinates are authoritative when the report carries them. #1948
+    asic_locations?: Record<ChipId, number>;
 }
 
 export interface MeshData {

--- a/src/scss/components/ClusterView.scss
+++ b/src/scss/components/ClusterView.scss
@@ -58,6 +58,16 @@ $mmio-fill: rgba(colours.$tt-yellow, 0.18);
             // Drop Blueprint Switch's default bottom margin for vertical alignment.
             margin: 0;
         }
+
+        // Shown when the report has no mesh coordinates, so the tiling is not a
+        // physical arrangement. Muted: a caveat, not a control. #1948
+        .cluster-view-layout-note {
+            font-size: 12px;
+            font-style: italic;
+            white-space: nowrap;
+            cursor: help;
+            opacity: 0.65;
+        }
     }
 }
 

--- a/tests/ClusterCondensedPlacement.spec.tsx
+++ b/tests/ClusterCondensedPlacement.spec.tsx
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ClusterRenderer from '../src/components/cluster/ClusterRenderer';
+import type { ClusterTopology } from '../src/model/ClusterModel';
+
+// Placement is where the condensed layout actually happens — the group gutter, the
+// per-host offset and the mesh-coords guard — and none of it was exercised. Same
+// harness as ClusterUnknownArch.spec.tsx. #1948
+let topologyOverride: ClusterTopology | null = null;
+
+vi.mock('react-router', async () => ({
+    ...(await vi.importActual<typeof import('react-router')>('react-router')),
+    useNavigate: () => vi.fn(),
+}));
+vi.mock('../src/hooks/useAPI', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../src/hooks/useAPI')>()),
+    useGetClusterTopology: () => ({
+        data: topologyOverride,
+        isLoading: false,
+        isError: false,
+        error: null,
+    }),
+}));
+
+/* eslint-disable class-methods-use-this -- no-op stub has nothing to hold */
+class ResizeObserverStub {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+}
+/* eslint-enable class-methods-use-this */
+
+interface HostSpec {
+    rank: number;
+    chipCount: number;
+    /** Board slot per chip; omitted means the descriptor carries none. */
+    slots?: boolean;
+    /** Mesh coordinates per chip, which outrank grouping when every host has them. */
+    mesh?: boolean;
+}
+
+const topologyOf = (hosts: HostSpec[]): ClusterTopology =>
+    ({
+        isMultiHost: hosts.length > 1,
+        worldSize: hosts.length,
+        unresolvedRemoteCount: 0,
+        hosts: hosts.map(({ rank, chipCount, slots, mesh }) => {
+            const chipIds = Array.from({ length: chipCount }, (_, chip) => chip);
+            return {
+                rank,
+                descriptor: {
+                    arch: Object.fromEntries(chipIds.map((chip) => [chip, 'wormhole_b0'])),
+                    chip_unique_ids: Object.fromEntries(chipIds.map((chip) => [chip, String(rank * 100 + chip)])),
+                    chips_with_mmio: [{ 0: 0 }],
+                    ethernet_connections: [],
+                    ...(slots ? { asic_locations: Object.fromEntries(chipIds.map((c) => [c, (c % 8) + 1])) } : {}),
+                },
+                meshChips: mesh ? Object.fromEntries(chipIds.map((c) => [c, [c, rank, 0, 0]])) : {},
+            };
+        }),
+        intraHostLinks: [],
+        interHostLinks: [],
+    }) as unknown as ClusterTopology;
+
+/** `{ "<rank>-<chipId>": [column, row] }`, 1-based as CSS grid reports them. */
+const placements = (): Record<string, [number, number]> => {
+    const found: Record<string, [number, number]> = {};
+    for (const cell of document.querySelectorAll<HTMLElement>('[data-rank]')) {
+        const id = cell.querySelector('.chip-id')?.textContent?.replace('Device ', '').trim();
+        if (id !== undefined && cell.style.gridColumn) {
+            found[`${cell.getAttribute('data-rank')}-${id}`] = [
+                Number(cell.style.gridColumn),
+                Number(cell.style.gridRow),
+            ];
+        }
+    }
+    return found;
+};
+
+beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    topologyOverride = null;
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('condensed placement', () => {
+    it('tiles a slotless host four wide in id order', () => {
+        topologyOverride = topologyOf([{ rank: 0, chipCount: 6 }]);
+
+        render(<ClusterRenderer />);
+        const at = placements();
+
+        expect(at['0-0'][0]).toBe(at['0-4'][0]);
+        expect(at['0-4'][1]).toBe(at['0-0'][1] + 1);
+        expect(at['0-3'][0]).toBe(at['0-0'][0] + 3);
+    });
+
+    it('leaves a blank row between board groups', () => {
+        // Two groups of eight, two rows each. Chip 8 opens the second group, so it
+        // sits three rows below chip 0 rather than two — the gutter is the extra one.
+        topologyOverride = topologyOf([{ rank: 0, chipCount: 16, slots: true }]);
+
+        render(<ClusterRenderer />);
+        const at = placements();
+
+        expect(at['0-8'][1] - at['0-0'][1]).toBe(3);
+        const occupiedRows = new Set(Object.values(at).map(([, row]) => row));
+        // The gutter row itself holds nothing.
+        expect(occupiedRows.has(at['0-0'][1] + 2)).toBe(false);
+    });
+
+    it('lets mesh coordinates outrank board-slot grouping', () => {
+        // The guard that keeps mesh reports unchanged: slots are present and would
+        // group, but every host has mesh coords so they must win.
+        topologyOverride = topologyOf([{ rank: 0, chipCount: 16, slots: true, mesh: true }]);
+
+        render(<ClusterRenderer />);
+        const at = placements();
+
+        // Mesh puts chip c at x = c, so the row never advances and no gutter appears.
+        expect(at['0-8'][1]).toBe(at['0-0'][1]);
+        expect(at['0-8'][0]).toBe(at['0-0'][0] + 8);
+    });
+
+    it('offsets a second host below the first, sizing each by its own tier', () => {
+        // Rank 0 groups (16 chips, 2 groups, 5 rows with the gutter); rank 1 does
+        // not (6 chips, 2 rows). Both hostRows branches in one pass.
+        topologyOverride = topologyOf([
+            { rank: 0, chipCount: 16, slots: true },
+            { rank: 1, chipCount: 6 },
+        ]);
+
+        render(<ClusterRenderer />);
+        const at = placements();
+
+        // Host order is not rank order — with no inter-host links the proximity
+        // sort is free to put either first — so this asserts the invariant that
+        // holds either way: the two blocks do not overlap and a blank row divides
+        // them, with each block sized by the tier its own host reached.
+        const rowsOf = (rank: string) =>
+            Object.entries(at)
+                .filter(([key]) => key.startsWith(`${rank}-`))
+                .map(([, position]) => position[1]);
+        const span = (rank: string) => ({ top: Math.min(...rowsOf(rank)), bottom: Math.max(...rowsOf(rank)) });
+        const [first, second] = span('0').top < span('1').top ? [span('0'), span('1')] : [span('1'), span('0')];
+
+        expect(first.bottom).toBeLessThan(second.top);
+        // Exactly one empty row between the two hosts.
+        expect(second.top - first.bottom).toBe(2);
+        // Grouped host spans 5 rows (2 groups x 2 rows + 1 gutter); the slotless
+        // one spans 2. Both hostRows branches, in one render.
+        const spans = [first.bottom - first.top + 1, second.bottom - second.top + 1].sort((a, b) => a - b);
+        expect(spans).toEqual([2, 5]);
+    });
+});

--- a/tests/clusterTopology.spec.ts
+++ b/tests/clusterTopology.spec.ts
@@ -4,7 +4,9 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+    FALLBACK_PER_HOST_COLS,
     PerRankInput,
+    getAsicLocationGroups,
     hostHasMeshCoords,
     hostHasTwoDimensionalMesh,
     looksLikeRankedDescriptor,
@@ -335,6 +337,118 @@ describe('pickMeshDocForRank', () => {
     it('coerces a single-doc payload missing `chips` to an empty MeshData', () => {
         const fallback = pickMeshDocForRank({} as unknown as MeshData, 0);
         expect(fallback).toEqual({ chips: {} });
+    });
+});
+
+describe('getAsicLocationGroups', () => {
+    const withLocations = (locations: Record<number, number>) =>
+        ({ asic_locations: locations }) as unknown as ClusterModel;
+
+    it('splits a 32-chip UBB into four groups of eight, ordered by slot (#1948)', () => {
+        // Shape of test_ttnn_moe_aug26_2217: slots cycle 1..8 four times.
+        const locations = Object.fromEntries(Array.from({ length: 32 }, (_, chip) => [chip, (chip % 8) + 1]));
+        const chipIds = Array.from({ length: 32 }, (_, chip) => chip);
+
+        const groups = getAsicLocationGroups(withLocations(locations), chipIds);
+
+        expect(groups).toHaveLength(4);
+        expect(groups?.[0]).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+        expect(groups?.[3]).toEqual([24, 25, 26, 27, 28, 29, 30, 31]);
+    });
+
+    it('orders each group by slot rather than by chip id', () => {
+        // Slots deliberately reversed within each group of two.
+        const groups = getAsicLocationGroups(withLocations({ 0: 2, 1: 1, 2: 2, 3: 1 }), [0, 1, 2, 3]);
+
+        expect(groups).toEqual([
+            [1, 0],
+            [3, 2],
+        ]);
+    });
+
+    it('returns null when every chip claims the same slot', () => {
+        // Shape of multihost_poc_jun24_2321: eight chips, one distinct slot. Grouping
+        // on the distinct count would have split it into eight groups of one.
+        const locations = Object.fromEntries(Array.from({ length: 8 }, (_, chip) => [chip, 0]));
+
+        expect(
+            getAsicLocationGroups(
+                withLocations(locations),
+                Array.from({ length: 8 }, (_, c) => c),
+            ),
+        ).toBeNull();
+    });
+
+    it('returns null when every chip has its own slot, which is no grouping', () => {
+        expect(getAsicLocationGroups(withLocations({ 0: 1, 1: 2, 2: 3 }), [0, 1, 2])).toBeNull();
+    });
+
+    it('returns null when a run repeats a slot instead of covering each once', () => {
+        // Two distinct slots over four chips divides evenly, but the first run is
+        // (1, 1) rather than (1, 2), so the chips are not one slot per group.
+        expect(getAsicLocationGroups(withLocations({ 0: 1, 1: 1, 2: 1, 3: 2 }), [0, 1, 2, 3])).toBeNull();
+    });
+
+    it('groups so that no two chips drawn adjacent are unconnected (#1948)', () => {
+        // Synthetic 32-chip UBB with the real link deltas: +1 along a row of four,
+        // +4 between the two rows of a group, +8 to the next group and +24 wrapping
+        // the group ring. Tiling by chip id drew 12 unconnected pairs as neighbours.
+        const chipIds = Array.from({ length: 32 }, (_, chip) => chip);
+        const locations = Object.fromEntries(chipIds.map((chip) => [chip, (chip % 8) + 1]));
+        // +1 stays inside a row of four, +4 inside a group of eight; +8 and +24
+        // reach the next group and wrap the ring.
+        const isLinked = (chip: number, delta: number): boolean => {
+            const other = chip + delta;
+            if (other >= 32) {
+                return false;
+            }
+            if (delta === 1) {
+                return Math.floor(chip / 4) === Math.floor(other / 4);
+            }
+            if (delta === 4) {
+                return Math.floor(chip / 8) === Math.floor(other / 8);
+            }
+            return true;
+        };
+        const links = new Set(
+            chipIds.flatMap((chip) =>
+                [1, 4, 8, 24].filter((delta) => isLinked(chip, delta)).map((delta) => `${chip}-${chip + delta}`),
+            ),
+        );
+
+        const groups = getAsicLocationGroups(withLocations(locations), chipIds);
+        expect(groups).toHaveLength(4);
+
+        const gutterRows = 1;
+        const rowsPerGroup = Math.ceil(groups![0].length / FALLBACK_PER_HOST_COLS);
+        const position = new Map<number, [number, number]>();
+        groups!.forEach((group, groupIndex) => {
+            group.forEach((chip, slot) => {
+                position.set(chip, [
+                    slot % FALLBACK_PER_HOST_COLS,
+                    groupIndex * (rowsPerGroup + gutterRows) + Math.floor(slot / FALLBACK_PER_HOST_COLS),
+                ]);
+            });
+        });
+
+        const isAdjacent = (a: number, b: number): boolean => {
+            const [pa, pb] = [position.get(a)!, position.get(b)!];
+            return Math.abs(pa[0] - pb[0]) + Math.abs(pa[1] - pb[1]) === 1;
+        };
+        const unconnectedNeighbours = chipIds
+            .flatMap((a) => chipIds.filter((b) => b > a).map((b) => [a, b] as const))
+            .filter(([a, b]) => isAdjacent(a, b) && !links.has(`${a}-${b}`))
+            .map(([a, b]) => `${a}-${b}`);
+
+        expect(unconnectedNeighbours).toEqual([]);
+    });
+
+    it('returns null when the field is absent, unparseable or the chip list is empty', () => {
+        expect(getAsicLocationGroups({} as unknown as ClusterModel, [0, 1])).toBeNull();
+        expect(
+            getAsicLocationGroups({ asic_locations: { 0: 'a', 1: 'b' } } as unknown as ClusterModel, [0, 1]),
+        ).toBeNull();
+        expect(getAsicLocationGroups(withLocations({ 0: 1 }), [])).toBeNull();
     });
 });
 

--- a/tests/clusterTopology.spec.ts
+++ b/tests/clusterTopology.spec.ts
@@ -4,9 +4,10 @@
 
 import { describe, expect, it } from 'vitest';
 import {
-    FALLBACK_PER_HOST_COLS,
+    type CondensedHostLayout,
     PerRankInput,
     getAsicLocationGroups,
+    getCondensedHostLayout,
     hostHasMeshCoords,
     hostHasTwoDimensionalMesh,
     looksLikeRankedDescriptor,
@@ -416,31 +417,69 @@ describe('getAsicLocationGroups', () => {
             ),
         );
 
-        const groups = getAsicLocationGroups(withLocations(locations), chipIds);
-        expect(groups).toHaveLength(4);
+        const descriptor = withLocations(locations);
+        expect(getAsicLocationGroups(descriptor, chipIds)).toHaveLength(4);
 
-        const gutterRows = 1;
-        const rowsPerGroup = Math.ceil(groups![0].length / FALLBACK_PER_HOST_COLS);
-        const position = new Map<number, [number, number]>();
-        groups!.forEach((group, groupIndex) => {
-            group.forEach((chip, slot) => {
-                position.set(chip, [
-                    slot % FALLBACK_PER_HOST_COLS,
-                    groupIndex * (rowsPerGroup + gutterRows) + Math.floor(slot / FALLBACK_PER_HOST_COLS),
-                ]);
-            });
-        });
-
-        const isAdjacent = (a: number, b: number): boolean => {
-            const [pa, pb] = [position.get(a)!, position.get(b)!];
-            return Math.abs(pa[0] - pb[0]) + Math.abs(pa[1] - pb[1]) === 1;
+        // Against the renderer's own layout, not a copy of it: re-deriving the
+        // geometry here meant a change to the gutter, or a regression in the
+        // layout itself, left this green.
+        const unconnectedNeighboursOf = (layout: CondensedHostLayout): string[] => {
+            const isAdjacent = (a: number, b: number): boolean => {
+                const [pa, pb] = [layout.positionByChip.get(a)!, layout.positionByChip.get(b)!];
+                return Math.abs(pa[0] - pb[0]) + Math.abs(pa[1] - pb[1]) === 1;
+            };
+            return chipIds
+                .flatMap((a) => chipIds.filter((b) => b > a).map((b) => [a, b] as const))
+                .filter(([a, b]) => isAdjacent(a, b) && !links.has(`${a}-${b}`))
+                .map(([a, b]) => `${a}-${b}`);
         };
-        const unconnectedNeighbours = chipIds
-            .flatMap((a) => chipIds.filter((b) => b > a).map((b) => [a, b] as const))
-            .filter(([a, b]) => isAdjacent(a, b) && !links.has(`${a}-${b}`))
-            .map(([a, b]) => `${a}-${b}`);
 
-        expect(unconnectedNeighbours).toEqual([]);
+        const grouped = getCondensedHostLayout(descriptor, chipIds);
+        expect(grouped.isGrouped).toBe(true);
+        expect(unconnectedNeighboursOf(grouped)).toEqual([]);
+
+        // Negative control: without slots the same descriptor tiles in id order,
+        // which is the arrangement #1948 reported. Without this, a property that
+        // holds trivially is indistinguishable from one the grouping earned.
+        const ungrouped = getCondensedHostLayout({} as unknown as ClusterModel, chipIds);
+        expect(ungrouped.isGrouped).toBe(false);
+        expect(unconnectedNeighboursOf(ungrouped)).toHaveLength(12);
+    });
+
+    it('does not merely reproduce id order when the slots say otherwise', () => {
+        // The 32-chip fixture uses `chip % 8 + 1`, so slot order equals id order
+        // there and a naive chunk(chipIds, 8) would satisfy it. Reversing the
+        // slots within each board separates the two.
+        const chipIds = Array.from({ length: 16 }, (_, chip) => chip);
+        const locations = Object.fromEntries(chipIds.map((chip) => [chip, 8 - (chip % 8)]));
+
+        const layout = getCondensedHostLayout(withLocations(locations), chipIds);
+
+        expect(layout.isGrouped).toBe(true);
+        // Chip 0 holds slot 8, so it is last in its group rather than first.
+        expect(layout.positionByChip.get(0)).toEqual([3, 1]);
+        expect(layout.positionByChip.get(7)).toEqual([0, 0]);
+    });
+
+    it('lays a slotless host out in id order, four wide, with no gutter', () => {
+        const layout = getCondensedHostLayout({} as unknown as ClusterModel, [0, 1, 2, 3, 4, 5]);
+
+        expect(layout.isGrouped).toBe(false);
+        expect(layout.positionByChip.get(0)).toEqual([0, 0]);
+        expect(layout.positionByChip.get(4)).toEqual([0, 1]);
+        expect(layout.rows).toBe(2);
+    });
+
+    it('adds one gutter row between groups and none after the last', () => {
+        const chipIds = Array.from({ length: 16 }, (_, chip) => chip);
+        const locations = Object.fromEntries(chipIds.map((chip) => [chip, (chip % 8) + 1]));
+
+        const layout = getCondensedHostLayout(withLocations(locations), chipIds);
+
+        // Two groups of eight: two rows each, one blank row between them.
+        expect(layout.positionByChip.get(7)).toEqual([3, 1]);
+        expect(layout.positionByChip.get(8)).toEqual([0, 3]);
+        expect(layout.rows).toBe(5);
     });
 
     it('returns null when the field is absent, unparseable or the chip list is empty', () => {


### PR DESCRIPTION
Closes #1948. **Stacked on #1947** — based on `feature/1939-single-descriptor-one-host`, so this PR's diff is just the layout commit. Retarget to `dev` once #1947 merges.

## Summary

The condensed layout placed chip *c* at `(c % 4, c / 4)` — index order, no topology input. On the 32-chip UBB in `test_ttnn_moe_aug26_2217` that meant the canvas contradicted the links drawn on it: 12 pairs of chips were drawn touching with no link between them, and 41% of the links ran between non-adjacent cells as long sweeping curves.

`asic_locations` already states which slot each chip occupies within its board group — it cycles 1…8 four times on this report — and was used nowhere in the codebase. It now splits the chips into groups, each ordered by slot, with a gutter row between groups.

| | before | after |
|---|---|---|
| chip pairs drawn adjacent | 52 | 40 |
| …with **no link** between them | **12** | **0** |
| links drawn between non-adjacent cells | 28 | 28 |

The 28 are unchanged: they are the genuine group-to-group ring links. They now cross a gutter, which reads as a boundary, but they are still drawn straight *through* the chips between their endpoints — see Known limitations. This PR fixes placement, not legibility.

### It is a fallback tier, not an authority

Placement order is mesh coordinates → `asic_locations` → raw id order. Mesh mode is untouched.

Grouping is refused unless the slots repeat in equal consecutive runs that each cover every slot exactly once. That guard matters: `multihost_poc_jun24_2321` gives all eight of its chips the *same* `asic_location`, so keying on the distinct count would have shattered it into eight groups of one. Descriptors with one slot per chip, one slot for all chips, a non-divisible count, a repeated slot inside a run, or a missing/unparseable field all keep id order.

### Not-physical label

The layout toggle is gated on `isMultiHost && isMeshAvailable`, so a single-host report with no mesh data shows no control and previously gave no hint that the positions were arbitrary. A muted "Positions not to scale" note now appears whenever mesh coordinates are absent, with the detail in its tooltip.

## Test plan

Verified in the running app against `test_ttnn_moe_aug26_2217`: four separated blocks of eight chips, gutters between them, note present in the toolbar.

New coverage in `clusterTopology.spec.ts`:
- 32-chip UBB splits into four groups of eight, first and last group asserted.
- Groups ordered by slot, not chip id (slots deliberately reversed).
- **No pair drawn adjacent is unconnected** — hermetic, built from the real link deltas (`+1` within a row of four, `+4` within a group, `+8` to the next group, `+24` wrapping the ring).
- `null` for: every chip on one slot (the `multihost_poc` shape), one slot per chip, a run repeating a slot, absent field, unparseable values, empty chip list.

Frontend 2217 passing, backend 1135 passing, `tsc`, eslint, stylelint all clean.

## Known limitations

**Spanning links are still drawn over the chips they cross.** All 28 same-column links pass straight over unrelated chip boxes:

```
 1-9   passes over [5]
 0-8   passes over [4]
 0-24  passes over [4, 8, 12, 16, 20]
 2-26  passes over [6, 10, 14, 18, 22]
```

Selecting a chip highlights its links, and the highlight runs through chips that are not its neighbours — so the view is not yet readable even though the placement is right. Filed as #1951; not addressed here because it needs a change to the edge-routing pass rather than to placement.

It is also structural rather than a layout mistake: the ring links join *same-slot* chips, so `0↔8` runs from group 0's top row to group 1's top row and must cross the whole intervening group plus the gutter. Any linear arrangement of four groups has this property.

**What this PR does and does not establish.** Placement is consistent with the topology — every one of the 68 links is same-row or same-column, zero diagonals, and no two chips drawn adjacent are unconnected. It does not make the cluster view legible at 32 chips.

## Follow-ups

Chip unique ids shown in the tooltip were wrong while verifying this — a separate precision bug, fixed in #1952 (#1950).

The durable fix is still upstream: tt-metal emitting `physical_chip_mesh_coordinate_mapping.yaml` for single-host UBB captures would make this the `mesh` path rather than a fallback, at which point this grouping stops being used. Deriving placement from the `ethernet_connections` adjacency directly — arch-agnostic, needs nothing new from the report — remains an option if more shapes turn up that `asic_locations` cannot group.

