### PR TITLE
Add TypeScript typechecking to PR CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -44,6 +44,10 @@ jobs:
         run: pnpm test
         background: true
 
+      - name: Typecheck
+        run: pnpm lint:ts
+        background: true
+
       - wait-all:
 
   backend-lint-and-test:

--- a/tests/viewUsage.spec.ts
+++ b/tests/viewUsage.spec.ts
@@ -8,6 +8,9 @@ import ROUTES, { ROUTE_PATTERNS } from '../src/definitions/Routes';
 import { UsageEvent, UsageView } from '../src/definitions/UsageEvent';
 import { USAGE_VIEW_BY_ROUTE, getUsageView, recordViewOpened } from '../src/functions/viewUsage';
 
+const DELIBERATE_TYPECHECK_FAILURE: string = 42;
+void DELIBERATE_TYPECHECK_FAILURE;
+
 const { recordUsage } = vi.hoisted(() => ({ recordUsage: vi.fn() }));
 
 vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage }));

--- a/tests/viewUsage.spec.ts
+++ b/tests/viewUsage.spec.ts
@@ -8,9 +8,6 @@ import ROUTES, { ROUTE_PATTERNS } from '../src/definitions/Routes';
 import { UsageEvent, UsageView } from '../src/definitions/UsageEvent';
 import { USAGE_VIEW_BY_ROUTE, getUsageView, recordViewOpened } from '../src/functions/viewUsage';
 
-const DELIBERATE_TYPECHECK_FAILURE: string = 42;
-void DELIBERATE_TYPECHECK_FAILURE;
-
 const { recordUsage } = vi.hoisted(() => ({ recordUsage: vi.fn() }));
 
 vi.mock('../src/functions/recordUsage', () => ({ default: recordUsage }));


### PR DESCRIPTION
## Summary
- run the existing whole-project TypeScript typecheck in the frontend PR job
- execute it in parallel with ESLint and Vitest
- include a temporary type error for one CI run to verify the new gate

**Note**
Specifying input files when running `tsc` will cause it to ignore any `.tsconfig`. There are packages that get around this behaviour but the ts linting is quite fast so I haven't added it here.

Closes #1969