### PR TITLE
Fix View in Graph button icon colour

### DIFF
--- a/src/scss/mixins/_navigation.scss
+++ b/src/scss/mixins/_navigation.scss
@@ -12,8 +12,12 @@
         color: $color;
     }
 
-    .bp6-icon.bp6-icon-#{$icon} {
-        color: $color;
+    // Match Blueprint's dark-theme button specificity so its default grey icon
+    // cannot override the product colour on in-page navigation buttons.
+    &.bp6-button:not(.bp6-disabled) {
+        .bp6-icon.bp6-icon-#{$icon} {
+            color: $color;
+        }
     }
 
     &.bp6-outlined:not(.bp6-disabled) {


### PR DESCRIPTION
This pull request improves the styling of in-page navigation buttons to ensure consistent icon coloring, especially when using Blueprint's dark theme. The main change is to increase the CSS specificity so that the intended product color is not overridden by Blueprint's default styles.

**Styling improvements:**

* Added a selector for `.bp6-button:not(.bp6-disabled)` in `_navigation.scss` to match Blueprint's dark-theme button specificity and prevent the default grey icon from overriding the product color on in-page navigation buttons.