### PR TITLE
Collapse a mesh op's circular buffers into one L1 legend row

### DIFF
--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -104,26 +104,34 @@ function L1Plots({
     const groupedMemoryReport = getGroupedMemoryReport(BufferType.L1);
     const isLengthyLegend = memoryReport.length > MAX_LEGEND_LENGTH;
 
-    const memoryReportWithCB: FragmentationEntry[] = [
-        ...memoryReport,
-        // Collapsed per device op: a mesh op emits the same CB once per device, which
-        // put 32 identical unlabelled rows in this legend interleaved with the
-        // fragmentation entries. One row now carries the device count. #1879
-        ...operationDetails.deviceOperations
-            .map((op) =>
+    // Only the collapse is memoised, not the concatenation and sort around it. The
+    // collapse is the part that allocates per CB per device operation (a Map, a Set
+    // per slot, two joined identity strings), and this component re-renders on
+    // `selectedAddressAtom` — every legend click — plus the region toggle and the
+    // scroll shades, none of which change CB data.
+    //
+    // The sort stays outside deliberately: `[...].sort()` mutates in place, and a
+    // `useMemo` wrapping it cannot be preserved by the compiler
+    // (`react-hooks/preserve-manual-memoization`), which is an error here. `toSorted`
+    // would fix that but needs an es2023 lib target. #1879
+    const collapsedCbEntries: FragmentationEntry[] = useMemo(
+        () =>
+            operationDetails.deviceOperations.flatMap((op) =>
                 collapseCbDeviceRows(op.cbList).map(
                     (cb) =>
                         ({
                             ...cb,
                             markerType: MarkerType.CB,
                             colorVariance: op.id,
-                            globallyAllocated: cb.globallyAllocated,
-                            deviceCount: cb.deviceCount,
                         }) as FragmentationEntry,
                 ),
-            )
-            .flat(),
-    ].sort((a, b) => a.address - b.address);
+            ),
+        [operationDetails.deviceOperations],
+    );
+
+    const memoryReportWithCB: FragmentationEntry[] = [...memoryReport, ...collapsedCbEntries].sort(
+        (a, b) => a.address - b.address,
+    );
 
     // keeping for now, to make sure nothing breaks
     // const bufferZoomRangeStart = Math.min(...bufferMemory.map((chunk) => chunk.address));

--- a/src/components/operation-details/L1Plots.tsx
+++ b/src/components/operation-details/L1Plots.tsx
@@ -27,6 +27,7 @@ import { FragmentationEntry, MarkerType } from '../../model/APIData';
 import { MemoryLegendGroup } from './MemoryLegendGroup';
 import { useGetL1SmallMarker, useGetL1StartMarker } from '../../hooks/useAPI';
 import useScrollShade from '../../hooks/useScrollShade';
+import { collapseCbDeviceRows } from '../../functions/collapseCbDeviceRows';
 
 interface L1PlotsProps {
     operationDetails: OperationDetails;
@@ -105,15 +106,19 @@ function L1Plots({
 
     const memoryReportWithCB: FragmentationEntry[] = [
         ...memoryReport,
+        // Collapsed per device op: a mesh op emits the same CB once per device, which
+        // put 32 identical unlabelled rows in this legend interleaved with the
+        // fragmentation entries. One row now carries the device count. #1879
         ...operationDetails.deviceOperations
             .map((op) =>
-                op.cbList.map(
+                collapseCbDeviceRows(op.cbList).map(
                     (cb) =>
                         ({
                             ...cb,
                             markerType: MarkerType.CB,
                             colorVariance: op.id,
                             globallyAllocated: cb.globallyAllocated,
+                            deviceCount: cb.deviceCount,
                         }) as FragmentationEntry,
                 ),
             )
@@ -318,6 +323,7 @@ function L1Plots({
                             colorVariance={chunk.colorVariance}
                             userL1ZoomRange={userL1ZoomRange}
                             isGloballyAllocated={chunk.globallyAllocated === true}
+                            deviceCount={chunk.deviceCount}
                         />
                     ))}
 

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -213,13 +213,18 @@ export const MemoryLegendElement = ({
                     whole string, so the size drifts left and stops lining up with the
                     plain sizes above and below it. #1879 */}
                 {multiplierLabels && <span className='legend-multipliers monospace'>{multiplierLabels}</span>}
+                {/* Wrapped rather than left as bare text: an unwrapped child of a flex
+                    container becomes an anonymous flex item, which cannot receive
+                    `text-overflow`, so this clipped mid-glyph instead of ellipsising. */}
                 {!isMultiDeviceBuffer && !chunk.empty && derivedTensor && (
-                    <>
+                    <span className='legend-description-text'>
                         {derivedTensor.operationIdentifier} {derivedTensor.operationIdentifier && ':'} Tensor{' '}
                         {derivedTensor.id}
-                    </>
+                    </span>
                 )}
-                {!isMultiDeviceBuffer && chunk.empty && emptyChunkLabel}
+                {!isMultiDeviceBuffer && chunk.empty && (
+                    <span className='legend-description-text'>{emptyChunkLabel}</span>
+                )}
             </div>
             {(bufferType || layout) && (
                 <div className='extra-info-slot'>

--- a/src/components/operation-details/MemoryLegendElement.tsx
+++ b/src/components/operation-details/MemoryLegendElement.tsx
@@ -86,8 +86,11 @@ export const MemoryLegendElement = ({
 
     const derivedTensor = operationDetails.getTensorForAddress(chunk.address);
     const isPerCoreBuffer = bufferType !== StringBufferType.DRAM && bufferType !== StringBufferType.SYSTEM_MEMORY;
-    const numCoresLabel = isPerCoreBuffer && numCores && numCores > 0 ? ` ${getCoreCountLabel(numCores)}` : '';
-    const deviceCountLabel = deviceCount > 1 ? ` ${getDeviceCountLabel(deviceCount)}` : '';
+    const numCoresLabel = isPerCoreBuffer && numCores && numCores > 0 ? getCoreCountLabel(numCores) : '';
+    const deviceCountLabel = deviceCount > 1 ? getDeviceCountLabel(deviceCount) : '';
+    // Joined so the cell renders nothing at all when neither applies, rather than an
+    // empty span that would still take the description cell's leading gap.
+    const multiplierLabels = [numCoresLabel, deviceCountLabel].filter(Boolean).join(' ');
 
     const resolvedColour =
         chunk.tensorId || derivedTensor
@@ -170,8 +173,6 @@ export const MemoryLegendElement = ({
                 ) : (
                     <>
                         {formatMemorySize(chunk.size, 2)}
-                        {numCoresLabel}
-                        {deviceCountLabel}
                         {isGloballyAllocated && (
                             <Tooltip
                                 content={
@@ -206,7 +207,12 @@ export const MemoryLegendElement = ({
                     </>
                 )}
             </div>
-            <div>
+            <div className='legend-description'>
+                {/* The multipliers live here rather than beside the size, which is
+                    right-aligned: a cell holding "8 KiB x 32 devices" right-aligns the
+                    whole string, so the size drifts left and stops lining up with the
+                    plain sizes above and below it. #1879 */}
+                {multiplierLabels && <span className='legend-multipliers monospace'>{multiplierLabels}</span>}
                 {!isMultiDeviceBuffer && !chunk.empty && derivedTensor && (
                     <>
                         {derivedTensor.operationIdentifier} {derivedTensor.operationIdentifier && ':'} Tensor{' '}

--- a/src/functions/cbDeviceSlots.ts
+++ b/src/functions/cbDeviceSlots.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * The device/repeat bookkeeping that decides how many devices a circular buffer
+ * row stands for. Shared by `processMemoryAllocations` (the per-DeviceOp legend and
+ * the pressure modal, #1844) and `collapseCbDeviceRows` (the L1 plot legend, #1879)
+ * so the three surfaces cannot disagree about a CB's device count — they were
+ * separate implementations agreeing only on the sentinel below.
+ */
+
+// Keeps a graph with no device dimension accumulating into one bucket. #1844
+export const SINGLE_DEVICE_KEY = 'single';
+
+/**
+ * @description Normalise a graph node's `device_id` to a number. `undefined` when
+ * absent or not a finite number — the field is missing in older captures and
+ * emitted as a string by at least one other. #1844
+ */
+export const normaliseDeviceId = (deviceId: number | string | undefined | null): number | undefined => {
+    if (deviceId === undefined || deviceId === null || deviceId === '') {
+        return undefined;
+    }
+    const asNumber = Number(deviceId);
+    return Number.isFinite(asNumber) ? asNumber : undefined;
+};
+
+/**
+ * @description Bucket key for the device a CB was allocated on. Normalises first so
+ * a raw graph value and an already-normalised one land in the same bucket: without
+ * that, one caller reading `params.device_id` and another reading a parsed field
+ * disagreed on anything unparseable.
+ */
+export const cbDeviceKey = (deviceId: number | string | undefined | null): string => {
+    const normalised = normaliseDeviceId(deviceId);
+    return normalised === undefined ? SINGLE_DEVICE_KEY : String(normalised);
+};
+
+/**
+ * @description Slot allocator for one CB scope. Call the returned function per CB
+ * with its identity and device key; CBs that fold onto one row share a slot.
+ *
+ * A repeat on the same device is a real second allocation rather than mesh fan-out,
+ * so keying on the device's own repeat count gives it its own slot and pairs it with
+ * the other devices' repeats instead of letting it displace the first.
+ */
+export const createCbSlotKeys = (): ((identity: string, deviceKey: string) => string) => {
+    const repeatsByDevice = new Map<string, number>();
+    return (identity: string, deviceKey: string): string => {
+        const repeatKey = `${identity}|${deviceKey}`;
+        const repeat = (repeatsByDevice.get(repeatKey) ?? 0) + 1;
+        repeatsByDevice.set(repeatKey, repeat);
+        return `${identity}|${repeat}`;
+    };
+};

--- a/src/functions/collapseCbDeviceRows.ts
+++ b/src/functions/collapseCbDeviceRows.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { CircularBuffer } from '../model/APIData';
+import { SINGLE_DEVICE_KEY } from './processMemoryAllocations';
+
+/**
+ * @description Normalise a graph node's `device_id` for use as a number.
+ * `undefined` for a capture with no device dimension, or a value that is not a
+ * finite number — the field is absent in older captures and emitted as a string
+ * by at least one other. #1844
+ */
+export const normaliseDeviceId = (deviceId: number | string | undefined): number | undefined => {
+    if (deviceId === undefined || deviceId === null || deviceId === '') {
+        return undefined;
+    }
+    const asNumber = Number(deviceId);
+    return Number.isFinite(asNumber) ? asNumber : undefined;
+};
+
+export interface CollapsedCircularBuffer extends CircularBuffer {
+    /** Devices this row stands for. 1 when the capture carries no device dimension. */
+    deviceCount: number;
+}
+
+/**
+ * @description Collapse one device operation's circular buffers so a mesh op's
+ * fan-out is a single row carrying a device count, instead of the same CB listed
+ * once per device. #1879
+ *
+ * The identity and repeat scheme mirrors `processMemoryAllocations`, which already
+ * does this for the per-DeviceOp legend and the pressure modal (#1844) — the three
+ * surfaces are on screen together and must not disagree about how many devices a CB
+ * spans. Op scoping is implicit here because `cbList` is already per operation.
+ *
+ * A second allocation of the same CB *on one device* is a real allocation rather
+ * than fan-out, so it keeps its own row: keying on the device's repeat count pairs
+ * it with the other devices' repeats instead of letting it collapse onto the first.
+ * The first occurrence in graph order is the row the rest fold onto.
+ */
+export const collapseCbDeviceRows = (cbList: readonly CircularBuffer[]): CollapsedCircularBuffer[] => {
+    const repeatsByDevice = new Map<string, number>();
+    const slotOrder: string[] = [];
+    const bySlot = new Map<string, { circularBuffer: CircularBuffer; deviceKeys: Set<string> }>();
+
+    for (const circularBuffer of cbList) {
+        const identity = [
+            circularBuffer.address,
+            circularBuffer.size,
+            circularBuffer.core_range_set,
+            circularBuffer.globallyAllocated === true,
+        ].join('|');
+        const deviceKey = String(circularBuffer.device_id ?? SINGLE_DEVICE_KEY);
+        const repeatKey = `${identity}|${deviceKey}`;
+        const repeat = (repeatsByDevice.get(repeatKey) ?? 0) + 1;
+        repeatsByDevice.set(repeatKey, repeat);
+
+        const slot = `${identity}|${repeat}`;
+        const existing = bySlot.get(slot);
+        if (existing) {
+            existing.deviceKeys.add(deviceKey);
+        } else {
+            bySlot.set(slot, { circularBuffer, deviceKeys: new Set([deviceKey]) });
+            slotOrder.push(slot);
+        }
+    }
+
+    return slotOrder.map((slot) => {
+        const entry = bySlot.get(slot);
+        return { ...(entry?.circularBuffer as CircularBuffer), deviceCount: entry?.deviceKeys.size ?? 1 };
+    });
+};

--- a/src/functions/collapseCbDeviceRows.ts
+++ b/src/functions/collapseCbDeviceRows.ts
@@ -3,21 +3,9 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import type { CircularBuffer } from '../model/APIData';
-import { SINGLE_DEVICE_KEY } from './processMemoryAllocations';
+import { cbDeviceKey, createCbSlotKeys } from './cbDeviceSlots';
 
-/**
- * @description Normalise a graph node's `device_id` for use as a number.
- * `undefined` for a capture with no device dimension, or a value that is not a
- * finite number — the field is absent in older captures and emitted as a string
- * by at least one other. #1844
- */
-export const normaliseDeviceId = (deviceId: number | string | undefined): number | undefined => {
-    if (deviceId === undefined || deviceId === null || deviceId === '') {
-        return undefined;
-    }
-    const asNumber = Number(deviceId);
-    return Number.isFinite(asNumber) ? asNumber : undefined;
-};
+export { normaliseDeviceId } from './cbDeviceSlots';
 
 export interface CollapsedCircularBuffer extends CircularBuffer {
     /** Devices this row stands for. 1 when the capture carries no device dimension. */
@@ -40,7 +28,7 @@ export interface CollapsedCircularBuffer extends CircularBuffer {
  * The first occurrence in graph order is the row the rest fold onto.
  */
 export const collapseCbDeviceRows = (cbList: readonly CircularBuffer[]): CollapsedCircularBuffer[] => {
-    const repeatsByDevice = new Map<string, number>();
+    const slotKeyOf = createCbSlotKeys();
     const slotOrder: string[] = [];
     const bySlot = new Map<string, { circularBuffer: CircularBuffer; deviceKeys: Set<string> }>();
 
@@ -51,12 +39,8 @@ export const collapseCbDeviceRows = (cbList: readonly CircularBuffer[]): Collaps
             circularBuffer.core_range_set,
             circularBuffer.globallyAllocated === true,
         ].join('|');
-        const deviceKey = String(circularBuffer.device_id ?? SINGLE_DEVICE_KEY);
-        const repeatKey = `${identity}|${deviceKey}`;
-        const repeat = (repeatsByDevice.get(repeatKey) ?? 0) + 1;
-        repeatsByDevice.set(repeatKey, repeat);
-
-        const slot = `${identity}|${repeat}`;
+        const deviceKey = cbDeviceKey(circularBuffer.device_id);
+        const slot = slotKeyOf(identity, deviceKey);
         const existing = bySlot.get(slot);
         if (existing) {
             existing.deviceKeys.add(deviceKey);

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -9,7 +9,9 @@ import { AllocationDetails, CBAllocationSummary, CBDeviceFanout, CBPressureSnaps
 import { getCoresInRangeList } from './math';
 
 // Keeps a graph with no device dimension accumulating into one bucket. #1844
-const SINGLE_DEVICE_KEY = 'single';
+// Exported so the L1 legend's own collapse buckets absent ids identically — the
+// two must not disagree about how many devices a CB spans. #1879
+export const SINGLE_DEVICE_KEY = 'single';
 
 export function processMemoryAllocations(
     graph: Node[],

--- a/src/functions/processMemoryAllocations.ts
+++ b/src/functions/processMemoryAllocations.ts
@@ -6,12 +6,13 @@ import { DeviceOperationNode, Node, NodeType } from '../model/APIData';
 import { L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { StringBufferType } from '../model/BufferType';
 import { AllocationDetails, CBAllocationSummary, CBDeviceFanout, CBPressureSnapshot } from '../model/MemoryAllocations';
+import { cbDeviceKey, createCbSlotKeys } from './cbDeviceSlots';
 import { getCoresInRangeList } from './math';
 
-// Keeps a graph with no device dimension accumulating into one bucket. #1844
-// Exported so the L1 legend's own collapse buckets absent ids identically — the
-// two must not disagree about how many devices a CB spans. #1879
-export const SINGLE_DEVICE_KEY = 'single';
+// Re-exported for callers that already import it from here. The device and repeat
+// bookkeeping this shares with `collapseCbDeviceRows` now lives in `cbDeviceSlots`,
+// so the two cannot disagree about a CB's device count. #1879
+export { SINGLE_DEVICE_KEY } from './cbDeviceSlots';
 
 export function processMemoryAllocations(
     graph: Node[],
@@ -39,7 +40,7 @@ export function processMemoryAllocations(
     let liveCBByIdentity = new Map<string, { summary: CBAllocationSummary; deviceKeys: Set<string> }>();
     // How many times each device has already allocated a given CB, so the key
     // above can separate repeats.
-    let cbRepeatsByDevice = new Map<string, number>();
+    let cbSlotKeyOf = createCbSlotKeys();
     const cbPressureByOpId = new Map<number, CBPressureSnapshot>();
     const cbFanout: CBDeviceFanout = {
         deviceCountByNodeId: new Map<number, number>(),
@@ -49,7 +50,7 @@ export function processMemoryAllocations(
     const resetLiveCBs = () => {
         liveCBs = [];
         liveCBByIdentity = new Map();
-        cbRepeatsByDevice = new Map();
+        cbSlotKeyOf = createCbSlotKeys();
     };
 
     const snapshotCBPressure = (opId: number) => {
@@ -127,7 +128,7 @@ export function processMemoryAllocations(
             // forward-compat with future tt-metal emit changes. #1651
             const rawGlobalFlag = node.params.globally_allocated as unknown;
             const globallyAllocated = rawGlobalFlag === '1' || rawGlobalFlag === 1;
-            const deviceKey = String(node.params.device_id ?? SINGLE_DEVICE_KEY);
+            const deviceKey = cbDeviceKey(node.params.device_id);
             if (!globallyAllocated) {
                 if (cores.length === 0) {
                     unattributedByDevice.set(deviceKey, (unattributedByDevice.get(deviceKey) ?? 0) + size);
@@ -156,10 +157,7 @@ export function processMemoryAllocations(
             // count gives it one, and pairs it with the other devices' repeats
             // instead of letting it displace the first allocation as the row
             // they all collapse onto.
-            const repeatKey = `${identity}|${deviceKey}`;
-            const repeat = (cbRepeatsByDevice.get(repeatKey) ?? 0) + 1;
-            cbRepeatsByDevice.set(repeatKey, repeat);
-            const identitySlot = `${identity}|${repeat}`;
+            const identitySlot = cbSlotKeyOf(identity, deviceKey);
             const existing = liveCBByIdentity.get(identitySlot);
             if (existing) {
                 existing.deviceKeys.add(deviceKey);

--- a/src/model/APIData.ts
+++ b/src/model/APIData.ts
@@ -209,6 +209,9 @@ export interface FragmentationEntry extends Chunk {
     largestEmpty?: boolean;
     // Mirrors `CircularBuffer.globallyAllocated` for the legend renderer. #1652
     globallyAllocated?: boolean;
+    // How many devices a collapsed CB row stands for, so the legend can say so
+    // rather than repeating the row once per device. #1879
+    deviceCount?: number;
 }
 
 // export interface ReportMetaData {

--- a/src/model/OperationDetails.ts
+++ b/src/model/OperationDetails.ts
@@ -24,6 +24,7 @@ import getChartData from '../functions/getChartData';
 import { calculateCondensed } from '../functions/calculateCondensed';
 import { L1_DEFAULT_MEMORY_SIZE, L1_NUM_CORES } from '../definitions/L1MemorySize';
 import { TensorDeallocationReport } from './BufferSummary';
+import { normaliseDeviceId } from '../functions/collapseCbDeviceRows';
 
 export interface OperationDetailsOptions {
     renderPattern: boolean;
@@ -262,6 +263,11 @@ export class OperationDetails implements Partial<OperationDetailsData> {
                                 num_cores: getCoresInRange(node.params.core_range_set),
                                 colorVariance: deviceOp.id,
                                 globallyAllocated,
+                                // Normalised here rather than read as a number: absent in
+                                // older captures and emitted as a string by at least one
+                                // other. Without it every device's copy of a CB became its
+                                // own legend row. #1844 / #1879
+                                device_id: normaliseDeviceId(node.params.device_id),
                             });
                         }
                     }

--- a/src/scss/components/MemoryLegendElement.scss
+++ b/src/scss/components/MemoryLegendElement.scss
@@ -65,6 +65,29 @@
         white-space: nowrap;
     }
 
+    // `min-width: 0` and the clip keep this cell's contents inside its own track:
+    // the device-operations view caps it at `$legend-tensor-column`, and without
+    // these the multipliers below would spill into the buffer-type column rather
+    // than truncate. Matches what #1897 asks of these labels. #1879
+    .legend-description {
+        display: flex;
+        min-width: 0;
+        align-items: center;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    // Sits in the left-aligned description cell, ahead of any tensor label. Dimmed
+    // because it qualifies the size rather than naming the row, and never shrinks —
+    // if the cell runs out of room the tensor identifier truncates instead, since
+    // the multiplier is the shorter and less recoverable of the two. #1879
+    .legend-multipliers {
+        flex: 0 0 auto;
+        margin-right: 8px;
+        color: $tt-grey-5;
+    }
+
     .legend-marker-swatch {
         width: 15px;
         height: 15px;

--- a/src/scss/components/MemoryLegendElement.scss
+++ b/src/scss/components/MemoryLegendElement.scss
@@ -65,16 +65,24 @@
         white-space: nowrap;
     }
 
-    // `min-width: 0` and the clip keep this cell's contents inside its own track:
-    // the device-operations view caps it at `$legend-tensor-column`, and without
-    // these the multipliers below would spill into the buffer-type column rather
-    // than truncate. Matches what #1897 asks of these labels. #1879
+    // `min-width: 0` and the clip keep this cell's contents inside its own track: the
+    // device-operations view caps it at `$legend-tensor-column`, and without these the
+    // multipliers below would spill into the buffer-type column. Matches what #1897
+    // asks of these labels. #1879
     .legend-description {
         display: flex;
         min-width: 0;
         align-items: center;
         overflow: hidden;
         white-space: nowrap;
+    }
+
+    // The ellipsis has to live on this rather than on the flex container: bare text
+    // inside a flex parent is an anonymous flex item and never receives
+    // `text-overflow`, which is why the tensor identifier used to clip mid-glyph.
+    .legend-description-text {
+        min-width: 0;
+        overflow: hidden;
         text-overflow: ellipsis;
     }
 

--- a/src/scss/definitions/_variables.scss
+++ b/src/scss/definitions/_variables.scss
@@ -40,11 +40,16 @@ $active-transfer-width: 380px;
 // Device-operation memory legend columns. Definite widths, because the cells are
 // `nowrap` and each row is its own grid — a share-based track takes its minimum
 // from the row's own text and so resolves differently per row. Sized to the
-// widest observed content plus headroom; the size column overflows by 11px on a
-// 3-digit core count beside the aliased-CB icon, absorbed by the column gap.
-$legend-size-column: 300px;
+// widest observed content plus headroom.
+//
+// The size column held `40.13 KiB x 50 cores x 32 devices` until the multipliers
+// moved to the tensor column (#1879), which left it three times wider than the
+// size alone needs and the tensor column 22px short of the labels it inherited.
+// 80px moves across; the pair still totals 480px, so the numeric gutter this view
+// aligns against does not shift. #1897 tracks the wider alignment problem.
+$legend-size-column: 220px;
 $legend-address-column: 90px;
-$legend-tensor-column: 180px;
+$legend-tensor-column: 260px;
 $legend-buffer-type-column: 130px;
 $legend-shape-column: 170px;
 

--- a/tests/L1PlotsCbDeviceRows.spec.tsx
+++ b/tests/L1PlotsCbDeviceRows.spec.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { resetPlotPropsCapture } from './mocks/plotComponent';
+import L1Plots from '../src/components/operation-details/L1Plots';
+import { OperationDetails } from '../src/model/OperationDetails';
+import { type Node, NodeType, type OperationDetailsData } from '../src/model/APIData';
+import { TestProviders } from './helpers/TestProviders';
+
+// Coverage either side of this seam existed — the pure collapse and the leaf legend
+// row — but not the seam itself: that `collapseCbDeviceRows` is called at all, that
+// `deviceCount` survives the `as FragmentationEntry` cast, and that it arrives at
+// `MemoryLegendElement`. #1879
+let nextId = 0;
+const mkNode = <T extends Partial<Node>>(node: T): Node => {
+    nextId += 1;
+    return { id: nextId, connections: [], inputs: [], outputs: [], stacking_level: 0, ...node } as Node;
+};
+
+const cbAcrossDevices = (address: number, size: number, devices: number): Node[] =>
+    Array.from({ length: devices }, (_, deviceId) =>
+        mkNode({
+            node_type: NodeType.circular_buffer_allocate,
+            params: {
+                core_range_set: '{[(x=0,y=0) - (x=0,y=0)]}',
+                size: String(size),
+                address: String(address),
+                globally_allocated: '0',
+                device_id: deviceId,
+            },
+        } as unknown as Partial<Node>),
+    );
+
+const buildDetails = (deviceOperations: Node[]): OperationDetails => {
+    nextId = 0;
+    const data = {
+        id: 1,
+        name: 'op',
+        inputs: [],
+        outputs: [],
+        stack_trace: '',
+        stack_trace_source_file_id: null,
+        operationFileIdentifier: 'op',
+        error: null,
+        buffers: [],
+        buffersSummary: [],
+        l1_sizes: [1_500_000],
+        device_operations: deviceOperations,
+    } as unknown as OperationDetailsData;
+    return new OperationDetails(data, [], [], { l1start: 0, l1end: 1_500_000 });
+};
+
+const MESH_OP = [
+    mkNode({
+        node_type: NodeType.function_start,
+        params: { name: 'matmul', device_id: 0 },
+    } as unknown as Partial<Node>),
+    ...cbAcrossDevices(0x1b400, 8192, 32),
+    mkNode({ node_type: NodeType.function_end, params: { name: 'matmul' } } as unknown as Partial<Node>),
+];
+
+const renderPlots = (showCircularBuffer: boolean) => {
+    const details = buildDetails(MESH_OP);
+    return render(
+        <TestProviders>
+            <L1Plots
+                operationDetails={details}
+                previousOperationDetails={details}
+                zoomedInViewMainMemory={false}
+                plotZoomRangeStart={0}
+                plotZoomRangeEnd={1_500_000}
+                showCircularBuffer={showCircularBuffer}
+                showL1Small={false}
+                onBufferClick={vi.fn()}
+                onLegendClick={vi.fn()}
+            />
+        </TestProviders>,
+    );
+};
+
+const cbLegendRows = (container: HTMLElement) =>
+    [...container.querySelectorAll('.legend-item')].filter((row) => /KiB|MiB|B\b/.test(row.textContent ?? ''));
+
+afterEach(() => {
+    cleanup();
+    resetPlotPropsCapture();
+});
+
+describe('L1 plot CB legend rows', () => {
+    it('draws one row for a 32-device CB, carrying the device count', () => {
+        // Without the collapse this op contributes 32 identical unlabelled rows.
+        const view = renderPlots(true);
+
+        const multipliers = [...view.container.querySelectorAll('.legend-multipliers')];
+        expect(multipliers).toHaveLength(1);
+        expect(multipliers[0].textContent).toBe('x 32 devices');
+    });
+
+    it('renders no CB rows at all while the toggle is off', () => {
+        const view = renderPlots(false);
+
+        expect(view.container.querySelectorAll('.legend-multipliers')).toHaveLength(0);
+    });
+
+    it('keeps the device count out of the right-aligned size cell', () => {
+        // The alignment half: the size cell must stay numeric.
+        const view = renderPlots(true);
+
+        const sizeCells = [...view.container.querySelectorAll('.format-numbers.monospace.nowrap')];
+        expect(sizeCells.some((cell) => /devices/.test(cell.textContent ?? ''))).toBe(false);
+        expect(cbLegendRows(view.container).length).toBeGreaterThan(0);
+    });
+});

--- a/tests/MemoryLegendElement.spec.tsx
+++ b/tests/MemoryLegendElement.spec.tsx
@@ -211,3 +211,43 @@ describe('MemoryLegendElement globally_allocated marker (#1651)', () => {
         );
     });
 });
+
+// The size cell is `text-align: right`, so a cell holding "8 KiB x 32 devices"
+// right-aligns the whole string and the size drifts left — measured on op 104 of
+// the MoE report as three distinct size right-edges (417 / 451 / 468 at 1900px)
+// where the buffer rows all sat at 417. Keeping the multipliers out of that cell
+// is what restores one edge for every row. #1879
+describe('MemoryLegendElement multiplier placement', () => {
+    const cbChunk = { address: 111616, size: 8192 };
+
+    it('keeps the size cell numeric so it can right-align with plain sizes', () => {
+        const container = renderLegendElement(cbChunk, { numCores: 46, deviceCount: 32 });
+
+        const sizeCell = container.querySelector('.format-numbers.monospace.nowrap');
+        expect(sizeCell).toBeInTheDocument();
+        expect(sizeCell?.textContent).toBe('8 KiB');
+        expect(sizeCell?.textContent).not.toContain('devices');
+        expect(sizeCell?.textContent).not.toContain('cores');
+    });
+
+    it('puts both multipliers in the left-aligned description cell', () => {
+        const container = renderLegendElement(cbChunk, { numCores: 46, deviceCount: 32 });
+
+        const multipliers = container.querySelector('.legend-description .legend-multipliers');
+        expect(multipliers).toBeInTheDocument();
+        expect(multipliers?.textContent).toBe('x 46 cores x 32 devices');
+    });
+
+    it('renders no multiplier span at all when neither applies', () => {
+        // An empty span would still take the description cell's leading gap.
+        const container = renderLegendElement(cbChunk);
+
+        expect(container.querySelector('.legend-multipliers')).not.toBeInTheDocument();
+    });
+
+    it('carries the device count alone when core count does not apply', () => {
+        const container = renderLegendElement(cbChunk, { deviceCount: 32 });
+
+        expect(container.querySelector('.legend-multipliers')?.textContent).toBe('x 32 devices');
+    });
+});

--- a/tests/OperationDetails.globallyAllocatedCB.spec.ts
+++ b/tests/OperationDetails.globallyAllocatedCB.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { OperationDetails } from '../src/model/OperationDetails';
 import { Node, NodeType, OperationDetailsData } from '../src/model/APIData';
 import { PlotDataCustom } from '../src/model/PlotData';
+import { collapseCbDeviceRows } from '../src/functions/collapseCbDeviceRows';
 
 let nextId = 0;
 function mkNode<T extends Partial<Node>>(node: T): Node {
@@ -42,7 +43,7 @@ const resolveGloballyAllocatedFlag = (options: { globallyAllocated?: boolean; ra
 const cbAllocate = (
     address: number,
     size: number,
-    options: { globallyAllocated?: boolean; rawFlag?: string | number } = {},
+    options: { globallyAllocated?: boolean; rawFlag?: string | number; deviceId?: number | string } = {},
 ) =>
     mkNode({
         node_type: NodeType.circular_buffer_allocate,
@@ -51,6 +52,7 @@ const cbAllocate = (
             size: String(size),
             address: String(address),
             globally_allocated: resolveGloballyAllocatedFlag(options),
+            ...(options.deviceId === undefined ? {} : { device_id: options.deviceId }),
         },
     } as unknown as Partial<Node>);
 
@@ -212,5 +214,53 @@ describe('OperationDetails.memoryData() CB trace split (#1652)', () => {
         const top = (data.cbChartData[0] as Partial<PlotDataCustom>).memoryData!;
         expect(top.address).toBe(0x1000);
         expect(top.address + top.size).toBeLessThan(0xff000);
+    });
+});
+
+// Deleting the `device_id` line from the cbList push left every other suite green
+// while the collapse silently fell into its "no device id -> keep the rows" branch,
+// so the feature was dead with no failing test. This covers the plumbing itself. #1879
+describe('OperationDetails circular_buffer_allocate device plumbing (#1879)', () => {
+    it('stamps device_id onto every cbList entry', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            ...[0, 1, 2, 3, 4, 5, 6, 7].map((deviceId) => cbAllocate(0x1000, 1024, { deviceId })),
+            functionEnd('matmul'),
+        ]);
+
+        const [matmul] = op.deviceOperations;
+        expect(matmul.cbList).toHaveLength(8);
+        expect(matmul.cbList.map((cb) => cb.device_id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it('feeds the collapse, so one mesh CB becomes one row for eight devices', () => {
+        // The end of the plumbing: without device_id on the entries this collapses
+        // to eight rows of one device rather than one row of eight.
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            ...[0, 1, 2, 3, 4, 5, 6, 7].map((deviceId) => cbAllocate(0x1000, 1024, { deviceId })),
+            functionEnd('matmul'),
+        ]);
+
+        const collapsed = collapseCbDeviceRows(op.deviceOperations[0].cbList);
+
+        expect(collapsed).toHaveLength(1);
+        expect(collapsed[0].deviceCount).toBe(8);
+    });
+
+    it('normalises a string device id, which at least one capture emits', () => {
+        const op = buildOperationDetails([
+            functionStart('matmul'),
+            cbAllocate(0x1000, 1024, { deviceId: '3' }),
+            functionEnd('matmul'),
+        ]);
+
+        expect(op.deviceOperations[0].cbList[0].device_id).toBe(3);
+    });
+
+    it('leaves device_id undefined when the capture has no device dimension', () => {
+        const op = buildOperationDetails([functionStart('matmul'), cbAllocate(0x1000, 1024), functionEnd('matmul')]);
+
+        expect(op.deviceOperations[0].cbList[0].device_id).toBeUndefined();
     });
 });

--- a/tests/cbDeviceSlots.spec.ts
+++ b/tests/cbDeviceSlots.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { SINGLE_DEVICE_KEY, cbDeviceKey, createCbSlotKeys, normaliseDeviceId } from '../src/functions/cbDeviceSlots';
+
+describe('normaliseDeviceId', () => {
+    it('accepts the number and string forms tt-metal emits', () => {
+        expect(normaliseDeviceId(0)).toBe(0);
+        expect(normaliseDeviceId(31)).toBe(31);
+        expect(normaliseDeviceId('12')).toBe(12);
+    });
+
+    it('is undefined for anything that is not a device id', () => {
+        expect(normaliseDeviceId(undefined)).toBeUndefined();
+        expect(normaliseDeviceId(null)).toBeUndefined();
+        expect(normaliseDeviceId('')).toBeUndefined();
+        expect(normaliseDeviceId('abc')).toBeUndefined();
+    });
+});
+
+describe('cbDeviceKey', () => {
+    it('buckets absent and unparseable ids together', () => {
+        // The divergence this shared helper exists to remove: one caller read
+        // `params.device_id` raw and the other a normalised field, so a capture mixing
+        // '' with 'abc' produced two rows of one device on one surface and one row of
+        // two devices on the other.
+        expect(cbDeviceKey(undefined)).toBe(SINGLE_DEVICE_KEY);
+        expect(cbDeviceKey('')).toBe(SINGLE_DEVICE_KEY);
+        expect(cbDeviceKey('abc')).toBe(SINGLE_DEVICE_KEY);
+    });
+
+    it('is idempotent, so a raw and an already-normalised id agree', () => {
+        expect(cbDeviceKey('7')).toBe(cbDeviceKey(7));
+        expect(cbDeviceKey(normaliseDeviceId('7'))).toBe(cbDeviceKey('7'));
+    });
+});
+
+describe('createCbSlotKeys', () => {
+    it('folds every device onto one slot for the same identity', () => {
+        const slotKeyOf = createCbSlotKeys();
+
+        const slots = ['0', '1', '2', '3'].map((device) => slotKeyOf('cb-a', device));
+
+        expect(new Set(slots).size).toBe(1);
+    });
+
+    it('gives a repeat on the same device its own slot', () => {
+        const slotKeyOf = createCbSlotKeys();
+
+        const first = slotKeyOf('cb-a', '0');
+        const second = slotKeyOf('cb-a', '0');
+
+        expect(second).not.toBe(first);
+    });
+
+    it('pairs the nth repeat across devices rather than letting it displace the first', () => {
+        const slotKeyOf = createCbSlotKeys();
+
+        const deviceZeroFirst = slotKeyOf('cb-a', '0');
+        const deviceOneFirst = slotKeyOf('cb-a', '1');
+        const deviceZeroSecond = slotKeyOf('cb-a', '0');
+        const deviceOneSecond = slotKeyOf('cb-a', '1');
+
+        expect(deviceOneFirst).toBe(deviceZeroFirst);
+        expect(deviceOneSecond).toBe(deviceZeroSecond);
+        expect(deviceZeroSecond).not.toBe(deviceZeroFirst);
+    });
+
+    it('keeps distinct identities apart', () => {
+        const slotKeyOf = createCbSlotKeys();
+
+        expect(slotKeyOf('cb-a', '0')).not.toBe(slotKeyOf('cb-b', '0'));
+    });
+
+    it('starts a fresh count per allocator, so one scope cannot leak into the next', () => {
+        expect(createCbSlotKeys()('cb-a', '0')).toBe(createCbSlotKeys()('cb-a', '0'));
+    });
+});

--- a/tests/collapseCbDeviceRows.spec.ts
+++ b/tests/collapseCbDeviceRows.spec.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from 'vitest';
+import { collapseCbDeviceRows, normaliseDeviceId } from '../src/functions/collapseCbDeviceRows';
+import type { CircularBuffer } from '../src/model/APIData';
+
+const cb = (overrides: Partial<CircularBuffer> = {}): CircularBuffer => ({
+    address: 111616,
+    size: 8192,
+    core_range_set: '{[0-1 - 10-4], [0-5 - 5-5]}',
+    num_cores: 46,
+    globallyAllocated: false,
+    ...overrides,
+});
+
+/** The op-104 shape from `test_ttnn_moe_aug26_2217`: one CB emitted per device. */
+const acrossDevices = (count: number, overrides: Partial<CircularBuffer> = {}): CircularBuffer[] =>
+    Array.from({ length: count }, (_, device) => cb({ device_id: device, ...overrides }));
+
+describe('normaliseDeviceId', () => {
+    it('accepts the number and string forms tt-metal emits', () => {
+        // Absent in older captures, a string in at least one other. #1844
+        expect(normaliseDeviceId(0)).toBe(0);
+        expect(normaliseDeviceId(31)).toBe(31);
+        expect(normaliseDeviceId('12')).toBe(12);
+    });
+
+    it('is undefined for anything that is not a device id', () => {
+        expect(normaliseDeviceId(undefined)).toBeUndefined();
+        expect(normaliseDeviceId('')).toBeUndefined();
+        expect(normaliseDeviceId('not a number')).toBeUndefined();
+    });
+});
+
+describe('collapseCbDeviceRows', () => {
+    it('folds a mesh op’s fan-out into one row carrying the device count', () => {
+        // Reported from op 104 of the MoE report: 96 CB nodes = 3 CBs x 32 devices,
+        // which the L1 legend drew as 96 unlabelled rows. #1879
+        const collapsed = collapseCbDeviceRows(acrossDevices(32));
+
+        expect(collapsed).toHaveLength(1);
+        expect(collapsed[0].deviceCount).toBe(32);
+        expect(collapsed[0].address).toBe(111616);
+    });
+
+    it('keeps distinct CBs apart while collapsing each one', () => {
+        const collapsed = collapseCbDeviceRows([
+            ...acrossDevices(32, { address: 111616, size: 8192 }),
+            ...acrossDevices(32, { address: 119808, size: 487424 }),
+            ...acrossDevices(32, { address: 607232, size: 917504 }),
+        ]);
+
+        expect(collapsed.map((entry) => [entry.address, entry.deviceCount])).toEqual([
+            [111616, 32],
+            [119808, 32],
+            [607232, 32],
+        ]);
+    });
+
+    it('gives a second allocation on the same device its own row', () => {
+        // A repeat on one device is a real second allocation, not fan-out, so it
+        // must not collapse onto the first — and it pairs with the other devices'
+        // repeats rather than displacing them.
+        const collapsed = collapseCbDeviceRows([
+            cb({ device_id: 0 }),
+            cb({ device_id: 1 }),
+            cb({ device_id: 0 }),
+            cb({ device_id: 1 }),
+        ]);
+
+        expect(collapsed).toHaveLength(2);
+        expect(collapsed.map((entry) => entry.deviceCount)).toEqual([2, 2]);
+    });
+
+    it('separates CBs that differ only in core range or aliasing', () => {
+        const collapsed = collapseCbDeviceRows([
+            ...acrossDevices(4, { core_range_set: '{[0-0 - 1-1]}' }),
+            ...acrossDevices(4, { core_range_set: '{[0-0 - 3-3]}' }),
+            ...acrossDevices(4, { globallyAllocated: true }),
+        ]);
+
+        expect(collapsed).toHaveLength(3);
+        expect(collapsed.every((entry) => entry.deviceCount === 4)).toBe(true);
+    });
+
+    it('leaves a single-device capture as one row with no fan-out', () => {
+        // Older captures carry no device_id at all; they must not report 1 device
+        // per row and must not merge two genuinely separate allocations.
+        const collapsed = collapseCbDeviceRows([cb(), cb({ address: 200000 })]);
+
+        expect(collapsed).toHaveLength(2);
+        expect(collapsed.map((entry) => entry.deviceCount)).toEqual([1, 1]);
+    });
+
+    it('cannot collapse fan-out when a capture carries no device id, so keeps the rows', () => {
+        // Without a device id every emission looks like a repeat on the same
+        // device. Fan-out and a genuine second allocation are indistinguishable, so
+        // the rows are preserved rather than merged on a guess — such a capture sees
+        // no improvement here, which is the honest outcome rather than a wrong count.
+        const collapsed = collapseCbDeviceRows([cb(), cb()]);
+
+        expect(collapsed).toHaveLength(2);
+        expect(collapsed.map((entry) => entry.deviceCount)).toEqual([1, 1]);
+    });
+
+    it('returns nothing for an operation with no circular buffers', () => {
+        expect(collapseCbDeviceRows([])).toEqual([]);
+    });
+
+    it('does not mutate the list it was given', () => {
+        const cbList = acrossDevices(4);
+
+        collapseCbDeviceRows(cbList);
+
+        expect(cbList).toHaveLength(4);
+        expect(cbList.every((entry) => !('deviceCount' in entry))).toBe(true);
+    });
+});

--- a/tests/memoryLegendColumnBudget.spec.ts
+++ b/tests/memoryLegendColumnBudget.spec.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// The device-operation memory legend's columns are definite widths in
+// `_variables.scss`, and #1879 moved the `x N cores x N devices` multipliers from the
+// size column into the tensor column. Asserted against the stylesheet because jsdom
+// cannot measure geometry.
+const VARIABLES = readFileSync(resolve(process.cwd(), 'src/scss/definitions/_variables.scss'), {
+    encoding: 'utf8',
+});
+
+const pxVar = (name: string): number => {
+    const match = VARIABLES.match(new RegExp(`\\$${name}:\\s*(\\d+)px`));
+    expect(match, `$${name} not found in _variables.scss`).not.toBeNull();
+    return Number(match?.[1]);
+};
+
+// `x 50 cores x 32 devices` measured 202px including its 8px gap on the report the
+// issue cites, so the 180px this column used to be truncated it mid-word.
+const WIDEST_OBSERVED_MULTIPLIER_PX = 202;
+
+// What the size and tensor columns summed to before the multipliers moved. It is not
+// a magic number: the pair's width is what places the numeric gutter to its right,
+// which #1897 records as correct today. Trade width between the two rather than
+// growing the pair, and update this with a note if the gutter is deliberately moved.
+const COLUMN_PAIR_BUDGET_PX = 480;
+
+describe('device operation legend column budget', () => {
+    it('gives the tensor column room for the multipliers it now carries', () => {
+        expect(pxVar('legend-tensor-column')).toBeGreaterThanOrEqual(WIDEST_OBSERVED_MULTIPLIER_PX);
+    });
+
+    it('keeps the size and tensor columns summing to their original budget', () => {
+        expect(
+            pxVar('legend-size-column') + pxVar('legend-tensor-column'),
+            'these two columns place the numeric gutter beside them — trade width between them rather than growing the pair',
+        ).toBe(COLUMN_PAIR_BUDGET_PX);
+    });
+
+    it('leaves the size column wider than a size plus its marker slot', () => {
+        // Narrowed once the multipliers left it; must still clear the widest size text
+        // with the aliased-CB marker reserved beside it.
+        expect(pxVar('legend-size-column')).toBeGreaterThan(pxVar('legend-marker-slot') + 100);
+    });
+});

--- a/tests/opGraphNodeStyles.spec.ts
+++ b/tests/opGraphNodeStyles.spec.ts
@@ -136,39 +136,3 @@ describe('op graph critical path styling', () => {
         expect(outlineOffset).toBeGreaterThan(ringWidth);
     });
 });
-
-// The two device-operation legend tracks are a fixed pair, and #1879 moved the
-// `x N cores x N devices` labels from the first into the second. Sizing them for
-// the old split clipped the labels at 180px, and widening the second without
-// narrowing the first would shift the numeric gutter this view aligns against —
-// which #1897 records as correct today. Both halves are asserted here because
-// geometry cannot be measured in jsdom.
-describe('device operation legend column budget', () => {
-    const VARIABLES = readFileSync(resolve(process.cwd(), 'src/scss/definitions/_variables.scss'), {
-        encoding: 'utf8',
-    });
-
-    const pxVar = (name: string): number => {
-        const match = VARIABLES.match(new RegExp(`\\$${name}:\\s*(\\d+)px`));
-        expect(match, `$${name} not found`).not.toBeNull();
-        return Number(match?.[1]);
-    };
-
-    it('gives the tensor column room for the multipliers it now carries', () => {
-        // `x 50 cores x 32 devices` measured 202px including its 8px gap, so the
-        // 180px this column used to be truncated it mid-word.
-        expect(pxVar('legend-tensor-column')).toBeGreaterThanOrEqual(202);
-    });
-
-    it('keeps the size and tensor columns summing to their original 480px', () => {
-        // Not an arbitrary total: the pair's width is what places the numeric
-        // gutter, so trading width between them is safe and growing the pair is not.
-        expect(pxVar('legend-size-column') + pxVar('legend-tensor-column')).toBe(480);
-    });
-
-    it('leaves the size column wider than a size plus its marker slot', () => {
-        // Narrowed once the multipliers left it; must still clear the widest size
-        // text with the aliased-CB marker reserved beside it.
-        expect(pxVar('legend-size-column')).toBeGreaterThan(pxVar('legend-marker-slot') + 100);
-    });
-});

--- a/tests/opGraphNodeStyles.spec.ts
+++ b/tests/opGraphNodeStyles.spec.ts
@@ -136,3 +136,39 @@ describe('op graph critical path styling', () => {
         expect(outlineOffset).toBeGreaterThan(ringWidth);
     });
 });
+
+// The two device-operation legend tracks are a fixed pair, and #1879 moved the
+// `x N cores x N devices` labels from the first into the second. Sizing them for
+// the old split clipped the labels at 180px, and widening the second without
+// narrowing the first would shift the numeric gutter this view aligns against —
+// which #1897 records as correct today. Both halves are asserted here because
+// geometry cannot be measured in jsdom.
+describe('device operation legend column budget', () => {
+    const VARIABLES = readFileSync(resolve(process.cwd(), 'src/scss/definitions/_variables.scss'), {
+        encoding: 'utf8',
+    });
+
+    const pxVar = (name: string): number => {
+        const match = VARIABLES.match(new RegExp(`\\$${name}:\\s*(\\d+)px`));
+        expect(match, `$${name} not found`).not.toBeNull();
+        return Number(match?.[1]);
+    };
+
+    it('gives the tensor column room for the multipliers it now carries', () => {
+        // `x 50 cores x 32 devices` measured 202px including its 8px gap, so the
+        // 180px this column used to be truncated it mid-word.
+        expect(pxVar('legend-tensor-column')).toBeGreaterThanOrEqual(202);
+    });
+
+    it('keeps the size and tensor columns summing to their original 480px', () => {
+        // Not an arbitrary total: the pair's width is what places the numeric
+        // gutter, so trading width between them is safe and growing the pair is not.
+        expect(pxVar('legend-size-column') + pxVar('legend-tensor-column')).toBe(480);
+    });
+
+    it('leaves the size column wider than a size plus its marker slot', () => {
+        // Narrowed once the multipliers left it; must still clear the widest size
+        // text with the aliased-CB marker reserved beside it.
+        expect(pxVar('legend-size-column')).toBeGreaterThan(pxVar('legend-marker-slot') + 100);
+    });
+});


### PR DESCRIPTION

<img width="1535" height="865" alt="image" src="https://github.com/user-attachments/assets/e9eac156-4159-402a-b280-333d7ef77198" />


## Summary

A mesh op emits the same circular buffer once per device, and the L1 plot's legend listed every copy. Op 104 (`ttnn.matmul`) of `test_ttnn_moe_aug26_2217` has **96** `circular_buffer_allocate` nodes for **3** distinct CBs across **32** devices, so the legend drew 96 unlabelled rows interleaved by address with the fragmentation entries. Each CB is now one row carrying its device count.

Fixing that exposed a second problem: the size cell is `text-align: right`, so appending the count produced `8 KiB x 32 devices` as a single right-aligned string and pushed the size out of line with the plain sizes above and below it. Both multipliers — `x N devices` and the pre-existing `x N cores` — move to the left-aligned description cell.

Closes #1879

### The row repetition

Before — every device's copy got its own unlabelled row, so three CBs filled 96 of them:

```
 0111616    L1 START
 0111616       8 KiB
 0111616       8 KiB
 0111616       8 KiB
                          ... 29 more identical rows
 0119808     476 KiB
 0119808     476 KiB
                          ... 30 more
 0607232     896 KiB
                          ... 31 more
 1524736   40.13 KiB  Empty space
```

After — one row per CB, saying how many devices it stands for:

```
 0111616    L1 START
 0111616       8 KiB  x 32 devices
 0119808     476 KiB  x 32 devices
 0607232     896 KiB  x 32 devices
 1524736   40.13 KiB  Empty space
 1565824       432 B  95 ttnn.to_layout tt_moe.py:687 : Tensor 470
```

### Why the count is not in the size cell

The obvious place for the label is beside the size, but that cell is `text-align: right`, so it right-aligns `8 KiB x 32 devices` as one string and the size no longer lines up with the plain sizes around it. Measured right-edge of the size cell across the first 14 legend rows, same report, 1900px viewport — the misalignment is a pixel effect that a code block cannot honestly show, so these are measurements rather than ASCII:

| label placement | distinct size right-edges |
|---|---|
| in the size cell | **3** — 417 for every buffer row, 451 and 468 for the three CB rows |
| in the description cell (shipped) | **1** — 417 for all 14 |

### Frontend

- `src/functions/cbDeviceSlots.ts` *(new)* — the device key and slot allocator that decide how many devices a row stands for, shared by `processMemoryAllocations` (#1844's legend and pressure modal) and the collapse below, so the three CB surfaces cannot disagree. `cbDeviceKey` normalises before bucketing, so a raw `params.device_id` and an already-normalised field land together.
- `src/functions/collapseCbDeviceRows.ts` *(new)* — collapses one device operation's CBs on top of that shared bookkeeping. A second allocation of the same CB **on one device** is a real allocation rather than fan-out and keeps its own row.
- `src/model/OperationDetails.ts` — the `cbList` push records `device_id`. The field was already declared on `Chunk` and simply never populated, which is why this surface had nothing to collapse on.
- `src/components/operation-details/L1Plots.tsx` — collapse per device operation before flattening into `memoryReportWithCB`; pass `deviceCount` through.
- `src/components/operation-details/MemoryLegendElement.tsx` — multipliers render in the description cell instead of the numeric one. No new prop: `deviceCount` already existed here.
- `src/scss/components/MemoryLegendElement.scss` — the description cell clips rather than spilling into the buffer-type column, and the ellipsis sits on a wrapped `.legend-description-text` rather than the flex container, which cannot pass it to bare text. The multiplier keeps its width and the tensor identifier truncates first: a truncated identifier is recoverable from the row, a truncated count is not.
- `src/scss/definitions/_variables.scss` — 80px moves from `$legend-size-column` to `$legend-tensor-column` on the device-operations view. Both were sized for the old split, where the size column carried `40.13 KiB x 50 cores x 32 devices`; afterwards it was three times wider than a size alone needs and the tensor column was 22px short of the labels it inherited. The pair still totals 480px, so the numeric gutter that view aligns against does not move.

Totals are untouched — `calculateCondensed` is envelope-based, so the duplicate rows never inflated anything.

- `src/components/operation-details/L1Plots.tsx` — the collapse is memoised on `[operationDetails.deviceOperations]`, since it allocates per CB per device operation and this component re-renders on every legend click. The surrounding concatenation and sort stay in the render body: `[...].sort()` mutates in place, so a `useMemo` over it cannot be preserved by the compiler and `react-hooks/preserve-manual-memoization` fails the build.

## Known limitations (out of scope, tracked separately)

- **Columns still drift at narrow viewports, before and after this change.** Each legend row is its own `inline-grid`, so alignment only holds while the elastic tracks clear their min-content floors — at 800px the plain sizes already spanned 324–375px on `dev`. That is #1897, which diagnoses it and proposes subgrid or moving the nesting indent out of the aligned area.
- **The plot still draws one rectangle per device per CB.** `cbChartDataByOperation` also flattens `cbList`, so 32 identical rectangles overlap. #1879 scopes to row repetition; whether the fill opacity compounds is unverified.
- **A capture with no `device_id` keeps its rows.** Without it, fan-out and a genuine repeat are indistinguishable, so merging would be a guess. All 2560 CB nodes in the reference report carry the field.
- **A mesh aliased-CB row leaves the tensor identifier 58px**, down from 180px, because `.legend-multipliers` takes 202px of the 260px column and does not shrink. Recorded on #1879; unexercised by any report in the corpus, since the reference report's CBs are all `globally_allocated=0`.

## Test plan

- [ ] Frontend: `pnpm test tests/collapseCbDeviceRows.spec.ts tests/cbDeviceSlots.spec.ts tests/MemoryLegendElement.spec.tsx tests/L1PlotsCbDeviceRows.spec.tsx tests/OperationDetails.globallyAllocatedCB.spec.ts tests/memoryLegendColumnBudget.spec.ts`
- [ ] `tsc`, `eslint`, `stylelint` clean on touched files
- [ ] Manual — open `test_ttnn_moe_aug26_2217` op 104, enable **Show Circular Buffers Details** on the L1 plot: three CB rows, each `x 32 devices`, sizes right-aligned with the buffer rows below
- [ ] Manual — device operations view on any report with CBs: `x N cores` reads in the description column and does not spill into the buffer-type column
- [ ] Manual — a single-device report still shows one row per CB with no device label

## Follow-ups

- #1897 — legend columns don't align across rows/nesting depths, the structural half of the alignment problem



