### PR TITLE
Record report load usage signals

### DIFF
--- a/backend/ttnn_visualizer/usage.py
+++ b/backend/ttnn_visualizer/usage.py
@@ -233,7 +233,13 @@ class ReportSource(str, Enum):
 
 
 class ReportLoadFailureReason(str, Enum):
-    """Why a report failed to load, coarsely enough to never carry a message body."""
+    """Why a report failed to load, coarsely enough to never carry a message body.
+
+    ``unsupported_version`` is NPE-only today. NPE refuses an out-of-range format
+    version and never shows the report. Profiler and performance reports still
+    activate on an incompatible DB major version: they toast a warning and count
+    as ``report_loaded``, because the UI continues to show them.
+    """
 
     UNSUPPORTED_VERSION = "unsupported_version"
     MISSING_FILE = "missing_file"

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -22,7 +22,7 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
     const needsProfiler = currentRoute?.needsProfilerReport ?? false;
     const needsPerformance = currentRoute?.needsPerformanceReport ?? false;
 
-    if (isLoading && !hasRestoredInstance) {
+    if (!hasRestoredInstance && (isLoading || Boolean(instance))) {
         return (
             <div className='instance-loader'>
                 <LoadingSpinner />

--- a/src/components/mlir/MlirFileResultsOverlay.tsx
+++ b/src/components/mlir/MlirFileResultsOverlay.tsx
@@ -29,6 +29,12 @@ import getResponseError from '../../functions/getResponseError';
 import { getActiveMlirServer } from '../../functions/mlirServer';
 import { MlirFileResult, MlirLoadedReport } from '../../model/MLIRJsonModel';
 import mapConvertedMlirServerResult from '../../functions/mapConvertedMlirServerResult';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../../definitions/UsageEvent';
+import {
+    getReportLoadFailureReason,
+    recordReportLoadFailed,
+    recordReportLoaded,
+} from '../../functions/reportLoadUsage';
 import 'styles/components/MlirFileResultsOverlay.scss';
 
 const MAX_MLIR_FILE_SELECTION = 2;
@@ -173,11 +179,13 @@ const MlirFileResultsOverlay = () => {
                 return;
             }
 
+            const mappedResult = mapConvertedMlirServerResult(retried, result.host ?? null);
+            if (mappedResult.status === ConnectionTestStates.FAILED) {
+                recordReportLoadFailed(ReportKind.MLIR, ReportLoadFailureReason.OTHER);
+            }
             setResults(
                 (current) =>
-                    current?.map((entry, entryIndex) =>
-                        entryIndex === index ? mapConvertedMlirServerResult(retried, entry.host ?? null) : entry,
-                    ) ?? current,
+                    current?.map((entry, entryIndex) => (entryIndex === index ? mappedResult : entry)) ?? current,
             );
         } catch (err: unknown) {
             // Skip writeback for user-triggered aborts (close, unmount, or per-row cancel).
@@ -206,6 +214,7 @@ const MlirFileResultsOverlay = () => {
                     ) ?? current,
             );
             createToastNotification('MLIR', message, ToastType.ERROR);
+            recordReportLoadFailed(ReportKind.MLIR, getReportLoadFailureReason(err));
         } finally {
             // Only delete the controller if it matches the one we stored for this retry.
             // Prevents a stale (completed) retry's finally block from evicting a new controller
@@ -250,8 +259,6 @@ const MlirFileResultsOverlay = () => {
             // the same peer name while staying on the MLIR route.
             setSplitViewEpoch((epoch) => epoch + 1);
         }
-        setMlirLoadedReports(loadedReports);
-
         // Local JSON loads live only in memory; only server uploads are stored
         // on disk and can be recorded as the instance's active MLIR so a reload
         // restores them. Persist index 0 only.
@@ -260,9 +267,13 @@ const MlirFileResultsOverlay = () => {
                 await setActiveMlir(primary.name, primary.host);
             } catch (err: unknown) {
                 createToastNotification('MLIR', getResponseError(err, 'Unable to set active MLIR'), ToastType.ERROR);
+                selectedResults.forEach(() => recordReportLoadFailed(ReportKind.MLIR, getReportLoadFailureReason(err)));
                 return;
             }
         }
+
+        setMlirLoadedReports(loadedReports);
+        selectedResults.forEach(() => recordReportLoaded(ReportKind.MLIR, ReportSource.UPLOAD));
 
         const toastDetail = comparison ? `${primary.filename} / ${comparison.filename}` : primary.filename;
         createToastNotification('MLIR', toastDetail, ToastType.SUCCESS);

--- a/src/components/mlir/MlirFileResultsOverlay.tsx
+++ b/src/components/mlir/MlirFileResultsOverlay.tsx
@@ -267,8 +267,6 @@ const MlirFileResultsOverlay = () => {
                 await setActiveMlir(primary.name, primary.host);
             } catch (err: unknown) {
                 createToastNotification('MLIR', getResponseError(err, 'Unable to set active MLIR'), ToastType.ERROR);
-                selectedResults.forEach(() => recordReportLoadFailed(ReportKind.MLIR, getReportLoadFailureReason(err)));
-                return;
             }
         }
 

--- a/src/components/mlir/MlirFileResultsOverlay.tsx
+++ b/src/components/mlir/MlirFileResultsOverlay.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useEffect, useRef, useState } from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useLocation, useNavigate } from 'react-router';
 import axios from 'axios';
@@ -62,6 +62,7 @@ const MlirFileResultsOverlay = () => {
     const [retryingIndices, setRetryingIndices] = useState<Set<number>>(new Set<number>());
     const retrySessionRef = useRef(0);
     const retryAbortControllersRef = useRef<Map<number, AbortController>>(new Map<number, AbortController>());
+    const [isViewing, setIsViewing] = useState(false);
 
     // Abort all in-flight retries on unmount to prevent setResults writebacks
     // on unmounted tree. Complements the axios.isCancel guard in the catch block.
@@ -233,8 +234,8 @@ const MlirFileResultsOverlay = () => {
         }
     };
 
