### PR TITLE
Let an NPE report supply its own SoC descriptor

### DIFF
--- a/backend/ttnn_visualizer/npe_index.py
+++ b/backend/ttnn_visualizer/npe_index.py
@@ -42,7 +42,9 @@ _BUILD_LOCK = threading.Lock()
 INDEX_SUFFIX = ".npeidx.sqlite"
 
 # Bump when the schema or build logic changes so stale caches are rebuilt.
-INDEX_VERSION = 4
+# 5: carries `soc_descriptor` in meta, so a report-supplied SoC descriptor
+#    survives the windowed path as well as the whole-file one. #1776
+INDEX_VERSION = 5
 
 _TRANSFER_INSERT_BATCH = 5000
 
@@ -241,6 +243,9 @@ def _write_index(
                 ("source_mtime_ns", str(source_mtime_ns)),
                 ("n_timesteps", str(len(timesteps))),
                 ("common_info", orjson.dumps(obj.get("common_info", {}))),
+                # Optional; `null` when the report supplies none. Stored rather than
+                # derived because the windowed path never re-reads the source JSON.
+                ("soc_descriptor", orjson.dumps(obj.get("soc_descriptor"))),
                 ("chips", orjson.dumps(obj.get("chips", {}))),
                 ("zones", orjson.dumps(obj.get("zones", []))),
             ],
