### PR TITLE
Record view-opened usage by route

### DIFF
--- a/backend/ttnn_visualizer/usage.py
+++ b/backend/ttnn_visualizer/usage.py
@@ -271,7 +271,9 @@ class UsageView(str, Enum):
 
     ``OPERATION_DETAILS`` is a real route and is owned by ``view_opened``. A future
     ``drilldown_opened`` event must exclude it, or one navigation would be counted
-    as two different actions.
+    as two different actions. It counts once per operation viewed rather than once
+    per visit to the surface, so its total is not comparable to the other nine and
+    should be read per-session or deduplicated.
     """
 
     REPORTS = "reports"

--- a/backend/ttnn_visualizer/usage.py
+++ b/backend/ttnn_visualizer/usage.py
@@ -269,9 +269,9 @@ class UsageView(str, Enum):
     and ``BUFFERS`` deliberately differ in name from their paths (``/graphtree``,
     ``/buffer-summary``) because the enum names the surface, not the URL.
 
-    ``OPERATION_DETAILS`` is a real route and so belongs here, but it is also a
-    Tier 3 drill-down target. Whichever issue adds ``drilldown_opened`` has to
-    decide which event owns it, or the same click is counted twice.
+    ``OPERATION_DETAILS`` is a real route and is owned by ``view_opened``. A future
+    ``drilldown_opened`` event must exclude it, or one navigation would be counted
+    as two different actions.
     """
 
     REPORTS = "reports"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,6 +18,8 @@ import FeedbackButton from './FeedbackButton';
 import FileStatusOverlay from './FileStatusOverlay';
 import MlirFileResultsOverlay from './mlir/MlirFileResultsOverlay';
 import { initUsageRecording } from '../functions/recordUsage';
