### PR TITLE
Say that report_name is required for a report to be written

### DIFF
--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -27,7 +27,7 @@ export TTNN_CONFIG_OVERRIDES='{
 |----------------------|-------------|
 | **enable_fast_runtime_mode** | Disable fast runtime mode to ensure all operations are properly traced. **Must be disabled to enable logging**. |
 | **enable_logging** | Synchronizes main thread after every operation and logs the operation. **Must be enabled**. |
-| **report_name** | Prefix of the folder name where the memory report is output. **Must have a value for data8 to be output to disk**. |
+| **report_name** | Prefix of the folder name where the memory report is output. **Must have a value for data to be output to disk**. |
 | **enable_detailed_buffer_report** | Enable to visualize the detailed buffer report after every operation. **Needed for full buffer information**. |
 | **enable_detailed_tensor_report** | Enable to visualize the values of input and output tensors of every operation. **Data not used by the visualizer**. |
 | **enable_graph_report** | Generates an SVG visualization of the computation graph and enables automatic report generation with pytest. **Must be enabled**. |
@@ -40,7 +40,9 @@ To run a test with custom input data, you can use the following command with sui
 pytest --disable-warnings --input-path="path/to/input.json" path/to/test_file.py::test_function[param]
 ```
 
-The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file (config.json is optional for the visualizer). The report will be created automatically when running TT-Metal model demos and tests with `pytest`, when `enable_logging` and `enable_graph_report` are `true`.
+The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file (config.json is optional for the visualizer). The report will be created automatically when running TT-Metal model demos and tests with `pytest`, when `enable_logging` and `enable_graph_report` are `true` **and `report_name` has a value**.
+
+Important: `report_name` is the option that fails silently. With it unset you get no report and no error — not an empty folder, nothing at all. Only tests collected under `tests/ttnn/` derive a name from the test id for you (in `tests/ttnn/conftest.py`); model demos under `models/` do not, so set `report_name` explicitly for those.
 
 <img width="909" alt="Memory report files" src="https://github.com/user-attachments/assets/ab31892a-2779-4fe1-9ad5-0f35f8329f9a" />
 

--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -40,9 +40,9 @@ To run a test with custom input data, you can use the following command with sui
 pytest --disable-warnings --input-path="path/to/input.json" path/to/test_file.py::test_function[param]
 ```
 
-The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file (config.json is optional for the visualizer). The report will be created automatically when running TT-Metal model demos and tests with `pytest`, when `enable_logging` and `enable_graph_report` are `true` **and `report_name` has a value**.
+The final output should be a folder within `${TT_METAL_HOME}/generated/ttnn/reports/` which should include at least a `db.sqlite` file (config.json is optional for the visualizer). The report is created automatically when running TT-Metal model demos and tests with `pytest`, provided `enable_logging` is `true`, `report_name` has a value, and `enable_graph_report` is `true`. (`enable_comparison_mode` also triggers generation, but it is not a substitute — see the table above.)
 
-Important: `report_name` is the option that fails silently. With it unset you get no report and no error — not an empty folder, nothing at all. Only tests collected under `tests/ttnn/` derive a name from the test id for you (in `tests/ttnn/conftest.py`); model demos under `models/` do not, so set `report_name` explicitly for those.
+Important: every one of those conditions fails silently. With any of them unset you get no report and no error, and not even an empty folder. `report_name` is the one most often missed — always set it explicitly, for tests as well as model demos.
 
 <img width="909" alt="Memory report files" src="https://github.com/user-attachments/assets/ab31892a-2779-4fe1-9ad5-0f35f8329f9a" />
 


### PR DESCRIPTION
## Summary

`docs/src/installing.md` describes when a memory report is created automatically and names two conditions, `enable_logging` and `enable_graph_report`, leaving out `report_name`. Setting exactly what that sentence lists produces **no report and no error** — not an empty folder, nothing.

All three conditions that gate report generation fail the same way — `enable_logging` at tt-metal's root `conftest.py:1271`, the `enable_graph_report`/`enable_comparison_mode` pair at `:1277`, and `report_name` at `graph_report.py:82-85` — each a bare `yield; return` with no log. `report_name` is the one this sentence omitted.

The config table above already said `report_name` "must have a value", but the two statements read independently, and this sentence is the one people skim when asking why they have no report.

Refs tenstorrent/tt-metal#54956 — surfaced while reviewing that fix, which corrects the equivalent trap in tt-metal's own `ttnn/tutorials/ttnn_visualizer.md`. **Our docs were already correct about `enable_graph_report`** (`true`, marked "Must be enabled"); this is the other half of the same failure, on our side.

### Docs

- `docs/src/installing.md` — the automatic-creation sentence now lists all three conditions (and notes that `enable_comparison_mode` also triggers generation, so the list is exhaustive rather than true-given-the-recommended-block), followed by a caveat that every one of them fails silently and that `report_name` should always be set explicitly. Written as plain prose to match the existing caveat style (`remote-sync.md:38`) rather than a MyST admonition: `myst_parser` is enabled so a directive would build, but it renders as a code block on GitHub, where these pages are also read. The paragraph deliberately describes no tt-metal internals, so there is no cross-repo claim here to rot.
- Same file — fixes a stray character in the `report_name` table row, which read "Must have a value for data8 to be output to disk".

## Verification

Claims about tt-metal were checked against its source rather than taken from the linked PR:

- all three gates bail with a bare `yield; return` and no log (root `conftest.py:1271`, `:1277`; `graph_report.py:82-85`)
- `report_path.mkdir()` sits *after* the gate (`graph_report.py:110`), which is why the doc can say "not even an empty folder" rather than hedging
- generation triggers on `enable_graph_report` **or** `enable_comparison_mode` (root `conftest.py:1277`)

## Test plan

- [ ] `pnpm run build:docs` succeeds
- [ ] Rendered `docs/output/src/installing.html` contains the amended condition and the caveat, and no longer contains `data8`
- [ ] The caveat renders as prose on GitHub as well as in the Sphinx build