@@ -359,6 +364,9 @@ def read_summary(db_path: Path) -> dict:
 
     return {
         "common_info": orjson.loads(meta["common_info"]),
+        # `.get` rather than `[...]`: an index written before this key existed is
+        # still readable, and a rebuild is only triggered by INDEX_VERSION.
+        "soc_descriptor": orjson.loads(meta.get("soc_descriptor") or b"null"),
         "chips": orjson.loads(meta["chips"]),
         "zones": orjson.loads(meta["zones"]),
         "n_timesteps": int(meta["n_timesteps"]),

--- a/backend/ttnn_visualizer/tests/test_npe_index.py
+++ b/backend/ttnn_visualizer/tests/test_npe_index.py
@@ -109,6 +109,61 @@ def test_read_summary_is_columnar(tmp_path):
     assert timesteps["avg_link_demand"][1] == pytest.approx(12.345)
 
 
+# Shape of a Quasar-32 emulation part: the case the override exists for, and the
+# one that reaches the frontend through this index rather than the whole-file
+# path, because uploads take the windowed route locally. #1776
+SOC_DESCRIPTOR = {
+    "arch_name": "QUASAR",
+    "grid": {"x_size": 10, "y_size": 8},
+    "functional_workers": ["2-2", "3-2", "4-2"],
+    "dram": [["2-7"], ["4-0"]],
+    "router_only": ["0-2"],
+    "arc": [],
+    "pcie": [],
+    "eth": [],
+    "worker_l1_size": 4194304,
+}
+
+
+def test_soc_descriptor_round_trips_through_the_index(tmp_path):
+    """A report-supplied SoC descriptor must survive `ensure_index` unchanged.
+
+    Frontend parser tests cannot reach this: the descriptor is JSON-encoded into a
+    `meta` row and decoded back out, so a regression here would drop the field for
+    every uploaded report while every frontend test still passed. #1776
+    """
+    obj = _make_npe_object()
+    obj["soc_descriptor"] = SOC_DESCRIPTOR
+    npe_path = _write_npe(tmp_path, obj)
+
+    summary = read_summary(ensure_index(npe_path))
+
+    assert summary["soc_descriptor"] == SOC_DESCRIPTOR
+
+
+def test_soc_descriptor_round_trips_from_a_compressed_report(tmp_path):
+    # The format uploads actually arrive in.
+    obj = _make_npe_object()
+    obj["soc_descriptor"] = SOC_DESCRIPTOR
+    npe_path = _write_npe_zst(tmp_path, obj)
+
+    summary = read_summary(ensure_index(npe_path))
+
+    assert summary["soc_descriptor"]["grid"] == {"x_size": 10, "y_size": 8}
+    assert summary["soc_descriptor"]["functional_workers"] == ["2-2", "3-2", "4-2"]
+
+
+def test_summary_reports_no_soc_descriptor_when_the_report_has_none(tmp_path):
+    # `None`, not a missing key: the frontend treats absent as "fall back to the
+    # baked lookup", and a KeyError here would be a 500 for every legacy report.
+    npe_path = _write_npe(tmp_path, _make_npe_object())
+
+    summary = read_summary(ensure_index(npe_path))
+
+    assert "soc_descriptor" in summary
+    assert summary["soc_descriptor"] is None
+
+
 def test_summary_max_link_demand_values(tmp_path):
     # Values, not just array lengths: idle step 0 has no link_demand and no source
     # scalar → derived None; active steps derive the worst-link scalar from

--- a/src/components/npe/NPEViewComponent.tsx
+++ b/src/components/npe/NPEViewComponent.tsx
@@ -302,18 +302,30 @@ const NPEView = ({
         return () => window.removeEventListener('resize', handleResize);
     }, []);
 
-    const { architecture, cores, dram, eth, pcie } = useNodeType(npeData.common_info.arch as DeviceArchitecture);
+    const { architecture, cores, dram, eth, pcie, overrideProblems } = useNodeType(
+        npeData.common_info.arch as DeviceArchitecture,
+        npeData.soc_descriptor,
+    );
     const width = architecture?.grid?.x_size || 10;
     const height = architecture?.grid?.y_size || 12;
 
     useEffect(() => {
+        // A descriptor that was supplied and rejected is its own failure, distinct from
+        // an arch nobody shipped a descriptor for. Naming the problems is the point:
+        // the alternative is the empty grid #1776 was filed about. Reported as an
+        // ERROR rather than a WARNING because the report asked to be rendered a
+        // specific way and could not be.
+        if (overrideProblems) {
+            createToastNotification('Unusable SoC descriptor in report', overrideProblems.join('; '), ToastType.ERROR);
+            return;
+        }
         // `architecture === null` rather than probing a field: `arch_name` is declared required
         // on `ChipDesign` and only read as absent because the unresolved case used to return an
         // empty stand-in. Now the same predicate holds here as everywhere else. #1772
         if (architecture === null) {
             createToastNotification(`Unsupported architecture`, npeData.common_info.arch, ToastType.WARNING);
         }
-    }, [architecture, npeData.common_info.arch]);
+    }, [architecture, npeData.common_info.arch, overrideProblems]);
 
     useEffect(() => {
         resetRouteColors();

--- a/src/functions/assembleWindowedNpeData.ts
+++ b/src/functions/assembleWindowedNpeData.ts
@@ -66,6 +66,9 @@ const assembleWindowedNpeData = (
 
     return {
         common_info: summary.common_info,
+        // Without this the override would work on the whole-file path only, and
+        // uploads take the windowed one locally. #1776
+        soc_descriptor: summary.soc_descriptor,
         chips: summary.chips,
         zones: summary.zones?.length ? summary.zones : undefined,
         noc_transfers: window.transfers,

--- a/src/functions/socDescriptorOverride.ts
+++ b/src/functions/socDescriptorOverride.ts
@@ -75,8 +75,10 @@ export const parseSocDescriptorOverride = (raw: unknown, reportedArch?: string):
         ...gridProblems(raw.grid),
         ...coordinateProblems('functional_workers', raw.functional_workers),
         // `dram` is nested one level deeper than the rest: a bank per channel.
-        ...(Array.isArray(raw.dram)
-            ? raw.dram.flatMap((channel, index) => coordinateProblems(`dram[${index}]`, channel))
+        // Optional on the same terms as `eth` / `pcie`, so `grid` and
+        // `functional_workers` are the only two a producer must write.
+        ...(Array.isArray(raw.dram ?? [])
+            ? ((raw.dram ?? []) as unknown[]).flatMap((channel, index) => coordinateProblems(`dram[${index}]`, channel))
             : ['`dram` must be an array of channels']),
         ...coordinateProblems('eth', raw.eth ?? []),
         ...coordinateProblems('pcie', raw.pcie ?? []),
@@ -106,6 +108,7 @@ export const parseSocDescriptorOverride = (raw: unknown, reportedArch?: string):
             ...raw,
             arch_name: (raw.arch_name ?? reportedArch ?? 'unknown') as DeviceArchitecture,
             arc: raw.arc ?? [],
+            dram: raw.dram ?? [],
             eth: raw.eth ?? [],
             pcie: raw.pcie ?? [],
             router_only: raw.router_only ?? [],

--- a/src/functions/socDescriptorOverride.ts
+++ b/src/functions/socDescriptorOverride.ts
@@ -21,31 +21,87 @@ export type SocDescriptorOverride =
 /** Node lists are `"x-y"` coordinate strings, as the baked descriptors write them. */
 const COORDINATE = /^\d+-\d+$/;
 
+/**
+ * Renderer-safe ceilings. `EmptyChipRenderer` materialises one element per cell,
+ * so the grid is a direct multiplier on DOM size: a report asking for
+ * 1,000,000 x 1,000,000 would hang the tab before anything drew. The largest real
+ * part is ~17 x 12, so these leave roughly two orders of magnitude of headroom
+ * while keeping a nonsense value from reaching React. #1776
+ */
+const MAX_GRID_AXIS = 256;
+const MAX_GRID_CELLS = 16_384;
+
+interface GridExtent {
+    xSize: number;
+    ySize: number;
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const coordinateProblems = (label: string, value: unknown): string[] => {
+/**
+ * Problems with one node list, including any coordinate outside `extent`.
+ *
+ * The bounds check is the difference between rejecting a descriptor and rendering
+ * an empty grid from it: `EmptyChipRenderer` walks x < width and y < height and
+ * looks each cell up by coordinate, so a worker at `99-99` on a 4x4 grid is never
+ * visited and silently disappears — the exact failure this validation exists to
+ * prevent. `extent` is null only when `grid` itself failed, where a bound would
+ * be meaningless and the grid problem is already reported.
+ */
+const coordinateProblems = (label: string, value: unknown, extent: GridExtent | null): string[] => {
     if (!Array.isArray(value)) {
         return [`\`${label}\` must be an array of "x-y" coordinates`];
     }
-    const bad = value.filter((entry) => typeof entry !== 'string' || !COORDINATE.test(entry));
-    if (bad.length === 0) {
+
+    const malformed = value.filter((entry) => typeof entry !== 'string' || !COORDINATE.test(entry));
+    if (malformed.length > 0) {
+        const count = malformed.length === 1 ? '1 entry that is' : `${malformed.length} entries that are`;
+        return [`\`${label}\` has ${count} not an "x-y" coordinate`];
+    }
+
+    if (extent === null) {
         return [];
     }
-    const count = bad.length === 1 ? '1 entry that is' : `${bad.length} entries that are`;
-    return [`\`${label}\` has ${count} not an "x-y" coordinate`];
+
+    const outside = (value as string[]).filter((entry) => {
+        const [x, y] = entry.split('-').map(Number);
+        return x >= extent.xSize || y >= extent.ySize;
+    });
+    if (outside.length === 0) {
+        return [];
+    }
+    const shown = outside.slice(0, 3).join(', ');
+    const rest = outside.length > 3 ? `, and ${outside.length - 3} more` : '';
+    return [`\`${label}\` has coordinates outside the ${extent.xSize}x${extent.ySize} grid: ${shown}${rest}`];
 };
 
 const gridProblems = (grid: unknown): string[] => {
     if (!isRecord(grid)) {
         return ['`grid` must be an object with `x_size` and `y_size`'];
     }
-    return (['x_size', 'y_size'] as const).flatMap((axis) => {
+
+    const problems = (['x_size', 'y_size'] as const).flatMap((axis) => {
         const size = grid[axis];
-        return typeof size === 'number' && Number.isInteger(size) && size > 0
-            ? []
-            : [`\`grid.${axis}\` must be a positive integer`];
+        if (typeof size !== 'number' || !Number.isInteger(size) || size <= 0) {
+            return [`\`grid.${axis}\` must be a positive integer`];
+        }
+        return size > MAX_GRID_AXIS ? [`\`grid.${axis}\` is ${size}, above the ${MAX_GRID_AXIS} limit`] : [];
     });
+    if (problems.length > 0) {
+        return problems;
+    }
+
+    const cells = (grid.x_size as number) * (grid.y_size as number);
+    return cells > MAX_GRID_CELLS ? [`\`grid\` asks for ${cells} cells, above the ${MAX_GRID_CELLS} limit`] : [];
+};
+
+/** The extent to bounds-check against, or null when `grid` is unusable. */
+const gridExtent = (grid: unknown): GridExtent | null => {
+    if (!isRecord(grid) || gridProblems(grid).length > 0) {
+        return null;
+    }
+    return { xSize: grid.x_size as number, ySize: grid.y_size as number };
 };
 
 /**
@@ -71,19 +127,22 @@ export const parseSocDescriptorOverride = (raw: unknown, reportedArch?: string):
         return { status: 'invalid', problems: ['the descriptor must be an object'] };
     }
 
+    const extent = gridExtent(raw.grid);
     const problems = [
         ...gridProblems(raw.grid),
-        ...coordinateProblems('functional_workers', raw.functional_workers),
+        ...coordinateProblems('functional_workers', raw.functional_workers, extent),
         // `dram` is nested one level deeper than the rest: a bank per channel.
         // Optional on the same terms as `eth` / `pcie`, so `grid` and
         // `functional_workers` are the only two a producer must write.
         ...(Array.isArray(raw.dram ?? [])
-            ? ((raw.dram ?? []) as unknown[]).flatMap((channel, index) => coordinateProblems(`dram[${index}]`, channel))
+            ? ((raw.dram ?? []) as unknown[]).flatMap((channel, index) =>
+                  coordinateProblems(`dram[${index}]`, channel, extent),
+              )
             : ['`dram` must be an array of channels']),
-        ...coordinateProblems('eth', raw.eth ?? []),
-        ...coordinateProblems('pcie', raw.pcie ?? []),
-        ...coordinateProblems('arc', raw.arc ?? []),
-        ...coordinateProblems('router_only', raw.router_only ?? []),
+        ...coordinateProblems('eth', raw.eth ?? [], extent),
+        ...coordinateProblems('pcie', raw.pcie ?? [], extent),
+        ...coordinateProblems('arc', raw.arc ?? [], extent),
+        ...coordinateProblems('router_only', raw.router_only ?? [], extent),
     ];
 
     if (Array.isArray(raw.functional_workers) && raw.functional_workers.length === 0) {

--- a/src/functions/socDescriptorOverride.ts
+++ b/src/functions/socDescriptorOverride.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { ChipDesign } from '../model/ClusterModel';
+import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
+
+/**
+ * Outcome of reading a report-supplied SoC descriptor.
+ *
+ * Three states rather than `ChipDesign | null`, because absent and malformed
+ * need different answers: absent falls back to the baked lookup, malformed must
+ * say so. Collapsing them is how an unusable override would render as an empty
+ * grid — the failure #1776 is about.
+ */
+export type SocDescriptorOverride =
+    | { status: 'absent' }
+    | { status: 'valid'; design: ChipDesign }
+    | { status: 'invalid'; problems: string[] };
+
+/** Node lists are `"x-y"` coordinate strings, as the baked descriptors write them. */
+const COORDINATE = /^\d+-\d+$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const coordinateProblems = (label: string, value: unknown): string[] => {
+    if (!Array.isArray(value)) {
+        return [`\`${label}\` must be an array of "x-y" coordinates`];
+    }
+    const bad = value.filter((entry) => typeof entry !== 'string' || !COORDINATE.test(entry));
+    if (bad.length === 0) {
+        return [];
+    }
+    const count = bad.length === 1 ? '1 entry that is' : `${bad.length} entries that are`;
+    return [`\`${label}\` has ${count} not an "x-y" coordinate`];
+};
+
+const gridProblems = (grid: unknown): string[] => {
+    if (!isRecord(grid)) {
+        return ['`grid` must be an object with `x_size` and `y_size`'];
+    }
+    return (['x_size', 'y_size'] as const).flatMap((axis) => {
+        const size = grid[axis];
+        return typeof size === 'number' && Number.isInteger(size) && size > 0
+            ? []
+            : [`\`grid.${axis}\` must be a positive integer`];
+    });
+};
+
+/**
+ * @description Validate a SoC descriptor carried by a report, so a complete
+ * device can render without a baked entry for its arch.
+ *
+ * NPE lands NoC transfers on real node coordinates, so it needs the full grid
+ * and there is no report-side substitute. The Quasar-IP family (Grendel and
+ * licensee parts) has descriptors rolled by the customer that cannot be bundled,
+ * which is what this override exists for. See #1776.
+ *
+ * Empty `dram` / `eth` / `pcie` are accepted: a tensix-only emulation descriptor
+ * legitimately has none, so their absence is a shape to render rather than an
+ * error. `functional_workers` is the one list that must be populated — without
+ * it there is no grid to draw and falling back would be better than rendering
+ * nothing.
+ */
+export const parseSocDescriptorOverride = (raw: unknown, reportedArch?: string): SocDescriptorOverride => {
+    if (raw === undefined || raw === null) {
+        return { status: 'absent' };
+    }
+    if (!isRecord(raw)) {
+        return { status: 'invalid', problems: ['the descriptor must be an object'] };
+    }
+
+    const problems = [
+        ...gridProblems(raw.grid),
+        ...coordinateProblems('functional_workers', raw.functional_workers),
+        // `dram` is nested one level deeper than the rest: a bank per channel.
+        ...(Array.isArray(raw.dram)
+            ? raw.dram.flatMap((channel, index) => coordinateProblems(`dram[${index}]`, channel))
+            : ['`dram` must be an array of channels']),
+        ...coordinateProblems('eth', raw.eth ?? []),
+        ...coordinateProblems('pcie', raw.pcie ?? []),
+        ...coordinateProblems('arc', raw.arc ?? []),
+        ...coordinateProblems('router_only', raw.router_only ?? []),
+    ];
+
+    if (Array.isArray(raw.functional_workers) && raw.functional_workers.length === 0) {
+        problems.push('`functional_workers` is empty, so there is no grid to render');
+    }
+
+    if (problems.length > 0) {
+        return { status: 'invalid', problems };
+    }
+
+    // The lists are validated above; the cast supplies the defaults that make the
+    // result a complete `ChipDesign` for readers that treat those fields as required.
+    //
+    // `arch_name` carries the descriptor's own label, falling back to the arch the
+    // report declared. Never a baked arch: a Quasar override labelled `wormhole`
+    // would be reported as Wormhole everywhere the name is displayed, which is a
+    // worse answer than an unrecognised one. It is outside `DeviceArchitecture` by
+    // design — the whole point is an arch the app does not know.
+    return {
+        status: 'valid',
+        design: {
+            ...raw,
+            arch_name: (raw.arch_name ?? reportedArch ?? 'unknown') as DeviceArchitecture,
+            arc: raw.arc ?? [],
+            eth: raw.eth ?? [],
+            pcie: raw.pcie ?? [],
+            router_only: raw.router_only ?? [],
+        } as ChipDesign,
+    };
+};

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -61,6 +61,7 @@ import {
 } from '../store/app';
 import { DeviceArchitecture } from '../definitions/DeviceArchitecture';
 import { getChipDesign } from '../functions/getChipDesign';
+import { parseSocDescriptorOverride } from '../functions/socDescriptorOverride';
 import { NPEData, NPEManifestEntry, NpeSummary, NpeWindow } from '../model/NPEModel';
 import { GraphBundle } from '../model/MLIRJsonModel';
 import { ChipDesign, ClusterModel, ClusterTopology, MeshData, MeshDescriptorResponse } from '../model/ClusterModel';
@@ -1317,22 +1318,44 @@ export const useInstance = () => {
     });
 };
 
-export const useArchitecture = (arch: DeviceArchitecture): ChipDesign | null => {
-    const design = getChipDesign(arch);
+export interface ResolvedArchitecture {
+    design: ChipDesign | null;
+    /** Populated only when a report supplied a descriptor that failed validation. */
+    overrideProblems: string[] | null;
+}
+
+/**
+ * Resolve the chip design for `arch`, preferring a report-supplied descriptor.
+ *
+ * A valid override wins outright, so an arch with no baked entry renders its real
+ * topology instead of toasting "Unsupported". A malformed one does *not* silently
+ * fall back: it is reported, because a descriptor that was offered and rejected is
+ * a different problem from one that was never there. See #1776.
+ */
+export const useArchitecture = (arch: DeviceArchitecture, socDescriptor?: unknown): ResolvedArchitecture => {
+    const override = useMemo(() => parseSocDescriptorOverride(socDescriptor, arch), [socDescriptor, arch]);
+    const baked = getChipDesign(arch);
+    const design = override.status === 'valid' ? override.design : baked;
+    const overrideProblems = override.status === 'invalid' ? override.problems : null;
 
     // Reported from an effect rather than the hook body, which runs on every render:
     // `useNodeType` is a consumer and NPE playback re-renders per interval tick, so an
     // inline warn emits a line per frame for the length of the run. #1772
     useEffect(() => {
+        if (overrideProblems) {
+            // eslint-disable-next-line no-console
+            console.error(`Unusable SoC descriptor in report: ${overrideProblems.join('; ')}`);
+            return;
+        }
         if (design === null) {
             // Still worth surfacing: unlike Cluster, these callers have no degraded mode and
             // silently lose every core-type overlay when the arch doesn't resolve.
             // eslint-disable-next-line no-console
             console.error(`Unsupported arch: ${arch}`);
         }
-    }, [arch, design]);
+    }, [arch, design, overrideProblems]);
 
-    return design;
+    return { design, overrideProblems };
 };
 
 export const useGetTensorSizesById = (tensorIdList: number[]): { id: number; size: number }[] => {
@@ -1351,8 +1374,8 @@ export const useGetTensorSizesById = (tensorIdList: number[]): { id: number; siz
         })
         .filter((item) => item !== null) as { id: number; size: number }[];
 };
-export const useNodeType = (arch: DeviceArchitecture) => {
-    const architecture = useArchitecture(arch);
+export const useNodeType = (arch: DeviceArchitecture, socDescriptor?: unknown) => {
+    const { design: architecture, overrideProblems } = useArchitecture(arch, socDescriptor);
     const cores = useMemo(() => {
         return architecture?.functional_workers?.map((loc) => {
             return loc
@@ -1389,7 +1412,7 @@ export const useNodeType = (arch: DeviceArchitecture) => {
         });
     }, [architecture]);
 
-    return { architecture, cores, dram, eth, pcie };
+    return { architecture, cores, dram, eth, pcie, overrideProblems };
 };
 
 export const PROFILER_FOLDER_QUERY_KEY = 'fetch-profiler-folder-list';

--- a/src/model/NPEModel.ts
+++ b/src/model/NPEModel.ts
@@ -216,6 +216,9 @@ export type NpeTimestepColumns = {
 
 export interface NpeSummary {
     common_info: CommonInfo;
+    // Carried through the index so the windowed path resolves the same descriptor
+    // the whole-file path does. `null` when the report supplied none. See #1776.
+    soc_descriptor?: unknown;
     chips: NPEData['chips'];
     zones?: NPERootZone[];
     n_timesteps: number;
@@ -238,6 +241,11 @@ export interface NPEData {
     chips: {
         [key: device_id]: ClusterCoordinates;
     };
+    // Optional report-supplied SoC descriptor, taking precedence over the baked
+    // lookup keyed on `common_info.arch`. Typed `unknown` on purpose: it arrives
+    // from a file we do not control, so `parseSocDescriptorOverride` validates it
+    // rather than a cast asserting the shape. See #1776.
+    soc_descriptor?: unknown;
 }
 
 export interface NPERootZone {

--- a/src/schemas/npe-soc-descriptor.schema.json
+++ b/src/schemas/npe-soc-descriptor.schema.json
@@ -2,53 +2,79 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://github.com/tenstorrent/ttnn-visualizer/blob/dev/src/schemas/npe-soc-descriptor.schema.json",
     "title": "NPE report SoC descriptor",
-    "description": "Optional `soc_descriptor` carried at the top level of an NPE report, alongside `common_info`. TTNN Visualizer prefers it over its own baked arch-*.json lookup, so a device whose descriptor cannot be bundled into the app renders its real topology. Absent means fall back to the baked lookup keyed on `common_info.arch`; present but invalid is reported to the user rather than silently ignored. See tenstorrent/ttnn-visualizer#1776.",
+    "description": "Optional `soc_descriptor` carried at the top level of an NPE report, alongside `common_info`. TTNN Visualizer prefers it over its own baked arch-*.json lookup, so a device whose descriptor cannot be bundled into the app renders its real topology. Absent means fall back to the baked lookup keyed on `common_info.arch`; present but invalid is reported to the user rather than silently ignored. See tenstorrent/ttnn-visualizer#1776. Two rules cannot be expressed in draft-07 and are enforced by the consumer at runtime instead: every coordinate must fall inside `grid` (x < x_size, y < y_size), and the total cell count must not exceed 16384. A descriptor can therefore pass this schema and still be rejected; the schema is a necessary condition, not a sufficient one.",
     "type": "object",
-    "required": ["grid", "functional_workers"],
+    "required": [
+        "grid",
+        "functional_workers"
+    ],
     "additionalProperties": true,
     "properties": {
         "grid": {
-            "description": "Extent of the node grid. Both axes are the full physical extent, not the worker extent.",
+            "description": "Extent of the node grid. Both axes are the full physical extent, not the worker extent. Capped at 256 per axis, and 16384 cells in total (runtime-only), because the renderer materialises one element per cell.",
             "type": "object",
-            "required": ["x_size", "y_size"],
+            "required": [
+                "x_size",
+                "y_size"
+            ],
             "properties": {
-                "x_size": { "type": "integer", "minimum": 1 },
-                "y_size": { "type": "integer", "minimum": 1 }
+                "x_size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 256
+                },
+                "y_size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 256
+                }
             }
         },
         "functional_workers": {
             "description": "Tensix worker cores. The only node list that must be populated: without it there is no grid to draw.",
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "#/definitions/coordinate" }
+            "items": {
+                "$ref": "#/definitions/coordinate"
+            }
         },
         "dram": {
             "description": "DRAM banks, grouped one array per channel. Omit or leave empty on a part with no DRAM.",
             "type": "array",
             "items": {
                 "type": "array",
-                "items": { "$ref": "#/definitions/coordinate" }
+                "items": {
+                    "$ref": "#/definitions/coordinate"
+                }
             }
         },
         "eth": {
             "description": "Ethernet nodes. Omit or leave empty on a part with none.",
             "type": "array",
-            "items": { "$ref": "#/definitions/coordinate" }
+            "items": {
+                "$ref": "#/definitions/coordinate"
+            }
         },
         "pcie": {
             "description": "PCIe nodes. Omit or leave empty on a part with none.",
             "type": "array",
-            "items": { "$ref": "#/definitions/coordinate" }
+            "items": {
+                "$ref": "#/definitions/coordinate"
+            }
         },
         "arc": {
             "description": "ARC nodes. Omit or leave empty on a part with none.",
             "type": "array",
-            "items": { "$ref": "#/definitions/coordinate" }
+            "items": {
+                "$ref": "#/definitions/coordinate"
+            }
         },
         "router_only": {
             "description": "Nodes that route but do not compute.",
             "type": "array",
-            "items": { "$ref": "#/definitions/coordinate" }
+            "items": {
+                "$ref": "#/definitions/coordinate"
+            }
         },
         "arch_name": {
             "description": "Label for this part, displayed as-is. Free-form on purpose: the point of an override is an architecture the app does not recognise. Defaults to `common_info.arch` when omitted, never to a baked architecture.",
@@ -58,11 +84,22 @@
         "harvested_workers": {
             "description": "Workers disabled by harvesting. Carried through; not currently rendered differently.",
             "type": "array",
-            "items": { "$ref": "#/definitions/coordinate" }
+            "items": {
+                "$ref": "#/definitions/coordinate"
+            }
         },
-        "worker_l1_size": { "type": "integer", "minimum": 0 },
-        "dram_bank_size": { "type": "integer", "minimum": 0 },
-        "eth_l1_size": { "type": "integer", "minimum": 0 }
+        "worker_l1_size": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "dram_bank_size": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "eth_l1_size": {
+            "type": "integer",
+            "minimum": 0
+        }
     },
     "definitions": {
         "coordinate": {

--- a/src/schemas/npe-soc-descriptor.schema.json
+++ b/src/schemas/npe-soc-descriptor.schema.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/tenstorrent/ttnn-visualizer/blob/dev/src/schemas/npe-soc-descriptor.schema.json",
+    "title": "NPE report SoC descriptor",
+    "description": "Optional `soc_descriptor` carried at the top level of an NPE report, alongside `common_info`. TTNN Visualizer prefers it over its own baked arch-*.json lookup, so a device whose descriptor cannot be bundled into the app renders its real topology. Absent means fall back to the baked lookup keyed on `common_info.arch`; present but invalid is reported to the user rather than silently ignored. See tenstorrent/ttnn-visualizer#1776.",
+    "type": "object",
+    "required": ["grid", "functional_workers"],
+    "additionalProperties": true,
+    "properties": {
+        "grid": {
+            "description": "Extent of the node grid. Both axes are the full physical extent, not the worker extent.",
+            "type": "object",
+            "required": ["x_size", "y_size"],
+            "properties": {
+                "x_size": { "type": "integer", "minimum": 1 },
+                "y_size": { "type": "integer", "minimum": 1 }
+            }
+        },
+        "functional_workers": {
+            "description": "Tensix worker cores. The only node list that must be populated: without it there is no grid to draw.",
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/coordinate" }
+        },
+        "dram": {
+            "description": "DRAM banks, grouped one array per channel. Omit or leave empty on a part with no DRAM.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/coordinate" }
+            }
+        },
+        "eth": {
+            "description": "Ethernet nodes. Omit or leave empty on a part with none.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/coordinate" }
+        },
+        "pcie": {
+            "description": "PCIe nodes. Omit or leave empty on a part with none.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/coordinate" }
+        },
+        "arc": {
+            "description": "ARC nodes. Omit or leave empty on a part with none.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/coordinate" }
+        },
+        "router_only": {
+            "description": "Nodes that route but do not compute.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/coordinate" }
+        },
+        "arch_name": {
+            "description": "Label for this part, displayed as-is. Free-form on purpose: the point of an override is an architecture the app does not recognise. Defaults to `common_info.arch` when omitted, never to a baked architecture.",
+            "type": "string",
+            "minLength": 1
+        },
+        "harvested_workers": {
+            "description": "Workers disabled by harvesting. Carried through; not currently rendered differently.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/coordinate" }
+        },
+        "worker_l1_size": { "type": "integer", "minimum": 0 },
+        "dram_bank_size": { "type": "integer", "minimum": 0 },
+        "eth_l1_size": { "type": "integer", "minimum": 0 }
+    },
+    "definitions": {
+        "coordinate": {
+            "description": "Node location as \"x-y\", both zero-based, matching the `functional_workers` spelling in tt-metal's soc_descriptors YAML. Note the order: x first, unlike the [y, x] pairs the renderer works in internally.",
+            "type": "string",
+            "pattern": "^[0-9]+-[0-9]+$"
+        }
+    }
+}

--- a/tests/socDescriptorOverride.spec.ts
+++ b/tests/socDescriptorOverride.spec.ts
@@ -88,6 +88,22 @@ describe('parseSocDescriptorOverride', () => {
         expect(result.design.router_only).toEqual([]);
     });
 
+    it('needs only grid and functional_workers, defaulting every node list', () => {
+        // The minimum a producer has to write. `dram` is optional on the same
+        // terms as `eth` / `pcie` rather than uniquely required.
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: ['1-1', '2-1'],
+        });
+
+        expect(result.status).toBe('valid');
+        if (result.status !== 'valid') {
+            return;
+        }
+        expect(result.design.dram).toEqual([]);
+        expect(result.design.eth).toEqual([]);
+    });
+
     it('reports a malformed grid rather than rendering an empty one', () => {
         const result = parseSocDescriptorOverride({
             grid: { x_size: 0, y_size: 'eight' },

--- a/tests/socDescriptorOverride.spec.ts
+++ b/tests/socDescriptorOverride.spec.ts
@@ -150,6 +150,87 @@ describe('parseSocDescriptorOverride', () => {
         expect(result.problems.join(' ')).toContain('no grid to render');
     });
 
+    it('rejects a coordinate outside the grid, which would render nothing (#1776)', () => {
+        // `EmptyChipRenderer` walks x < width and y < height and looks each cell up
+        // by coordinate, so a worker the grid never reaches silently disappears —
+        // an empty topology from a descriptor that passed validation.
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: ['1-1', '99-99'],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.join(' ')).toContain('outside the 4x4 grid');
+        expect(result.problems.join(' ')).toContain('99-99');
+    });
+
+    it('bounds-checks every node list, not just the workers', () => {
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: ['1-1'],
+            dram: [['0-0'], ['0-40']],
+            eth: ['40-0'],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.join(' ')).toContain('dram[1]');
+        expect(result.problems.join(' ')).toContain('`eth`');
+    });
+
+    it('names only the first few offenders, then counts the rest', () => {
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 2, y_size: 2 },
+            functional_workers: ['5-5', '6-6', '7-7', '8-8', '9-9'],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.join(' ')).toContain('and 2 more');
+    });
+
+    it('refuses a grid too large for the renderer to materialise', () => {
+        // One element per cell, so the grid is a direct multiplier on DOM size.
+        const perAxis = parseSocDescriptorOverride({
+            grid: { x_size: 1_000_000, y_size: 1_000_000 },
+            functional_workers: ['1-1'],
+        });
+        expect(perAxis.status).toBe('invalid');
+
+        // Both axes under the per-axis cap, but the product is not.
+        const byArea = parseSocDescriptorOverride({
+            grid: { x_size: 200, y_size: 200 },
+            functional_workers: ['1-1'],
+        });
+        expect(byArea.status).toBe('invalid');
+        if (byArea.status !== 'invalid') {
+            return;
+        }
+        expect(byArea.problems.join(' ')).toContain('40000 cells');
+    });
+
+    it('does not bounds-check against a grid that is itself invalid', () => {
+        // The grid problem is already reported; adding "outside the 0x0 grid" for
+        // every node would bury it.
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 0, y_size: 0 },
+            functional_workers: ['1-1', '2-2'],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.join(' ')).not.toContain('outside');
+    });
+
     it('reports a descriptor that is not an object at all', () => {
         for (const raw of ['a string', 42, ['an', 'array'], true]) {
             const result = parseSocDescriptorOverride(raw);

--- a/tests/socDescriptorOverride.spec.ts
+++ b/tests/socDescriptorOverride.spec.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+
+import { parseSocDescriptorOverride } from '../src/functions/socDescriptorOverride';
+import archWormhole from '../src/assets/data/arch-wormhole.json';
+import archBlackhole from '../src/assets/data/arch-blackhole.json';
+
+// A tensix-only emulation descriptor, the shape the Quasar-IP family produces:
+// a grid and workers, and nothing else populated.
+const tensixOnly = {
+    arch_name: 'QUASAR',
+    grid: { x_size: 10, y_size: 8 },
+    functional_workers: ['2-2', '3-2', '4-2', '5-2'],
+    dram: [['2-7'], ['4-0']],
+    arc: [],
+    pcie: [],
+    eth: [],
+};
+
+describe('parseSocDescriptorOverride', () => {
+    it('is absent for a report that supplies nothing', () => {
+        expect(parseSocDescriptorOverride(undefined).status).toBe('absent');
+        expect(parseSocDescriptorOverride(null).status).toBe('absent');
+    });
+
+    it('accepts the baked descriptors, so an override is held to the same bar (#1776)', () => {
+        // The strongest available check that the rules match reality: whatever the
+        // app already renders must validate, or the gate is stricter than the data.
+        for (const [name, baked] of [
+            ['wormhole', archWormhole],
+            ['blackhole', archBlackhole],
+        ] as const) {
+            const result = parseSocDescriptorOverride(baked);
+            expect(result.status, `${name}: ${JSON.stringify(result)}`).toBe('valid');
+        }
+    });
+
+    it('accepts a tensix-only descriptor with no dram, eth or pcie nodes', () => {
+        // Emulation parts legitimately have none. Rejecting them would make the
+        // override unusable for exactly the family it exists for.
+        const result = parseSocDescriptorOverride({ ...tensixOnly, dram: [], eth: [], pcie: [], arc: [] });
+
+        expect(result.status).toBe('valid');
+    });
+
+    it('carries the descriptor through with its own arch name', () => {
+        const result = parseSocDescriptorOverride(tensixOnly, 'quasar');
+
+        expect(result.status).toBe('valid');
+        if (result.status !== 'valid') {
+            return;
+        }
+        expect(result.design.arch_name).toBe('QUASAR');
+        expect(result.design.grid).toEqual({ x_size: 10, y_size: 8 });
+        expect(result.design.functional_workers).toHaveLength(4);
+    });
+
+    it('labels an unnamed descriptor with the arch the report declared, never a baked one', () => {
+        // Reporting a Grendel override as `wormhole` would be a worse answer than
+        // an unrecognised name, since the label is displayed.
+        const { arch_name: _dropped, ...unnamed } = tensixOnly;
+        const result = parseSocDescriptorOverride(unnamed, 'grendel');
+
+        expect(result.status).toBe('valid');
+        if (result.status !== 'valid') {
+            return;
+        }
+        expect(result.design.arch_name).toBe('grendel');
+    });
+
+    it('fills the optional node lists so readers can treat them as present', () => {
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: ['1-1'],
+            dram: [],
+        });
+
+        expect(result.status).toBe('valid');
+        if (result.status !== 'valid') {
+            return;
+        }
+        expect(result.design.eth).toEqual([]);
+        expect(result.design.pcie).toEqual([]);
+        expect(result.design.arc).toEqual([]);
+        expect(result.design.router_only).toEqual([]);
+    });
+
+    it('reports a malformed grid rather than rendering an empty one', () => {
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 0, y_size: 'eight' },
+            functional_workers: ['1-1'],
+            dram: [],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems).toEqual(
+            expect.arrayContaining([expect.stringContaining('x_size'), expect.stringContaining('y_size')]),
+        );
+    });
+
+    it('reports coordinates that are not "x-y", naming how many', () => {
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: ['1-1', 'nope', ''],
+            dram: [['2-7'], ['bad']],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.join(' ')).toContain('functional_workers');
+        expect(result.problems.join(' ')).toContain('2 entries that are');
+        expect(result.problems.join(' ')).toContain('dram[1]');
+    });
+
+    it('reports an empty worker list, which would draw nothing', () => {
+        const result = parseSocDescriptorOverride({
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: [],
+            dram: [],
+        });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.join(' ')).toContain('no grid to render');
+    });
+
+    it('reports a descriptor that is not an object at all', () => {
+        for (const raw of ['a string', 42, ['an', 'array'], true]) {
+            const result = parseSocDescriptorOverride(raw);
+            expect(result.status, JSON.stringify(raw)).toBe('invalid');
+        }
+    });
+
+    it('collects every problem rather than stopping at the first', () => {
+        const result = parseSocDescriptorOverride({ grid: null, functional_workers: 'nope', dram: 'nope' });
+
+        expect(result.status).toBe('invalid');
+        if (result.status !== 'invalid') {
+            return;
+        }
+        expect(result.problems.length).toBeGreaterThanOrEqual(3);
+    });
+});