+import useRecordViewOpened from '../hooks/useRecordViewOpened';
+import { isModalOpen } from '../functions/modalRoute';
 
 const BounceIn = cssTransition({
     enter: `Toastify--animate Toastify__bounce-enter`,
@@ -29,12 +31,14 @@ const BounceIn = cssTransition({
 
 function Layout() {
     const location = useLocation();
-    const state = location.state as { background?: Location };
+    const isTopologyOpen = isModalOpen(location, ROUTES.CLUSTER);
 
     // Starts the usage flush lifecycle; it records nothing on its own. Here rather than at
     // module scope so importing the sender has no side effect, and so the listeners are
     // owned the way every other listener in this app is.
     useEffect(() => initUsageRecording(), []);
+
+    useRecordViewOpened();
 
     return (
         <>
@@ -58,7 +62,7 @@ function Layout() {
 
                 <main>
                     <ModalAwareOutlet />
-                    {location.pathname === ROUTES.CLUSTER && state?.background && <ClusterRenderer />}
+                    {isTopologyOpen && <ClusterRenderer />}
                 </main>
             </div>
 

--- a/src/definitions/Routes.ts
+++ b/src/definitions/Routes.ts
@@ -15,4 +15,13 @@ const ROUTES = Object.freeze({
     CLUSTER: '/cluster',
 });
 
+// Parameterised shapes are shared by React Router and usage-view matching. Keeping them
+// here means changing a route cannot silently leave instrumentation matching its old URL.
+export const ROUTE_PATTERNS = Object.freeze({
+    OPERATION_DETAILS: `${ROUTES.OPERATIONS}/:operationId`,
+    GRAPHTREE: `${ROUTES.GRAPHTREE}/:operationId?`,
+    NPE: `${ROUTES.NPE}/:filepath?`,
+    MLIR: `${ROUTES.MLIR}/:filepath?`,
+});
+
 export default ROUTES;

--- a/src/definitions/UsageEvent.ts
+++ b/src/definitions/UsageEvent.ts
@@ -62,6 +62,9 @@ export enum ReportLoadFailureReason {
  *
  * `styleguide` is excluded and stays excluded: counting a development surface would
  * pollute reach.
+ *
+ * `OPERATION_DETAILS` is owned by `view_opened`. A future `drilldown_opened` event must
+ * exclude it, or one navigation would be counted as two different actions.
  */
 export enum UsageView {
     REPORTS = 'reports',

--- a/src/definitions/UsageEvent.ts
+++ b/src/definitions/UsageEvent.ts
@@ -64,7 +64,9 @@ export enum ReportLoadFailureReason {
  * pollute reach.
  *
  * `OPERATION_DETAILS` is owned by `view_opened`. A future `drilldown_opened` event must
- * exclude it, or one navigation would be counted as two different actions.
+ * exclude it, or one navigation would be counted as two different actions. It counts
+ * once per operation viewed rather than once per visit to the surface, so its total is
+ * not comparable to the other nine and should be read per-session or deduplicated.
  */
 export enum UsageView {
     REPORTS = 'reports',

--- a/src/functions/modalRoute.ts
+++ b/src/functions/modalRoute.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type { Location } from 'react-router';
+
+interface ModalLocationState {
+    background?: Location;
+}
+
+export function getModalBackground(location: Location): Location | null {
+    const state = location.state as ModalLocationState | null;
+    return state?.background ?? null;
+}
+
+export function isModalOpen(location: Location, modalPath: string): boolean {
+    return location.pathname === modalPath && getModalBackground(location) !== null;
+}
+
+export function isReturningFromModal(previous: Location, current: Location, modalPath: string): boolean {
+    const background = getModalBackground(previous);
+
+    // The key identifies the exact history entry behind the modal. Comparing only
+    // pathnames would also suppress a real navigation to the same path with different
+    // search parameters or state.
+    return previous.pathname === modalPath && background?.key === current.key;
+}

--- a/src/functions/modalRoute.ts
+++ b/src/functions/modalRoute.ts
@@ -3,25 +3,34 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import type { Location } from 'react-router';
+import { NAVIGATION_ITEMS } from '../definitions/NavigationItems';
 
-interface ModalLocationState {
+export interface ModalLocationState {
     background?: Location;
 }
 
-export function getModalBackground(location: Location): Location | null {
+export const MODAL_ROUTES: readonly string[] = Object.freeze(
+    NAVIGATION_ITEMS.filter((item) => item.isModal).map((item) => item.route),
+);
+
+export function getModalBackground(location: Pick<Location, 'state'>): Location | null {
     const state = location.state as ModalLocationState | null;
     return state?.background ?? null;
 }
 
-export function isModalOpen(location: Location, modalPath: string): boolean {
+export function isModalOpen(location: Pick<Location, 'pathname' | 'state'>, modalPath: string): boolean {
     return location.pathname === modalPath && getModalBackground(location) !== null;
 }
 
-export function isReturningFromModal(previous: Location, current: Location, modalPath: string): boolean {
+export function isReturningFromModal(previous: Location, current: Location): boolean {
     const background = getModalBackground(previous);
 
     // The key identifies the exact history entry behind the modal. Comparing only
     // pathnames would also suppress a real navigation to the same path with different
     // search parameters or state.
-    return previous.pathname === modalPath && background?.key === current.key;
+    return MODAL_ROUTES.includes(previous.pathname) && background?.key === current.key;
+}
+
+export function modalNavigationState(location: Location): { state: ModalLocationState } {
+    return { state: { background: location } };
 }

--- a/src/functions/viewUsage.ts
+++ b/src/functions/viewUsage.ts
@@ -2,18 +2,17 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { matchPath } from 'react-router';
+import { type Location, matchPath } from 'react-router';
 import ROUTES, { ROUTE_PATTERNS } from '../definitions/Routes';
 import { UsageEvent, UsageView } from '../definitions/UsageEvent';
+import { isModalOpen } from './modalRoute';
 import recordUsage from './recordUsage';
 
 type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
 
-interface RouteUsageDefinition {
-    view: UsageView;
-    pattern?: string;
-    nestedView?: UsageView;
-}
+type RouteUsageDefinition =
+    | { view: UsageView; requiresModalBackground?: true }
+    | { view: UsageView; pattern: string; nestedView?: UsageView };
 
 /**
  * The single inventory of which application routes are countable views.
@@ -31,33 +30,56 @@ export const USAGE_VIEW_BY_ROUTE = Object.freeze({
     [ROUTES.TENSORS]: { view: UsageView.TENSORS },
     [ROUTES.BUFFERS]: { view: UsageView.BUFFERS },
     [ROUTES.STYLEGUIDE]: null,
-    [ROUTES.GRAPHTREE]: { view: UsageView.GRAPH, pattern: ROUTE_PATTERNS.GRAPHTREE, nestedView: UsageView.GRAPH },
+    [ROUTES.GRAPHTREE]: { view: UsageView.GRAPH, pattern: ROUTE_PATTERNS.GRAPHTREE },
     [ROUTES.PERFORMANCE]: { view: UsageView.PERFORMANCE },
-    [ROUTES.NPE]: { view: UsageView.NPE, pattern: ROUTE_PATTERNS.NPE, nestedView: UsageView.NPE },
-    [ROUTES.MLIR]: { view: UsageView.MLIR, pattern: ROUTE_PATTERNS.MLIR, nestedView: UsageView.MLIR },
-    [ROUTES.CLUSTER]: { view: UsageView.TOPOLOGY },
+    [ROUTES.NPE]: { view: UsageView.NPE, pattern: ROUTE_PATTERNS.NPE },
+    [ROUTES.MLIR]: { view: UsageView.MLIR, pattern: ROUTE_PATTERNS.MLIR },
+    [ROUTES.CLUSTER]: { view: UsageView.TOPOLOGY, requiresModalBackground: true },
 }) satisfies Readonly<Record<RoutePath, RouteUsageDefinition | null>>;
 
 const ROUTE_USAGE_ENTRIES = Object.entries(USAGE_VIEW_BY_ROUTE) as [RoutePath, RouteUsageDefinition | null][];
 
-export function getUsageView(pathname: string): UsageView | null {
+let lastSeenPathname: string | null = null;
+
+export function resetRememberedViewPathname(): void {
+    lastSeenPathname = null;
+}
+
+/**
+ * True when this pathname is a new view location. Survives a shell remount so a
+ * `ProtectedRoute` bounce cannot reopen the page it lands on.
+ */
+export function rememberViewPathname(pathname: string): boolean {
+    if (lastSeenPathname === pathname) {
+        return false;
+    }
+
+    lastSeenPathname = pathname;
+    return true;
+}
+
+export function getUsageView(location: Pick<Location, 'pathname' | 'state'>): UsageView | null {
     for (const [route, definition] of ROUTE_USAGE_ENTRIES) {
-        if (matchPath({ path: route, end: true }, pathname)) {
+        if (matchPath({ path: route, end: true }, location.pathname)) {
+            if (definition && 'requiresModalBackground' in definition && definition.requiresModalBackground) {
+                return isModalOpen(location, route) ? definition.view : null;
+            }
+
             return definition?.view ?? null;
         }
 
-        if (
-            definition?.nestedView &&
-            definition.pattern &&
-            matchPath(
+        if (definition && 'pattern' in definition) {
+            const matched = matchPath(
                 {
                     path: definition.pattern,
                     end: true,
                 },
-                pathname,
-            )
-        ) {
-            return definition.nestedView;
+                location.pathname,
+            );
+
+            if (matched) {
+                return definition.nestedView ?? definition.view;
+            }
         }
     }
 

--- a/src/functions/viewUsage.ts
+++ b/src/functions/viewUsage.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { matchPath } from 'react-router';
+import ROUTES, { ROUTE_PATTERNS } from '../definitions/Routes';
+import { UsageEvent, UsageView } from '../definitions/UsageEvent';
+import recordUsage from './recordUsage';
+
+type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
+
+interface RouteUsageDefinition {
+    view: UsageView;
+    pattern?: string;
+    nestedView?: UsageView;
+}
+
+/**
+ * The single inventory of which application routes are countable views.
+ *
+ * `null` is an explicit exclusion rather than an omitted key, so adding a route
+ * without deciding how it should be counted fails type-checking.
+ */
+export const USAGE_VIEW_BY_ROUTE = Object.freeze({
+    [ROUTES.HOME]: { view: UsageView.REPORTS },
+    [ROUTES.OPERATIONS]: {
+        view: UsageView.OPERATIONS,
+        pattern: ROUTE_PATTERNS.OPERATION_DETAILS,
+        nestedView: UsageView.OPERATION_DETAILS,
+    },
+    [ROUTES.TENSORS]: { view: UsageView.TENSORS },
+    [ROUTES.BUFFERS]: { view: UsageView.BUFFERS },
+    [ROUTES.STYLEGUIDE]: null,
+    [ROUTES.GRAPHTREE]: { view: UsageView.GRAPH, pattern: ROUTE_PATTERNS.GRAPHTREE, nestedView: UsageView.GRAPH },
+    [ROUTES.PERFORMANCE]: { view: UsageView.PERFORMANCE },
+    [ROUTES.NPE]: { view: UsageView.NPE, pattern: ROUTE_PATTERNS.NPE, nestedView: UsageView.NPE },
+    [ROUTES.MLIR]: { view: UsageView.MLIR, pattern: ROUTE_PATTERNS.MLIR, nestedView: UsageView.MLIR },
+    [ROUTES.CLUSTER]: { view: UsageView.TOPOLOGY },
+}) satisfies Readonly<Record<RoutePath, RouteUsageDefinition | null>>;
+
+const ROUTE_USAGE_DEFINITIONS = Object.values(USAGE_VIEW_BY_ROUTE) as (RouteUsageDefinition | null)[];
+
+export function getUsageView(pathname: string): UsageView | null {
+    const exactDefinition = USAGE_VIEW_BY_ROUTE[pathname as RoutePath];
+
+    if (exactDefinition !== undefined) {
+        return exactDefinition?.view ?? null;
+    }
+
+    for (const definition of ROUTE_USAGE_DEFINITIONS) {
+        if (
+            definition?.nestedView &&
+            definition.pattern &&
+            matchPath(
+                {
+                    path: definition.pattern,
+                    end: true,
+                },
+                pathname,
+            )
+        ) {
+            return definition.nestedView;
+        }
+    }
+
+    return null;
+}
+
+export function recordViewOpened(view: UsageView): void {
+    recordUsage({ event: UsageEvent.VIEW_OPENED, details: { view } });
+}

--- a/src/functions/viewUsage.ts
+++ b/src/functions/viewUsage.ts
@@ -38,16 +38,14 @@ export const USAGE_VIEW_BY_ROUTE = Object.freeze({
     [ROUTES.CLUSTER]: { view: UsageView.TOPOLOGY },
 }) satisfies Readonly<Record<RoutePath, RouteUsageDefinition | null>>;
 
-const ROUTE_USAGE_DEFINITIONS = Object.values(USAGE_VIEW_BY_ROUTE) as (RouteUsageDefinition | null)[];
+const ROUTE_USAGE_ENTRIES = Object.entries(USAGE_VIEW_BY_ROUTE) as [RoutePath, RouteUsageDefinition | null][];
 
 export function getUsageView(pathname: string): UsageView | null {
-    const exactDefinition = USAGE_VIEW_BY_ROUTE[pathname as RoutePath];
+    for (const [route, definition] of ROUTE_USAGE_ENTRIES) {
+        if (matchPath({ path: route, end: true }, pathname)) {
+            return definition?.view ?? null;
+        }
 
-    if (exactDefinition !== undefined) {
-        return exactDefinition?.view ?? null;
-    }
-
-    for (const definition of ROUTE_USAGE_DEFINITIONS) {
         if (
             definition?.nestedView &&
             definition.pattern &&

--- a/src/hooks/useMainNavigationItems.ts
+++ b/src/hooks/useMainNavigationItems.ts
@@ -10,6 +10,7 @@ import ROUTES from '../definitions/Routes';
 import { activeMlirJsonAtom, activePerformanceReportAtom, activeProfilerReportAtom } from '../store/app';
 import { useGetClusterDescription } from './useAPI';
 import getServerConfig from '../functions/getServerConfig';
+import { getModalBackground } from '../functions/modalRoute';
 
 export interface ResolvedNavigationItem extends NavigationItem {
     isDisabled: boolean;
@@ -73,7 +74,7 @@ export function useMainNavigationItems(): MainNavigationItems {
             return true;
         }
 
-        const backgroundPath = location.state?.background?.pathname;
+        const backgroundPath = getModalBackground(location)?.pathname;
 
         return !!backgroundPath && (backgroundPath === path || isNestedMatch(backgroundPath, path));
     };

--- a/src/hooks/useMainNavigationItems.ts
+++ b/src/hooks/useMainNavigationItems.ts
@@ -10,7 +10,7 @@ import ROUTES from '../definitions/Routes';
 import { activeMlirJsonAtom, activePerformanceReportAtom, activeProfilerReportAtom } from '../store/app';
 import { useGetClusterDescription } from './useAPI';
 import getServerConfig from '../functions/getServerConfig';
-import { getModalBackground } from '../functions/modalRoute';
+import { getModalBackground, modalNavigationState } from '../functions/modalRoute';
 
 export interface ResolvedNavigationItem extends NavigationItem {
     isDisabled: boolean;
@@ -102,7 +102,7 @@ export function useMainNavigationItems(): MainNavigationItems {
 
             // A modal route keeps the page beneath it mounted, which react-router does
             // from the background location rather than from the path.
-            void navigate(item.route, item.isModal ? { state: { background: location } } : undefined);
+            void navigate(item.route, item.isModal ? modalNavigationState(location) : undefined);
         },
         [navigate, location],
     );

--- a/src/hooks/useRecordViewOpened.ts
+++ b/src/hooks/useRecordViewOpened.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useEffect, useRef } from 'react';
+import { type Location, useLocation } from 'react-router';
+import ROUTES from '../definitions/Routes';
+import { isModalOpen, isReturningFromModal } from '../functions/modalRoute';
+import { getUsageView, recordViewOpened } from '../functions/viewUsage';
+
+/**
+ * Record countable route changes from the one shell shared by every view.
+ */
+export default function useRecordViewOpened(): void {
+    const location = useLocation();
+    const previousLocation = useRef<Location | null>(null);
+
+    useEffect(() => {
+        const previous = previousLocation.current;
+        previousLocation.current = location;
+
+        // React StrictMode repeats effect setup with the same location. Search/hash-only
+        // changes likewise do not open a different view.
+        if (previous?.pathname === location.pathname) {
+            return;
+        }
+
+        // Closing topology restores the history entry which remained mounted beneath it;
+        // that view was never reopened.
+        if (previous && isReturningFromModal(previous, location, ROUTES.CLUSTER)) {
+            return;
+        }
+
+        // `/cluster` without background state renders no topology overlay, so counting
+        // such a deep link would claim a view opened when the user received a blank route.
+        if (location.pathname === ROUTES.CLUSTER && !isModalOpen(location, ROUTES.CLUSTER)) {
+            return;
+        }
+
+        const view = getUsageView(location.pathname);
+        if (view !== null) {
+            recordViewOpened(view);
+        }
+    }, [location]);
+}

--- a/src/hooks/useRecordViewOpened.ts
+++ b/src/hooks/useRecordViewOpened.ts
@@ -4,9 +4,8 @@
 
 import { useEffect, useRef } from 'react';
 import { type Location, useLocation } from 'react-router';
-import ROUTES from '../definitions/Routes';
-import { isModalOpen, isReturningFromModal } from '../functions/modalRoute';
-import { getUsageView, recordViewOpened } from '../functions/viewUsage';
+import { isReturningFromModal } from '../functions/modalRoute';
+import { getUsageView, recordViewOpened, rememberViewPathname } from '../functions/viewUsage';
 
 /**
  * Record countable route changes from the one shell shared by every view.
@@ -19,25 +18,19 @@ export default function useRecordViewOpened(): void {
         const previous = previousLocation.current;
         previousLocation.current = location;
 
-        // React StrictMode repeats effect setup with the same location. Search/hash-only
-        // changes likewise do not open a different view.
-        if (previous?.pathname === location.pathname) {
+        // Module-scope so a ProtectedRoute bounce that remounts Layout cannot re-open the
+        // view it lands on. Same-pathname StrictMode and search/hash-only changes share it.
+        if (!rememberViewPathname(location.pathname)) {
             return;
         }
 
-        // Closing topology restores the history entry which remained mounted beneath it;
+        // Closing a modal restores the history entry which remained mounted beneath it;
         // that view was never reopened.
-        if (previous && isReturningFromModal(previous, location, ROUTES.CLUSTER)) {
+        if (previous && isReturningFromModal(previous, location)) {
             return;
         }
 
-        // `/cluster` without background state renders no topology overlay, so counting
-        // such a deep link would claim a view opened when the user received a blank route.
-        if (location.pathname === ROUTES.CLUSTER && !isModalOpen(location, ROUTES.CLUSTER)) {
-            return;
-        }
-
-        const view = getUsageView(location.pathname);
+        const view = getUsageView(location);
         if (view !== null) {
             recordViewOpened(view);
         }

--- a/src/libs/ModalAwareOutlet.tsx
+++ b/src/libs/ModalAwareOutlet.tsx
@@ -4,11 +4,11 @@
 
 import { useLocation, useRoutes } from 'react-router';
 import { routeObjectList } from '../routes/routeObjectList';
+import { getModalBackground } from '../functions/modalRoute';
 
 export function ModalAwareOutlet() {
     const location = useLocation();
-    const state = location.state as { background?: Location };
-    const backgroundLocation = state?.background;
+    const backgroundLocation = getModalBackground(location);
 
     return useRoutes(routeObjectList, backgroundLocation || location);
 }

--- a/src/routes/routeObjectList.tsx
+++ b/src/routes/routeObjectList.tsx
@@ -11,7 +11,7 @@ import Styleguide from './Styleguide';
 import GraphView from './GraphView';
 import Performance from './Performance';
 import NPE from './NPE';
-import ROUTES from '../definitions/Routes';
+import ROUTES, { ROUTE_PATTERNS } from '../definitions/Routes';
 import { NAVIGATION_ITEMS, NavRequirement } from '../definitions/NavigationItems';
 import MLIR from './MLIR';
 
@@ -30,7 +30,7 @@ export const routeObjectList = [
         element: <Operations />,
     },
     {
-        path: stripFirstSlash(`${ROUTES.OPERATIONS}/:operationId`),
+        path: stripFirstSlash(ROUTE_PATTERNS.OPERATION_DETAILS),
         element: <OperationDetails />,
     },
     {
@@ -46,7 +46,7 @@ export const routeObjectList = [
         element: <Styleguide />,
     },
     {
-        path: stripFirstSlash(`${ROUTES.GRAPHTREE}/:operationId?`),
+        path: stripFirstSlash(ROUTE_PATTERNS.GRAPHTREE),
         element: <GraphView />,
     },
     {
@@ -54,11 +54,11 @@ export const routeObjectList = [
         element: <Performance />,
     },
     {
-        path: stripFirstSlash(`${ROUTES.NPE}/:filepath?`),
+        path: stripFirstSlash(ROUTE_PATTERNS.NPE),
         element: <NPE />,
     },
     {
-        path: stripFirstSlash(`${ROUTES.MLIR}/:filepath?`),
+        path: stripFirstSlash(ROUTE_PATTERNS.MLIR),
         element: <MLIR />,
     },
     {

--- a/tests/Layout.spec.tsx
+++ b/tests/Layout.spec.tsx
@@ -7,8 +7,9 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { StrictMode } from 'react';
 import type { ComponentType } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
-import { MemoryRouter } from 'react-router';
+import { type InitialEntry, MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ROUTES from '../src/definitions/Routes';
 import { UsageEvent, UsageView } from '../src/definitions/UsageEvent';
 
 /**
@@ -36,15 +37,22 @@ vi.mock('../src/components/ServerModeBanner', () => ({ default: () => <div data-
 vi.mock('../src/components/FooterInfobar', () => ({ default: () => <div data-testid='stub-footer-infobar' /> }));
 vi.mock('../src/components/FeedbackButton', () => ({ default: () => null }));
 vi.mock('../src/components/FileStatusOverlay', () => ({ default: () => null }));
-vi.mock('../src/components/cluster/ClusterRenderer', () => ({ default: () => null }));
+vi.mock('../src/components/cluster/ClusterRenderer', () => ({
+    default: () => <div data-testid='stub-cluster-renderer' />,
+}));
 vi.mock('../src/components/mlir/MlirFileResultsOverlay', () => ({ default: () => null }));
 vi.mock('../src/libs/ModalAwareOutlet', () => ({ ModalAwareOutlet: () => null }));
 
-function renderLayout(Layout: ComponentType) {
+async function resetViewOpenedMemory() {
+    const { resetRememberedViewPathname } = await import('../src/functions/viewUsage');
+    resetRememberedViewPathname();
+}
+
+function renderLayout(Layout: ComponentType, initialEntries: InitialEntry[] = ['/']) {
     return render(
         <StrictMode>
             <HelmetProvider>
-                <MemoryRouter>
+                <MemoryRouter initialEntries={initialEntries}>
                     <Layout />
                 </MemoryRouter>
             </HelmetProvider>
@@ -53,7 +61,8 @@ function renderLayout(Layout: ComponentType) {
 }
 
 describe('Layout usage recording wiring', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
+        await resetViewOpenedMemory();
         vi.clearAllMocks();
     });
 
@@ -100,7 +109,8 @@ describe('Layout usage recording wiring', () => {
 });
 
 describe('Layout shell placement', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
+        await resetViewOpenedMemory();
         vi.clearAllMocks();
     });
 
@@ -138,5 +148,37 @@ describe('Layout shell placement', () => {
         const shell = await renderShell();
 
         expect(shell).not.toContainElement(screen.getByTestId('stub-footer-infobar'));
+    });
+});
+
+describe('Layout topology overlay', () => {
+    beforeEach(async () => {
+        await resetViewOpenedMemory();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('does not render the overlay for a topology pathname with no background', async () => {
+        const { default: Layout } = await import('../src/components/Layout');
+
+        renderLayout(Layout, [ROUTES.CLUSTER]);
+
+        expect(screen.queryByTestId('stub-cluster-renderer')).not.toBeInTheDocument();
+    });
+
+    it('renders the overlay when topology is opened over a background view', async () => {
+        const { default: Layout } = await import('../src/components/Layout');
+
+        renderLayout(Layout, [
+            {
+                pathname: ROUTES.CLUSTER,
+                state: { background: { pathname: ROUTES.OPERATIONS, key: 'bg', search: '', hash: '', state: null } },
+            },
+        ]);
+
+        expect(screen.getByTestId('stub-cluster-renderer')).toBeInTheDocument();
     });
 });

--- a/tests/Layout.spec.tsx
+++ b/tests/Layout.spec.tsx
@@ -9,6 +9,7 @@ import type { ComponentType } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UsageEvent, UsageView } from '../src/definitions/UsageEvent';
 
 /**
  * Covers the shell's wiring and the one structural invariant it asserts about itself.
@@ -26,8 +27,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const teardown = vi.hoisted(() => vi.fn());
 const initUsageRecording = vi.hoisted(() => vi.fn(() => teardown));
+const recordUsage = vi.hoisted(() => vi.fn());
 
-vi.mock('../src/functions/recordUsage', () => ({ initUsageRecording }));
+vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage, initUsageRecording }));
 
 vi.mock('../src/components/SideNavigation', () => ({ default: () => <div data-testid='stub-side-navigation' /> }));
 vi.mock('../src/components/ServerModeBanner', () => ({ default: () => <div data-testid='stub-server-mode-banner' /> }));
@@ -65,6 +67,18 @@ describe('Layout usage recording wiring', () => {
         renderLayout(Layout);
 
         expect(initUsageRecording).toHaveBeenCalled();
+    });
+
+    it('records the initial route once under StrictMode', async () => {
+        const { default: Layout } = await import('../src/components/Layout');
+
+        renderLayout(Layout);
+
+        expect(recordUsage).toHaveBeenCalledTimes(1);
+        expect(recordUsage).toHaveBeenCalledWith({
+            event: UsageEvent.VIEW_OPENED,
+            details: { view: UsageView.REPORTS },
+        });
     });
 
     it('balances every start with a teardown, including StrictMode remount', async () => {

--- a/tests/recordUsage.spec.ts
+++ b/tests/recordUsage.spec.ts
@@ -483,7 +483,7 @@ describe('recordUsage gating', () => {
         const { recordUsage, flushUsage, initUsageRecording, post } = await loadRecorder();
         const teardown = startRecording(initUsageRecording);
 
-        recordUsage(REPORT_LOADED);
+        recordUsage(VIEW_OPENED);
         flushUsage();
         window.dispatchEvent(new Event('pagehide'));
         vi.advanceTimersByTime(FLUSH_INTERVAL_MS);

--- a/tests/routePatterns.spec.ts
+++ b/tests/routePatterns.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { matchRoutes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { ROUTE_PATTERNS } from '../src/definitions/Routes';
+import { routeObjectList } from '../src/routes/routeObjectList';
+
+const PATTERN_PARAM = /\/:[^/?]+[?]*/g;
+
+function patternBase(pattern: string): string {
+    return pattern.replace(PATTERN_PARAM, '');
+}
+
+function matchingChildPath(pathname: string): string | undefined {
+    const matches = matchRoutes([{ path: '/', children: routeObjectList }], pathname);
+
+    return matches?.find((match) => typeof match.route.path === 'string' && match.route.path !== '/')?.route.path;
+}
+
+const stripFirstSlash = (path: string) => (path.startsWith('/') ? path.slice(1) : path);
+
+describe('ROUTE_PATTERNS', () => {
+    it.each(Object.values(ROUTE_PATTERNS))(
+        'keeps %s matching both its bare path and a parameterised child',
+        (pattern) => {
+            const base = patternBase(pattern);
+            const relativePattern = stripFirstSlash(pattern);
+
+            expect(matchingChildPath(`${base}/x`)).toBe(relativePattern);
+
+            // Optional params share one route object with the bare path. Required params
+            // have a static sibling for the bare path; dropping `?` makes the bare path
+            // match nothing.
+            if (pattern.includes('?')) {
+                expect(matchingChildPath(base)).toBe(relativePattern);
+            } else {
+                expect(matchingChildPath(base)).toBeDefined();
+                expect(matchingChildPath(base)).not.toBe(relativePattern);
+            }
+        },
+    );
+});

--- a/tests/useRecordViewOpened.spec.tsx
+++ b/tests/useRecordViewOpened.spec.tsx
@@ -9,6 +9,8 @@ import { type Location, MemoryRouter, useLocation, useNavigate } from 'react-rou
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ROUTES from '../src/definitions/Routes';
 import { UsageView } from '../src/definitions/UsageEvent';
+import { modalNavigationState } from '../src/functions/modalRoute';
+import { resetRememberedViewPathname } from '../src/functions/viewUsage';
 import useRecordViewOpened from '../src/hooks/useRecordViewOpened';
 
 const { recordViewOpened } = vi.hoisted(() => ({ recordViewOpened: vi.fn() }));
@@ -47,9 +49,21 @@ function NavigationHarness() {
             </button>
             <button
                 type='button'
-                onClick={() => navigate(ROUTES.CLUSTER, { state: { background: location } })}
+                onClick={() => navigate(ROUTES.CLUSTER, modalNavigationState(location))}
             >
                 Open topology
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(ROUTES.STYLEGUIDE)}
+            >
+                Open styleguide
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate('/does-not-exist')}
+            >
+                Open unknown
             </button>
             <button
                 type='button'
@@ -84,6 +98,7 @@ const renderRecorder = (initialEntry: string) =>
 
 describe('useRecordViewOpened', () => {
     beforeEach(() => {
+        resetRememberedViewPathname();
         recordViewOpened.mockClear();
     });
 
@@ -180,6 +195,28 @@ describe('useRecordViewOpened', () => {
         recordViewOpened.mockClear();
 
         fireEvent.click(screen.getByRole('button', { name: 'Change query' }));
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+    });
+
+    it('does not record excluded or unknown routes', () => {
+        renderRecorder(ROUTES.STYLEGUIDE);
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open unknown' }));
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+    });
+
+    it('does not re-record the same pathname after the recorder remounts', () => {
+        const { unmount } = renderRecorder(ROUTES.HOME);
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+
+        unmount();
+        recordViewOpened.mockClear();
+        renderRecorder(ROUTES.HOME);
 
         expect(recordViewOpened).not.toHaveBeenCalled();
     });

--- a/tests/useRecordViewOpened.spec.tsx
+++ b/tests/useRecordViewOpened.spec.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { type Location, MemoryRouter, useLocation, useNavigate } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ROUTES from '../src/definitions/Routes';
+import { UsageView } from '../src/definitions/UsageEvent';
+import useRecordViewOpened from '../src/hooks/useRecordViewOpened';
+
+const { recordViewOpened } = vi.hoisted(() => ({ recordViewOpened: vi.fn() }));
+
+vi.mock('../src/functions/viewUsage', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../src/functions/viewUsage')>();
+    return { ...actual, recordViewOpened };
+});
+
+function NavigationHarness() {
+    useRecordViewOpened();
+
+    const location = useLocation();
+    const navigate = useNavigate();
+    const background = location.state?.background as Location | undefined;
+
+    return (
+        <>
+            <button
+                type='button'
+                onClick={() => navigate(ROUTES.TENSORS)}
+            >
+                Open tensors
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(`${ROUTES.OPERATIONS}/2`)}
+            >
+                Open operation 2
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(`${ROUTES.GRAPHTREE}/2`)}
+            >
+                Open graph operation 2
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(ROUTES.CLUSTER, { state: { background: location } })}
+            >
+                Open topology
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(-1)}
+            >
+                Close topology
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(`${background?.pathname ?? ROUTES.OPERATIONS}?filter=changed`)}
+            >
+                Open changed background
+            </button>
+            <button
+                type='button'
+                onClick={() => navigate(`${location.pathname}?filter=active`)}
+            >
+                Change query
+            </button>
+        </>
+    );
+}
+
+const renderRecorder = (initialEntry: string) =>
+    render(
+        <StrictMode>
+            <MemoryRouter initialEntries={[initialEntry]}>
+                <NavigationHarness />
+            </MemoryRouter>
+        </StrictMode>,
+    );
+
+describe('useRecordViewOpened', () => {
+    beforeEach(() => {
+        recordViewOpened.mockClear();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('records the initial view once under StrictMode', () => {
+        renderRecorder(ROUTES.OPERATIONS);
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+        expect(recordViewOpened).toHaveBeenCalledWith(UsageView.OPERATIONS);
+    });
+
+    it('records a parameter change even when the view is unchanged', () => {
+        renderRecorder(`${ROUTES.OPERATIONS}/1`);
+        recordViewOpened.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open operation 2' }));
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+        expect(recordViewOpened).toHaveBeenCalledWith(UsageView.OPERATION_DETAILS);
+    });
+
+    it('records graph parameter changes as graph views', () => {
+        renderRecorder(`${ROUTES.GRAPHTREE}/1`);
+        recordViewOpened.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open graph operation 2' }));
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+        expect(recordViewOpened).toHaveBeenCalledWith(UsageView.GRAPH);
+    });
+
+    it('records every view in a sequence of static and parameterised navigations', () => {
+        renderRecorder(ROUTES.OPERATIONS);
+        recordViewOpened.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open tensors' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Open operation 2' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Open graph operation 2' }));
+
+        expect(recordViewOpened.mock.calls).toEqual([
+            [UsageView.TENSORS],
+            [UsageView.OPERATION_DETAILS],
+            [UsageView.GRAPH],
+        ]);
+    });
+
+    it('records each topology open but never reopens its background on close', () => {
+        renderRecorder(ROUTES.OPERATIONS);
+        recordViewOpened.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open topology' }));
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+        expect(recordViewOpened).toHaveBeenCalledWith(UsageView.TOPOLOGY);
+
+        recordViewOpened.mockClear();
+        fireEvent.click(screen.getByRole('button', { name: 'Close topology' }));
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open topology' }));
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+        expect(recordViewOpened).toHaveBeenCalledWith(UsageView.TOPOLOGY);
+
+        recordViewOpened.mockClear();
+        fireEvent.click(screen.getByRole('button', { name: 'Close topology' }));
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+    });
+
+    it('does not count a topology pathname which renders no overlay', () => {
+        renderRecorder(ROUTES.CLUSTER);
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+    });
+
+    it('does not mistake a new background-path entry for closing the topology modal', () => {
+        renderRecorder(ROUTES.OPERATIONS);
+        fireEvent.click(screen.getByRole('button', { name: 'Open topology' }));
+        recordViewOpened.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open changed background' }));
+
+        expect(recordViewOpened).toHaveBeenCalledTimes(1);
+        expect(recordViewOpened).toHaveBeenCalledWith(UsageView.OPERATIONS);
+    });
+
+    it('does not treat query-only navigation as opening another view', () => {
+        renderRecorder(ROUTES.OPERATIONS);
+        recordViewOpened.mockClear();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change query' }));
+
+        expect(recordViewOpened).not.toHaveBeenCalled();
+    });
+});

--- a/tests/viewUsage.spec.ts
+++ b/tests/viewUsage.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it, vi } from 'vitest';
+import ROUTES from '../src/definitions/Routes';
+import { UsageEvent, UsageView } from '../src/definitions/UsageEvent';
+import { USAGE_VIEW_BY_ROUTE, getUsageView, recordViewOpened } from '../src/functions/viewUsage';
+
+const { recordUsage } = vi.hoisted(() => ({ recordUsage: vi.fn() }));
+
+vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage }));
+
+describe('usage view route mapping', () => {
+    it('makes an explicit decision for every route', () => {
+        expect(new Set(Object.keys(USAGE_VIEW_BY_ROUTE))).toEqual(new Set(Object.values(ROUTES)));
+    });
+
+    it.each([
+        [ROUTES.HOME, UsageView.REPORTS],
+        [ROUTES.OPERATIONS, UsageView.OPERATIONS],
+        [ROUTES.TENSORS, UsageView.TENSORS],
+        [ROUTES.BUFFERS, UsageView.BUFFERS],
+        [ROUTES.GRAPHTREE, UsageView.GRAPH],
+        [ROUTES.PERFORMANCE, UsageView.PERFORMANCE],
+        [ROUTES.NPE, UsageView.NPE],
+        [ROUTES.MLIR, UsageView.MLIR],
+        [ROUTES.CLUSTER, UsageView.TOPOLOGY],
+    ])('maps %s to %s', (pathname, expected) => {
+        expect(getUsageView(pathname)).toBe(expected);
+    });
+
+    it.each([
+        [`${ROUTES.OPERATIONS}/42`, UsageView.OPERATION_DETAILS],
+        [`${ROUTES.GRAPHTREE}/42`, UsageView.GRAPH],
+        [`${ROUTES.NPE}/trace.json`, UsageView.NPE],
+        [`${ROUTES.MLIR}/model.mlir`, UsageView.MLIR],
+    ])('maps parameterised pathname %s to %s', (pathname, expected) => {
+        expect(getUsageView(pathname)).toBe(expected);
+    });
+
+    it.each([ROUTES.STYLEGUIDE, '/does-not-exist', `${ROUTES.TENSORS}/unexpected`])(
+        'does not count excluded or unknown pathname %s',
+        (pathname) => {
+            expect(getUsageView(pathname)).toBeNull();
+        },
+    );
+});
+
+describe('recordViewOpened', () => {
+    it('records the closed view vocabulary payload', () => {
+        recordViewOpened(UsageView.OPERATIONS);
+
+        expect(recordUsage).toHaveBeenCalledWith({
+            event: UsageEvent.VIEW_OPENED,
+            details: { view: UsageView.OPERATIONS },
+        });
+    });
+});

--- a/tests/viewUsage.spec.ts
+++ b/tests/viewUsage.spec.ts
@@ -22,11 +22,9 @@ describe('usage view route mapping', () => {
     });
 
     it('uses every parameterised pattern in a route definition', () => {
-        const patterns = Object.values(USAGE_VIEW_BY_ROUTE)
-            .filter((definition): definition is { view: UsageView; pattern: string } =>
-                Boolean(definition && 'pattern' in definition),
-            )
-            .map((definition) => definition.pattern);
+        const patterns = Object.values(USAGE_VIEW_BY_ROUTE).flatMap((definition) =>
+            definition && 'pattern' in definition ? [definition.pattern] : [],
+        );
 
         expect(Object.values(ROUTE_PATTERNS).every((pattern) => patterns.includes(pattern))).toBe(true);
     });

--- a/tests/viewUsage.spec.ts
+++ b/tests/viewUsage.spec.ts
@@ -31,6 +31,13 @@ describe('usage view route mapping', () => {
     });
 
     it.each([
+        [`${ROUTES.OPERATIONS}/`, UsageView.OPERATIONS],
+        [ROUTES.TENSORS.toUpperCase(), UsageView.TENSORS],
+    ])('matches static pathname %s the same way React Router does', (pathname, expected) => {
+        expect(getUsageView(pathname)).toBe(expected);
+    });
+
+    it.each([
         [`${ROUTES.OPERATIONS}/42`, UsageView.OPERATION_DETAILS],
         [`${ROUTES.GRAPHTREE}/42`, UsageView.GRAPH],
         [`${ROUTES.NPE}/trace.json`, UsageView.NPE],

--- a/tests/viewUsage.spec.ts
+++ b/tests/viewUsage.spec.ts
@@ -3,7 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it, vi } from 'vitest';
-import ROUTES from '../src/definitions/Routes';
+import type { Location } from 'react-router';
+import ROUTES, { ROUTE_PATTERNS } from '../src/definitions/Routes';
 import { UsageEvent, UsageView } from '../src/definitions/UsageEvent';
 import { USAGE_VIEW_BY_ROUTE, getUsageView, recordViewOpened } from '../src/functions/viewUsage';
 
@@ -11,9 +12,23 @@ const { recordUsage } = vi.hoisted(() => ({ recordUsage: vi.fn() }));
 
 vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage }));
 
+function locationAt(pathname: string, state: Location['state'] = null): Pick<Location, 'pathname' | 'state'> {
+    return { pathname, state };
+}
+
 describe('usage view route mapping', () => {
     it('makes an explicit decision for every route', () => {
         expect(new Set(Object.keys(USAGE_VIEW_BY_ROUTE))).toEqual(new Set(Object.values(ROUTES)));
+    });
+
+    it('uses every parameterised pattern in a route definition', () => {
+        const patterns = Object.values(USAGE_VIEW_BY_ROUTE)
+            .filter((definition): definition is { view: UsageView; pattern: string } =>
+                Boolean(definition && 'pattern' in definition),
+            )
+            .map((definition) => definition.pattern);
+
+        expect(Object.values(ROUTE_PATTERNS).every((pattern) => patterns.includes(pattern))).toBe(true);
     });
 
     it.each([
@@ -25,16 +40,15 @@ describe('usage view route mapping', () => {
         [ROUTES.PERFORMANCE, UsageView.PERFORMANCE],
         [ROUTES.NPE, UsageView.NPE],
         [ROUTES.MLIR, UsageView.MLIR],
-        [ROUTES.CLUSTER, UsageView.TOPOLOGY],
     ])('maps %s to %s', (pathname, expected) => {
-        expect(getUsageView(pathname)).toBe(expected);
+        expect(getUsageView(locationAt(pathname))).toBe(expected);
     });
 
     it.each([
         [`${ROUTES.OPERATIONS}/`, UsageView.OPERATIONS],
         [ROUTES.TENSORS.toUpperCase(), UsageView.TENSORS],
     ])('matches static pathname %s the same way React Router does', (pathname, expected) => {
-        expect(getUsageView(pathname)).toBe(expected);
+        expect(getUsageView(locationAt(pathname))).toBe(expected);
     });
 
     it.each([
@@ -43,13 +57,27 @@ describe('usage view route mapping', () => {
         [`${ROUTES.NPE}/trace.json`, UsageView.NPE],
         [`${ROUTES.MLIR}/model.mlir`, UsageView.MLIR],
     ])('maps parameterised pathname %s to %s', (pathname, expected) => {
-        expect(getUsageView(pathname)).toBe(expected);
+        expect(getUsageView(locationAt(pathname))).toBe(expected);
+    });
+
+    it('does not count a topology pathname which renders no overlay', () => {
+        expect(getUsageView(locationAt(ROUTES.CLUSTER))).toBeNull();
+    });
+
+    it('maps an open topology overlay to topology', () => {
+        expect(
+            getUsageView(
+                locationAt(ROUTES.CLUSTER, {
+                    background: { pathname: ROUTES.OPERATIONS, key: 'bg', search: '', hash: '', state: null },
+                }),
+            ),
+        ).toBe(UsageView.TOPOLOGY);
     });
 
     it.each([ROUTES.STYLEGUIDE, '/does-not-exist', `${ROUTES.TENSORS}/unexpected`])(
         'does not count excluded or unknown pathname %s',
         (pathname) => {
-            expect(getUsageView(pathname)).toBeNull();
+            expect(getUsageView(locationAt(pathname))).toBeNull();
         },
     );
 });


### PR DESCRIPTION
## Summary
- map application routes to the closed usage-view vocabulary
- record view opens centrally, including parameter changes and topology modal navigation
- share parameterised route and modal-state semantics to prevent drift
- add route, navigation, gating, and StrictMode coverage

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm lint:ts`
- `pnpm build`
- `uv run pytest backend/ttnn_visualizer/tests/test_usage_frontend_parity.py`
- `pnpm flask:lint`

Closes #1832