-    const handleView = async () => {
-        if (!results || selectedIndices.length === 0) {
+    const handleView = async (event: MouseEvent<HTMLElement>) => {
+        if (isViewing || !results || selectedIndices.length === 0) {
             return;
         }
 
@@ -248,6 +249,10 @@ const MlirFileResultsOverlay = () => {
         if (selectedResults.length === 0 || selectedResults.length !== selectedIndices.length) {
             return;
         }
+
+        // State does not commit between the two click events of a double-click.
+        event.currentTarget.setAttribute('disabled', '');
+        setIsViewing(true);
 
         const [primary, comparison] = selectedResults;
         // Server graphs are relabelled on the backend; local JSON at load time.
@@ -280,6 +285,7 @@ const MlirFileResultsOverlay = () => {
         if (location.pathname !== ROUTES.MLIR) {
             void navigate(ROUTES.MLIR);
         }
+        setIsViewing(false);
     };
 
     return (
@@ -325,7 +331,7 @@ const MlirFileResultsOverlay = () => {
             <div className={Classes.DIALOG_FOOTER_ACTIONS}>
                 <Button
                     intent={Intent.PRIMARY}
-                    disabled={selectedIndices.length === 0}
+                    disabled={selectedIndices.length === 0 || isViewing}
                     onClick={handleView}
                 >
                     View

--- a/src/components/mlir/MlirJsonFileLoader.tsx
+++ b/src/components/mlir/MlirJsonFileLoader.tsx
@@ -23,6 +23,8 @@ import sanitiseFileName from '../../functions/sanitiseFileName';
 import mapConvertedMlirServerResult from '../../functions/mapConvertedMlirServerResult';
 import relabelMlirGraphIds from '../../functions/relabelMlirGraphIds';
 import uniqueMlirName from '../../functions/uniqueMlirName';
+import { ReportKind, ReportLoadFailureReason } from '../../definitions/UsageEvent';
+import { getReportLoadFailureReason, recordReportLoadFailed } from '../../functions/reportLoadUsage';
 import 'styles/components/FileLoader.scss';
 
 const ICON_MAP: Record<ConnectionTestStates, IconName> = {
@@ -95,6 +97,7 @@ const MlirJsonFileLoader = ({ server = null, disabled = false }: MlirJsonFileLoa
                         persisted: false,
                     };
                 } catch {
+                    recordReportLoadFailed(ReportKind.MLIR, ReportLoadFailureReason.PARSE_ERROR);
                     return {
                         filename: file.name,
                         name: null,
@@ -160,6 +163,7 @@ const MlirJsonFileLoader = ({ server = null, disabled = false }: MlirJsonFileLoa
                     setMlirRetryFiles(null);
                     setUploadStatus(ConnectionTestStates.FAILED);
                     setStatusMessage('Upload failed');
+                    selectedFiles.forEach(() => recordReportLoadFailed(ReportKind.MLIR, ReportLoadFailureReason.OTHER));
                     return;
                 }
 
@@ -167,6 +171,11 @@ const MlirJsonFileLoader = ({ server = null, disabled = false }: MlirJsonFileLoa
                 // failed conversion. Clear retained File blobs after all-
                 // success batches to avoid unnecessary memory retention.
                 const hasRetryableFailures = results.some((result) => result.status === ConnectionTestStates.FAILED);
+                results.forEach((result) => {
+                    if (result.status === ConnectionTestStates.FAILED) {
+                        recordReportLoadFailed(ReportKind.MLIR, ReportLoadFailureReason.OTHER);
+                    }
+                });
                 if (!hasRetryableFailures) {
                     setMlirRetryFiles(null);
                 }
@@ -183,6 +192,7 @@ const MlirJsonFileLoader = ({ server = null, disabled = false }: MlirJsonFileLoa
             setMlirRetryFiles(null);
             setUploadStatus(ConnectionTestStates.FAILED);
             setStatusMessage(getResponseError(err, server ? 'Unable to upload MLIR file' : 'Unable to load MLIR file'));
+            selectedFiles.forEach(() => recordReportLoadFailed(ReportKind.MLIR, getReportLoadFailureReason(err)));
         }
     };
 

--- a/src/components/mlir/MlirJsonFileLoader.tsx
+++ b/src/components/mlir/MlirJsonFileLoader.tsx
@@ -25,6 +25,7 @@ import relabelMlirGraphIds from '../../functions/relabelMlirGraphIds';
 import uniqueMlirName from '../../functions/uniqueMlirName';
 import { ReportKind, ReportLoadFailureReason } from '../../definitions/UsageEvent';
 import { getReportLoadFailureReason, recordReportLoadFailed } from '../../functions/reportLoadUsage';
+import { MLIRValidationError, MLIR_LOAD_FAILURE_REASON_BY_VALIDATION_ERROR } from '../../definitions/MLIRData';
 import 'styles/components/FileLoader.scss';
 
 const ICON_MAP: Record<ConnectionTestStates, IconName> = {
@@ -97,7 +98,10 @@ const MlirJsonFileLoader = ({ server = null, disabled = false }: MlirJsonFileLoa
                         persisted: false,
                     };
                 } catch {
-                    recordReportLoadFailed(ReportKind.MLIR, ReportLoadFailureReason.PARSE_ERROR);
+                    recordReportLoadFailed(
+                        ReportKind.MLIR,
+                        MLIR_LOAD_FAILURE_REASON_BY_VALIDATION_ERROR[MLIRValidationError.INVALID_JSON],
+                    );
                     return {
                         filename: file.name,
                         name: null,

--- a/src/components/npe/NPEDemoSelect.tsx
+++ b/src/components/npe/NPEDemoSelect.tsx
@@ -37,9 +37,10 @@ interface NPEDemoSelectProps {
     selectedDemo: NPEDemoData | null;
     setSelectedDemo: (demo: NPEDemoData | null) => void;
     setDemoData: (data: NPEData | null) => void;
+    onDemoSelected: () => void;
 }
 
-const NPEDemoSelect = ({ selectedDemo, setSelectedDemo, setDemoData }: NPEDemoSelectProps) => {
+const NPEDemoSelect = ({ selectedDemo, setSelectedDemo, setDemoData, onDemoSelected }: NPEDemoSelectProps) => {
     const renderItem: ItemRenderer<NPEDemoData> = (item, { handleClick, modifiers }) => (
         <div
             className='folder-picker-menu-item'
@@ -68,6 +69,7 @@ const NPEDemoSelect = ({ selectedDemo, setSelectedDemo, setDemoData }: NPEDemoSe
                 />
             }
             onItemSelect={(item) => {
+                onDemoSelected();
                 setSelectedDemo(item);
                 setDemoData(item.data);
             }}

--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { useAtom } from 'jotai';
-import { useQueryClient } from '@tanstack/react-query';
+import { type Query, useQueryClient } from '@tanstack/react-query';
 import { FileInput, FormGroup, Icon, IconName, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import useLocalConnection from '../../hooks/useLocal';
@@ -15,6 +15,8 @@ import createToastNotification from '../../functions/createToastNotification';
 import { ToastType } from '../../definitions/ToastType';
 import getResponseError from '../../functions/getResponseError';
 import sanitiseFileName from '../../functions/sanitiseFileName';
+import { ReportKind, ReportLoadFailureReason } from '../../definitions/UsageEvent';
+import { getReportLoadFailureReason, recordReportLoadFailed } from '../../functions/reportLoadUsage';
 import 'styles/components/FileLoader.scss';
 
 const ICON_MAP: Record<ConnectionTestStates, IconName> = {
@@ -33,7 +35,14 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
     [ConnectionTestStates.WARNING]: Intent.WARNING,
 };
 
-const NPEFileLoader = () => {
+const NPE_QUERY_KEYS = new Set<string>([NPE_SUMMARY_QUERY_KEY, NPE_WINDOW_QUERY_KEY, NPE_QUERY_KEY]);
+const isNpeQuery = (query: Query): boolean => NPE_QUERY_KEYS.has(String(query.queryKey[0]));
+
+interface NPEFileLoaderProps {
+    onUploadAccepted: (fileName: string) => void;
+}
+
+const NPEFileLoader = ({ onUploadAccepted }: NPEFileLoaderProps) => {
     const [statusMessage, setStatusMessage] = useState<string | null>(null);
     const { uploadNpeFile } = useLocalConnection();
     const queryClient = useQueryClient();
@@ -41,12 +50,12 @@ const NPEFileLoader = () => {
     const [uploadStatus, setUploadStatus] = useState<ConnectionTestStates>(ConnectionTestStates.IDLE);
 
     const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
-        setStatusMessage('Uploading...');
-        setUploadStatus(ConnectionTestStates.PROGRESS);
-
-        if (!event.target.files) {
+        if (!event.target.files?.length) {
             return;
         }
+
+        setStatusMessage('Uploading...');
+        setUploadStatus(ConnectionTestStates.PROGRESS);
 
         const file = event.target.files?.[0];
 
@@ -56,16 +65,18 @@ const NPEFileLoader = () => {
             if (response?.data?.status !== ConnectionTestStates.OK) {
                 setUploadStatus(ConnectionTestStates.FAILED);
                 setStatusMessage(response?.data?.message ?? 'Upload failed');
+                recordReportLoadFailed(ReportKind.NPE, ReportLoadFailureReason.OTHER);
             } else {
                 const fileName = file.name;
                 // Re-uploading a same-named file reuses the NPE query keys, and the
                 // windowed hooks are staleTime: Infinity — drop the cached summary /
                 // windows so the freshly-rebuilt server index is refetched instead of
                 // serving the previous report's data.
-                queryClient.removeQueries({ queryKey: [NPE_SUMMARY_QUERY_KEY] });
-                queryClient.removeQueries({ queryKey: [NPE_WINDOW_QUERY_KEY] });
-                queryClient.removeQueries({ queryKey: [NPE_QUERY_KEY] });
-                setActiveNpe(sanitiseFileName(fileName));
+                await queryClient.cancelQueries({ predicate: isNpeQuery });
+                queryClient.removeQueries({ predicate: isNpeQuery });
+                const sanitisedFileName = sanitiseFileName(fileName);
+                onUploadAccepted(sanitisedFileName);
+                setActiveNpe(sanitisedFileName);
                 createToastNotification('Active NPE', fileName, ToastType.SUCCESS);
                 setUploadStatus(ConnectionTestStates.OK);
                 setStatusMessage(`${fileName} uploaded successfully`);
@@ -73,6 +84,7 @@ const NPEFileLoader = () => {
         } catch (err: unknown) {
             setUploadStatus(ConnectionTestStates.FAILED);
             setStatusMessage(getResponseError(err, 'Unable to upload file'));
+            recordReportLoadFailed(ReportKind.NPE, getReportLoadFailureReason(err));
         }
     };
 

--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { useAtom } from 'jotai';
-import { type Query, useQueryClient } from '@tanstack/react-query';
+import { type QueryFilters, useQueryClient } from '@tanstack/react-query';
 import { FileInput, FormGroup, Icon, IconName, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import useLocalConnection from '../../hooks/useLocal';
@@ -36,7 +36,9 @@ const INTENT_MAP: Record<ConnectionTestStates, Intent> = {
 };
 
 const NPE_QUERY_KEYS = new Set<string>([NPE_SUMMARY_QUERY_KEY, NPE_WINDOW_QUERY_KEY, NPE_QUERY_KEY]);
-const isNpeQuery = (query: Query): boolean => NPE_QUERY_KEYS.has(String(query.queryKey[0]));
+const NPE_QUERY_FILTER: QueryFilters<readonly unknown[]> = {
+    predicate: (query) => NPE_QUERY_KEYS.has(String(query.queryKey[0])),
+};
 
 interface NPEFileLoaderProps {
     onUploadAccepted: (fileName: string) => void;
@@ -72,8 +74,8 @@ const NPEFileLoader = ({ onUploadAccepted }: NPEFileLoaderProps) => {
                 // windowed hooks are staleTime: Infinity — drop the cached summary /
                 // windows so the freshly-rebuilt server index is refetched instead of
                 // serving the previous report's data.
-                await queryClient.cancelQueries({ predicate: isNpeQuery });
-                queryClient.removeQueries({ predicate: isNpeQuery });
+                await queryClient.cancelQueries(NPE_QUERY_FILTER);
+                queryClient.removeQueries(NPE_QUERY_FILTER);
                 const sanitisedFileName = sanitiseFileName(fileName);
                 onUploadAccepted(sanitisedFileName);
                 setActiveNpe(sanitisedFileName);

--- a/src/components/npe/NPEFileLoader.tsx
+++ b/src/components/npe/NPEFileLoader.tsx
@@ -41,7 +41,7 @@ const NPE_QUERY_FILTER: QueryFilters<readonly unknown[]> = {
 };
 
 interface NPEFileLoaderProps {
-    onUploadAccepted: (fileName: string) => void;
+    onUploadAccepted: () => void;
 }
 
 const NPEFileLoader = ({ onUploadAccepted }: NPEFileLoaderProps) => {
@@ -77,7 +77,7 @@ const NPEFileLoader = ({ onUploadAccepted }: NPEFileLoaderProps) => {
                 await queryClient.cancelQueries(NPE_QUERY_FILTER);
                 queryClient.removeQueries(NPE_QUERY_FILTER);
                 const sanitisedFileName = sanitiseFileName(fileName);
-                onUploadAccepted(sanitisedFileName);
+                onUploadAccepted();
                 setActiveNpe(sanitisedFileName);
                 createToastNotification('Active NPE', fileName, ToastType.SUCCESS);
                 setUploadStatus(ConnectionTestStates.OK);

--- a/src/components/npe/NpeWindowedView.tsx
+++ b/src/components/npe/NpeWindowedView.tsx
@@ -12,17 +12,27 @@ import { TEST_IDS } from '../../definitions/TestIds';
 import { NpeSummary } from '../../model/NPEModel';
 import NPEProcessingStatus from '../NPEProcessingStatus';
 import NPEView from './NPEViewComponent';
+import { validateNpeVersion } from '../../functions/validateNpeData';
 
 interface NpeWindowedViewProps {
     fileName: string | null;
+    loadAttemptId: number | null;
+    onInitialLoadSuccess: (attemptId: number) => void;
+    onInitialLoadFailure: (attemptId: number, errorCode: NPEValidationError, error?: unknown) => void;
 }
 
 // #861 PoC container: drives the selected timestep, fetches only that step's
 // window, and feeds an assembled NPEData into the unchanged NPEView. Scrubbing
 // updates `selectedTimestep`, which refetches the next window.
-const NpeWindowedView = ({ fileName }: NpeWindowedViewProps) => {
+const NpeWindowedView = ({
+    fileName,
+    loadAttemptId,
+    onInitialLoadSuccess,
+    onInitialLoadFailure,
+}: NpeWindowedViewProps) => {
     const [selectedTimestep, setSelectedTimestep] = useState(0);
     const initialisedSummary = useRef<NpeSummary | null>(null);
+    const settledLoadAttemptIdRef = useRef<number | null>(null);
     const {
         data: summary,
         isLoading: isLoadingSummary,
@@ -48,7 +58,14 @@ const NpeWindowedView = ({ fileName }: NpeWindowedViewProps) => {
     // Stable per-step aggregate skeleton for the timeline, built once per summary
     // so scrubbing neither rebuilds ~54k step objects nor churns the timeline's
     // O(n_timesteps) heat-bar memo.
-    const baseTimestepData = useMemo(() => (summary ? buildTimestepSkeleton(summary) : null), [summary]);
+    const versionError = useMemo(
+        () => (summary ? validateNpeVersion(summary.common_info?.version) : NPEValidationError.OK),
+        [summary],
+    );
+    const baseTimestepData = useMemo(
+        () => (summary && versionError === NPEValidationError.OK ? buildTimestepSkeleton(summary) : null),
+        [summary, versionError],
+    );
 
     // Assemble at `selectedTimestep` (not `npeWindow.t`) so an in-flight seek keeps
     // the previous frame on the rendered step instead of flashing empty.
@@ -59,6 +76,40 @@ const NpeWindowedView = ({ fileName }: NpeWindowedViewProps) => {
                 : null,
         [summary, npeWindow, baseTimestepData, selectedTimestep],
     );
+    useEffect(() => {
+        if (loadAttemptId === null || settledLoadAttemptIdRef.current === loadAttemptId) {
+            return;
+        }
+
+        if (isSummaryError) {
+            settledLoadAttemptIdRef.current = loadAttemptId;
+            onInitialLoadFailure(loadAttemptId, NPEValidationError.DEFAULT, summaryError);
+        } else if (summary && summary.n_timesteps === 0) {
+            settledLoadAttemptIdRef.current = loadAttemptId;
+            onInitialLoadFailure(loadAttemptId, NPEValidationError.EMPTY_NPE_TRACE);
+        } else if (versionError !== NPEValidationError.OK) {
+            settledLoadAttemptIdRef.current = loadAttemptId;
+            onInitialLoadFailure(loadAttemptId, versionError);
+        } else if (isWindowError && !isLoadingSummary && !npeData) {
+            settledLoadAttemptIdRef.current = loadAttemptId;
+            onInitialLoadFailure(loadAttemptId, NPEValidationError.DEFAULT, windowError);
+        } else if (npeData) {
+            settledLoadAttemptIdRef.current = loadAttemptId;
+            onInitialLoadSuccess(loadAttemptId);
+        }
+    }, [
+        isLoadingSummary,
+        isSummaryError,
+        isWindowError,
+        loadAttemptId,
+        npeData,
+        onInitialLoadFailure,
+        onInitialLoadSuccess,
+        summary,
+        summaryError,
+        versionError,
+        windowError,
+    ]);
 
     if (!fileName) {
         return null;
@@ -81,6 +132,15 @@ const NpeWindowedView = ({ fileName }: NpeWindowedViewProps) => {
         content = (
             <NPEProcessingStatus
                 errorCode={NPEValidationError.EMPTY_NPE_TRACE}
+                dataVersion={summary.common_info?.version ?? null}
+                hasUploadedFile
+                isLoading={false}
+            />
+        );
+    } else if (summary && versionError !== NPEValidationError.OK) {
+        content = (
+            <NPEProcessingStatus
+                errorCode={versionError}
                 dataVersion={summary.common_info?.version ?? null}
                 hasUploadedFile
                 isLoading={false}

--- a/src/components/npe/NpeWindowedView.tsx
+++ b/src/components/npe/NpeWindowedView.tsx
@@ -13,26 +13,19 @@ import { NpeSummary } from '../../model/NPEModel';
 import NPEProcessingStatus from '../NPEProcessingStatus';
 import NPEView from './NPEViewComponent';
 import { validateNpeVersion } from '../../functions/validateNpeData';
+import type { NpeLoadAttemptController } from '../../hooks/useNpeLoadAttempt';
 
 interface NpeWindowedViewProps {
     fileName: string | null;
-    loadAttemptId: number | null;
-    onInitialLoadSuccess: (attemptId: number) => void;
-    onInitialLoadFailure: (attemptId: number, errorCode: NPEValidationError, error?: unknown) => void;
+    loadAttempt: NpeLoadAttemptController;
 }
 
 // #861 PoC container: drives the selected timestep, fetches only that step's
 // window, and feeds an assembled NPEData into the unchanged NPEView. Scrubbing
 // updates `selectedTimestep`, which refetches the next window.
-const NpeWindowedView = ({
-    fileName,
-    loadAttemptId,
-    onInitialLoadSuccess,
-    onInitialLoadFailure,
-}: NpeWindowedViewProps) => {
+const NpeWindowedView = ({ fileName, loadAttempt }: NpeWindowedViewProps) => {
     const [selectedTimestep, setSelectedTimestep] = useState(0);
     const initialisedSummary = useRef<NpeSummary | null>(null);
-    const settledLoadAttemptIdRef = useRef<number | null>(null);
     const {
         data: summary,
         isLoading: isLoadingSummary,
@@ -77,34 +70,27 @@ const NpeWindowedView = ({
         [summary, npeWindow, baseTimestepData, selectedTimestep],
     );
     useEffect(() => {
-        if (loadAttemptId === null || settledLoadAttemptIdRef.current === loadAttemptId) {
+        if (loadAttempt.id === null) {
             return;
         }
 
         if (isSummaryError) {
-            settledLoadAttemptIdRef.current = loadAttemptId;
-            onInitialLoadFailure(loadAttemptId, NPEValidationError.DEFAULT, summaryError);
+            loadAttempt.fail(loadAttempt.id, NPEValidationError.DEFAULT, summaryError);
         } else if (summary && summary.n_timesteps === 0) {
-            settledLoadAttemptIdRef.current = loadAttemptId;
-            onInitialLoadFailure(loadAttemptId, NPEValidationError.EMPTY_NPE_TRACE);
+            loadAttempt.fail(loadAttempt.id, NPEValidationError.EMPTY_NPE_TRACE);
         } else if (versionError !== NPEValidationError.OK) {
-            settledLoadAttemptIdRef.current = loadAttemptId;
-            onInitialLoadFailure(loadAttemptId, versionError);
+            loadAttempt.fail(loadAttempt.id, versionError);
         } else if (isWindowError && !isLoadingSummary && !npeData) {
-            settledLoadAttemptIdRef.current = loadAttemptId;
-            onInitialLoadFailure(loadAttemptId, NPEValidationError.DEFAULT, windowError);
+            loadAttempt.fail(loadAttempt.id, NPEValidationError.DEFAULT, windowError);
         } else if (npeData) {
-            settledLoadAttemptIdRef.current = loadAttemptId;
-            onInitialLoadSuccess(loadAttemptId);
+            loadAttempt.complete(loadAttempt.id);
         }
     }, [
         isLoadingSummary,
         isSummaryError,
         isWindowError,
-        loadAttemptId,
+        loadAttempt,
         npeData,
-        onInitialLoadFailure,
-        onInitialLoadSuccess,
         summary,
         summaryError,
         versionError,

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -51,6 +51,12 @@ import {
 import { TEST_IDS } from '../../definitions/TestIds';
 import { DBVersionValidation } from '../../definitions/Versions';
 import { evaluateDbVersion } from '../../functions/compareDbVersion';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../../definitions/UsageEvent';
+import {
+    getReportLoadFailureReason,
+    recordReportLoadFailed,
+    recordReportLoaded,
+} from '../../functions/reportLoadUsage';
 
 const ICON_MAP: Record<ConnectionTestStates, IconName> = {
     [ConnectionTestStates.IDLE]: IconNames.DOT,
@@ -166,7 +172,7 @@ const LocalFolderOptions = () => {
         useReportLinkBadgeIds();
 
     const handleReportDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
-        if (!e.target.files) {
+        if (!e.target.files?.length) {
             return;
         }
 
@@ -175,6 +181,7 @@ const LocalFolderOptions = () => {
 
         if (!checkRequiredReportFiles(files)) {
             setProfilerFolder(invalidReportStatus);
+            recordReportLoadFailed(ReportKind.PROFILER, ReportLoadFailureReason.MISSING_FILE);
             return;
         }
 
@@ -200,9 +207,11 @@ const LocalFolderOptions = () => {
             createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, updatedReport.reportName, ToastType.SUCCESS);
             setProfilerReportLocation(ReportLocation.LOCAL);
             setProfilerFolder(connectionOkStatus);
+            recordReportLoaded(ReportKind.PROFILER, ReportSource.UPLOAD);
         } catch (err: unknown) {
             const message = getResponseError(err, 'Unable to upload selected directory');
             setProfilerFolder({ status: ConnectionTestStates.FAILED, message });
+            recordReportLoadFailed(ReportKind.PROFILER, getReportLoadFailureReason(err));
         } finally {
             clearReportCaches(queryClient);
             setIsUploadingReport(false);
@@ -210,7 +219,7 @@ const LocalFolderOptions = () => {
     };
 
     const handlePerformanceDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
-        if (!e.target.files) {
+        if (!e.target.files?.length) {
             return;
         }
 
@@ -219,6 +228,7 @@ const LocalFolderOptions = () => {
 
         if (!checkRequiredPerformanceFiles(files)) {
             setPerformanceFolder(invalidProfilerStatus);
+            recordReportLoadFailed(ReportKind.PERFORMANCE, ReportLoadFailureReason.MISSING_FILE);
             return;
         }
 
@@ -230,6 +240,7 @@ const LocalFolderOptions = () => {
 
             if (response?.data?.status !== ConnectionTestStates.OK) {
                 setPerformanceFolder(directoryErrorStatus);
+                recordReportLoadFailed(ReportKind.PERFORMANCE, ReportLoadFailureReason.MISSING_FILE);
             } else {
                 const fileName = getFolderName(files);
                 setPerformanceDataUploadLabel(`${files.length} files uploaded`);
@@ -237,10 +248,12 @@ const LocalFolderOptions = () => {
                 setActivePerformanceReport({ path: fileName, reportName: fileName });
                 createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, fileName, ToastType.SUCCESS);
                 setPerformanceFolder(connectionOkStatus);
+                recordReportLoaded(ReportKind.PERFORMANCE, ReportSource.UPLOAD);
             }
         } catch (err: unknown) {
             const message = getResponseError(err, 'Unable to upload selected directory');
             setPerformanceFolder({ status: ConnectionTestStates.FAILED, message });
+            recordReportLoadFailed(ReportKind.PERFORMANCE, getReportLoadFailureReason(err));
         } finally {
             clearReportCaches(queryClient);
             setIsPerformanceUploading(false);
@@ -248,20 +261,26 @@ const LocalFolderOptions = () => {
     };
 
     const handleSelectProfiler = async (folder: ReportFolder) => {
-        await withActivatingReport(async () => {
-            // Backend handles updating only the specific parts of active_report
-            await updateInstance({
-                active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
+        try {
+            await withActivatingReport(async () => {
+                // Backend handles updating only the specific parts of active_report
+                await updateInstance({
+                    active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
+                });
+
+                if (hasBeenNormalised(folder)) {
+                    createDataIntegrityWarning(folder);
+                }
+
+                createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, folder.reportName ?? '', ToastType.SUCCESS);
+                setActiveProfilerReport(folder);
+                setProfilerReportLocation(ReportLocation.LOCAL);
+                recordReportLoaded(ReportKind.PROFILER, ReportSource.LOCAL_TT_METAL);
             });
-
-            if (hasBeenNormalised(folder)) {
-                createDataIntegrityWarning(folder);
-            }
-
-            createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, folder.reportName ?? '', ToastType.SUCCESS);
-            setActiveProfilerReport(folder);
-            setProfilerReportLocation(ReportLocation.LOCAL);
-        });
+        } catch (err: unknown) {
+            recordReportLoadFailed(ReportKind.PROFILER, getReportLoadFailureReason(err));
+            throw err;
+        }
     };
 
     const deleteReport = async (folder: ReportFolder, options: DeleteReportOptions) => {
@@ -296,16 +315,22 @@ const LocalFolderOptions = () => {
         });
 
     const handleSelectPerformance = async (folder: ReportFolder) => {
-        await withActivatingReport(async () => {
-            // Backend handles updating only the specific parts of active_report
-            await updateInstance({
-                active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },
-            });
+        try {
+            await withActivatingReport(async () => {
+                // Backend handles updating only the specific parts of active_report
+                await updateInstance({
+                    active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },
+                });
 
-            createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
-            setActivePerformanceReport(folder);
-            setPerformanceReportLocation(ReportLocation.LOCAL);
-        });
+                createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
+                setActivePerformanceReport(folder);
+                setPerformanceReportLocation(ReportLocation.LOCAL);
+                recordReportLoaded(ReportKind.PERFORMANCE, ReportSource.LOCAL_TT_METAL);
+            });
+        } catch (err: unknown) {
+            recordReportLoadFailed(ReportKind.PERFORMANCE, getReportLoadFailureReason(err));
+            throw err;
+        }
     };
 
     const handleDeletePerformance = (folder: ReportFolder) =>

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -171,6 +171,15 @@ const LocalFolderOptions = () => {
     const { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds } =
         useReportLinkBadgeIds();
 
+    const activateLocalReport = async (kind: ReportKind, action: () => Promise<void>) => {
+        try {
+            await withActivatingReport(action);
+            recordReportLoaded(kind, ReportSource.LOCAL_TT_METAL);
+        } catch (err: unknown) {
+            recordReportLoadFailed(kind, getReportLoadFailureReason(err));
+        }
+    };
+
     const handleReportDirectoryOpen = async (e: ChangeEvent<HTMLInputElement>) => {
         if (!e.target.files?.length) {
             return;
@@ -261,26 +270,20 @@ const LocalFolderOptions = () => {
     };
 
     const handleSelectProfiler = async (folder: ReportFolder) => {
-        try {
-            await withActivatingReport(async () => {
-                // Backend handles updating only the specific parts of active_report
-                await updateInstance({
-                    active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
-                });
-
-                if (hasBeenNormalised(folder)) {
-                    createDataIntegrityWarning(folder);
-                }
-
-                createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, folder.reportName ?? '', ToastType.SUCCESS);
-                setActiveProfilerReport(folder);
-                setProfilerReportLocation(ReportLocation.LOCAL);
-                recordReportLoaded(ReportKind.PROFILER, ReportSource.LOCAL_TT_METAL);
+        await activateLocalReport(ReportKind.PROFILER, async () => {
+            // Backend handles updating only the specific parts of active_report
+            await updateInstance({
+                active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
             });
-        } catch (err: unknown) {
-            recordReportLoadFailed(ReportKind.PROFILER, getReportLoadFailureReason(err));
-            throw err;
-        }
+
+            if (hasBeenNormalised(folder)) {
+                createDataIntegrityWarning(folder);
+            }
+
+            createToastNotification(ACTIVE_MEMORY_REPORT_TOAST_TITLE, folder.reportName ?? '', ToastType.SUCCESS);
+            setActiveProfilerReport(folder);
+            setProfilerReportLocation(ReportLocation.LOCAL);
+        });
     };
 
     const deleteReport = async (folder: ReportFolder, options: DeleteReportOptions) => {
@@ -315,22 +318,16 @@ const LocalFolderOptions = () => {
         });
 
     const handleSelectPerformance = async (folder: ReportFolder) => {
-        try {
-            await withActivatingReport(async () => {
-                // Backend handles updating only the specific parts of active_report
-                await updateInstance({
-                    active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },
-                });
-
-                createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
-                setActivePerformanceReport(folder);
-                setPerformanceReportLocation(ReportLocation.LOCAL);
-                recordReportLoaded(ReportKind.PERFORMANCE, ReportSource.LOCAL_TT_METAL);
+        await activateLocalReport(ReportKind.PERFORMANCE, async () => {
+            // Backend handles updating only the specific parts of active_report
+            await updateInstance({
+                active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },
             });
-        } catch (err: unknown) {
-            recordReportLoadFailed(ReportKind.PERFORMANCE, getReportLoadFailureReason(err));
-            throw err;
-        }
+
+            createToastNotification(ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE, folder.reportName, ToastType.SUCCESS);
+            setActivePerformanceReport(folder);
+            setPerformanceReportLocation(ReportLocation.LOCAL);
+        });
     };
 
     const handleDeletePerformance = (folder: ReportFolder) =>

--- a/src/components/report-selection/LocalFolderSelector.tsx
+++ b/src/components/report-selection/LocalFolderSelector.tsx
@@ -21,8 +21,10 @@ import {
     ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE,
     MEMORY_REPORT_DELETED_TOAST_TITLE,
     MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE,
+    MEMORY_REPORT_LOAD_FAILED_TOAST_TITLE,
     PERFORMANCE_REPORT_DELETED_TOAST_TITLE,
     PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE,
+    PERFORMANCE_REPORT_LOAD_FAILED_TOAST_TITLE,
 } from '../../definitions/notifyActiveReport';
 import createToastNotification from '../../functions/createToastNotification';
 import { ToastType } from '../../definitions/ToastType';
@@ -171,11 +173,12 @@ const LocalFolderOptions = () => {
     const { linkedPerfIds, unlinkedPerfIds, linkedProfilerReportIds, unlinkedProfilerReportIds } =
         useReportLinkBadgeIds();
 
-    const activateLocalReport = async (kind: ReportKind, action: () => Promise<void>) => {
+    const activateLocalReport = async (kind: ReportKind, failedTitle: string, action: () => Promise<void>) => {
         try {
             await withActivatingReport(action);
             recordReportLoaded(kind, ReportSource.LOCAL_TT_METAL);
         } catch (err: unknown) {
+            createToastNotification(failedTitle, getResponseError(err), ToastType.ERROR);
             recordReportLoadFailed(kind, getReportLoadFailureReason(err));
         }
     };
@@ -199,6 +202,12 @@ const LocalFolderOptions = () => {
 
         try {
             const response = await uploadLocalFolder(files);
+
+            if (response?.data?.status != null && response.data.status !== ConnectionTestStates.OK) {
+                setProfilerFolder(invalidReportStatus);
+                recordReportLoadFailed(ReportKind.PROFILER, ReportLoadFailureReason.MISSING_FILE);
+                return;
+            }
 
             setProfilerUploadLabel(`${files.length} files uploaded`);
             response.data = normaliseReportFolder(response.data);
@@ -270,7 +279,7 @@ const LocalFolderOptions = () => {
     };
 
     const handleSelectProfiler = async (folder: ReportFolder) => {
-        await activateLocalReport(ReportKind.PROFILER, async () => {
+        await activateLocalReport(ReportKind.PROFILER, MEMORY_REPORT_LOAD_FAILED_TOAST_TITLE, async () => {
             // Backend handles updating only the specific parts of active_report
             await updateInstance({
                 active_report: { profiler_name: folder.path, profiler_location: ReportLocation.LOCAL },
@@ -318,7 +327,7 @@ const LocalFolderOptions = () => {
         });
 
     const handleSelectPerformance = async (folder: ReportFolder) => {
-        await activateLocalReport(ReportKind.PERFORMANCE, async () => {
+        await activateLocalReport(ReportKind.PERFORMANCE, PERFORMANCE_REPORT_LOAD_FAILED_TOAST_TITLE, async () => {
             // Backend handles updating only the specific parts of active_report
             await updateInstance({
                 active_report: { performance_name: folder.path, performance_location: ReportLocation.LOCAL },

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -19,11 +19,11 @@ import { getRankedReportLabel } from '../../functions/reportRank';
 import useRemoteConnection from '../../hooks/useRemote';
 import HighlightedText from '../HighlightedText';
 import FolderLinkStatusIcon from './FolderLinkStatusIcon';
-
-type FolderTypes = 'performance' | 'profiler';
+import { ReportKind } from '../../definitions/UsageEvent';
+import { RemoteFolderType } from '../../definitions/Reports';
 
 interface RemoteFolderRendererOptions {
-    type: FolderTypes;
+    type: RemoteFolderType;
     selectedFolder?: RemoteFolder;
     connection?: RemoteConnection;
     showReportName?: boolean;
@@ -87,7 +87,7 @@ interface RemoteFolderSelectorProps {
     fallbackLabel?: string;
     icon?: IconName;
     onSelectFolder: (folder: RemoteFolder) => void;
-    type: FolderTypes;
+    type: RemoteFolderType;
     showReportName?: boolean;
     linkedIds?: Set<string> | null;
     unlinkedIds?: Set<string> | null;
@@ -176,7 +176,7 @@ const getRemoteFolderLabel = (folder: RemoteFolder): string => getRankedReportLa
 
 const formatRemoteFolderPath = (
     folder: RemoteFolder,
-    type: FolderTypes,
+    type: RemoteFolderType,
     selectedConnection?: RemoteConnection,
 ): string => {
     if (!folder || !selectedConnection) {
@@ -187,9 +187,9 @@ const formatRemoteFolderPath = (
         return getRemoteFolderLabel(folder);
     }
 
-    const paths: Record<FolderTypes, string | undefined> = {
-        profiler: selectedConnection.profilerPath,
-        performance: selectedConnection.performancePath,
+    const paths: Record<RemoteFolderType, string | undefined> = {
+        [ReportKind.PROFILER]: selectedConnection.profilerPath,
+        [ReportKind.PERFORMANCE]: selectedConnection.performancePath,
     };
 
     const pathToReplace = paths?.[type] ?? '';
@@ -200,7 +200,7 @@ const formatRemoteFolderPath = (
 };
 
 const filterFolders =
-    (type: FolderTypes, connection?: RemoteConnection): ItemPredicate<RemoteFolder> =>
+    (type: RemoteFolderType, connection?: RemoteConnection): ItemPredicate<RemoteFolder> =>
     (query, folder) => {
         const normalisedQuery = query.toLowerCase();
 

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
-import { AxiosResponse, HttpStatusCode } from 'axios';
+import axios, { AxiosResponse, HttpStatusCode } from 'axios';
 import { useAtom, useStore } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../model/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
@@ -51,6 +51,14 @@ import { clearReportCaches, updateInstance, useReportMetadata } from '../../hook
 import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation } from '../../definitions/Versions';
 import { evaluateDbVersion } from '../../functions/compareDbVersion';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../../definitions/UsageEvent';
+import {
+    getReportLoadFailureReason,
+    recordReportLoadFailed,
+    recordReportLoaded,
+} from '../../functions/reportLoadUsage';
+
+const UNEXPECTED_MOUNT_STATUS_MESSAGE = 'Remote report could not be mounted';
 
 const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
@@ -386,6 +394,7 @@ const RemoteSyncConfigurator = () => {
             reportName: folder.reportName,
             syncedName: folder.syncedName,
         });
+        recordReportLoaded(ReportKind.PROFILER, ReportSource.REMOTE_SYNC);
     };
 
     const applyPerformanceReportSelection = (folder: RemoteFolder) => {
@@ -396,6 +405,7 @@ const RemoteSyncConfigurator = () => {
             reportName: folder.reportName,
             syncedName: folder.syncedName,
         });
+        recordReportLoaded(ReportKind.PERFORMANCE, ReportSource.REMOTE_SYNC);
     };
 
     const updateReportSelection = (folder: RemoteFolder) => {
@@ -421,11 +431,13 @@ const RemoteSyncConfigurator = () => {
         err: unknown,
         mount: (connection: RemoteConnection) => Promise<AxiosResponse>,
         applySelection: (folder: RemoteFolder) => void,
+        kind: ReportKind,
     ) => {
         const connection = selectedConnection;
 
         if (!connection) {
             notifyFolderSyncError(err);
+            recordReportLoadFailed(kind, getReportLoadFailureReason(err));
             return;
         }
 
@@ -442,8 +454,12 @@ const RemoteSyncConfigurator = () => {
 
                 return;
             }
-        } catch {
+            recordReportLoadFailed(kind, ReportLoadFailureReason.OTHER);
+        } catch (mountError: unknown) {
             // Mount itself failed; surface the original sync error below.
+            if (!axios.isCancel(mountError)) {
+                recordReportLoadFailed(kind, getReportLoadFailureReason(mountError));
+            }
         }
 
         notifyFolderSyncError(err);
@@ -453,6 +469,7 @@ const RemoteSyncConfigurator = () => {
         err: unknown,
         selectedReport: RemoteFolder | undefined,
         mountLocalFallback: (folder: RemoteFolder, err: unknown) => Promise<void>,
+        kind: ReportKind,
     ) => {
         const failureAction = getRemoteSyncFailureAction(err, selectedReport);
 
@@ -466,6 +483,7 @@ const RemoteSyncConfigurator = () => {
         }
 
         notifyFolderSyncError(err);
+        recordReportLoadFailed(kind, getReportLoadFailureReason(err));
     };
 
     const mountAndActivateFolder = async (
@@ -473,13 +491,16 @@ const RemoteSyncConfigurator = () => {
         {
             mount,
             activateWithToast,
+            kind,
         }: {
             mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
             activateWithToast: (folder: RemoteFolder) => void;
+            kind: ReportKind;
         },
     ) => {
         const connection = selectedConnection;
         if (!connection) {
+            recordReportLoadFailed(kind, ReportLoadFailureReason.OTHER);
             return;
         }
 
@@ -493,9 +514,16 @@ const RemoteSyncConfigurator = () => {
                     if (hasBeenNormalised(folder)) {
                         createDataIntegrityWarning(folder);
                     }
+                } else {
+                    const mountError = new Error(UNEXPECTED_MOUNT_STATUS_MESSAGE);
+                    notifyRemoteFolderMountError(mountError);
+                    recordReportLoadFailed(kind, ReportLoadFailureReason.OTHER);
                 }
             } catch (err: unknown) {
                 notifyRemoteFolderMountError(err);
+                if (!axios.isCancel(err)) {
+                    recordReportLoadFailed(kind, getReportLoadFailureReason(err));
+                }
             }
         });
     };
@@ -510,6 +538,7 @@ const RemoteSyncConfigurator = () => {
         activateWithToast,
         applySelection,
         getActivePath,
+        kind,
     }: {
         selected: RemoteFolder | undefined;
         setSyncing: (syncing: boolean) => void;
@@ -520,6 +549,7 @@ const RemoteSyncConfigurator = () => {
         activateWithToast: (folder: RemoteFolder) => void;
         applySelection: (folder: RemoteFolder) => void;
         getActivePath: () => string | null | undefined;
+        kind: ReportKind;
     }) => {
         setSyncing(true);
 
@@ -550,18 +580,29 @@ const RemoteSyncConfigurator = () => {
                 updateSaved(connection, updatedFolders);
 
                 if (updatedFolder && shouldActivateAfterSync()) {
-                    await mountAndActivateFolder(updatedFolder, { mount, activateWithToast });
+                    await mountAndActivateFolder(updatedFolder, { mount, activateWithToast, kind });
                 }
             } catch (err: unknown) {
-                await handleSyncFailure(err, selected, async (report, syncErr) => {
-                    if (!shouldActivateAfterSync()) {
-                        notifyFolderSyncError(syncErr);
-                        return;
-                    }
-                    await withActivatingReport(() =>
-                        mountLocalFolderOnSyncFailure(report, syncErr, (conn) => mount(conn, report), applySelection),
-                    );
-                });
+                await handleSyncFailure(
+                    err,
+                    selected,
+                    async (report, syncErr) => {
+                        if (!shouldActivateAfterSync()) {
+                            notifyFolderSyncError(syncErr);
+                            return;
+                        }
+                        await withActivatingReport(() =>
+                            mountLocalFolderOnSyncFailure(
+                                report,
+                                syncErr,
+                                (conn) => mount(conn, report),
+                                applySelection,
+                                kind,
+                            ),
+                        );
+                    },
+                    kind,
+                );
             }
         } finally {
             // REMOTE_SYNC registry clear is owned by syncRemoteFolder's finally.
@@ -580,6 +621,7 @@ const RemoteSyncConfigurator = () => {
             activateWithToast: updateReportSelection,
             applySelection: applyProfilerReportSelection,
             getActivePath: () => jotaiStore.get(activeProfilerReportAtom)?.path,
+            kind: ReportKind.PROFILER,
         });
 
     const syncSelectedPerfReportFolder = (folder?: RemoteFolder) =>
@@ -593,6 +635,7 @@ const RemoteSyncConfigurator = () => {
             activateWithToast: updatePerformanceSelection,
             applySelection: applyPerformanceReportSelection,
             getActivePath: () => jotaiStore.get(activePerformanceReportAtom)?.path,
+            kind: ReportKind.PERFORMANCE,
         });
 
     /**
@@ -607,11 +650,13 @@ const RemoteSyncConfigurator = () => {
             syncFolder,
             mount,
             activateWithToast,
+            kind,
         }: {
             setSelected: (folder: RemoteFolder) => void;
             syncFolder: (folder: RemoteFolder) => Promise<void>;
             mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
             activateWithToast: (folder: RemoteFolder) => void;
+            kind: ReportKind;
         },
     ) => {
         setSelected(folder);
@@ -621,7 +666,7 @@ const RemoteSyncConfigurator = () => {
             return;
         }
 
-        await mountAndActivateFolder(folder, { mount, activateWithToast });
+        await mountAndActivateFolder(folder, { mount, activateWithToast, kind });
     };
 
     const isProfilerRemote = profilerReportLocation === ReportLocation.REMOTE;
@@ -778,6 +823,7 @@ const RemoteSyncConfigurator = () => {
                             syncFolder: syncSelectedReportFolder,
                             mount: (connection, report) => remote.mountRemoteFolder(connection, report),
                             activateWithToast: updateReportSelection,
+                            kind: ReportKind.PROFILER,
                         })
                     }
                     type='profiler'
@@ -812,6 +858,7 @@ const RemoteSyncConfigurator = () => {
                             syncFolder: syncSelectedPerfReportFolder,
                             mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
                             activateWithToast: updatePerformanceSelection,
+                            kind: ReportKind.PERFORMANCE,
                         })
                     }
                     type='performance'

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { FormGroup } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
-import axios, { AxiosResponse, HttpStatusCode } from 'axios';
+import { AxiosResponse, HttpStatusCode } from 'axios';
 import { useAtom, useStore } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../model/RemoteConnection';
 import { ReportLocation } from '../../definitions/Reports';
@@ -25,8 +25,9 @@ import isRemoteFolderOutdated from '../../functions/isRemoteFolderOutdated';
 import mergeRemoteFolders from '../../functions/mergeRemoteFolders';
 import { isSameConnection } from '../../functions/remoteConnection';
 import notifyFolderSyncError, {
+    notifyAndRecordFolderSyncError,
+    notifyAndRecordRemoteFolderMountError,
     notifyFolderListSyncError,
-    notifyRemoteFolderMountError,
 } from '../../functions/notifyFolderSyncError';
 import notifyFolderSyncLocalFallback, {
     notifyLocalSyncedReportsListFallback,
@@ -52,13 +53,7 @@ import { ActiveReport } from '../../model/APIData';
 import { DBVersionValidation } from '../../definitions/Versions';
 import { evaluateDbVersion } from '../../functions/compareDbVersion';
 import { ReportKind, ReportLoadFailureReason, ReportSource } from '../../definitions/UsageEvent';
-import {
-    getReportLoadFailureReason,
-    recordReportLoadFailed,
-    recordReportLoaded,
-} from '../../functions/reportLoadUsage';
-
-const UNEXPECTED_MOUNT_STATUS_MESSAGE = 'Remote report could not be mounted';
+import { recordReportLoadFailed, recordReportLoadFailure, recordReportLoaded } from '../../functions/reportLoadUsage';
 
 interface RemoteReportActions {
     mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
@@ -456,8 +451,7 @@ const RemoteSyncConfigurator = () => {
         const connection = selectedConnection;
 
         if (!connection) {
-            notifyFolderSyncError(err);
-            recordReportLoadFailed(kind, getReportLoadFailureReason(err));
+            notifyAndRecordFolderSyncError(kind, err);
             return;
         }
 
@@ -474,12 +468,8 @@ const RemoteSyncConfigurator = () => {
 
                 return;
             }
-            recordReportLoadFailed(kind, ReportLoadFailureReason.OTHER);
         } catch (mountError: unknown) {
-            // Mount itself failed; surface the original sync error below.
-            if (!axios.isCancel(mountError)) {
-                recordReportLoadFailed(kind, getReportLoadFailureReason(mountError));
-            }
+            recordReportLoadFailure(kind, mountError);
         }
 
         notifyFolderSyncError(err);
@@ -502,8 +492,7 @@ const RemoteSyncConfigurator = () => {
             return;
         }
 
-        notifyFolderSyncError(err);
-        recordReportLoadFailed(kind, getReportLoadFailureReason(err));
+        notifyAndRecordFolderSyncError(kind, err);
     };
 
     const mountAndActivateFolder = async (
@@ -526,16 +515,9 @@ const RemoteSyncConfigurator = () => {
                     if (hasBeenNormalised(folder)) {
                         createDataIntegrityWarning(folder);
                     }
-                } else {
-                    const mountError = new Error(UNEXPECTED_MOUNT_STATUS_MESSAGE);
-                    notifyRemoteFolderMountError(mountError);
-                    recordReportLoadFailed(kind, ReportLoadFailureReason.OTHER);
                 }
             } catch (err: unknown) {
-                notifyRemoteFolderMountError(err);
-                if (!axios.isCancel(err)) {
-                    recordReportLoadFailed(kind, getReportLoadFailureReason(err));
-                }
+                notifyAndRecordRemoteFolderMountError(kind, err);
             }
         });
     };

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -9,7 +9,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { AxiosResponse, HttpStatusCode } from 'axios';
 import { useAtom, useStore } from 'jotai';
 import { RemoteConnection, RemoteFolder } from '../../model/RemoteConnection';
-import { ReportLocation } from '../../definitions/Reports';
+import { RemoteFolderType, ReportLocation } from '../../definitions/Reports';
 import {
     ACTIVE_MEMORY_REPORT_TOAST_TITLE,
     ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE,
@@ -59,7 +59,7 @@ interface RemoteReportActions {
     mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
     activateWithToast: (folder: RemoteFolder) => void;
     applySelection: (folder: RemoteFolder) => void;
-    kind: ReportKind;
+    type: RemoteFolderType;
 }
 
 const RemoteSyncConfigurator = () => {
@@ -432,13 +432,13 @@ const RemoteSyncConfigurator = () => {
         mount: (connection, report) => remote.mountRemoteFolder(connection, report),
         activateWithToast: updateReportSelection,
         applySelection: applyProfilerReportSelection,
-        kind: ReportKind.PROFILER,
+        type: ReportKind.PROFILER,
     };
     const performanceReportActions: RemoteReportActions = {
         mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
         activateWithToast: updatePerformanceSelection,
         applySelection: applyPerformanceReportSelection,
-        kind: ReportKind.PERFORMANCE,
+        type: ReportKind.PERFORMANCE,
     };
 
     const mountLocalFolderOnSyncFailure = async (
@@ -446,12 +446,12 @@ const RemoteSyncConfigurator = () => {
         err: unknown,
         mount: (connection: RemoteConnection) => Promise<AxiosResponse>,
         applySelection: (folder: RemoteFolder) => void,
-        kind: ReportKind,
+        type: RemoteFolderType,
     ) => {
         const connection = selectedConnection;
 
         if (!connection) {
-            notifyAndRecordFolderSyncError(kind, err);
+            notifyAndRecordFolderSyncError(type, err);
             return;
         }
 
@@ -469,7 +469,7 @@ const RemoteSyncConfigurator = () => {
                 return;
             }
         } catch (mountError: unknown) {
-            recordReportLoadFailure(kind, mountError);
+            recordReportLoadFailure(type, mountError);
         }
 
         notifyFolderSyncError(err);
@@ -479,7 +479,7 @@ const RemoteSyncConfigurator = () => {
         err: unknown,
         selectedReport: RemoteFolder | undefined,
         mountLocalFallback: (folder: RemoteFolder, err: unknown) => Promise<void>,
-        kind: ReportKind,
+        type: RemoteFolderType,
     ) => {
         const failureAction = getRemoteSyncFailureAction(err, selectedReport);
 
@@ -492,16 +492,16 @@ const RemoteSyncConfigurator = () => {
             return;
         }
 
-        notifyAndRecordFolderSyncError(kind, err);
+        notifyAndRecordFolderSyncError(type, err);
     };
 
     const mountAndActivateFolder = async (
         folder: RemoteFolder,
-        { mount, activateWithToast, kind }: Pick<RemoteReportActions, 'mount' | 'activateWithToast' | 'kind'>,
+        { mount, activateWithToast, type }: Pick<RemoteReportActions, 'mount' | 'activateWithToast' | 'type'>,
     ) => {
         const connection = selectedConnection;
         if (!connection) {
-            recordReportLoadFailed(kind, ReportLoadFailureReason.OTHER);
+            recordReportLoadFailed(type, ReportLoadFailureReason.OTHER);
             return;
         }
 
@@ -517,7 +517,7 @@ const RemoteSyncConfigurator = () => {
                     }
                 }
             } catch (err: unknown) {
-                notifyAndRecordRemoteFolderMountError(kind, err);
+                notifyAndRecordRemoteFolderMountError(type, err);
             }
         });
     };
@@ -532,7 +532,7 @@ const RemoteSyncConfigurator = () => {
         activateWithToast,
         applySelection,
         getActivePath,
-        kind,
+        type,
     }: {
         selected: RemoteFolder | undefined;
         setSyncing: (syncing: boolean) => void;
@@ -543,7 +543,7 @@ const RemoteSyncConfigurator = () => {
         activateWithToast: (folder: RemoteFolder) => void;
         applySelection: (folder: RemoteFolder) => void;
         getActivePath: () => string | null | undefined;
-        kind: ReportKind;
+        type: RemoteFolderType;
     }) => {
         setSyncing(true);
 
@@ -574,7 +574,7 @@ const RemoteSyncConfigurator = () => {
                 updateSaved(connection, updatedFolders);
 
                 if (updatedFolder && shouldActivateAfterSync()) {
-                    await mountAndActivateFolder(updatedFolder, { mount, activateWithToast, kind });
+                    await mountAndActivateFolder(updatedFolder, { mount, activateWithToast, type });
                 }
             } catch (err: unknown) {
                 await handleSyncFailure(
@@ -591,11 +591,11 @@ const RemoteSyncConfigurator = () => {
                                 syncErr,
                                 (conn) => mount(conn, report),
                                 applySelection,
-                                kind,
+                                type,
                             ),
                         );
                     },
-                    kind,
+                    type,
                 );
             }
         } finally {
@@ -638,11 +638,11 @@ const RemoteSyncConfigurator = () => {
             syncFolder,
             mount,
             activateWithToast,
-            kind,
+            type,
         }: {
             setSelected: (folder: RemoteFolder) => void;
             syncFolder: (folder: RemoteFolder) => Promise<void>;
-        } & Pick<RemoteReportActions, 'mount' | 'activateWithToast' | 'kind'>,
+        } & Pick<RemoteReportActions, 'mount' | 'activateWithToast' | 'type'>,
     ) => {
         setSelected(folder);
 
@@ -651,7 +651,7 @@ const RemoteSyncConfigurator = () => {
             return;
         }
 
-        await mountAndActivateFolder(folder, { mount, activateWithToast, kind });
+        await mountAndActivateFolder(folder, { mount, activateWithToast, type });
     };
 
     const isProfilerRemote = profilerReportLocation === ReportLocation.REMOTE;
@@ -809,7 +809,7 @@ const RemoteSyncConfigurator = () => {
                             ...profilerReportActions,
                         })
                     }
-                    type='profiler'
+                    type={profilerReportActions.type}
                     showReportName
                 >
                     {(isProfilerRemote || isSyncingReportFolder) && selectedReportFolder && (
@@ -842,7 +842,7 @@ const RemoteSyncConfigurator = () => {
                             ...performanceReportActions,
                         })
                     }
-                    type='performance'
+                    type={performanceReportActions.type}
                 >
                     {(isPerformanceRemote || isSyncingPerformanceFolder) && selectedPerformanceFolder && (
                         <RemoteSyncButton

--- a/src/components/report-selection/RemoteSyncConfigurator.tsx
+++ b/src/components/report-selection/RemoteSyncConfigurator.tsx
@@ -60,6 +60,13 @@ import {
 
 const UNEXPECTED_MOUNT_STATUS_MESSAGE = 'Remote report could not be mounted';
 
+interface RemoteReportActions {
+    mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
+    activateWithToast: (folder: RemoteFolder) => void;
+    applySelection: (folder: RemoteFolder) => void;
+    kind: ReportKind;
+}
+
 const RemoteSyncConfigurator = () => {
     const remote = useRemoteConnection();
     const { setPersistentSelectedConnection, setPersistentSavedConnectionList } = remote;
@@ -426,6 +433,19 @@ const RemoteSyncConfigurator = () => {
         );
     };
 
+    const profilerReportActions: RemoteReportActions = {
+        mount: (connection, report) => remote.mountRemoteFolder(connection, report),
+        activateWithToast: updateReportSelection,
+        applySelection: applyProfilerReportSelection,
+        kind: ReportKind.PROFILER,
+    };
+    const performanceReportActions: RemoteReportActions = {
+        mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
+        activateWithToast: updatePerformanceSelection,
+        applySelection: applyPerformanceReportSelection,
+        kind: ReportKind.PERFORMANCE,
+    };
+
     const mountLocalFolderOnSyncFailure = async (
         selectedReport: RemoteFolder,
         err: unknown,
@@ -488,15 +508,7 @@ const RemoteSyncConfigurator = () => {
 
     const mountAndActivateFolder = async (
         folder: RemoteFolder,
-        {
-            mount,
-            activateWithToast,
-            kind,
-        }: {
-            mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
-            activateWithToast: (folder: RemoteFolder) => void;
-            kind: ReportKind;
-        },
+        { mount, activateWithToast, kind }: Pick<RemoteReportActions, 'mount' | 'activateWithToast' | 'kind'>,
     ) => {
         const connection = selectedConnection;
         if (!connection) {
@@ -617,11 +629,8 @@ const RemoteSyncConfigurator = () => {
             sync: (connection, report) => remote.syncRemoteFolder(connection, report),
             getSaved: remote.persistentState.getSavedReportFolders,
             updateSaved: updateSavedReportFolders,
-            mount: (connection, report) => remote.mountRemoteFolder(connection, report),
-            activateWithToast: updateReportSelection,
-            applySelection: applyProfilerReportSelection,
             getActivePath: () => jotaiStore.get(activeProfilerReportAtom)?.path,
-            kind: ReportKind.PROFILER,
+            ...profilerReportActions,
         });
 
     const syncSelectedPerfReportFolder = (folder?: RemoteFolder) =>
@@ -631,11 +640,8 @@ const RemoteSyncConfigurator = () => {
             sync: (connection, report) => remote.syncRemoteFolder(connection, undefined, report),
             getSaved: remote.persistentState.getSavedPerformanceFolders,
             updateSaved: updateSavedPerformanceFolders,
-            mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
-            activateWithToast: updatePerformanceSelection,
-            applySelection: applyPerformanceReportSelection,
             getActivePath: () => jotaiStore.get(activePerformanceReportAtom)?.path,
-            kind: ReportKind.PERFORMANCE,
+            ...performanceReportActions,
         });
 
     /**
@@ -654,10 +660,7 @@ const RemoteSyncConfigurator = () => {
         }: {
             setSelected: (folder: RemoteFolder) => void;
             syncFolder: (folder: RemoteFolder) => Promise<void>;
-            mount: (connection: RemoteConnection, folder: RemoteFolder) => Promise<AxiosResponse>;
-            activateWithToast: (folder: RemoteFolder) => void;
-            kind: ReportKind;
-        },
+        } & Pick<RemoteReportActions, 'mount' | 'activateWithToast' | 'kind'>,
     ) => {
         setSelected(folder);
 
@@ -821,9 +824,7 @@ const RemoteSyncConfigurator = () => {
                         selectAndActivateFolder(folder, {
                             setSelected: setSelectedReportFolder,
                             syncFolder: syncSelectedReportFolder,
-                            mount: (connection, report) => remote.mountRemoteFolder(connection, report),
-                            activateWithToast: updateReportSelection,
-                            kind: ReportKind.PROFILER,
+                            ...profilerReportActions,
                         })
                     }
                     type='profiler'
@@ -856,9 +857,7 @@ const RemoteSyncConfigurator = () => {
                         selectAndActivateFolder(folder, {
                             setSelected: setSelectedPerformanceFolder,
                             syncFolder: syncSelectedPerfReportFolder,
-                            mount: (connection, report) => remote.mountRemoteFolder(connection, undefined, report),
-                            activateWithToast: updatePerformanceSelection,
-                            kind: ReportKind.PERFORMANCE,
+                            ...performanceReportActions,
                         })
                     }
                     type='performance'

--- a/src/definitions/MLIRData.ts
+++ b/src/definitions/MLIRData.ts
@@ -2,8 +2,16 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import { ReportLoadFailureReason } from './UsageEvent';
+
 export enum MLIRValidationError {
     OK,
     DEFAULT,
     INVALID_JSON,
 }
+
+export const MLIR_LOAD_FAILURE_REASON_BY_VALIDATION_ERROR: Record<MLIRValidationError, ReportLoadFailureReason> = {
+    [MLIRValidationError.OK]: ReportLoadFailureReason.OTHER,
+    [MLIRValidationError.DEFAULT]: ReportLoadFailureReason.OTHER,
+    [MLIRValidationError.INVALID_JSON]: ReportLoadFailureReason.PARSE_ERROR,
+};

--- a/src/definitions/NPEData.ts
+++ b/src/definitions/NPEData.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { ReportLoadFailureReason } from './UsageEvent';
+
 export const MIN_SUPPORTED_VERSION = '1.0.0';
 export const LEGACY_VISUALIZER_VERSION = '0.32.3'; // Version of the visualizer that supports pre-version data format
 
@@ -19,6 +21,15 @@ export enum NPEValidationError {
     INVALID_NPE_DATA,
     EMPTY_NPE_TRACE,
 }
+
+export const NPE_LOAD_FAILURE_REASON_BY_VALIDATION_ERROR: Record<NPEValidationError, ReportLoadFailureReason | null> = {
+    [NPEValidationError.OK]: null,
+    [NPEValidationError.DEFAULT]: null,
+    [NPEValidationError.INVALID_NPE_VERSION]: ReportLoadFailureReason.UNSUPPORTED_VERSION,
+    [NPEValidationError.INVALID_JSON]: ReportLoadFailureReason.PARSE_ERROR,
+    [NPEValidationError.INVALID_NPE_DATA]: ReportLoadFailureReason.PARSE_ERROR,
+    [NPEValidationError.EMPTY_NPE_TRACE]: ReportLoadFailureReason.OTHER,
+};
 
 /** Discriminant on synthetic client 422 bodies — parse vs shape must not share one UI label. */
 export enum NpeClientErrorKind {

--- a/src/definitions/Reports.ts
+++ b/src/definitions/Reports.ts
@@ -2,10 +2,14 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import { ReportKind } from './UsageEvent';
+
 export enum ReportLocation {
     LOCAL = 'local',
     REMOTE = 'remote',
 }
+
+export type RemoteFolderType = ReportKind.PROFILER | ReportKind.PERFORMANCE;
 
 // A report's `world_size` is the number of ranks it spans. Anything above this
 // is a multi-host capture, which the API currently scopes to rank 0. #1842

--- a/src/definitions/UsageEvent.ts
+++ b/src/definitions/UsageEvent.ts
@@ -44,6 +44,7 @@ export enum ReportSource {
 }
 
 export enum ReportLoadFailureReason {
+    // NPE-only today: profiler/performance incompatible DB versions still load.
     UNSUPPORTED_VERSION = 'unsupported_version',
     MISSING_FILE = 'missing_file',
     PARSE_ERROR = 'parse_error',

--- a/src/definitions/notifyActiveReport.ts
+++ b/src/definitions/notifyActiveReport.ts
@@ -5,6 +5,9 @@
 export const ACTIVE_MEMORY_REPORT_TOAST_TITLE = 'Active memory report';
 export const ACTIVE_PERFORMANCE_REPORT_TOAST_TITLE = 'Active performance report';
 
+export const MEMORY_REPORT_LOAD_FAILED_TOAST_TITLE = 'Unable to open memory report';
+export const PERFORMANCE_REPORT_LOAD_FAILED_TOAST_TITLE = 'Unable to open performance report';
+
 export const MEMORY_REPORT_DELETED_TOAST_TITLE = 'Memory report deleted';
 export const PERFORMANCE_REPORT_DELETED_TOAST_TITLE = 'Performance report deleted';
 export const MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE = 'Unable to delete memory report';

--- a/src/functions/getNpeReportLoadFailureReason.ts
+++ b/src/functions/getNpeReportLoadFailureReason.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import axios, { HttpStatusCode } from 'axios';
+import { NPEValidationError, NPE_LOAD_FAILURE_REASON_BY_VALIDATION_ERROR } from '../definitions/NPEData';
+import { ReportLoadFailureReason } from '../definitions/UsageEvent';
+import { getReportLoadFailureReason } from './reportLoadUsage';
+
+export default function getNpeReportLoadFailureReason(
+    validationError: NPEValidationError,
+    error: unknown = null,
+): ReportLoadFailureReason {
+    const validationReason = NPE_LOAD_FAILURE_REASON_BY_VALIDATION_ERROR[validationError];
+    if (validationReason !== null) {
+        return validationReason;
+    }
+
+    if (axios.isAxiosError(error) && (error.status ?? error.response?.status) === HttpStatusCode.UnprocessableEntity) {
+        return ReportLoadFailureReason.PARSE_ERROR;
+    }
+
+    return getReportLoadFailureReason(error);
+}

--- a/src/functions/notifyFolderSyncError.ts
+++ b/src/functions/notifyFolderSyncError.ts
@@ -3,9 +3,11 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import axios from 'axios';
+import { ReportKind } from '../definitions/UsageEvent';
 import createToastNotification from './createToastNotification';
 import { ToastType } from '../definitions/ToastType';
 import getResponseError from './getResponseError';
+import { recordReportLoadFailure } from './reportLoadUsage';
 
 export const FOLDER_LIST_SYNC_ERROR_TOAST_TITLE = 'Folder list sync error';
 export const FOLDER_SYNC_ERROR_TOAST_TITLE = 'Folder sync error';
@@ -22,6 +24,12 @@ export default function notifyFolderSyncError(err: unknown): void {
     createToastNotification(FOLDER_SYNC_ERROR_TOAST_TITLE, getResponseError(err), ToastType.ERROR);
 }
 
+/** Toast a sync failure and record it, sharing the cancel skip. */
+export function notifyAndRecordFolderSyncError(kind: ReportKind, err: unknown): void {
+    notifyFolderSyncError(err);
+    recordReportLoadFailure(kind, err);
+}
+
 /** Surfaces failures when listing remote folders (SSH or transport errors). */
 export function notifyFolderListSyncError(detail: string): void {
     createToastNotification(FOLDER_LIST_SYNC_ERROR_TOAST_TITLE, detail, ToastType.ERROR);
@@ -34,4 +42,10 @@ export function notifyRemoteFolderMountError(err: unknown): void {
     }
 
     createToastNotification(REMOTE_FOLDER_MOUNT_ERROR_TOAST_TITLE, getResponseError(err), ToastType.ERROR);
+}
+
+/** Toast a mount failure and record it, sharing the cancel skip. */
+export function notifyAndRecordRemoteFolderMountError(kind: ReportKind, err: unknown): void {
+    notifyRemoteFolderMountError(err);
+    recordReportLoadFailure(kind, err);
 }

--- a/src/functions/reportLoadUsage.ts
+++ b/src/functions/reportLoadUsage.ts
@@ -19,6 +19,15 @@ export function recordReportLoadFailed(kind: ReportKind, reason: ReportLoadFailu
     recordUsage({ event: UsageEvent.REPORT_LOAD_FAILED, details: { kind, reason_class: reason } });
 }
 
+/** Classify and record a failure, skipping axios cancels so abort is not a load failure. */
+export function recordReportLoadFailure(kind: ReportKind, error: unknown): void {
+    if (axios.isCancel(error)) {
+        return;
+    }
+
+    recordReportLoadFailed(kind, getReportLoadFailureReason(error));
+}
+
 export function getReportLoadFailureReason(
     error: unknown,
     options: ReportLoadFailureOptions = {},

--- a/src/functions/reportLoadUsage.ts
+++ b/src/functions/reportLoadUsage.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import axios, { HttpStatusCode } from 'axios';
+import { ReportKind, ReportLoadFailureReason, ReportSource, UsageEvent } from '../definitions/UsageEvent';
+import { NPEValidationError } from '../definitions/NPEData';
+import recordUsage from './recordUsage';
+
+interface ReportLoadFailureOptions {
+    unprocessableEntityReason?: ReportLoadFailureReason;
+}
+
+export function recordReportLoaded(kind: ReportKind, source: ReportSource): void {
+    recordUsage({ event: UsageEvent.REPORT_LOADED, details: { kind, source } });
+}
+
+export function recordReportLoadFailed(kind: ReportKind, reason: ReportLoadFailureReason): void {
+    recordUsage({ event: UsageEvent.REPORT_LOAD_FAILED, details: { kind, reason_class: reason } });
+}
+
+export function getReportLoadFailureReason(
+    error: unknown,
+    options: ReportLoadFailureOptions = {},
+): ReportLoadFailureReason {
+    if (!axios.isAxiosError(error)) {
+        return ReportLoadFailureReason.OTHER;
+    }
+
+    const status = error.status ?? error.response?.status;
+
+    switch (status) {
+        case HttpStatusCode.Unauthorized:
+        case HttpStatusCode.Forbidden:
+            return ReportLoadFailureReason.PERMISSION;
+        case HttpStatusCode.NotFound:
+            return ReportLoadFailureReason.MISSING_FILE;
+        case HttpStatusCode.PayloadTooLarge:
+            return ReportLoadFailureReason.TOO_LARGE;
+        case HttpStatusCode.UnprocessableEntity:
+            return options.unprocessableEntityReason ?? ReportLoadFailureReason.OTHER;
+        default:
+            return ReportLoadFailureReason.OTHER;
+    }
+}
+
+export function getNpeReportLoadFailureReason(
+    validationError: NPEValidationError,
+    error: unknown = null,
+): ReportLoadFailureReason {
+    switch (validationError) {
+        case NPEValidationError.INVALID_NPE_VERSION:
+            return ReportLoadFailureReason.UNSUPPORTED_VERSION;
+        case NPEValidationError.INVALID_JSON:
+        case NPEValidationError.INVALID_NPE_DATA:
+            return ReportLoadFailureReason.PARSE_ERROR;
+        default:
+            return getReportLoadFailureReason(error, {
+                unprocessableEntityReason: ReportLoadFailureReason.PARSE_ERROR,
+            });
+    }
+}

--- a/src/functions/reportLoadUsage.ts
+++ b/src/functions/reportLoadUsage.ts
@@ -4,12 +4,7 @@
 
 import axios, { HttpStatusCode } from 'axios';
 import { ReportKind, ReportLoadFailureReason, ReportSource, UsageEvent } from '../definitions/UsageEvent';
-import { NPEValidationError } from '../definitions/NPEData';
 import recordUsage from './recordUsage';
-
-interface ReportLoadFailureOptions {
-    unprocessableEntityReason?: ReportLoadFailureReason;
-}
 
 export function recordReportLoaded(kind: ReportKind, source: ReportSource): void {
     recordUsage({ event: UsageEvent.REPORT_LOADED, details: { kind, source } });
@@ -28,10 +23,7 @@ export function recordReportLoadFailure(kind: ReportKind, error: unknown): void 
     recordReportLoadFailed(kind, getReportLoadFailureReason(error));
 }
 
-export function getReportLoadFailureReason(
-    error: unknown,
-    options: ReportLoadFailureOptions = {},
-): ReportLoadFailureReason {
+export function getReportLoadFailureReason(error: unknown): ReportLoadFailureReason {
     if (!axios.isAxiosError(error)) {
         return ReportLoadFailureReason.OTHER;
     }
@@ -46,26 +38,7 @@ export function getReportLoadFailureReason(
             return ReportLoadFailureReason.MISSING_FILE;
         case HttpStatusCode.PayloadTooLarge:
             return ReportLoadFailureReason.TOO_LARGE;
-        case HttpStatusCode.UnprocessableEntity:
-            return options.unprocessableEntityReason ?? ReportLoadFailureReason.OTHER;
         default:
             return ReportLoadFailureReason.OTHER;
-    }
-}
-
-export function getNpeReportLoadFailureReason(
-    validationError: NPEValidationError,
-    error: unknown = null,
-): ReportLoadFailureReason {
-    switch (validationError) {
-        case NPEValidationError.INVALID_NPE_VERSION:
-            return ReportLoadFailureReason.UNSUPPORTED_VERSION;
-        case NPEValidationError.INVALID_JSON:
-        case NPEValidationError.INVALID_NPE_DATA:
-            return ReportLoadFailureReason.PARSE_ERROR;
-        default:
-            return getReportLoadFailureReason(error, {
-                unprocessableEntityReason: ReportLoadFailureReason.PARSE_ERROR,
-            });
     }
 }

--- a/src/functions/validateNpeData.ts
+++ b/src/functions/validateNpeData.ts
@@ -6,6 +6,20 @@ import { MIN_SUPPORTED_VERSION, NPEValidationError } from '../definitions/NPEDat
 import { NPEData } from '../model/NPEModel';
 import { semverParse } from './semverParse';
 
+export const validateNpeVersion = (dataVersion: unknown): NPEValidationError => {
+    const parsedVersion = typeof dataVersion === 'string' ? semverParse(dataVersion) : null;
+
+    if (!parsedVersion) {
+        return NPEValidationError.INVALID_NPE_VERSION;
+    }
+
+    const minSupportedVersion = semverParse(MIN_SUPPORTED_VERSION);
+
+    return minSupportedVersion && parsedVersion.major === minSupportedVersion.major
+        ? NPEValidationError.OK
+        : NPEValidationError.INVALID_NPE_VERSION;
+};
+
 export const validateNpeData = (data: unknown): NPEValidationError => {
     if (typeof data !== 'object' || data === null) {
         return NPEValidationError.INVALID_NPE_DATA;
@@ -33,17 +47,5 @@ export const validateNpeData = (data: unknown): NPEValidationError => {
         return NPEValidationError.EMPTY_NPE_TRACE;
     }
 
-    const parsedVersion = dataVersion ? semverParse(dataVersion) : null;
-
-    if (!parsedVersion) {
-        return NPEValidationError.INVALID_NPE_VERSION;
-    }
-
-    const minSupportedVersion = semverParse(MIN_SUPPORTED_VERSION);
-
-    if (!minSupportedVersion || parsedVersion.major !== minSupportedVersion.major) {
-        return NPEValidationError.INVALID_NPE_VERSION;
-    }
-
-    return NPEValidationError.OK;
+    return validateNpeVersion(dataVersion);
 };

--- a/src/hooks/useNpeLoadAttempt.ts
+++ b/src/hooks/useNpeLoadAttempt.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { NPEValidationError } from '../definitions/NPEData';
+import { ReportKind, ReportSource } from '../definitions/UsageEvent';
+import getNpeReportLoadFailureReason from '../functions/getNpeReportLoadFailureReason';
+import { recordReportLoadFailed, recordReportLoaded } from '../functions/reportLoadUsage';
+
+interface NpeLoadAttempt {
+    id: number;
+    source: ReportSource;
+}
+
+export interface NpeLoadAttemptController {
+    id: number | null;
+    complete: (attemptId: number) => void;
+    fail: (attemptId: number, errorCode: NPEValidationError, error?: unknown) => void;
+}
+
+export default function useNpeLoadAttempt() {
+    const nextIdRef = useRef(0);
+    const pendingAttemptRef = useRef<NpeLoadAttempt | null>(null);
+    const [pendingAttemptId, setPendingAttemptId] = useState<number | null>(null);
+
+    const begin = useCallback((source: ReportSource) => {
+        nextIdRef.current += 1;
+        const attempt = { id: nextIdRef.current, source };
+        pendingAttemptRef.current = attempt;
+        setPendingAttemptId(attempt.id);
+    }, []);
+
+    const complete = useCallback((attemptId: number) => {
+        const attempt = pendingAttemptRef.current;
+        if (!attempt || attempt.id !== attemptId) {
+            return;
+        }
+
+        pendingAttemptRef.current = null;
+        setPendingAttemptId(null);
+        recordReportLoaded(ReportKind.NPE, attempt.source);
+    }, []);
+
+    const fail = useCallback((attemptId: number, errorCode: NPEValidationError, error: unknown = null) => {
+        const attempt = pendingAttemptRef.current;
+        if (!attempt || attempt.id !== attemptId) {
+            return;
+        }
+
+        pendingAttemptRef.current = null;
+        setPendingAttemptId(null);
+        recordReportLoadFailed(ReportKind.NPE, getNpeReportLoadFailureReason(errorCode, error));
+    }, []);
+
+    const controller = useMemo<NpeLoadAttemptController>(
+        () => ({ id: pendingAttemptId, complete, fail }),
+        [complete, fail, pendingAttemptId],
+    );
+
+    return { begin, controller };
+}

--- a/src/hooks/useRestoreInstance.tsx
+++ b/src/hooks/useRestoreInstance.tsx
@@ -23,7 +23,7 @@ const useRestoreInstance = () => {
     const store = useStore();
     const { data: instance, isLoading } = useInstance();
     const remote = useRemoteConnection();
-    const { data: reports } = useReportFolderList();
+    const { data: reports, isError: isReportFolderListError } = useReportFolderList();
     const { resetMemoryListStates } = useResetMemoryListStates();
 
     const [hasRestoredInstance, setHasRestoredInstance] = useState<boolean>(false);
@@ -38,7 +38,7 @@ const useRestoreInstance = () => {
     const previousProfilerPathRef = useRef<string | null | undefined>(undefined);
 
     useEffect(() => {
-        if (!instance || reports === null || hasRestoredInstance) {
+        if (!instance || (reports === null && !isReportFolderListError) || hasRestoredInstance) {
             return;
         }
 
@@ -104,6 +104,7 @@ const useRestoreInstance = () => {
         setActiveMlirJson,
         instance,
         hasRestoredInstance,
+        isReportFolderListError,
         reports,
         remote.persistentState,
         store,

--- a/src/routes/NPE.tsx
+++ b/src/routes/NPE.tsx
@@ -101,7 +101,10 @@ const NPE = () => {
     const npeData = useMemo(() => demoData || loadedData || loadedTimeline, [demoData, loadedData, loadedTimeline]);
 
     // Demos are hosted-only. Keep their source wired for vocabulary parity, but
-    // recordUsage intentionally drops the event because SERVER_MODE records nothing.
+    // recordUsage drops the event under SERVER_MODE. The non-windowed settle
+    // effect below is retained for that hosted path and for #1802; local uploads
+    // record via NpeWindowedView, so this effect emits nothing where recording
+    // is enabled.
     const isDemoEnabled = isServerMode;
     // Prefer RQ isLoading (isPending && isFetching) over bare isFetching so a
     // background refetch cannot pin the spinner after data is already present.
@@ -135,6 +138,13 @@ const NPE = () => {
             return;
         }
 
+        // Nothing has settled yet — do not treat a pending attempt as a parse
+        // error because npeData is still empty (e.g. between beginLoadAttempt
+        // and the atom write that enables a query).
+        if (!isNpeQueryEnabled && !isTimelineQueryEnabled && demoData == null) {
+            return;
+        }
+
         if (canShowView) {
             completeLoadAttempt(pendingLoadAttemptId);
         } else if (errorCode !== NPEValidationError.OK) {
@@ -143,10 +153,13 @@ const NPE = () => {
     }, [
         canShowView,
         completeLoadAttempt,
+        demoData,
         errorCode,
         failLoadAttempt,
         fetchError,
         isLoading,
+        isNpeQueryEnabled,
+        isTimelineQueryEnabled,
         isWindowedView,
         pendingLoadAttemptId,
     ]);

--- a/src/routes/NPE.tsx
+++ b/src/routes/NPE.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router';
@@ -18,6 +18,17 @@ import NPEDemoSelect, { NPEDemoData } from '../components/npe/NPEDemoSelect';
 import { NPEValidationError } from '../definitions/NPEData';
 import { getNpeValidationErrorFromFetch } from '../functions/getNpeValidationErrorFromFetch';
 import { validateNpeData } from '../functions/validateNpeData';
+import { ReportKind, ReportSource } from '../definitions/UsageEvent';
+import {
+    getNpeReportLoadFailureReason,
+    recordReportLoadFailed,
+    recordReportLoaded,
+} from '../functions/reportLoadUsage';
+
+interface NpeLoadAttempt {
+    id: number;
+    source: ReportSource;
+}
 
 const NPE = () => {
     const { filepath } = useParams<{ filepath?: string }>();
@@ -48,6 +59,44 @@ const NPE = () => {
     } = useNPETimelineFile(filepath);
     const [demoData, setDemoData] = useState<NPEData | null>(null);
     const [selectedDemo, setSelectedDemo] = useState<NPEDemoData | null>(null);
+    const nextLoadAttemptIdRef = useRef(0);
+    const pendingLoadAttemptRef = useRef<NpeLoadAttempt | null>(null);
+    const [pendingLoadAttemptId, setPendingLoadAttemptId] = useState<number | null>(null);
+
+    const beginLoadAttempt = useCallback((source: ReportSource) => {
+        nextLoadAttemptIdRef.current += 1;
+        const attempt = { id: nextLoadAttemptIdRef.current, source };
+        pendingLoadAttemptRef.current = attempt;
+        setPendingLoadAttemptId(attempt.id);
+    }, []);
+
+    const completeLoadAttempt = useCallback((attemptId: number) => {
+        const attempt = pendingLoadAttemptRef.current;
+        if (!attempt || attempt.id !== attemptId) {
+            return;
+        }
+
+        pendingLoadAttemptRef.current = null;
+        setPendingLoadAttemptId(null);
+        recordReportLoaded(ReportKind.NPE, attempt.source);
+    }, []);
+
+    const failLoadAttempt = useCallback((attemptId: number, errorCode: NPEValidationError, error: unknown = null) => {
+        const attempt = pendingLoadAttemptRef.current;
+        if (!attempt || attempt.id !== attemptId) {
+            return;
+        }
+
+        pendingLoadAttemptRef.current = null;
+        setPendingLoadAttemptId(null);
+        recordReportLoadFailed(ReportKind.NPE, getNpeReportLoadFailureReason(errorCode, error));
+    }, []);
+    const handleUploadAccepted = useCallback(() => {
+        setSelectedDemo(null);
+        setDemoData(null);
+        beginLoadAttempt(ReportSource.UPLOAD);
+    }, [beginLoadAttempt]);
+    const handleDemoSelected = useCallback(() => beginLoadAttempt(ReportSource.DEMO), [beginLoadAttempt]);
 
     const npeData = useMemo(() => demoData || loadedData || loadedTimeline, [demoData, loadedData, loadedTimeline]);
 
@@ -79,6 +128,27 @@ const NPE = () => {
 
     const canShowView = !isLoading && errorCode === NPEValidationError.OK && npeData != null;
 
+    useEffect(() => {
+        if (isWindowedView || pendingLoadAttemptId === null || isLoading) {
+            return;
+        }
+
+        if (canShowView) {
+            completeLoadAttempt(pendingLoadAttemptId);
+        } else if (errorCode !== NPEValidationError.OK) {
+            failLoadAttempt(pendingLoadAttemptId, errorCode, fetchError);
+        }
+    }, [
+        canShowView,
+        completeLoadAttempt,
+        errorCode,
+        failLoadAttempt,
+        fetchError,
+        isLoading,
+        isWindowedView,
+        pendingLoadAttemptId,
+    ]);
+
     let mainContent;
     if (isWindowedView) {
         // key on the report so a report switch fully remounts: resets the
@@ -88,6 +158,9 @@ const NPE = () => {
             <NpeWindowedView
                 key={npeFileName}
                 fileName={npeFileName}
+                loadAttemptId={pendingLoadAttemptId}
+                onInitialLoadSuccess={completeLoadAttempt}
+                onInitialLoadFailure={failLoadAttempt}
             />
         );
     } else if (canShowView) {
@@ -115,7 +188,7 @@ const NPE = () => {
 
             <h1 className='page-title'>NOC performance estimator</h1>
             <div className='inline-loaders'>
-                {!filepath && <NPEFileLoader />}
+                {!filepath && <NPEFileLoader onUploadAccepted={handleUploadAccepted} />}
 
                 {isDemoEnabled && (
                     <>
@@ -123,6 +196,7 @@ const NPE = () => {
                             selectedDemo={selectedDemo}
                             setSelectedDemo={setSelectedDemo}
                             setDemoData={setDemoData}
+                            onDemoSelected={handleDemoSelected}
                         />
                         <br />
                     </>

--- a/src/routes/NPE.tsx
+++ b/src/routes/NPE.tsx
@@ -100,6 +100,8 @@ const NPE = () => {
 
     const npeData = useMemo(() => demoData || loadedData || loadedTimeline, [demoData, loadedData, loadedTimeline]);
 
+    // Demos are hosted-only. Keep their source wired for vocabulary parity, but
+    // recordUsage intentionally drops the event because SERVER_MODE records nothing.
     const isDemoEnabled = isServerMode;
     // Prefer RQ isLoading (isPending && isFetching) over bare isFetching so a
     // background refetch cannot pin the spinner after data is already present.

--- a/src/routes/NPE.tsx
+++ b/src/routes/NPE.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router';
@@ -18,17 +18,8 @@ import NPEDemoSelect, { NPEDemoData } from '../components/npe/NPEDemoSelect';
 import { NPEValidationError } from '../definitions/NPEData';
 import { getNpeValidationErrorFromFetch } from '../functions/getNpeValidationErrorFromFetch';
 import { validateNpeData } from '../functions/validateNpeData';
-import { ReportKind, ReportSource } from '../definitions/UsageEvent';
-import {
-    getNpeReportLoadFailureReason,
-    recordReportLoadFailed,
-    recordReportLoaded,
-} from '../functions/reportLoadUsage';
-
-interface NpeLoadAttempt {
-    id: number;
-    source: ReportSource;
-}
+import { ReportSource } from '../definitions/UsageEvent';
+import useNpeLoadAttempt from '../hooks/useNpeLoadAttempt';
 
 const NPE = () => {
     const { filepath } = useParams<{ filepath?: string }>();
@@ -59,38 +50,7 @@ const NPE = () => {
     } = useNPETimelineFile(filepath);
     const [demoData, setDemoData] = useState<NPEData | null>(null);
     const [selectedDemo, setSelectedDemo] = useState<NPEDemoData | null>(null);
-    const nextLoadAttemptIdRef = useRef(0);
-    const pendingLoadAttemptRef = useRef<NpeLoadAttempt | null>(null);
-    const [pendingLoadAttemptId, setPendingLoadAttemptId] = useState<number | null>(null);
-
-    const beginLoadAttempt = useCallback((source: ReportSource) => {
-        nextLoadAttemptIdRef.current += 1;
-        const attempt = { id: nextLoadAttemptIdRef.current, source };
-        pendingLoadAttemptRef.current = attempt;
-        setPendingLoadAttemptId(attempt.id);
-    }, []);
-
-    const completeLoadAttempt = useCallback((attemptId: number) => {
-        const attempt = pendingLoadAttemptRef.current;
-        if (!attempt || attempt.id !== attemptId) {
-            return;
-        }
-
-        pendingLoadAttemptRef.current = null;
-        setPendingLoadAttemptId(null);
-        recordReportLoaded(ReportKind.NPE, attempt.source);
-    }, []);
-
-    const failLoadAttempt = useCallback((attemptId: number, errorCode: NPEValidationError, error: unknown = null) => {
-        const attempt = pendingLoadAttemptRef.current;
-        if (!attempt || attempt.id !== attemptId) {
-            return;
-        }
-
-        pendingLoadAttemptRef.current = null;
-        setPendingLoadAttemptId(null);
-        recordReportLoadFailed(ReportKind.NPE, getNpeReportLoadFailureReason(errorCode, error));
-    }, []);
+    const { begin: beginLoadAttempt, controller: loadAttempt } = useNpeLoadAttempt();
     const handleUploadAccepted = useCallback(() => {
         setSelectedDemo(null);
         setDemoData(null);
@@ -134,7 +94,7 @@ const NPE = () => {
     const canShowView = !isLoading && errorCode === NPEValidationError.OK && npeData != null;
 
     useEffect(() => {
-        if (isWindowedView || pendingLoadAttemptId === null || isLoading) {
+        if (isWindowedView || loadAttempt.id === null || isLoading) {
             return;
         }
 
@@ -146,22 +106,20 @@ const NPE = () => {
         }
 
         if (canShowView) {
-            completeLoadAttempt(pendingLoadAttemptId);
+            loadAttempt.complete(loadAttempt.id);
         } else if (errorCode !== NPEValidationError.OK) {
-            failLoadAttempt(pendingLoadAttemptId, errorCode, fetchError);
+            loadAttempt.fail(loadAttempt.id, errorCode, fetchError);
         }
     }, [
         canShowView,
-        completeLoadAttempt,
         demoData,
         errorCode,
-        failLoadAttempt,
         fetchError,
         isLoading,
         isNpeQueryEnabled,
         isTimelineQueryEnabled,
         isWindowedView,
-        pendingLoadAttemptId,
+        loadAttempt,
     ]);
 
     let mainContent;
@@ -173,9 +131,7 @@ const NPE = () => {
             <NpeWindowedView
                 key={npeFileName}
                 fileName={npeFileName}
-                loadAttemptId={pendingLoadAttemptId}
-                onInitialLoadSuccess={completeLoadAttempt}
-                onInitialLoadFailure={failLoadAttempt}
+                loadAttempt={loadAttempt}
             />
         );
     } else if (canShowView) {

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -552,6 +552,83 @@ describe('MlirFileResultsOverlay', () => {
 });
 
 describe('MlirJsonFileLoader clearSplitPeers', () => {
+    it('records only failed files from a mixed server conversion batch', async () => {
+        uploadMlirFileToServer.mockResolvedValueOnce({
+            data: {
+                results: [
+                    {
+                        filename: 'valid.mlir',
+                        name: 'valid',
+                        status: ConnectionTestStates.OK,
+                        graph: GRAPH,
+                    },
+                    {
+                        filename: 'invalid.mlir',
+                        name: null,
+                        status: ConnectionTestStates.FAILED,
+                        message: 'Conversion failed',
+                        graph: null,
+                    },
+                ],
+            },
+        });
+        const { container } = render(
+            <MemoryRouter>
+                <MlirJsonFileLoader server={SERVER} />
+            </MemoryRouter>,
+        );
+
+        fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+            target: {
+                files: [new File(['module {}'], 'valid.mlir'), new File(['invalid'], 'invalid.mlir')],
+            },
+        });
+
+        await waitFor(() =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.MLIR, ReportLoadFailureReason.OTHER),
+        );
+        expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+    });
+
+    it('records every selected file when the server returns no results', async () => {
+        uploadMlirFileToServer.mockResolvedValueOnce({ data: { results: [] } });
+        const { container } = render(
+            <MemoryRouter>
+                <MlirJsonFileLoader server={SERVER} />
+            </MemoryRouter>,
+        );
+
+        fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+            target: {
+                files: [new File(['a'], 'a.mlir'), new File(['b'], 'b.mlir')],
+            },
+        });
+
+        await waitFor(() => expect(recordReportLoadFailed).toHaveBeenCalledTimes(2));
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+    });
+
+    it('records every selected file when the server upload rejects', async () => {
+        uploadMlirFileToServer.mockRejectedValueOnce(new Error('upload failed'));
+        const { container } = render(
+            <MemoryRouter>
+                <MlirJsonFileLoader server={SERVER} />
+            </MemoryRouter>,
+        );
+
+        fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+            target: {
+                files: [new File(['a'], 'a.mlir'), new File(['b'], 'b.mlir')],
+            },
+        });
+
+        await waitFor(() => expect(recordReportLoadFailed).toHaveBeenCalledTimes(2));
+        expect(recordReportLoadFailed).toHaveBeenNthCalledWith(1, ReportKind.MLIR, ReportLoadFailureReason.OTHER);
+        expect(recordReportLoadFailed).toHaveBeenNthCalledWith(2, ReportKind.MLIR, ReportLoadFailureReason.OTHER);
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+    });
+
     it('records invalid local JSON as a parse failure', async () => {
         const { container } = render(
             <MemoryRouter>

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -42,11 +42,11 @@ vi.mock('../src/functions/createToastNotification', async () => {
     return toastNotificationModuleMock(createToastNotification);
 });
 
-vi.mock('../src/functions/reportLoadUsage', () => ({
-    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
-    recordReportLoaded,
-    recordReportLoadFailed,
-}));
+vi.mock('../src/functions/reportLoadUsage', async (importOriginal) => {
+    const { reportLoadUsageSpiesMock } = await import('./helpers/mockReportLoadUsage');
+
+    return reportLoadUsageSpiesMock(importOriginal, recordReportLoaded, recordReportLoadFailed);
+});
 
 const GRAPH: GraphBundle = { graphs: [{ id: 'g', nodes: [] }] };
 const SERVER: MlirServerConnection = {
@@ -268,7 +268,7 @@ describe('MlirFileResultsOverlay', () => {
         });
     });
 
-    it('does not show a success toast when persisting active MLIR fails', async () => {
+    it('still loads converted graphs when persisting active MLIR fails', async () => {
         setActiveMlir.mockRejectedValueOnce(new Error('persist failed'));
         renderOverlay([
             {
@@ -287,14 +287,14 @@ describe('MlirFileResultsOverlay', () => {
         await waitFor(() => {
             expect(setActiveMlir).toHaveBeenCalledWith('a', 'worker-01');
         });
-        expect(createToastNotification).toHaveBeenCalledTimes(1);
+        expect(createToastNotification).toHaveBeenCalledTimes(2);
         expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'persist failed', 'error');
-        expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.MLIR, ReportLoadFailureReason.OTHER);
-        expect(recordReportLoaded).not.toHaveBeenCalled();
-        expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([]);
+        expect(recordReportLoadFailed).not.toHaveBeenCalled();
+        expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.MLIR, ReportSource.UPLOAD);
+        expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([{ name: 'a', data: GRAPH }]);
     });
 
-    it('records one failure per selected report when split-view persistence fails', async () => {
+    it('records one load per selected report when split-view persistence fails', async () => {
         setActiveMlir.mockRejectedValueOnce(new Error('persist failed'));
         renderOverlay([
             {
@@ -319,9 +319,12 @@ describe('MlirFileResultsOverlay', () => {
         fireEvent.click(screen.getByText('b.mlir'));
         fireEvent.click(screen.getByRole('button', { name: /view/i }));
 
-        await waitFor(() => expect(recordReportLoadFailed).toHaveBeenCalledTimes(2));
-        expect(recordReportLoaded).not.toHaveBeenCalled();
-        expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([]);
+        await waitFor(() => expect(recordReportLoaded).toHaveBeenCalledTimes(2));
+        expect(recordReportLoadFailed).not.toHaveBeenCalled();
+        expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([
+            { name: 'a', data: GRAPH },
+            { name: 'b', data: GRAPH },
+        ]);
     });
 
     it('retries conversion for a failed server file', async () => {

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -144,6 +144,39 @@ describe('MlirFileResultsOverlay', () => {
         expect(getDefaultStore().get(mlirFileResultsAtom)).not.toBeNull();
     });
 
+    it('ignores a second View click while persistence is in flight', async () => {
+        let finishPersistence!: () => void;
+        setActiveMlir.mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    finishPersistence = resolve;
+                }),
+        );
+        renderOverlay([
+            {
+                filename: 'a.mlir',
+                host: 'worker-01',
+                name: 'a',
+                status: ConnectionTestStates.OK,
+                graph: GRAPH,
+                persisted: true,
+            },
+        ]);
+
+        fireEvent.click(screen.getByText('a.mlir'));
+        const viewButton = screen.getByRole('button', { name: /view/i });
+        fireEvent.click(viewButton);
+        fireEvent.click(viewButton);
+
+        expect(viewButton).toBeDisabled();
+        expect(setActiveMlir).toHaveBeenCalledTimes(1);
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+
+        finishPersistence();
+
+        await waitFor(() => expect(recordReportLoaded).toHaveBeenCalledTimes(1));
+    });
+
     it('reopens the results overlay via the loader button after it has been closed', async () => {
         getDefaultStore().set(mlirFileResultsAtom, [
             { filename: 'a.json', name: 'a', status: ConnectionTestStates.OK, graph: GRAPH, persisted: false },

--- a/tests/MlirFileResultsOverlay.spec.tsx
+++ b/tests/MlirFileResultsOverlay.spec.tsx
@@ -22,11 +22,14 @@ import {
 } from '../src/store/app';
 import { GraphBundle, MlirFileResult } from '../src/model/MLIRJsonModel';
 import { MlirServerConnection } from '../src/model/MlirServer';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
 
 const setActiveMlir = vi.fn();
 const uploadMlirFileToServer = vi.fn();
-const { createToastNotification } = vi.hoisted(() => ({
+const { createToastNotification, recordReportLoaded, recordReportLoadFailed } = vi.hoisted(() => ({
     createToastNotification: vi.fn(),
+    recordReportLoaded: vi.fn(),
+    recordReportLoadFailed: vi.fn(),
 }));
 
 vi.mock('../src/hooks/useMlirRemote', () => ({
@@ -38,6 +41,12 @@ vi.mock('../src/functions/createToastNotification', async () => {
 
     return toastNotificationModuleMock(createToastNotification);
 });
+
+vi.mock('../src/functions/reportLoadUsage', () => ({
+    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
+    recordReportLoaded,
+    recordReportLoadFailed,
+}));
 
 const GRAPH: GraphBundle = { graphs: [{ id: 'g', nodes: [] }] };
 const SERVER: MlirServerConnection = {
@@ -129,6 +138,7 @@ describe('MlirFileResultsOverlay', () => {
         });
         expect(getDefaultStore().get(activeMlirJsonAtom)).toBe('a');
         expect(setActiveMlir).toHaveBeenCalledWith('a', 'worker-01');
+        expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.MLIR, ReportSource.UPLOAD);
         // The overlay closes but the results are retained so it can be reopened.
         expect(getDefaultStore().get(mlirFileResultsOpenAtom)).toBe(false);
         expect(getDefaultStore().get(mlirFileResultsAtom)).not.toBeNull();
@@ -169,6 +179,7 @@ describe('MlirFileResultsOverlay', () => {
             expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([{ name: 'a', data: GRAPH }]);
         });
         expect(setActiveMlir).not.toHaveBeenCalled();
+        expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.MLIR, ReportSource.UPLOAD);
     });
 
     it('allows selecting up to two successful files and ignores a third', async () => {
@@ -234,6 +245,7 @@ describe('MlirFileResultsOverlay', () => {
         // Persist index 0 only — peer is session-scoped.
         expect(setActiveMlir).toHaveBeenCalledTimes(1);
         expect(setActiveMlir).toHaveBeenCalledWith('a', 'worker-01');
+        expect(recordReportLoaded).toHaveBeenCalledTimes(2);
         expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'a.mlir / b.mlir', 'success');
     });
 
@@ -277,6 +289,39 @@ describe('MlirFileResultsOverlay', () => {
         });
         expect(createToastNotification).toHaveBeenCalledTimes(1);
         expect(createToastNotification).toHaveBeenCalledWith('MLIR', 'persist failed', 'error');
+        expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.MLIR, ReportLoadFailureReason.OTHER);
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+        expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([]);
+    });
+
+    it('records one failure per selected report when split-view persistence fails', async () => {
+        setActiveMlir.mockRejectedValueOnce(new Error('persist failed'));
+        renderOverlay([
+            {
+                filename: 'a.mlir',
+                host: 'worker-01',
+                name: 'a',
+                status: ConnectionTestStates.OK,
+                graph: GRAPH,
+                persisted: true,
+            },
+            {
+                filename: 'b.mlir',
+                host: 'worker-01',
+                name: 'b',
+                status: ConnectionTestStates.OK,
+                graph: GRAPH,
+                persisted: true,
+            },
+        ]);
+
+        fireEvent.click(screen.getByText('a.mlir'));
+        fireEvent.click(screen.getByText('b.mlir'));
+        fireEvent.click(screen.getByRole('button', { name: /view/i }));
+
+        await waitFor(() => expect(recordReportLoadFailed).toHaveBeenCalledTimes(2));
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+        expect(getDefaultStore().get(mlirLoadedReportsAtom)).toEqual([]);
     });
 
     it('retries conversion for a failed server file', async () => {
@@ -507,6 +552,24 @@ describe('MlirFileResultsOverlay', () => {
 });
 
 describe('MlirJsonFileLoader clearSplitPeers', () => {
+    it('records invalid local JSON as a parse failure', async () => {
+        const { container } = render(
+            <MemoryRouter>
+                <MlirJsonFileLoader />
+            </MemoryRouter>,
+        );
+        const file = new File(['not json'], 'invalid.json', { type: 'application/json' });
+        file.text = () => Promise.resolve('not json');
+
+        fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+            target: { files: [file] },
+        });
+
+        await waitFor(() =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.MLIR, ReportLoadFailureReason.PARSE_ERROR),
+        );
+    });
+
     it('drops loaded split peers when a new local results batch starts', async () => {
         getDefaultStore().set(mlirLoadedReportsAtom, [
             { name: 'primary', data: GRAPH },

--- a/tests/NPEFileLoader.spec.tsx
+++ b/tests/NPEFileLoader.spec.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AxiosError, HttpStatusCode } from 'axios';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import NPEFileLoader from '../src/components/npe/NPEFileLoader';
@@ -16,10 +17,11 @@ vi.mock('../src/hooks/useLocal', () => ({
     default: () => ({ uploadNpeFile }),
 }));
 
-vi.mock('../src/functions/reportLoadUsage', () => ({
-    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
-    recordReportLoadFailed,
-}));
+vi.mock('../src/functions/reportLoadUsage', async (importOriginal) => {
+    const { reportLoadUsageSpiesMock } = await import('./helpers/mockReportLoadUsage');
+
+    return reportLoadUsageSpiesMock(importOriginal, vi.fn(), recordReportLoadFailed);
+});
 
 vi.mock('../src/functions/createToastNotification', async () => {
     const { toastNotificationModuleMock } = await import('./helpers/mockToastNotification');
@@ -75,7 +77,7 @@ describe('NPEFileLoader re-upload cache-bust', () => {
         expect(client.getQueryData(['npe-window', 'old-report', 0])).toBeUndefined();
         expect(client.getQueryData(['fetch-npe', 'old-report'])).toBeUndefined();
         expect(client.getQueryData(['unrelated-query'])).toEqual({});
-        expect(onUploadAccepted).toHaveBeenCalledWith('report.npeviz');
+        expect(onUploadAccepted).toHaveBeenCalledTimes(1);
     });
 
     it('does not bust caches when the upload fails', async () => {
@@ -88,5 +90,27 @@ describe('NPEFileLoader re-upload cache-bust', () => {
         await waitFor(() => expect(uploadNpeFile).toHaveBeenCalled());
         expect(removeQueries).not.toHaveBeenCalled();
         expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.OTHER);
+    });
+
+    it('classifies an upload 404 as missing_file without recording the body', async () => {
+        const error = new AxiosError('gone');
+        error.status = HttpStatusCode.NotFound;
+        error.response = {
+            status: HttpStatusCode.NotFound,
+            data: { error: 'private response message' },
+            statusText: '',
+            headers: {},
+            config: error.config!,
+        };
+        uploadNpeFile.mockRejectedValue(error);
+        const { container } = renderLoader();
+
+        const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+        fireEvent.change(input, { target: { files: [new File(['x'], 'report.npeviz.zst')] } });
+
+        await waitFor(() =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.MISSING_FILE),
+        );
+        expect(JSON.stringify(recordReportLoadFailed.mock.calls)).not.toContain('private response message');
     });
 });

--- a/tests/NPEFileLoader.spec.tsx
+++ b/tests/NPEFileLoader.spec.tsx
@@ -7,11 +7,18 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import NPEFileLoader from '../src/components/npe/NPEFileLoader';
 import { ConnectionTestStates } from '../src/definitions/ConnectionStatus';
+import { ReportKind, ReportLoadFailureReason } from '../src/definitions/UsageEvent';
 
 const uploadNpeFile = vi.fn();
+const { recordReportLoadFailed } = vi.hoisted(() => ({ recordReportLoadFailed: vi.fn() }));
 
 vi.mock('../src/hooks/useLocal', () => ({
     default: () => ({ uploadNpeFile }),
+}));
+
+vi.mock('../src/functions/reportLoadUsage', () => ({
+    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
+    recordReportLoadFailed,
 }));
 
 vi.mock('../src/functions/createToastNotification', async () => {
@@ -27,29 +34,48 @@ afterEach(() => {
 
 const renderLoader = () => {
     const client = new QueryClient();
+    client.setQueryData(['npe-summary', 'old-report'], {});
+    client.setQueryData(['npe-window', 'old-report', 0], {});
+    client.setQueryData(['fetch-npe', 'old-report'], {});
+    client.setQueryData(['unrelated-query'], {});
     const removeQueries = vi.spyOn(client, 'removeQueries');
+    const onUploadAccepted = vi.fn();
     const utils = render(
         <QueryClientProvider client={client}>
-            <NPEFileLoader />
+            <NPEFileLoader onUploadAccepted={onUploadAccepted} />
         </QueryClientProvider>,
     );
-    return { ...utils, removeQueries };
+    return { ...utils, client, removeQueries, onUploadAccepted };
 };
 
 describe('NPEFileLoader re-upload cache-bust', () => {
+    it('does not record cancelling the file picker as a failed load', () => {
+        const { container } = renderLoader();
+        const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+        fireEvent.change(input, { target: { files: [] } });
+
+        expect(uploadNpeFile).not.toHaveBeenCalled();
+        expect(recordReportLoadFailed).not.toHaveBeenCalled();
+    });
+
     it('drops the NPE summary / window / trace caches on a successful upload', async () => {
         uploadNpeFile.mockResolvedValue({ data: { status: ConnectionTestStates.OK } });
-        const { container, removeQueries } = renderLoader();
+        const { container, client, removeQueries, onUploadAccepted } = renderLoader();
 
         const input = container.querySelector('input[type="file"]') as HTMLInputElement;
         fireEvent.change(input, { target: { files: [new File(['x'], 'report.npeviz.zst')] } });
 
         await waitFor(() => expect(removeQueries).toHaveBeenCalled());
 
-        const removedKeys = removeQueries.mock.calls.map((call) => (call[0] as { queryKey: string[] }).queryKey[0]);
         // staleTime: Infinity means a same-name re-upload would otherwise serve the
         // previous report — all three windowed keys must be evicted.
-        expect(removedKeys).toEqual(expect.arrayContaining(['npe-summary', 'npe-window', 'fetch-npe']));
+        expect(removeQueries).toHaveBeenCalledTimes(1);
+        expect(client.getQueryData(['npe-summary', 'old-report'])).toBeUndefined();
+        expect(client.getQueryData(['npe-window', 'old-report', 0])).toBeUndefined();
+        expect(client.getQueryData(['fetch-npe', 'old-report'])).toBeUndefined();
+        expect(client.getQueryData(['unrelated-query'])).toEqual({});
+        expect(onUploadAccepted).toHaveBeenCalledWith('report.npeviz');
     });
 
     it('does not bust caches when the upload fails', async () => {
@@ -61,5 +87,6 @@ describe('NPEFileLoader re-upload cache-bust', () => {
 
         await waitFor(() => expect(uploadNpeFile).toHaveBeenCalled());
         expect(removeQueries).not.toHaveBeenCalled();
+        expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.OTHER);
     });
 });

--- a/tests/NPERoute.spec.tsx
+++ b/tests/NPERoute.spec.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AxiosError, HttpStatusCode } from 'axios';
 import { getDefaultStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,6 +11,7 @@ import { TestProviders } from './helpers/TestProviders';
 import { minimalValidNpeData } from './helpers/npeFixtures';
 import { activeNpeOpTraceAtom } from '../src/store/app';
 import { TEST_IDS } from '../src/definitions/TestIds';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
 
 // Mutable holders shared with the hoisted mock factories so each case can flip
 // SERVER_MODE / route params and inspect how useNpe was gated.
@@ -20,11 +21,18 @@ const h = vi.hoisted(() => ({
     serverMode: true as boolean,
     params: {} as { filepath?: string },
     useNpeArgs: [] as (string | null)[],
+    windowedProps: null as {
+        loadAttemptId: number | null;
+        onInitialLoadSuccess: (attemptId: number) => void;
+        onInitialLoadFailure: (attemptId: number, errorCode: number, error?: unknown) => void;
+    } | null,
 }));
 
-const { mockUseNpe, mockUseNPETimelineFile } = vi.hoisted(() => ({
+const { mockUseNpe, mockUseNPETimelineFile, recordReportLoaded, recordReportLoadFailed } = vi.hoisted(() => ({
     mockUseNpe: vi.fn(),
     mockUseNPETimelineFile: vi.fn(),
+    recordReportLoaded: vi.fn(),
+    recordReportLoadFailed: vi.fn(),
 }));
 
 vi.mock('../src/functions/getServerConfig', () => ({ default: () => ({ SERVER_MODE: h.serverMode }) }));
@@ -51,13 +59,49 @@ vi.mock('../src/hooks/useAPI', async () => {
     };
 });
 vi.mock('../src/components/npe/NpeWindowedView', () => ({
-    default: () => <div data-testid={TEST_IDS.NPE_WINDOWED_VIEW} />,
+    default: (props: NonNullable<typeof h.windowedProps>) => {
+        h.windowedProps = props;
+        return <div data-testid={TEST_IDS.NPE_WINDOWED_VIEW} />;
+    },
 }));
 vi.mock('../src/components/npe/NPEViewComponent', () => ({
     default: () => <div data-testid={TEST_IDS.NPE_VIEW} />,
 }));
-vi.mock('../src/components/npe/NPEFileLoader', () => ({ default: () => null }));
-vi.mock('../src/components/npe/NPEDemoSelect', () => ({ default: () => null }));
+vi.mock('../src/components/npe/NPEFileLoader', () => ({
+    default: ({ onUploadAccepted }: { onUploadAccepted: (fileName: string) => void }) => (
+        <button
+            onClick={() => {
+                onUploadAccepted('trace.json');
+                getDefaultStore().set(activeNpeOpTraceAtom, 'trace.json');
+            }}
+        >
+            accept-npe-upload
+        </button>
+    ),
+}));
+vi.mock('../src/components/npe/NPEDemoSelect', () => ({
+    default: ({
+        setDemoData,
+        onDemoSelected,
+    }: {
+        setDemoData: (data: typeof minimalValidNpeData) => void;
+        onDemoSelected: () => void;
+    }) => (
+        <button
+            onClick={() => {
+                onDemoSelected();
+                setDemoData(minimalValidNpeData);
+            }}
+        >
+            select-npe-demo
+        </button>
+    ),
+}));
+vi.mock('../src/functions/reportLoadUsage', () => ({
+    getNpeReportLoadFailureReason: () => ReportLoadFailureReason.PARSE_ERROR,
+    recordReportLoaded,
+    recordReportLoadFailed,
+}));
 
 // Import after vi.mock so the route under test sees the stubs.
 // eslint-disable-next-line import/first
@@ -97,6 +141,7 @@ beforeEach(() => {
     h.serverMode = true;
     h.params = {};
     h.useNpeArgs = [];
+    h.windowedProps = null;
     mockUseNpe.mockReturnValue(settledNpe);
     mockUseNPETimelineFile.mockReturnValue(idleTimeline);
 });
@@ -145,6 +190,65 @@ describe('NPE route windowed-view gate', () => {
         h.serverMode = false;
         renderRoute(null);
         expect(screen.queryByTestId(TEST_IDS.NPE_WINDOWED_VIEW)).toBeNull();
+    });
+});
+
+describe('NPE report-load recording', () => {
+    it('does not count an active report restored without a user load attempt', () => {
+        renderRoute();
+
+        expect(screen.getByTestId(TEST_IDS.NPE_VIEW)).toBeInTheDocument();
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+        expect(recordReportLoadFailed).not.toHaveBeenCalled();
+    });
+
+    it('ignores stale windowed completions and counts only the latest upload attempt', async () => {
+        h.serverMode = false;
+        renderRoute();
+
+        fireEvent.click(screen.getByRole('button', { name: 'accept-npe-upload' }));
+        await waitFor(() => expect(h.windowedProps?.loadAttemptId).toBe(1));
+        const staleAttemptId = h.windowedProps?.loadAttemptId;
+
+        fireEvent.click(screen.getByRole('button', { name: 'accept-npe-upload' }));
+        await waitFor(() => expect(h.windowedProps?.loadAttemptId).toBe(2));
+
+        h.windowedProps?.onInitialLoadSuccess(staleAttemptId ?? -1);
+        expect(recordReportLoaded).not.toHaveBeenCalled();
+
+        h.windowedProps?.onInitialLoadSuccess(2);
+        expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.NPE, ReportSource.UPLOAD);
+        h.windowedProps?.onInitialLoadSuccess(2);
+        h.windowedProps?.onInitialLoadFailure(2, 1);
+        expect(recordReportLoaded).toHaveBeenCalledTimes(1);
+        expect(recordReportLoadFailed).not.toHaveBeenCalled();
+    });
+
+    it('records a validated demo using the demo source', async () => {
+        renderRoute(null);
+
+        fireEvent.click(screen.getByRole('button', { name: 'select-npe-demo' }));
+
+        await waitFor(() => expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.NPE, ReportSource.DEMO));
+        expect(recordReportLoaded).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not validate a hosted upload against stale demo data', async () => {
+        renderRoute(null);
+        fireEvent.click(screen.getByRole('button', { name: 'select-npe-demo' }));
+        await waitFor(() => expect(recordReportLoaded).toHaveBeenCalledTimes(1));
+        recordReportLoaded.mockClear();
+
+        mockUseNpe.mockReturnValue({
+            data: { malformed: true },
+            isLoading: false,
+            error: null,
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'accept-npe-upload' }));
+
+        await waitFor(() => expect(recordReportLoadFailed).toHaveBeenCalledTimes(1));
+        expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.PARSE_ERROR);
+        expect(recordReportLoaded).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/NPERoute.spec.tsx
+++ b/tests/NPERoute.spec.tsx
@@ -5,7 +5,7 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AxiosError, HttpStatusCode } from 'axios';
-import { getDefaultStore } from 'jotai';
+import { getDefaultStore, useSetAtom } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestProviders } from './helpers/TestProviders';
 import { minimalValidNpeData } from './helpers/npeFixtures';
@@ -20,7 +20,7 @@ interface MockNpeWindowedViewProps {
 }
 
 interface MockNpeFileLoaderProps {
-    onUploadAccepted: (fileName: string) => void;
+    onUploadAccepted: () => void;
 }
 
 interface MockNpeDemoSelectProps {
@@ -79,16 +79,20 @@ vi.mock('../src/components/npe/NPEViewComponent', () => ({
     default: () => <div data-testid={TEST_IDS.NPE_VIEW} />,
 }));
 vi.mock('../src/components/npe/NPEFileLoader', () => ({
-    default: ({ onUploadAccepted }: MockNpeFileLoaderProps) => (
-        <button
-            onClick={() => {
-                onUploadAccepted('trace.json');
-                getDefaultStore().set(activeNpeOpTraceAtom, 'trace.json');
-            }}
-        >
-            accept-npe-upload
-        </button>
-    ),
+    default: function MockNpeFileLoader({ onUploadAccepted }: MockNpeFileLoaderProps) {
+        const setActiveNpe = useSetAtom(activeNpeOpTraceAtom);
+
+        return (
+            <button
+                onClick={() => {
+                    onUploadAccepted();
+                    setActiveNpe('trace.json');
+                }}
+            >
+                accept-npe-upload
+            </button>
+        );
+    },
 }));
 vi.mock('../src/components/npe/NPEDemoSelect', () => ({
     default: ({ setDemoData, onDemoSelected }: MockNpeDemoSelectProps) => (
@@ -102,11 +106,11 @@ vi.mock('../src/components/npe/NPEDemoSelect', () => ({
         </button>
     ),
 }));
-vi.mock('../src/functions/reportLoadUsage', () => ({
-    getNpeReportLoadFailureReason: () => ReportLoadFailureReason.PARSE_ERROR,
-    recordReportLoaded,
-    recordReportLoadFailed,
-}));
+vi.mock('../src/functions/reportLoadUsage', async (importOriginal) => {
+    const { reportLoadUsageSpiesMock } = await import('./helpers/mockReportLoadUsage');
+
+    return reportLoadUsageSpiesMock(importOriginal, recordReportLoaded, recordReportLoadFailed);
+});
 
 // Import after vi.mock so the route under test sees the stubs.
 // eslint-disable-next-line import/first
@@ -254,6 +258,21 @@ describe('NPE report-load recording', () => {
         await waitFor(() => expect(recordReportLoadFailed).toHaveBeenCalledTimes(1));
         expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.PARSE_ERROR);
         expect(recordReportLoaded).not.toHaveBeenCalled();
+    });
+
+    it('classifies a hosted NPE fetch 404 as missing_file', async () => {
+        renderRoute(null);
+        mockUseNpe.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            error: makeHttpError(HttpStatusCode.NotFound, 'not found'),
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'accept-npe-upload' }));
+
+        await waitFor(() =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.MISSING_FILE),
+        );
+        expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/tests/NPERoute.spec.tsx
+++ b/tests/NPERoute.spec.tsx
@@ -13,6 +13,21 @@ import { activeNpeOpTraceAtom } from '../src/store/app';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
 
+interface MockNpeWindowedViewProps {
+    loadAttemptId: number | null;
+    onInitialLoadSuccess: (attemptId: number) => void;
+    onInitialLoadFailure: (attemptId: number, errorCode: number, error?: unknown) => void;
+}
+
+interface MockNpeFileLoaderProps {
+    onUploadAccepted: (fileName: string) => void;
+}
+
+interface MockNpeDemoSelectProps {
+    setDemoData: (data: typeof minimalValidNpeData) => void;
+    onDemoSelected: () => void;
+}
+
 // Mutable holders shared with the hoisted mock factories so each case can flip
 // SERVER_MODE / route params and inspect how useNpe was gated.
 const h = vi.hoisted(() => ({
@@ -21,11 +36,7 @@ const h = vi.hoisted(() => ({
     serverMode: true as boolean,
     params: {} as { filepath?: string },
     useNpeArgs: [] as (string | null)[],
-    windowedProps: null as {
-        loadAttemptId: number | null;
-        onInitialLoadSuccess: (attemptId: number) => void;
-        onInitialLoadFailure: (attemptId: number, errorCode: number, error?: unknown) => void;
-    } | null,
+    windowedProps: null as MockNpeWindowedViewProps | null,
 }));
 
 const { mockUseNpe, mockUseNPETimelineFile, recordReportLoaded, recordReportLoadFailed } = vi.hoisted(() => ({
@@ -68,7 +79,7 @@ vi.mock('../src/components/npe/NPEViewComponent', () => ({
     default: () => <div data-testid={TEST_IDS.NPE_VIEW} />,
 }));
 vi.mock('../src/components/npe/NPEFileLoader', () => ({
-    default: ({ onUploadAccepted }: { onUploadAccepted: (fileName: string) => void }) => (
+    default: ({ onUploadAccepted }: MockNpeFileLoaderProps) => (
         <button
             onClick={() => {
                 onUploadAccepted('trace.json');
@@ -80,13 +91,7 @@ vi.mock('../src/components/npe/NPEFileLoader', () => ({
     ),
 }));
 vi.mock('../src/components/npe/NPEDemoSelect', () => ({
-    default: ({
-        setDemoData,
-        onDemoSelected,
-    }: {
-        setDemoData: (data: typeof minimalValidNpeData) => void;
-        onDemoSelected: () => void;
-    }) => (
+    default: ({ setDemoData, onDemoSelected }: MockNpeDemoSelectProps) => (
         <button
             onClick={() => {
                 onDemoSelected();

--- a/tests/NPERoute.spec.tsx
+++ b/tests/NPERoute.spec.tsx
@@ -12,11 +12,14 @@ import { minimalValidNpeData } from './helpers/npeFixtures';
 import { activeNpeOpTraceAtom } from '../src/store/app';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
+import { NPEValidationError } from '../src/definitions/NPEData';
 
 interface MockNpeWindowedViewProps {
-    loadAttemptId: number | null;
-    onInitialLoadSuccess: (attemptId: number) => void;
-    onInitialLoadFailure: (attemptId: number, errorCode: number, error?: unknown) => void;
+    loadAttempt: {
+        id: number | null;
+        complete: (attemptId: number) => void;
+        fail: (attemptId: number, errorCode: NPEValidationError, error?: unknown) => void;
+    };
 }
 
 interface MockNpeFileLoaderProps {
@@ -216,19 +219,19 @@ describe('NPE report-load recording', () => {
         renderRoute();
 
         fireEvent.click(screen.getByRole('button', { name: 'accept-npe-upload' }));
-        await waitFor(() => expect(h.windowedProps?.loadAttemptId).toBe(1));
-        const staleAttemptId = h.windowedProps?.loadAttemptId;
+        await waitFor(() => expect(h.windowedProps?.loadAttempt.id).toBe(1));
+        const staleAttemptId = h.windowedProps?.loadAttempt.id;
 
         fireEvent.click(screen.getByRole('button', { name: 'accept-npe-upload' }));
-        await waitFor(() => expect(h.windowedProps?.loadAttemptId).toBe(2));
+        await waitFor(() => expect(h.windowedProps?.loadAttempt.id).toBe(2));
 
-        h.windowedProps?.onInitialLoadSuccess(staleAttemptId ?? -1);
+        h.windowedProps?.loadAttempt.complete(staleAttemptId ?? -1);
         expect(recordReportLoaded).not.toHaveBeenCalled();
 
-        h.windowedProps?.onInitialLoadSuccess(2);
+        h.windowedProps?.loadAttempt.complete(2);
         expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.NPE, ReportSource.UPLOAD);
-        h.windowedProps?.onInitialLoadSuccess(2);
-        h.windowedProps?.onInitialLoadFailure(2, 1);
+        h.windowedProps?.loadAttempt.complete(2);
+        h.windowedProps?.loadAttempt.fail(2, NPEValidationError.DEFAULT);
         expect(recordReportLoaded).toHaveBeenCalledTimes(1);
         expect(recordReportLoadFailed).not.toHaveBeenCalled();
     });

--- a/tests/NpeWindowedView.spec.tsx
+++ b/tests/NpeWindowedView.spec.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AxiosError } from 'axios';
@@ -10,6 +10,7 @@ import NpeWindowedView from '../src/components/npe/NpeWindowedView';
 import { useNpeSummary, useNpeWindow } from '../src/hooks/useAPI';
 import { CommonInfo, NoCType, NpeSummary, NpeWindow } from '../src/model/NPEModel';
 import { TEST_IDS } from '../src/definitions/TestIds';
+import { NPEValidationError } from '../src/definitions/NPEData';
 
 vi.mock('../src/hooks/useAPI', () => ({
     useNpeSummary: vi.fn(),
@@ -57,6 +58,17 @@ const npeWindow: NpeWindow = {
 
 const mockedSummary = vi.mocked(useNpeSummary);
 const mockedWindow = vi.mocked(useNpeWindow);
+const onInitialLoadSuccess = vi.fn();
+const onInitialLoadFailure = vi.fn();
+
+const windowedView = (loadAttemptId: number | null = null) => (
+    <NpeWindowedView
+        fileName='trace.json'
+        loadAttemptId={loadAttemptId}
+        onInitialLoadSuccess={onInitialLoadSuccess}
+        onInitialLoadFailure={onInitialLoadFailure}
+    />
+);
 
 type SummaryHook = ReturnType<typeof useNpeSummary>;
 type WindowHook = ReturnType<typeof useNpeWindow>;
@@ -67,7 +79,7 @@ afterEach(() => {
 });
 
 describe('NpeWindowedView', () => {
-    it('surfaces index-build errors instead of an infinite spinner', () => {
+    it('surfaces and records index-build errors instead of an infinite spinner', async () => {
         mockedSummary.mockReturnValue({
             data: undefined,
             isLoading: false,
@@ -76,11 +88,19 @@ describe('NpeWindowedView', () => {
         } as SummaryHook);
         mockedWindow.mockReturnValue({ data: undefined, isError: false, error: null } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView(10));
 
         expect(screen.getByText('Unable to load NPE report')).toBeDefined();
         expect(screen.getByText('index build failed')).toBeDefined();
         expect(screen.queryByTestId(TEST_IDS.NPE_VIEW)).toBeNull();
+        await waitFor(() =>
+            expect(onInitialLoadFailure).toHaveBeenCalledWith(
+                10,
+                NPEValidationError.DEFAULT,
+                expect.objectContaining({ message: 'index build failed' }),
+            ),
+        );
+        expect(onInitialLoadFailure).toHaveBeenCalledTimes(1);
     });
 
     it('shows a building-index spinner while the summary loads', () => {
@@ -92,7 +112,7 @@ describe('NpeWindowedView', () => {
         } as SummaryHook);
         mockedWindow.mockReturnValue({ data: undefined, isError: false, error: null } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView());
 
         expect(screen.getByText('Processing…')).toBeDefined();
         expect(screen.queryByTestId(TEST_IDS.NPE_VIEW)).toBeNull();
@@ -107,10 +127,44 @@ describe('NpeWindowedView', () => {
         } as SummaryHook);
         mockedWindow.mockReturnValue({ data: npeWindow, isError: false, error: null } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView());
 
         // active_count = [0, 2, 0] → first active step is index 1.
         expect(screen.getByTestId(TEST_IDS.NPE_VIEW).textContent).toBe('step:1');
+    });
+
+    it('reports one successful initial load for the active attempt', async () => {
+        mockedSummary.mockReturnValue({
+            data: summary,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as SummaryHook);
+        mockedWindow.mockReturnValue({ data: npeWindow, isError: false, error: null } as WindowHook);
+
+        render(windowedView(7));
+
+        await waitFor(() => expect(onInitialLoadSuccess).toHaveBeenCalledWith(7));
+        expect(onInitialLoadSuccess).toHaveBeenCalledTimes(1);
+        expect(onInitialLoadFailure).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported summary version before counting the load', async () => {
+        mockedSummary.mockReturnValue({
+            data: { ...summary, common_info: { ...summary.common_info, version: '2.0.0' } },
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as SummaryHook);
+        mockedWindow.mockReturnValue({ data: npeWindow, isError: false, error: null } as WindowHook);
+
+        render(windowedView(8));
+
+        await waitFor(() =>
+            expect(onInitialLoadFailure).toHaveBeenCalledWith(8, NPEValidationError.INVALID_NPE_VERSION),
+        );
+        expect(onInitialLoadSuccess).not.toHaveBeenCalled();
+        expect(screen.getByTestId(TEST_IDS.NPE_PROCESSING_INVALID_VERSION)).toBeDefined();
     });
 
     it('degrades in place on a window error when a previous frame is available', () => {
@@ -128,15 +182,16 @@ describe('NpeWindowedView', () => {
             error: new Error('timestep 42 out of range') as AxiosError,
         } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView(9));
 
         expect(screen.getByText('Timestep failed to load')).toBeDefined();
         expect(screen.getByText(/timestep 42 out of range/)).toBeDefined();
         // The scrubber-bearing view is still rendered so the user can recover.
         expect(screen.getByTestId(TEST_IDS.NPE_VIEW)).toBeDefined();
+        expect(onInitialLoadFailure).not.toHaveBeenCalled();
     });
 
-    it('shows an empty-report notice for a zero-timestep trace', () => {
+    it('shows and records an empty-report notice for a zero-timestep trace', async () => {
         const emptySummary: NpeSummary = {
             ...summary,
             n_timesteps: 0,
@@ -158,18 +213,19 @@ describe('NpeWindowedView', () => {
         } as SummaryHook);
         mockedWindow.mockReturnValue({ data: undefined, isError: false, error: null } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView(11));
 
         expect(screen.getByTestId(TEST_IDS.NPE_PROCESSING_EMPTY_TRACE)).toBeDefined();
         expect(screen.getByText('Empty NPE trace')).toBeDefined();
         expect(screen.queryByTestId(TEST_IDS.NPE_VIEW)).toBeNull();
+        await waitFor(() => expect(onInitialLoadFailure).toHaveBeenCalledWith(11, NPEValidationError.EMPTY_NPE_TRACE));
     });
 
     it('re-clamps the selected timestep when a new (shorter) summary arrives', () => {
         // Report A: 3 steps, auto-jumps to the active step 1.
         mockedSummary.mockReturnValue({ data: summary, isLoading: false, isError: false, error: null } as SummaryHook);
         mockedWindow.mockReturnValue({ data: npeWindow, isError: false, error: null } as WindowHook);
-        const { rerender } = render(<NpeWindowedView fileName='trace.json' />);
+        const { rerender } = render(windowedView());
         expect(screen.getByTestId(TEST_IDS.NPE_VIEW).textContent).toBe('step:1');
 
         // Same-name re-upload → fresh summary object with a single idle step. The
@@ -189,13 +245,13 @@ describe('NpeWindowedView', () => {
         };
         mockedSummary.mockReturnValue({ data: shorter, isLoading: false, isError: false, error: null } as SummaryHook);
         act(() => {
-            rerender(<NpeWindowedView fileName='trace.json' />);
+            rerender(windowedView());
         });
 
         expect(screen.getByTestId(TEST_IDS.NPE_VIEW).textContent).toBe('step:0');
     });
 
-    it('surfaces a first-window error when no frame has loaded yet', () => {
+    it('surfaces and records a first-window error when no frame has loaded yet', async () => {
         mockedSummary.mockReturnValue({
             data: summary,
             isLoading: false,
@@ -208,11 +264,18 @@ describe('NpeWindowedView', () => {
             error: new Error('window fetch failed') as AxiosError,
         } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView(12));
 
         expect(screen.getByText('Unable to load NPE timestep')).toBeDefined();
         expect(screen.getByText('window fetch failed')).toBeDefined();
         expect(screen.queryByTestId(TEST_IDS.NPE_VIEW)).toBeNull();
+        await waitFor(() =>
+            expect(onInitialLoadFailure).toHaveBeenCalledWith(
+                12,
+                NPEValidationError.DEFAULT,
+                expect.objectContaining({ message: 'window fetch failed' }),
+            ),
+        );
     });
 
     it('keeps showing Processing… when a window errors while the summary is still loading', () => {
@@ -231,7 +294,7 @@ describe('NpeWindowedView', () => {
             error: new Error('timestep 0 out of range') as AxiosError,
         } as WindowHook);
 
-        render(<NpeWindowedView fileName='trace.json' />);
+        render(windowedView());
 
         expect(screen.getByText('Processing…')).toBeDefined();
         expect(screen.queryByText('Unable to load NPE timestep')).toBeNull();

--- a/tests/NpeWindowedView.spec.tsx
+++ b/tests/NpeWindowedView.spec.tsx
@@ -64,9 +64,11 @@ const onInitialLoadFailure = vi.fn();
 const windowedView = (loadAttemptId: number | null = null) => (
     <NpeWindowedView
         fileName='trace.json'
-        loadAttemptId={loadAttemptId}
-        onInitialLoadSuccess={onInitialLoadSuccess}
-        onInitialLoadFailure={onInitialLoadFailure}
+        loadAttempt={{
+            id: loadAttemptId,
+            complete: onInitialLoadSuccess,
+            fail: onInitialLoadFailure,
+        }}
     />
 );
 
@@ -145,7 +147,6 @@ describe('NpeWindowedView', () => {
         render(windowedView(7));
 
         await waitFor(() => expect(onInitialLoadSuccess).toHaveBeenCalledWith(7));
-        expect(onInitialLoadSuccess).toHaveBeenCalledTimes(1);
         expect(onInitialLoadFailure).not.toHaveBeenCalled();
     });
 

--- a/tests/getNpeReportLoadFailureReason.spec.ts
+++ b/tests/getNpeReportLoadFailureReason.spec.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { AxiosError, HttpStatusCode } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { NPEValidationError } from '../src/definitions/NPEData';
+import { ReportLoadFailureReason } from '../src/definitions/UsageEvent';
+import getNpeReportLoadFailureReason from '../src/functions/getNpeReportLoadFailureReason';
+
+const getAxiosError = (status: number): AxiosError => {
+    const error = new AxiosError('private response message');
+    error.status = status;
+    return error;
+};
+
+describe('getNpeReportLoadFailureReason', () => {
+    it.each([
+        [NPEValidationError.INVALID_NPE_VERSION, ReportLoadFailureReason.UNSUPPORTED_VERSION],
+        [NPEValidationError.INVALID_JSON, ReportLoadFailureReason.PARSE_ERROR],
+        [NPEValidationError.INVALID_NPE_DATA, ReportLoadFailureReason.PARSE_ERROR],
+        [NPEValidationError.EMPTY_NPE_TRACE, ReportLoadFailureReason.OTHER],
+        [NPEValidationError.OK, ReportLoadFailureReason.OTHER],
+        [NPEValidationError.DEFAULT, ReportLoadFailureReason.OTHER],
+    ])('maps validation error %i to %s', (validationError, expected) => {
+        expect(getNpeReportLoadFailureReason(validationError)).toBe(expected);
+    });
+
+    it('uses the HTTP failure when validation has no more specific reason', () => {
+        expect(getNpeReportLoadFailureReason(NPEValidationError.DEFAULT, getAxiosError(HttpStatusCode.NotFound))).toBe(
+            ReportLoadFailureReason.MISSING_FILE,
+        );
+    });
+
+    it('classifies the NPE endpoint 422 contract as a parse error', () => {
+        expect(
+            getNpeReportLoadFailureReason(
+                NPEValidationError.DEFAULT,
+                getAxiosError(HttpStatusCode.UnprocessableEntity),
+            ),
+        ).toBe(ReportLoadFailureReason.PARSE_ERROR);
+    });
+});

--- a/tests/helpers/mockReportLoadUsage.ts
+++ b/tests/helpers/mockReportLoadUsage.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import axios from 'axios';
+import { Mock } from 'vitest';
+import type * as ReportLoadUsage from '../../src/functions/reportLoadUsage';
+import { ReportKind } from '../../src/definitions/UsageEvent';
+
+type ReportLoadUsageModule = typeof ReportLoadUsage;
+
+/**
+ * Keep the real classifiers while spying on record calls. `recordReportLoadFailure`
+ * has to be re-wired here: the original closes over the unmocked `recordReportLoadFailed`.
+ */
+export async function reportLoadUsageSpiesMock(
+    importOriginal: () => Promise<ReportLoadUsageModule>,
+    recordReportLoaded: Mock,
+    recordReportLoadFailed: Mock,
+): Promise<ReportLoadUsageModule> {
+    const actual = await importOriginal();
+
+    return {
+        ...actual,
+        recordReportLoaded,
+        recordReportLoadFailed,
+        recordReportLoadFailure: (kind: ReportKind, error: unknown) => {
+            if (axios.isCancel(error)) {
+                return;
+            }
+
+            recordReportLoadFailed(kind, actual.getReportLoadFailureReason(error));
+        },
+    };
+}

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -25,6 +25,7 @@ import { getDeleteActionLabel } from '../src/functions/managedEntityLabels';
 import { isActivatingReportAtom } from '../src/store/app';
 import testForPortal from './helpers/testForPortal';
 import createMockFile, { MOCK_FOLDER } from './helpers/createMockFile';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
 
 // Scrub the markup after each test
 const WAIT_FOR_OPTIONS = { timeout: 1000 };
@@ -35,11 +36,20 @@ const mockPerfFolderList = [...mockPerformanceReportFolders];
 
 // The folder list is the mocked query's only source of truth, so deleting has to remove from it
 // for anything downstream of the delete to be observable.
-const { mockUpdateInstance, mockDeleteProfiler, mockDeletePerformance, mockProfilerFolders } = vi.hoisted(() => ({
+const {
+    mockUpdateInstance,
+    mockDeleteProfiler,
+    mockDeletePerformance,
+    mockProfilerFolders,
+    recordReportLoaded,
+    recordReportLoadFailed,
+} = vi.hoisted(() => ({
     mockUpdateInstance: vi.fn(),
     mockDeleteProfiler: vi.fn(),
     mockDeletePerformance: vi.fn(),
     mockProfilerFolders: [] as { path: string; reportName: string }[],
+    recordReportLoaded: vi.fn(),
+    recordReportLoadFailed: vi.fn(),
 }));
 
 vi.mock('../src/hooks/useLocal', async () => {
@@ -83,6 +93,12 @@ vi.mock('../src/hooks/useAPI', async () => {
     };
 });
 
+vi.mock('../src/functions/reportLoadUsage', () => ({
+    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
+    recordReportLoaded,
+    recordReportLoadFailed,
+}));
+
 const defaultUpdateInstance = (updates: {
     active_report?: { profiler_name?: string | { path: string }; performance_name?: string | { path: string } };
 }) => {
@@ -113,6 +129,8 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+    recordReportLoaded.mockClear();
+    recordReportLoadFailed.mockClear();
     // Restore both lists in place: the mock factories closed over these array references.
     mockProfilerFolders.splice(0, mockProfilerFolders.length, ...mockProfilerFolderList);
     mockPerfFolderList.splice(0, mockPerfFolderList.length, ...mockPerformanceReportFolders);
@@ -239,6 +257,8 @@ it('updates the instance when a profiler report is selected and creates toast me
 
     expect(getAllButtonsWithText(reportName)).toHaveLength(1);
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(1);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PROFILER, ReportSource.LOCAL_TT_METAL);
+    expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
 it('updates the instance when a performance report is selected and creates toast message', async () => {
@@ -263,6 +283,8 @@ it('updates the instance when a performance report is selected and creates toast
 
     expect(getAllButtonsWithText(path)).toHaveLength(1);
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(1);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportSource.LOCAL_TT_METAL);
+    expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
 it('handles invalid memory report upload', async () => {
@@ -288,6 +310,21 @@ it('handles invalid memory report upload', async () => {
     );
 
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(2);
+    expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PROFILER, ReportLoadFailureReason.MISSING_FILE);
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+});
+
+it('does not record cancelling a local file picker as a failed load', () => {
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    fireEvent.change(screen.getByTestId(TEST_IDS.LOCAL_PROFILER_UPLOAD), { target: { files: [] } });
+    fireEvent.change(screen.getByTestId(TEST_IDS.LOCAL_PERFORMANCE_UPLOAD), { target: { files: [] } });
+
+    expect(recordReportLoadFailed).not.toHaveBeenCalled();
 });
 
 it('handles valid memory report upload', async () => {
@@ -318,6 +355,8 @@ it('handles valid memory report upload', async () => {
     const { reportName } = mockProfilerFolderList[0];
     expect(getAllButtonsWithText(reportName)).toHaveLength(1);
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(1);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PROFILER, ReportSource.UPLOAD);
+    expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
 it('handles invalid performance report upload', async () => {
@@ -341,6 +380,8 @@ it('handles invalid performance report upload', async () => {
             ),
         WAIT_FOR_OPTIONS,
     );
+    expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportLoadFailureReason.MISSING_FILE);
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
 });
 
 it('handles valid performance report upload', async () => {
@@ -379,6 +420,8 @@ it('handles valid performance report upload', async () => {
 
     expect(getAllButtonsWithText(MOCK_FOLDER)).toHaveLength(1);
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(1);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportSource.UPLOAD);
+    expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
 it('handles valid performance report upload without tracy', async () => {

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { Classes } from '@blueprintjs/core';
-import { HttpStatusCode } from 'axios';
+import { AxiosError, HttpStatusCode } from 'axios';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { TestProviders } from './helpers/TestProviders';
@@ -17,9 +17,11 @@ import { CONFIRM_DELETE_LABEL, ManagedEntity } from '../src/definitions/ManagedE
 import {
     MEMORY_REPORT_DELETED_TOAST_TITLE,
     MEMORY_REPORT_DELETE_FAILED_TOAST_TITLE,
+    MEMORY_REPORT_LOAD_FAILED_TOAST_TITLE,
     PERFORMANCE_REPORT_DELETED_TOAST_TITLE,
     PERFORMANCE_REPORT_DELETE_FAILED_TOAST_TITLE,
 } from '../src/definitions/notifyActiveReport';
+import { ConnectionTestStates } from '../src/definitions/ConnectionStatus';
 import { TEST_IDS } from '../src/definitions/TestIds';
 import { getDeleteActionLabel } from '../src/functions/managedEntityLabels';
 import { isActivatingReportAtom } from '../src/store/app';
@@ -41,6 +43,7 @@ const {
     mockDeleteProfiler,
     mockDeletePerformance,
     mockProfilerFolders,
+    mockUploadLocalFolder,
     recordReportLoaded,
     recordReportLoadFailed,
 } = vi.hoisted(() => ({
@@ -48,6 +51,7 @@ const {
     mockDeleteProfiler: vi.fn(),
     mockDeletePerformance: vi.fn(),
     mockProfilerFolders: [] as { path: string; reportName: string }[],
+    mockUploadLocalFolder: vi.fn(),
     recordReportLoaded: vi.fn(),
     recordReportLoadFailed: vi.fn(),
 }));
@@ -58,7 +62,7 @@ vi.mock('../src/hooks/useLocal', async () => {
     return {
         default: () => ({
             ...actual.default(),
-            uploadLocalFolder: vi.fn().mockResolvedValue({ status: 200, data: mockProfilerFolderList[0] }),
+            uploadLocalFolder: (...args: unknown[]) => mockUploadLocalFolder(...args),
             uploadLocalPerformanceFolder: vi.fn().mockImplementation(() => {
                 // Add the uploaded folder to the mock list
                 const uploadedFolder = { path: MOCK_FOLDER, reportName: MOCK_FOLDER };
@@ -93,11 +97,11 @@ vi.mock('../src/hooks/useAPI', async () => {
     };
 });
 
-vi.mock('../src/functions/reportLoadUsage', () => ({
-    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
-    recordReportLoaded,
-    recordReportLoadFailed,
-}));
+vi.mock('../src/functions/reportLoadUsage', async (importOriginal) => {
+    const { reportLoadUsageSpiesMock } = await import('./helpers/mockReportLoadUsage');
+
+    return reportLoadUsageSpiesMock(importOriginal, recordReportLoaded, recordReportLoadFailed);
+});
 
 const defaultUpdateInstance = (updates: {
     active_report?: { profiler_name?: string | { path: string }; performance_name?: string | { path: string } };
@@ -131,6 +135,8 @@ afterEach(() => {
 beforeEach(() => {
     recordReportLoaded.mockClear();
     recordReportLoadFailed.mockClear();
+    mockUploadLocalFolder.mockReset();
+    mockUploadLocalFolder.mockResolvedValue({ status: 200, data: mockProfilerFolderList[0] });
     // Restore both lists in place: the mock factories closed over these array references.
     mockProfilerFolders.splice(0, mockProfilerFolders.length, ...mockProfilerFolderList);
     mockPerfFolderList.splice(0, mockPerfFolderList.length, ...mockPerformanceReportFolders);
@@ -305,6 +311,11 @@ it('records a failed profiler selection without reporting a successful load', as
     );
     expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
     expect(recordReportLoaded).not.toHaveBeenCalled();
+    await waitFor(
+        () => expect(screen.getByText(MEMORY_REPORT_LOAD_FAILED_TOAST_TITLE)).not.toBeNull(),
+        WAIT_FOR_OPTIONS,
+    );
+    expect(screen.getByTestId(TEST_IDS.TOAST_FILENAME).textContent).to.contain('update failed');
 });
 
 it('records a failed performance selection without reporting a successful load', async () => {
@@ -326,6 +337,38 @@ it('records a failed performance selection without reporting a successful load',
     );
     expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
     expect(recordReportLoaded).not.toHaveBeenCalled();
+});
+
+it('classifies a 404 local profiler activation as missing_file without recording the body', async () => {
+    const error = new AxiosError('gone');
+    error.status = HttpStatusCode.NotFound;
+    error.response = {
+        status: HttpStatusCode.NotFound,
+        data: { error: 'private response message' },
+        statusText: '',
+        headers: {},
+        config: error.config!,
+    };
+    mockUpdateInstance.mockRejectedValueOnce(error);
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    getAllButtonsWithText(SELECT_REPORT_TEXT)[0].click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+    screen.getByText(mockProfilerFolderList[0].reportName).click();
+
+    await waitFor(
+        () =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(
+                ReportKind.PROFILER,
+                ReportLoadFailureReason.MISSING_FILE,
+            ),
+        WAIT_FOR_OPTIONS,
+    );
+    expect(JSON.stringify(recordReportLoadFailed.mock.calls)).not.toContain('private response message');
 });
 
 it('handles invalid memory report upload', async () => {
@@ -398,6 +441,32 @@ it('handles valid memory report upload', async () => {
     expect(getAllButtonsWithText(SELECT_REPORT_TEXT)).toHaveLength(1);
     expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PROFILER, ReportSource.UPLOAD);
     expect(recordReportLoaded).toHaveBeenCalledTimes(1);
+});
+
+it('does not record a successful profiler upload when the payload status is failed', async () => {
+    mockUploadLocalFolder.mockResolvedValueOnce({
+        status: 200,
+        data: { status: ConnectionTestStates.FAILED, message: 'Invalid project directory.' },
+    });
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    fireEvent.change(screen.getByTestId(TEST_IDS.LOCAL_PROFILER_UPLOAD), {
+        target: { files: [createMockFile('db.sqlite', 'text/x-sqlite3')] },
+    });
+
+    await waitFor(
+        () =>
+            expect(screen.getByTestId(TEST_IDS.LOCAL_PROFILER_STATUS).textContent).to.equal(
+                'Selected directory does not contain a valid report',
+            ),
+        WAIT_FOR_OPTIONS,
+    );
+    expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PROFILER, ReportLoadFailureReason.MISSING_FILE);
+    expect(recordReportLoaded).not.toHaveBeenCalled();
 });
 
 it('handles invalid performance report upload', async () => {

--- a/tests/localFolderSelector.spec.tsx
+++ b/tests/localFolderSelector.spec.tsx
@@ -287,6 +287,47 @@ it('updates the instance when a performance report is selected and creates toast
     expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
+it('records a failed profiler selection without reporting a successful load', async () => {
+    mockUpdateInstance.mockRejectedValueOnce(new Error('update failed'));
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    getAllButtonsWithText(SELECT_REPORT_TEXT)[0].click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+    screen.getByText(mockProfilerFolderList[0].reportName).click();
+
+    await waitFor(
+        () => expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PROFILER, ReportLoadFailureReason.OTHER),
+        WAIT_FOR_OPTIONS,
+    );
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+    expect(recordReportLoaded).not.toHaveBeenCalled();
+});
+
+it('records a failed performance selection without reporting a successful load', async () => {
+    mockUpdateInstance.mockRejectedValueOnce(new Error('update failed'));
+    render(
+        <TestProviders>
+            <LocalFolderSelector />
+        </TestProviders>,
+    );
+
+    getAllButtonsWithText(SELECT_REPORT_TEXT)[1].click();
+    await waitFor(testForPortal, WAIT_FOR_OPTIONS);
+    screen.getByText(new RegExp(mockPerformanceReportFolders[0].path, 'i')).click();
+
+    await waitFor(
+        () =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportLoadFailureReason.OTHER),
+        WAIT_FOR_OPTIONS,
+    );
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+    expect(recordReportLoaded).not.toHaveBeenCalled();
+});
+
 it('handles invalid memory report upload', async () => {
     render(
         <TestProviders>

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -54,6 +54,7 @@ import { SshConfigHostsQueryResult, noSshConfigResult } from './helpers/sshConfi
 import testForPortal from './helpers/testForPortal';
 import { TestProviders } from './helpers/TestProviders';
 import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
+import { RemoteFolderType } from '../src/definitions/Reports';
 
 // Scrub the markup after each test
 afterEach(() => {
@@ -152,7 +153,7 @@ it('shows a loading spinner on the remote folder selector button when loading', 
                 remoteFolderList={mockRemoteProfilerFolderList as RemoteFolder[]}
                 loading
                 onSelectFolder={() => undefined}
-                type='profiler'
+                type={ReportKind.PROFILER}
             />
         </TestProviders>,
     );
@@ -1589,7 +1590,7 @@ const mockRemoteFolderApis = (url: string, selectedReport: RemoteFolder) => {
     return Promise.resolve({ data: [] } as AxiosResponse);
 };
 
-const selectRemoteFolder = async (type: 'profiler' | 'performance', remotePath: string) => {
+const selectRemoteFolder = async (type: RemoteFolderType, remotePath: string) => {
     const fetchButton = getButtonWithText(FETCH_REMOTE_FOLDERS);
     fetchButton.click();
 
@@ -1603,7 +1604,7 @@ const selectRemoteFolder = async (type: 'profiler' | 'performance', remotePath: 
     const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
     // Layout is [profiler, performance]. Default fixture has empty profilerPath so only
     // performance is enabled; when both paths exist both buttons enable.
-    const button = type === 'performance' ? enabledButtons[enabledButtons.length - 1] : selectButtons[0];
+    const button = type === ReportKind.PERFORMANCE ? enabledButtons[enabledButtons.length - 1] : selectButtons[0];
     expect(button).toBeDefined();
     expect(button).toHaveProperty(HTML_DISABLED, false);
     button!.click();
@@ -1613,8 +1614,8 @@ const selectRemoteFolder = async (type: 'profiler' | 'performance', remotePath: 
     screen.getByText(remotePath).click();
 };
 
-const selectProfilerFolder = (remotePath: string) => selectRemoteFolder('profiler', remotePath);
-const selectPerformanceFolder = (remotePath: string) => selectRemoteFolder('performance', remotePath);
+const selectProfilerFolder = (remotePath: string) => selectRemoteFolder(ReportKind.PROFILER, remotePath);
+const selectPerformanceFolder = (remotePath: string) => selectRemoteFolder(ReportKind.PERFORMANCE, remotePath);
 
 const MULTIHOST_ROOT = '/tt-metal/generated/profiler/ttrun';
 
@@ -1657,7 +1658,7 @@ const renderPerformanceSelector = async (
             <RemoteFolderSelector
                 remoteFolderList={folderList}
                 onSelectFolder={onSelectFolder}
-                type='performance'
+                type={ReportKind.PERFORMANCE}
             />
         </TestProviders>,
     );
@@ -1696,7 +1697,7 @@ it('names the selected rank on the collapsed button', () => {
                 remoteFolderList={multihostFolders}
                 remoteFolder={rankFolder(1)}
                 onSelectFolder={() => undefined}
-                type='performance'
+                type={ReportKind.PERFORMANCE}
             />
         </TestProviders>,
     );

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -5,7 +5,7 @@
 import '@testing-library/jest-dom/vitest';
 import { Classes } from '@blueprintjs/core';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { AxiosResponse, CanceledError } from 'axios';
+import { AxiosError, AxiosResponse, CanceledError, HttpStatusCode } from 'axios';
 import { useAtomValue } from 'jotai';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyncConfigurator';
@@ -123,11 +123,11 @@ vi.mock('../src/libs/axiosInstance', () => ({
     },
 }));
 
-vi.mock('../src/functions/reportLoadUsage', () => ({
-    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
-    recordReportLoaded,
-    recordReportLoadFailed,
-}));
+vi.mock('../src/functions/reportLoadUsage', async (importOriginal) => {
+    const { reportLoadUsageSpiesMock } = await import('./helpers/mockReportLoadUsage');
+
+    return reportLoadUsageSpiesMock(importOriginal, recordReportLoaded, recordReportLoadFailed);
+});
 
 // The edit dialog renders SshConfigHostPicker; without this it would issue a real request from
 // jsdom, and the picker would be absent because the query failed rather than because of a fixture.
@@ -1128,6 +1128,53 @@ it('shows Folder sync error when Sync and local mount both fail', async () => {
     }, WAIT_FOR_OPTIONS);
     expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportLoadFailureReason.OTHER);
     expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+});
+
+it('classifies a 404 remote mount as missing_file without recording the body', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+    const error = new AxiosError('gone');
+    error.status = HttpStatusCode.NotFound;
+    error.response = {
+        status: HttpStatusCode.NotFound,
+        data: { error: 'private response message' },
+        statusText: '',
+        headers: {},
+        config: error.config!,
+    };
+
+    const selectedReport: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    mockPost.mockImplementation((url: string) => {
+        if (url.includes('/api/remote/use')) {
+            return Promise.reject(error);
+        }
+
+        return mockRemoteFolderApis(url, selectedReport);
+    });
+
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+
+    await selectPerformanceFolder(selectedReport.remotePath);
+
+    await waitFor(
+        () =>
+            expect(recordReportLoadFailed).toHaveBeenCalledWith(
+                ReportKind.PERFORMANCE,
+                ReportLoadFailureReason.MISSING_FILE,
+            ),
+        WAIT_FOR_OPTIONS,
+    );
+    expect(JSON.stringify(recordReportLoadFailed.mock.calls)).not.toContain('private response message');
 });
 
 it('loads local synced reports when Fetch remote list fails but local list has folders', async () => {

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -5,7 +5,7 @@
 import '@testing-library/jest-dom/vitest';
 import { Classes } from '@blueprintjs/core';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { AxiosResponse } from 'axios';
+import { AxiosResponse, CanceledError } from 'axios';
 import { useAtomValue } from 'jotai';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import RemoteSyncConfigurator from '../src/components/report-selection/RemoteSyncConfigurator';
@@ -53,6 +53,7 @@ import {
 import { SshConfigHostsQueryResult, noSshConfigResult } from './helpers/sshConfigFixtures';
 import testForPortal from './helpers/testForPortal';
 import { TestProviders } from './helpers/TestProviders';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
 
 // Scrub the markup after each test
 afterEach(() => {
@@ -80,14 +81,21 @@ const IsActivatingReportProbe = () => {
     return <span data-testid={IS_ACTIVATING_REPORT_PROBE_TEST_ID}>{isActivatingReport ? 'true' : 'false'}</span>;
 };
 
-const { mockUseReportFolderList, mockUsePerfFolderList, mockUseInstance, mockUseReportMetadata } = vi.hoisted(() => {
-    return {
-        mockUseReportFolderList: vi.fn(),
-        mockUsePerfFolderList: vi.fn(),
-        mockUseInstance: vi.fn(),
-        mockUseReportMetadata: vi.fn(),
-    };
-});
+const {
+    mockUseReportFolderList,
+    mockUsePerfFolderList,
+    mockUseInstance,
+    mockUseReportMetadata,
+    recordReportLoaded,
+    recordReportLoadFailed,
+} = vi.hoisted(() => ({
+    mockUseReportFolderList: vi.fn(),
+    mockUsePerfFolderList: vi.fn(),
+    mockUseInstance: vi.fn(),
+    mockUseReportMetadata: vi.fn(),
+    recordReportLoaded: vi.fn(),
+    recordReportLoadFailed: vi.fn(),
+}));
 
 const useSshConfigHostsMock = vi.hoisted(() => vi.fn<(enabled?: boolean) => SshConfigHostsQueryResult>());
 
@@ -113,6 +121,12 @@ vi.mock('../src/libs/axiosInstance', () => ({
         // "axiosInstance.get is not a function" swallowed by a query's error state.
         get: vi.fn(),
     },
+}));
+
+vi.mock('../src/functions/reportLoadUsage', () => ({
+    getReportLoadFailureReason: () => ReportLoadFailureReason.OTHER,
+    recordReportLoaded,
+    recordReportLoadFailed,
 }));
 
 // The edit dialog renders SshConfigHostPicker; without this it would issue a real request from
@@ -698,6 +712,8 @@ it('disables remote report selectors while mount is confirming the active report
         });
         expect(screen.getByTestId(TEST_IDS.REMOTE_SYNC_BUTTON)).toHaveProperty(HTML_DISABLED, false);
     }, WAIT_FOR_OPTIONS);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportSource.REMOTE_SYNC);
+    expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
 it('re-enables remote report selectors when mount fails', async () => {
@@ -745,6 +761,39 @@ it('re-enables remote report selectors when mount fails', async () => {
         const enabledButtons = selectButtons.filter((btn) => !btn.hasAttribute(HTML_DISABLED));
         expect(enabledButtons.length).toBeGreaterThan(0);
     }, WAIT_FOR_OPTIONS);
+    expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportLoadFailureReason.OTHER);
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+});
+
+it('does not record a cancelled remote mount as a load failure', async () => {
+    const axiosInstance = await import('../src/libs/axiosInstance');
+    const mockPost = vi.mocked(axiosInstance.default.post);
+    const selectedReport: RemoteFolder = {
+        ...mockRemotePerformanceFolderList[0],
+        lastSynced: mockRemotePerformanceFolderList[0].lastModified + 1000,
+    };
+
+    mockPost.mockImplementation((url: string) =>
+        url.includes('/api/remote/use')
+            ? Promise.reject(new CanceledError())
+            : mockRemoteFolderApis(url, selectedReport),
+    );
+    setupConnection(remoteConnection);
+
+    render(
+        <TestProviders>
+            <RemoteSyncConfigurator />
+        </TestProviders>,
+    );
+    await selectPerformanceFolder(selectedReport.remotePath);
+    await waitFor(() => {
+        const enabledButtons = screen
+            .queryAllByTestId(TEST_IDS.REMOTE_FOLDER_SELECTOR_BUTTON)
+            .filter((button) => !button.hasAttribute(HTML_DISABLED));
+        expect(enabledButtons.length).toBeGreaterThan(0);
+    }, WAIT_FOR_OPTIONS);
+
+    expect(recordReportLoadFailed).not.toHaveBeenCalled();
 });
 
 it('mounts a previously synced outdated performance folder on selection without syncing', async () => {
@@ -775,6 +824,7 @@ it('mounts a previously synced outdated performance folder on selection without 
 
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(false);
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportSource.REMOTE_SYNC);
 });
 
 it('mounts a previously synced outdated memory folder on selection without syncing', async () => {
@@ -811,6 +861,7 @@ it('mounts a previously synced outdated memory folder on selection without synci
 
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(false);
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PROFILER, ReportSource.REMOTE_SYNC);
 });
 
 it('does not activate remote report when a local report is chosen mid-sync', async () => {
@@ -975,6 +1026,9 @@ it('falls back to the local copy when never-synced select sync fails', async () 
 
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/sync'))).toBe(true);
     expect(mockPost.mock.calls.some(([url]) => String(url).includes('/api/remote/use'))).toBe(true);
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportSource.REMOTE_SYNC);
+    expect(recordReportLoadFailed).not.toHaveBeenCalled();
+    expect(recordReportLoaded).toHaveBeenCalledTimes(1);
 });
 
 it('mounts the local copy and warns when Sync fails for a previously synced folder', async () => {
@@ -1072,6 +1126,8 @@ it('shows Folder sync error when Sync and local mount both fail', async () => {
         expect(screen.getByText(FOLDER_SYNC_ERROR_TOAST_TITLE)).not.toBeNull();
         expect(screen.queryByText(FOLDER_SYNC_LOCAL_FALLBACK_TOAST_TITLE)).toBeNull();
     }, WAIT_FOR_OPTIONS);
+    expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.PERFORMANCE, ReportLoadFailureReason.OTHER);
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
 });
 
 it('loads local synced reports when Fetch remote list fails but local list has folders', async () => {

--- a/tests/reportLoadUsage.spec.ts
+++ b/tests/reportLoadUsage.spec.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { AxiosError, HttpStatusCode } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getNpeReportLoadFailureReason,
+    getReportLoadFailureReason,
+    recordReportLoadFailed,
+    recordReportLoaded,
+} from '../src/functions/reportLoadUsage';
+import { ReportKind, ReportLoadFailureReason, ReportSource, UsageEvent } from '../src/definitions/UsageEvent';
+import { NPEValidationError } from '../src/definitions/NPEData';
+
+const { recordUsage } = vi.hoisted(() => ({ recordUsage: vi.fn() }));
+
+vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage }));
+
+const getAxiosError = (status: number, body: unknown = null): AxiosError => {
+    const error = new AxiosError('private response message');
+    error.response = {
+        status,
+        data: body,
+        statusText: '',
+        headers: {},
+        config: error.config!,
+    };
+    return error;
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('report-load usage payloads', () => {
+    it('records only the bounded kind and source for a successful load', () => {
+        recordReportLoaded(ReportKind.PROFILER, ReportSource.REMOTE_SYNC);
+
+        expect(recordUsage).toHaveBeenCalledWith({
+            event: UsageEvent.REPORT_LOADED,
+            details: { kind: ReportKind.PROFILER, source: ReportSource.REMOTE_SYNC },
+        });
+    });
+
+    it('records only the bounded kind and reason for a failed load', () => {
+        recordReportLoadFailed(ReportKind.NPE, ReportLoadFailureReason.PARSE_ERROR);
+
+        expect(recordUsage).toHaveBeenCalledWith({
+            event: UsageEvent.REPORT_LOAD_FAILED,
+            details: { kind: ReportKind.NPE, reason_class: ReportLoadFailureReason.PARSE_ERROR },
+        });
+        expect(JSON.stringify(recordUsage.mock.calls)).not.toContain('private response message');
+    });
+});
+
+describe('getReportLoadFailureReason', () => {
+    it.each([
+        [HttpStatusCode.Unauthorized, ReportLoadFailureReason.PERMISSION],
+        [HttpStatusCode.Forbidden, ReportLoadFailureReason.PERMISSION],
+        [HttpStatusCode.NotFound, ReportLoadFailureReason.MISSING_FILE],
+        [HttpStatusCode.PayloadTooLarge, ReportLoadFailureReason.TOO_LARGE],
+    ])('maps HTTP %i to %s', (status, expected) => {
+        expect(getReportLoadFailureReason(getAxiosError(status))).toBe(expected);
+    });
+
+    it('does not guess what an endpoint-specific 422 means', () => {
+        expect(
+            getReportLoadFailureReason(
+                getAxiosError(HttpStatusCode.UnprocessableEntity, { error: 'private response message' }),
+            ),
+        ).toBe(ReportLoadFailureReason.OTHER);
+    });
+
+    it('accepts an explicit 422 classification from a caller that knows its contract', () => {
+        expect(
+            getReportLoadFailureReason(getAxiosError(HttpStatusCode.UnprocessableEntity), {
+                unprocessableEntityReason: ReportLoadFailureReason.PARSE_ERROR,
+            }),
+        ).toBe(ReportLoadFailureReason.PARSE_ERROR);
+    });
+
+    it('uses the bounded fallback for transport and unknown failures', () => {
+        expect(getReportLoadFailureReason(new Error('private response message'))).toBe(ReportLoadFailureReason.OTHER);
+        expect(getReportLoadFailureReason(getAxiosError(HttpStatusCode.InternalServerError))).toBe(
+            ReportLoadFailureReason.OTHER,
+        );
+    });
+});
+
+describe('getNpeReportLoadFailureReason', () => {
+    it.each([
+        [NPEValidationError.INVALID_NPE_VERSION, ReportLoadFailureReason.UNSUPPORTED_VERSION],
+        [NPEValidationError.INVALID_JSON, ReportLoadFailureReason.PARSE_ERROR],
+        [NPEValidationError.INVALID_NPE_DATA, ReportLoadFailureReason.PARSE_ERROR],
+    ])('maps validation error %i to %s', (validationError, expected) => {
+        expect(getNpeReportLoadFailureReason(validationError)).toBe(expected);
+    });
+
+    it('uses the HTTP failure when validation has no more specific reason', () => {
+        expect(
+            getNpeReportLoadFailureReason(
+                NPEValidationError.DEFAULT,
+                getAxiosError(HttpStatusCode.NotFound, { error: 'private response message' }),
+            ),
+        ).toBe(ReportLoadFailureReason.MISSING_FILE);
+    });
+});

--- a/tests/reportLoadUsage.spec.ts
+++ b/tests/reportLoadUsage.spec.ts
@@ -2,12 +2,13 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { AxiosError, HttpStatusCode } from 'axios';
+import { AxiosError, CanceledError, HttpStatusCode } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     getNpeReportLoadFailureReason,
     getReportLoadFailureReason,
     recordReportLoadFailed,
+    recordReportLoadFailure,
     recordReportLoaded,
 } from '../src/functions/reportLoadUsage';
 import { ReportKind, ReportLoadFailureReason, ReportSource, UsageEvent } from '../src/definitions/UsageEvent';
@@ -19,6 +20,7 @@ vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage }));
 
 const getAxiosError = (status: number, body: unknown = null): AxiosError => {
     const error = new AxiosError('private response message');
+    error.status = status;
     error.response = {
         status,
         data: body,
@@ -44,11 +46,12 @@ describe('report-load usage payloads', () => {
     });
 
     it('records only the bounded kind and reason for a failed load', () => {
-        recordReportLoadFailed(ReportKind.NPE, ReportLoadFailureReason.PARSE_ERROR);
+        const error = getAxiosError(HttpStatusCode.InternalServerError, { error: 'private response message' });
+        recordReportLoadFailed(ReportKind.NPE, getNpeReportLoadFailureReason(NPEValidationError.DEFAULT, error));
 
         expect(recordUsage).toHaveBeenCalledWith({
             event: UsageEvent.REPORT_LOAD_FAILED,
-            details: { kind: ReportKind.NPE, reason_class: ReportLoadFailureReason.PARSE_ERROR },
+            details: { kind: ReportKind.NPE, reason_class: ReportLoadFailureReason.OTHER },
         });
         expect(JSON.stringify(recordUsage.mock.calls)).not.toContain('private response message');
     });
@@ -104,5 +107,26 @@ describe('getNpeReportLoadFailureReason', () => {
                 getAxiosError(HttpStatusCode.NotFound, { error: 'private response message' }),
             ),
         ).toBe(ReportLoadFailureReason.MISSING_FILE);
+    });
+});
+
+describe('recordReportLoadFailure', () => {
+    it('skips axios cancels', () => {
+        recordReportLoadFailure(ReportKind.PROFILER, new CanceledError('aborted'));
+
+        expect(recordUsage).not.toHaveBeenCalled();
+    });
+
+    it('classifies an HTTP error without recording the response body', () => {
+        recordReportLoadFailure(
+            ReportKind.PROFILER,
+            getAxiosError(HttpStatusCode.NotFound, { error: 'private response message' }),
+        );
+
+        expect(recordUsage).toHaveBeenCalledWith({
+            event: UsageEvent.REPORT_LOAD_FAILED,
+            details: { kind: ReportKind.PROFILER, reason_class: ReportLoadFailureReason.MISSING_FILE },
+        });
+        expect(JSON.stringify(recordUsage.mock.calls)).not.toContain('private response message');
     });
 });

--- a/tests/reportLoadUsage.spec.ts
+++ b/tests/reportLoadUsage.spec.ts
@@ -5,14 +5,12 @@
 import { AxiosError, CanceledError, HttpStatusCode } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-    getNpeReportLoadFailureReason,
     getReportLoadFailureReason,
     recordReportLoadFailed,
     recordReportLoadFailure,
     recordReportLoaded,
 } from '../src/functions/reportLoadUsage';
 import { ReportKind, ReportLoadFailureReason, ReportSource, UsageEvent } from '../src/definitions/UsageEvent';
-import { NPEValidationError } from '../src/definitions/NPEData';
 
 const { recordUsage } = vi.hoisted(() => ({ recordUsage: vi.fn() }));
 
@@ -47,7 +45,7 @@ describe('report-load usage payloads', () => {
 
     it('records only the bounded kind and reason for a failed load', () => {
         const error = getAxiosError(HttpStatusCode.InternalServerError, { error: 'private response message' });
-        recordReportLoadFailed(ReportKind.NPE, getNpeReportLoadFailureReason(NPEValidationError.DEFAULT, error));
+        recordReportLoadFailed(ReportKind.NPE, getReportLoadFailureReason(error));
 
         expect(recordUsage).toHaveBeenCalledWith({
             event: UsageEvent.REPORT_LOAD_FAILED,
@@ -75,38 +73,11 @@ describe('getReportLoadFailureReason', () => {
         ).toBe(ReportLoadFailureReason.OTHER);
     });
 
-    it('accepts an explicit 422 classification from a caller that knows its contract', () => {
-        expect(
-            getReportLoadFailureReason(getAxiosError(HttpStatusCode.UnprocessableEntity), {
-                unprocessableEntityReason: ReportLoadFailureReason.PARSE_ERROR,
-            }),
-        ).toBe(ReportLoadFailureReason.PARSE_ERROR);
-    });
-
     it('uses the bounded fallback for transport and unknown failures', () => {
         expect(getReportLoadFailureReason(new Error('private response message'))).toBe(ReportLoadFailureReason.OTHER);
         expect(getReportLoadFailureReason(getAxiosError(HttpStatusCode.InternalServerError))).toBe(
             ReportLoadFailureReason.OTHER,
         );
-    });
-});
-
-describe('getNpeReportLoadFailureReason', () => {
-    it.each([
-        [NPEValidationError.INVALID_NPE_VERSION, ReportLoadFailureReason.UNSUPPORTED_VERSION],
-        [NPEValidationError.INVALID_JSON, ReportLoadFailureReason.PARSE_ERROR],
-        [NPEValidationError.INVALID_NPE_DATA, ReportLoadFailureReason.PARSE_ERROR],
-    ])('maps validation error %i to %s', (validationError, expected) => {
-        expect(getNpeReportLoadFailureReason(validationError)).toBe(expected);
-    });
-
-    it('uses the HTTP failure when validation has no more specific reason', () => {
-        expect(
-            getNpeReportLoadFailureReason(
-                NPEValidationError.DEFAULT,
-                getAxiosError(HttpStatusCode.NotFound, { error: 'private response message' }),
-            ),
-        ).toBe(ReportLoadFailureReason.MISSING_FILE);
     });
 });
 

--- a/tests/useNpeLoadAttempt.spec.ts
+++ b/tests/useNpeLoadAttempt.spec.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { NPEValidationError } from '../src/definitions/NPEData';
+import { ReportKind, ReportLoadFailureReason, ReportSource } from '../src/definitions/UsageEvent';
+import useNpeLoadAttempt from '../src/hooks/useNpeLoadAttempt';
+
+const { recordReportLoaded, recordReportLoadFailed } = vi.hoisted(() => ({
+    recordReportLoaded: vi.fn(),
+    recordReportLoadFailed: vi.fn(),
+}));
+
+vi.mock('../src/functions/reportLoadUsage', async (importOriginal) => {
+    const { reportLoadUsageSpiesMock } = await import('./helpers/mockReportLoadUsage');
+
+    return reportLoadUsageSpiesMock(importOriginal, recordReportLoaded, recordReportLoadFailed);
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+it('settles an active failure at most once', () => {
+    const { result } = renderHook(() => useNpeLoadAttempt());
+
+    act(() => result.current.begin(ReportSource.UPLOAD));
+    const attemptId = result.current.controller.id;
+    expect(attemptId).not.toBeNull();
+
+    act(() => result.current.controller.fail(attemptId ?? -1, NPEValidationError.INVALID_JSON));
+    act(() => {
+        result.current.controller.fail(attemptId ?? -1, NPEValidationError.DEFAULT);
+        result.current.controller.complete(attemptId ?? -1);
+    });
+
+    expect(recordReportLoadFailed).toHaveBeenCalledTimes(1);
+    expect(recordReportLoadFailed).toHaveBeenCalledWith(ReportKind.NPE, ReportLoadFailureReason.PARSE_ERROR);
+    expect(recordReportLoaded).not.toHaveBeenCalled();
+});
+
+it('ignores stale failures after a newer attempt begins', () => {
+    const { result } = renderHook(() => useNpeLoadAttempt());
+
+    act(() => result.current.begin(ReportSource.UPLOAD));
+    const staleAttemptId = result.current.controller.id;
+    act(() => result.current.begin(ReportSource.DEMO));
+    const activeAttemptId = result.current.controller.id;
+
+    act(() => result.current.controller.fail(staleAttemptId ?? -1, NPEValidationError.INVALID_JSON));
+    expect(recordReportLoadFailed).not.toHaveBeenCalled();
+
+    act(() => result.current.controller.complete(activeAttemptId ?? -1));
+    expect(recordReportLoaded).toHaveBeenCalledOnce();
+    expect(recordReportLoaded).toHaveBeenCalledWith(ReportKind.NPE, ReportSource.DEMO);
+});

--- a/tests/useRestoreInstance.spec.tsx
+++ b/tests/useRestoreInstance.spec.tsx
@@ -12,9 +12,11 @@ import type { GraphBundle } from '../src/model/MLIRJsonModel';
 
 const mockResetMemoryListStates = vi.fn();
 
-const { mockUseInstance, mockUseReportFolderList } = vi.hoisted(() => ({
+const { mockUseInstance, mockUseReportFolderList, recordReportLoaded, recordReportLoadFailed } = vi.hoisted(() => ({
     mockUseInstance: vi.fn(),
     mockUseReportFolderList: vi.fn(),
+    recordReportLoaded: vi.fn(),
+    recordReportLoadFailed: vi.fn(),
 }));
 
 vi.mock('../src/hooks/useAPI', () => ({
@@ -29,6 +31,11 @@ vi.mock('../src/hooks/useRemote', () => ({
             getSavedReportFolders: () => [],
         },
     }),
+}));
+
+vi.mock('../src/functions/reportLoadUsage', () => ({
+    recordReportLoaded,
+    recordReportLoadFailed,
 }));
 
 vi.mock('../src/hooks/useRestoreScrollPosition', async () => {
@@ -103,6 +110,33 @@ it('does not reset memory list state during initial instance hydration', async (
     });
 
     expect(mockResetMemoryListStates).toHaveBeenCalledTimes(0);
+});
+
+it('does not record restored reports as user-initiated loads', async () => {
+    mockUseInstance.mockReturnValue({
+        data: {
+            active_report: {
+                profiler_name: 'restored-profiler',
+                profiler_location: 'local',
+                performance_name: 'restored-performance',
+                performance_location: 'local',
+                npe_name: 'restored-npe',
+                mlir_name: 'restored-mlir',
+            },
+            remote_profiler_folder: null,
+        },
+        isLoading: false,
+    });
+
+    render(
+        <TestProviders>
+            <HookHarness />
+        </TestProviders>,
+    );
+
+    await waitFor(() => expect(screen.getByText('restored')).toBeTruthy());
+    expect(recordReportLoaded).not.toHaveBeenCalled();
+    expect(recordReportLoadFailed).not.toHaveBeenCalled();
 });
 
 it('resets memory list state on first report change after null baseline', async () => {

--- a/tests/useRestoreInstance.spec.tsx
+++ b/tests/useRestoreInstance.spec.tsx
@@ -9,6 +9,8 @@ import { TestProviders } from './helpers/TestProviders';
 import useRestoreInstance from '../src/hooks/useRestoreInstance';
 import { activeProfilerReportAtom, mlirLoadedReportsAtom } from '../src/store/app';
 import type { GraphBundle } from '../src/model/MLIRJsonModel';
+import ProtectedRoute from '../src/components/ProtectedRoute';
+import ROUTES from '../src/definitions/Routes';
 
 const mockResetMemoryListStates = vi.fn();
 
@@ -137,6 +139,82 @@ it('does not record restored reports as user-initiated loads', async () => {
     await waitFor(() => expect(screen.getByText('restored')).toBeTruthy());
     expect(recordReportLoaded).not.toHaveBeenCalled();
     expect(recordReportLoadFailed).not.toHaveBeenCalled();
+});
+
+it('keeps report selection unavailable until instance restoration has settled', async () => {
+    mockUseReportFolderList.mockReturnValue({ data: null });
+    mockUseInstance.mockReturnValue({
+        data: {
+            active_report: {
+                profiler_name: 'restored-profiler',
+                profiler_location: 'local',
+                performance_name: null,
+                performance_location: null,
+                npe_name: null,
+            },
+            remote_profiler_folder: null,
+        },
+        isLoading: false,
+    });
+
+    const getProtectedSelection = () => (
+        <TestProviders>
+            <ProtectedRoute>
+                <button type='button'>choose-report</button>
+            </ProtectedRoute>
+        </TestProviders>
+    );
+    const { rerender } = render(getProtectedSelection());
+
+    expect(screen.queryByRole('button', { name: 'choose-report' })).toBeNull();
+    expect(screen.getByText('Initializing instance...')).toBeTruthy();
+
+    mockUseReportFolderList.mockReturnValue({ data: [] });
+    rerender(getProtectedSelection());
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'choose-report' })).toBeTruthy());
+    expect(recordReportLoaded).not.toHaveBeenCalled();
+    expect(recordReportLoadFailed).not.toHaveBeenCalled();
+});
+
+it('shows restoration progress before evaluating report-required redirects', () => {
+    mockUseReportFolderList.mockReturnValue({ data: null });
+    mockUseInstance.mockReturnValue({
+        data: {
+            active_report: {
+                profiler_name: null,
+                profiler_location: null,
+                performance_name: null,
+                performance_location: null,
+                npe_name: null,
+            },
+            remote_profiler_folder: null,
+        },
+        isLoading: false,
+    });
+
+    render(
+        <TestProviders initialEntries={[ROUTES.OPERATIONS]}>
+            <ProtectedRoute>
+                <div>operations</div>
+            </ProtectedRoute>
+        </TestProviders>,
+    );
+
+    expect(screen.getByText('Initializing instance...')).toBeTruthy();
+    expect(screen.queryByText('operations')).toBeNull();
+});
+
+it('restores the instance when the report list is unavailable', async () => {
+    mockUseReportFolderList.mockReturnValue({ data: null, isError: true });
+
+    render(
+        <TestProviders>
+            <HookHarness />
+        </TestProviders>,
+    );
+
+    await waitFor(() => expect(screen.getByText('restored')).toBeTruthy());
 });
 
 it('resets memory list state on first report change after null baseline', async () => {


### PR DESCRIPTION
## Summary
- record successful report loads with bounded report kind and source values across local, remote, NPE, and MLIR flows
- classify report load failures without recording response bodies or stack traces
- preserve exact-once semantics for user-initiated NPE and MLIR loads while excluding boot restoration
- add regression coverage for success, failure, cancellation, stale attempts, and multi-file cardinality

## Testing
- `pnpm lint`
- `pnpm lint:ts`
- `pnpm test` (211 files, 2,411 tests)

Closes #1831