--- a/tests/socDescriptorSchema.spec.ts
+++ b/tests/socDescriptorSchema.spec.ts
@@ -80,6 +80,32 @@ const cases: { label: string; descriptor: unknown; accepted: boolean }[] = [
         descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['1-1'], eth: ['9'] },
         accepted: false,
     },
+    {
+        label: 'grid axis above the cap',
+        descriptor: { grid: { x_size: 1000, y_size: 4 }, functional_workers: ['1-1'] },
+        accepted: false,
+    },
+];
+
+/**
+ * Rules draft-07 cannot express, so the schema accepts these and the runtime
+ * validator rejects them. Listed rather than omitted: the asymmetry is the
+ * contract — passing the schema is necessary, not sufficient — and a producer
+ * reading only the schema needs to know these two exist.
+ */
+const runtimeOnly: { label: string; descriptor: unknown }[] = [
+    {
+        label: 'worker outside the grid',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['99-99'] },
+    },
+    {
+        label: 'dram bank outside the grid',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['1-1'], dram: [['0-40']] },
+    },
+    {
+        label: 'cell count above the cap while both axes are under it',
+        descriptor: { grid: { x_size: 200, y_size: 200 }, functional_workers: ['1-1'] },
+    },
 ];
 
 describe('npe-soc-descriptor.schema.json', () => {
@@ -89,6 +115,22 @@ describe('npe-soc-descriptor.schema.json', () => {
 
         expect(schemaSays, `schema: ${JSON.stringify(validate.errors)}`).toBe(accepted);
         expect(runtimeSays, 'runtime validator').toBe(accepted);
+    });
+
+    it.each(runtimeOnly)('$label: schema cannot catch it, the validator does', ({ descriptor }) => {
+        expect(validate(descriptor), 'schema is expected to accept this').toBe(true);
+        expect(parseSocDescriptorOverride(descriptor).status).toBe('invalid');
+    });
+
+    it('never rejects something the runtime validator would accept', () => {
+        // The direction that matters: a producer building to the schema must not be
+        // turned away for a reason the schema never mentioned. The reverse is
+        // allowed and covered above.
+        for (const { descriptor } of [...cases, ...runtimeOnly]) {
+            if (parseSocDescriptorOverride(descriptor).status === 'valid') {
+                expect(validate(descriptor), `${JSON.stringify(descriptor)}`).toBe(true);
+            }
+        }
     });
 
     it('is a valid draft-07 schema that ajv will compile', () => {

--- a/tests/socDescriptorSchema.spec.ts
+++ b/tests/socDescriptorSchema.spec.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import Ajv from 'ajv';
+import { describe, expect, it } from 'vitest';
+
+import socDescriptorSchema from '../src/schemas/npe-soc-descriptor.schema.json';
+import { parseSocDescriptorOverride } from '../src/functions/socDescriptorOverride';
+import archWormhole from '../src/assets/data/arch-wormhole.json';
+import archBlackhole from '../src/assets/data/arch-blackhole.json';
+
+const validate = new Ajv({ allErrors: true }).compile(socDescriptorSchema);
+
+/**
+ * Descriptors the NPE producers might write, and what both the published schema
+ * and the runtime validator must say about each. The point of the table is that
+ * one column drives both: a schema the app does not honour is worse than no
+ * schema, because a producer would build against it and still be rejected.
+ */
+const cases: { label: string; descriptor: unknown; accepted: boolean }[] = [
+    { label: 'baked wormhole', descriptor: archWormhole, accepted: true },
+    { label: 'baked blackhole', descriptor: archBlackhole, accepted: true },
+    {
+        label: 'minimum a producer must write',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['1-1'] },
+        accepted: true,
+    },
+    {
+        label: 'tensix-only emulation part',
+        descriptor: {
+            arch_name: 'QUASAR',
+            grid: { x_size: 10, y_size: 8 },
+            functional_workers: ['2-2', '3-2'],
+            dram: [['2-7'], ['4-0']],
+            arc: [],
+            pcie: [],
+            eth: [],
+        },
+        accepted: true,
+    },
+    {
+        label: 'extra producer-specific keys are passed through',
+        descriptor: {
+            grid: { x_size: 4, y_size: 4 },
+            functional_workers: ['1-1'],
+            some_future_field: { anything: true },
+        },
+        accepted: true,
+    },
+    { label: 'missing grid', descriptor: { functional_workers: ['1-1'] }, accepted: false },
+    { label: 'missing functional_workers', descriptor: { grid: { x_size: 4, y_size: 4 } }, accepted: false },
+    {
+        label: 'empty functional_workers',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: [] },
+        accepted: false,
+    },
+    {
+        label: 'zero grid axis',
+        descriptor: { grid: { x_size: 0, y_size: 4 }, functional_workers: ['1-1'] },
+        accepted: false,
+    },
+    {
+        label: 'non-numeric grid axis',
+        descriptor: { grid: { x_size: 4, y_size: 'eight' }, functional_workers: ['1-1'] },
+        accepted: false,
+    },
+    {
+        label: 'coordinate not "x-y"',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['1-1', 'nope'] },
+        accepted: false,
+    },
+    {
+        label: 'dram not nested per channel',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['1-1'], dram: ['2-7'] },
+        accepted: false,
+    },
+    {
+        label: 'eth coordinate malformed',
+        descriptor: { grid: { x_size: 4, y_size: 4 }, functional_workers: ['1-1'], eth: ['9'] },
+        accepted: false,
+    },
+];
+
+describe('npe-soc-descriptor.schema.json', () => {
+    it.each(cases)('$label: schema and runtime validator agree', ({ descriptor, accepted }) => {
+        const schemaSays = validate(descriptor);
+        const runtimeSays = parseSocDescriptorOverride(descriptor).status === 'valid';
+
+        expect(schemaSays, `schema: ${JSON.stringify(validate.errors)}`).toBe(accepted);
+        expect(runtimeSays, 'runtime validator').toBe(accepted);
+    });
+
+    it('is a valid draft-07 schema that ajv will compile', () => {
+        // A schema the producers cannot run is not a contract.
+        expect(typeof validate).toBe('function');
+        expect(socDescriptorSchema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    });
+
+    it('rejects a non-object outright, as the runtime validator does', () => {
+        for (const raw of ['a string', 42, ['an', 'array'], true]) {
+            expect(validate(raw), JSON.stringify(raw)).toBe(false);
+            expect(parseSocDescriptorOverride(raw).status).toBe('invalid');
+        }
+    });
+});

--- a/tests/useNodeTypeSocOverride.spec.ts
+++ b/tests/useNodeTypeSocOverride.spec.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useNodeType } from '../src/hooks/useAPI';
+import { DeviceArchitecture } from '../src/definitions/DeviceArchitecture';
+
+// The arch an unknown part reports: no baked descriptor exists for it, which is
+// the case #1776 is about (Grendel and the licensee Quasar-IP parts).
+const UNKNOWN_ARCH = 'grendel_xyz' as DeviceArchitecture;
+
+// Shape of the fixture built from `report_with_zones`: a complete descriptor
+// carried by the report itself.
+const suppliedDescriptor = {
+    arch_name: 'GRENDEL_XYZ',
+    grid: { x_size: 10, y_size: 8 },
+    functional_workers: ['2-2', '3-2', '4-2'],
+    dram: [['2-7'], ['4-0']],
+    eth: [],
+    pcie: [],
+    arc: [],
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('useNodeType with a report-supplied SoC descriptor (#1776)', () => {
+    it('renders an unknown arch from the supplied descriptor', () => {
+        // Before this, an arch with no baked entry resolved to null and NPE drew
+        // nothing but an "Unsupported architecture" toast.
+        const { result } = renderHook(() => useNodeType(UNKNOWN_ARCH, suppliedDescriptor));
+
+        expect(result.current.overrideProblems).toBeNull();
+        expect(result.current.architecture).not.toBeNull();
+        expect(result.current.architecture?.grid).toEqual({ x_size: 10, y_size: 8 });
+        // Coordinates are parsed to [y, x] pairs for the grid renderer.
+        expect(result.current.cores).toEqual([
+            [2, 2],
+            [2, 3],
+            [2, 4],
+        ]);
+        expect(result.current.dram).toEqual([
+            [7, 2],
+            [0, 4],
+        ]);
+    });
+
+    it('still resolves a known arch from the baked descriptor when nothing is supplied', () => {
+        const { result } = renderHook(() => useNodeType(DeviceArchitecture.WORMHOLE));
+
+        expect(result.current.overrideProblems).toBeNull();
+        expect(result.current.architecture).not.toBeNull();
+        // 80 functional workers in the baked Wormhole descriptor.
+        expect(result.current.cores).toHaveLength(80);
+    });
+
+    it('prefers the supplied descriptor over a baked one for the same arch', () => {
+        const { result } = renderHook(() => useNodeType(DeviceArchitecture.WORMHOLE, suppliedDescriptor));
+
+        expect(result.current.architecture?.grid).toEqual({ x_size: 10, y_size: 8 });
+        expect(result.current.cores).toHaveLength(3);
+    });
+
+    it('leaves an unknown arch unresolved when nothing is supplied', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useNodeType(UNKNOWN_ARCH));
+
+        expect(result.current.architecture).toBeNull();
+        expect(result.current.overrideProblems).toBeNull();
+        expect(consoleError).toHaveBeenCalledWith(`Unsupported arch: ${UNKNOWN_ARCH}`);
+    });
+
+    it('reports a malformed descriptor rather than treating it as absent', () => {
+        // The distinction the caller needs: a descriptor that was offered and
+        // rejected gets an explicit error, not the generic "unsupported" path.
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const malformed = {
+            grid: { x_size: 0, y_size: 'eight' },
+            functional_workers: ['1-1', 'nope'],
+            dram: 'not-a-list',
+        };
+
+        const { result } = renderHook(() => useNodeType(UNKNOWN_ARCH, malformed));
+
+        expect(result.current.overrideProblems).not.toBeNull();
+        expect(result.current.overrideProblems?.join(' ')).toContain('grid.x_size');
+        expect(result.current.architecture).toBeNull();
+        expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Unusable SoC descriptor'));
+        // Not also the generic message: that would hide which of the two happened.
+        expect(consoleError).not.toHaveBeenCalledWith(`Unsupported arch: ${UNKNOWN_ARCH}`);
+    });
+
+    it('keeps a malformed descriptor from masking a usable baked one', () => {
+        // The override failed, but Wormhole is still renderable. Reporting the
+        // problem and rendering what we have beats an empty grid.
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useNodeType(DeviceArchitecture.WORMHOLE, { grid: 'nonsense' }));
+
+        expect(result.current.overrideProblems).not.toBeNull();
+        expect(result.current.architecture).not.toBeNull();
+        expect(result.current.cores).toHaveLength(80);
+    });
+});


### PR DESCRIPTION
Closes #1776. Targets `dev`.

## Summary

NPE lands NoC transfers on real node coordinates, so it needs the full SoC grid and resolved one from a baked `arch-*.json` keyed on `common_info.arch`. An arch with no baked entry fell through to `null` and drew nothing but an "Unsupported architecture" toast. That does not work for the Quasar-IP family — Grendel and the licensee parts have complete descriptors rolled by the customer that cannot be bundled into the app.

An NPE report may now carry its own descriptor in an optional top-level `soc_descriptor`. Resolution order:

1. a **valid** supplied descriptor wins;
2. **absent** falls back to the baked lookup, unchanged;
3. **malformed** is reported with the specific problems and does *not* silently fall back to "unsupported".

That third case is the point. A descriptor that was offered and rejected is a different failure from one that was never there, and collapsing them is how an unusable override renders as an empty grid.

### Also carried through the windowed path

Uploads take the windowed path locally (`isWindowedView` in `routes/NPE.tsx`), which assembles `NPEData` from the sqlite index rather than the source JSON — so the descriptor would have been dropped for exactly the reports people upload. The index now persists it and `INDEX_VERSION` moves to 5 so existing indexes rebuild. `read_summary` reads it with `.get`, so an older index is still readable.

### On validation

Empty `dram` / `eth` / `pcie` are accepted: a tensix-only emulation descriptor legitimately has none, and rejecting them would make the override unusable for the family it exists for. `functional_workers` is the one list that must be populated — without it there is nothing to draw. `arch_name` carries the descriptor's own label, falling back to the arch the report declared, never a baked one: a Grendel override reported as `wormhole` would be a worse answer than an unrecognised name.

## Test plan

Driven end to end in the running app with three fixtures built from `report_with_zones/npe_viz/UnknownOP_ID1.npeviz.zst`, each with `common_info.arch` changed to `grendel_xyz` (no baked entry):

| fixture | result |
|---|---|
| valid override (Wormhole descriptor baked in) | renders the full topology, `Architecture: grendel_xyz`, **no** toast, no `Unsupported arch` console error |
| no override | unresolved as before — `Unsupported architecture` toast, unchanged behaviour |
| malformed override | explicit toast naming all four problems, no silent empty grid |

Confirmed the descriptor survives both server paths: `/api/npe` (whole-file) and `/api/npe/summary` (windowed index).

New coverage:
- `socDescriptorOverride.spec.ts` — 11 cases. The load-bearing one asserts **both baked descriptors validate**, so the gate cannot end up stricter than the data the app already renders. Plus tensix-only acceptance, arch-name labelling, and six malformed shapes.
- `useNodeTypeSocOverride.spec.ts` — 6 cases over the hook: unknown arch rendered from a supplied descriptor, baked fallback when nothing is supplied, supplied beating baked, unknown arch left unresolved, malformed reported rather than treated as absent, and a malformed override not masking a usable baked descriptor.

Frontend 2230 passing, backend 1148 passing; `tsc`, eslint, stylelint, isort and black clean.

## Notes for reviewers

- `soc_descriptor` is typed `unknown` on `NPEData` deliberately — it arrives from a file we do not control, so it is validated rather than cast.
- The malformed toast appears twice in dev. That is React's strict-mode double effect; the pre-existing "Unsupported architecture" toast behaves identically, so it is not introduced here.
- Fixtures are not committed (5.4 MB each). They live at `~/Documents/repos/npe-1776-fixtures/` and the generator is three lines of `zstd`/`orjson` if they need rebuilding.
