### PR TITLE
Remove report sorting by link status

### DIFF
--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -2,17 +2,13 @@
 //
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Button, ButtonVariant, MenuItem, Position, Tooltip } from '@blueprintjs/core';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { IconNames } from '@blueprintjs/icons';
 import { useInstance } from '../../hooks/useAPI';
 import 'styles/components/FolderPicker.scss';
-import {
-    getFolderLinkState,
-    shouldShowFolderLinkStatus,
-    sortByFolderLinkState,
-} from '../../functions/folderLinkStatus';
+import { getFolderLinkState, shouldShowFolderLinkStatus } from '../../functions/folderLinkStatus';
 import { ReportFolder } from '../../definitions/Reports';
 import getServerConfig from '../../functions/getServerConfig';
 import isDirectReportMode from '../../functions/isDirectReportMode';
@@ -77,18 +73,6 @@ const LocalFolderPicker = ({
     const isDeleteDisabled = loading;
     const showLinkStatus = shouldShowFolderLinkStatus(linkedIds, unlinkedIds);
 
-    // Linked first, unknown next, failed links last — preserve server order within each group.
-    const sortedItems = useMemo(
-        () =>
-            sortByFolderLinkState(
-                items ?? [],
-                (folder) => getReportId(folder.syncedName, folder.path),
-                linkedIds,
-                unlinkedIds,
-            ),
-        [items, linkedIds, unlinkedIds],
-    );
-
     const renderItem: ItemRenderer<ReportFolder> = (folder, { handleClick, handleFocus, modifiers, query }) => {
         if (!modifiers.matchesPredicate) {
             return null;
@@ -149,7 +133,7 @@ const LocalFolderPicker = ({
         <>
             <Select<ReportFolder>
                 className='folder-picker'
-                items={sortedItems}
+                items={items ?? []}
                 itemPredicate={(query, item) => !query || item.path.toLowerCase().includes(query.toLowerCase())}
                 itemRenderer={renderItem}
                 noResults={

--- a/src/components/report-selection/LocalFolderPicker.tsx
+++ b/src/components/report-selection/LocalFolderPicker.tsx
@@ -22,7 +22,10 @@ import FolderLinkStatusIcon from './FolderLinkStatusIcon';
 import SelectRowActions from './SelectRowActions';
 
 interface LocalFolderPickerProps {
-    /** `null` while the folder list query is still loading — the component renders disabled. */
+    /**
+     * `null` while the folder list query is still loading — the component renders disabled.
+     * Folders render in the supplied order; link-status badges do not reorder them.
+     */
     items: ReportFolder[] | null;
     value: string | null;
     handleSelect: (folder: ReportFolder) => void;

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -5,13 +5,9 @@
 import { Button, MenuItem } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import { type ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode } from 'react';
 import 'styles/components/FolderPicker.scss';
-import {
-    getFolderLinkState,
-    shouldShowFolderLinkStatus,
-    sortByFolderLinkState,
-} from '../../functions/folderLinkStatus';
+import { getFolderLinkState, shouldShowFolderLinkStatus } from '../../functions/folderLinkStatus';
 import { RemoteConnection, RemoteFolder } from '../../model/RemoteConnection';
 import { TEST_IDS } from '../../definitions/TestIds';
 import { getReportId } from '../../functions/reportLinks';
@@ -114,16 +110,11 @@ const RemoteFolderSelector = ({
 
     const isDisabled = loading || remoteFolderList?.length === 0 || disabled;
 
-    const sortedFolderList = useMemo(
-        () => sortByFolderLinkState(remoteFolderList ?? [], getRemoteFolderId, linkedIds, unlinkedIds),
-        [remoteFolderList, linkedIds, unlinkedIds],
-    );
-
     return (
         <div className='form-container'>
             <Select
                 className='remote-select'
-                items={sortedFolderList}
+                items={remoteFolderList}
                 itemRenderer={remoteFolderRenderer({
                     type,
                     selectedFolder: remoteFolder,
@@ -147,7 +138,7 @@ const RemoteFolderSelector = ({
             >
                 <Button
                     icon={icon}
-                    endIcon={sortedFolderList.length > 0 ? IconNames.CARET_DOWN : undefined}
+                    endIcon={remoteFolderList.length > 0 ? IconNames.CARET_DOWN : undefined}
                     disabled={isDisabled}
                     loading={loading}
                     text={remoteFolder ? getRemoteFolderLabel(remoteFolder) : fallbackLabel}

--- a/src/components/report-selection/RemoteFolderSelector.tsx
+++ b/src/components/report-selection/RemoteFolderSelector.tsx
@@ -77,6 +77,7 @@ const remoteFolderRenderer =
 
 interface RemoteFolderSelectorProps {
     remoteFolder?: RemoteFolder;
+    /** Folders render in the supplied order; link-status badges do not reorder them. */
     remoteFolderList?: RemoteFolder[];
     loading?: boolean;
     disabled?: boolean;

--- a/src/functions/folderLinkStatus.ts
+++ b/src/functions/folderLinkStatus.ts
@@ -20,35 +20,6 @@ export const getFolderLinkState = (
     return FolderLinkState.UNKNOWN;
 };
 
-/** Linked first, unknown middle, failed links last — stable within each group. */
-const FOLDER_LINK_SORT_RANK: Record<FolderLinkState, number> = {
-    [FolderLinkState.LINKED]: 0,
-    [FolderLinkState.UNKNOWN]: 1,
-    [FolderLinkState.UNLINKED]: 2,
-};
-
-export const compareByFolderLinkState = (
-    aId: string | null,
-    bId: string | null,
-    linkedIds?: Set<string> | null,
-    unlinkedIds?: Set<string> | null,
-): number =>
-    FOLDER_LINK_SORT_RANK[getFolderLinkState(aId, linkedIds, unlinkedIds)] -
-    FOLDER_LINK_SORT_RANK[getFolderLinkState(bId, linkedIds, unlinkedIds)];
-
 /** True when badge sets are present and at least one known link/unlinked id exists. */
 export const shouldShowFolderLinkStatus = (linkedIds?: Set<string> | null, unlinkedIds?: Set<string> | null): boolean =>
     Boolean(linkedIds?.size || unlinkedIds?.size);
-
-export const sortByFolderLinkState = <T>(
-    items: T[],
-    getId: (item: T) => string | null,
-    linkedIds?: Set<string> | null,
-    unlinkedIds?: Set<string> | null,
-): T[] => {
-    if (!shouldShowFolderLinkStatus(linkedIds, unlinkedIds)) {
-        return items;
-    }
-
-    return [...items].sort((a, b) => compareByFolderLinkState(getId(a), getId(b), linkedIds, unlinkedIds));
-};

--- a/tests/LocalFolderPicker.spec.tsx
+++ b/tests/LocalFolderPicker.spec.tsx
@@ -43,7 +43,7 @@ const folders: ReportFolder[] = [
 const deleteLabel = (folder: ReportFolder) => getDeleteActionLabel(ManagedEntity.REPORT, folder.reportName);
 
 describe('LocalFolderPicker link badges', () => {
-    it('sorts linked first, unknown middle, unlinked last', async () => {
+    it('preserves the supplied order when showing link badges', async () => {
         render(
             <TestProviders>
                 <LocalFolderPicker
@@ -63,7 +63,7 @@ describe('LocalFolderPicker link badges', () => {
             (el) => el.textContent,
         );
 
-        expect(labels).toEqual(['/linked-run', '/unknown-run', '/unlinked-run']);
+        expect(labels).toEqual(['/unknown-run', '/unlinked-run', '/linked-run']);
     });
 
     it('disables the picker when disabled is set', () => {
@@ -159,9 +159,8 @@ describe('LocalFolderPicker link badges', () => {
         fireEvent.click(screen.getByText('Select a report...'));
         await waitFor(testForPortal, WAIT_FOR_OPTIONS);
 
-        // Rows render sorted, so read the row's own label rather than assuming the items order.
         const secondRow = screen.getAllByTestId(TEST_IDS.FOLDER_PICKER_ROW)[1];
-        const secondRowFolder = folders.find((folder) => secondRow.textContent?.includes(`/${folder.path}`))!;
+        const secondRowFolder = folders[1];
 
         fireEvent.click(within(secondRow).getByLabelText(deleteLabel(secondRowFolder)));
 

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -1650,6 +1650,9 @@ const renderPerformanceSelector = async (
     connectionList: RemoteConnection[],
     folderList: RemoteFolder[] = multihostFolders,
     onSelectFolder: (folder: RemoteFolder) => void = () => undefined,
+    type: RemoteFolderType = ReportKind.PERFORMANCE,
+    linkedIds?: Set<string>,
+    unlinkedIds?: Set<string>,
 ) => {
     setupConnection(connectionList);
 
@@ -1658,7 +1661,9 @@ const renderPerformanceSelector = async (
             <RemoteFolderSelector
                 remoteFolderList={folderList}
                 onSelectFolder={onSelectFolder}
-                type={ReportKind.PERFORMANCE}
+                type={type}
+                linkedIds={linkedIds}
+                unlinkedIds={unlinkedIds}
             />
         </TestProviders>,
     );
@@ -1666,6 +1671,33 @@ const renderPerformanceSelector = async (
     getButtonWithText(NO_SELECTION).click();
     await waitFor(testForPortal, WAIT_FOR_OPTIONS);
 };
+
+const expectSuppliedOrder = async (type: RemoteFolderType) => {
+    const folders = [rankFolder(1), rankFolder(0)];
+
+    await renderPerformanceSelector(
+        multihostConnection,
+        folders,
+        () => undefined,
+        type,
+        new Set([folders[1].syncedName!]),
+        new Set([folders[0].syncedName!]),
+    );
+
+    const options = screen.getAllByRole('menuitem');
+    expect(options.map((option) => option.textContent)).toEqual([
+        expect.stringContaining(`Rank 1: ${TIMESTAMP}`),
+        expect.stringContaining(`Rank 0: ${TIMESTAMP}`),
+    ]);
+};
+
+it('preserves supplied order regardless of performance report link status', async () => {
+    await expectSuppliedOrder(ReportKind.PERFORMANCE);
+});
+
+it('preserves supplied order regardless of memory report link status', async () => {
+    await expectSuppliedOrder(ReportKind.PROFILER);
+});
 
 it('tells apart ranks whose reports share a name', async () => {
     await renderPerformanceSelector(multihostConnection);

--- a/tests/remoteFolderSelector.spec.tsx
+++ b/tests/remoteFolderSelector.spec.tsx
@@ -1646,14 +1646,23 @@ const rankFolder = (rank: number, reportName = TIMESTAMP): RemoteFolder => ({
 // granularity, so sharing a name is the normal case rather than the edge case.
 const multihostFolders: RemoteFolder[] = [rankFolder(0), rankFolder(1)];
 
-const renderPerformanceSelector = async (
-    connectionList: RemoteConnection[],
-    folderList: RemoteFolder[] = multihostFolders,
-    onSelectFolder: (folder: RemoteFolder) => void = () => undefined,
-    type: RemoteFolderType = ReportKind.PERFORMANCE,
-    linkedIds?: Set<string>,
-    unlinkedIds?: Set<string>,
-) => {
+interface RenderRemoteFolderSelectorOptions {
+    connectionList: RemoteConnection[];
+    folderList?: RemoteFolder[];
+    onSelectFolder?: (folder: RemoteFolder) => void;
+    type?: RemoteFolderType;
+    linkedIds?: Set<string>;
+    unlinkedIds?: Set<string>;
+}
+
+const renderPerformanceSelector = async ({
+    connectionList,
+    folderList = multihostFolders,
+    onSelectFolder = () => undefined,
+    type = ReportKind.PERFORMANCE,
+    linkedIds,
+    unlinkedIds,
+}: RenderRemoteFolderSelectorOptions) => {
     setupConnection(connectionList);
 
     render(
@@ -1675,14 +1684,13 @@ const renderPerformanceSelector = async (
 const expectSuppliedOrder = async (type: RemoteFolderType) => {
     const folders = [rankFolder(1), rankFolder(0)];
 
-    await renderPerformanceSelector(
-        multihostConnection,
-        folders,
-        () => undefined,
+    await renderPerformanceSelector({
+        connectionList: multihostConnection,
+        folderList: folders,
         type,
-        new Set([folders[1].syncedName!]),
-        new Set([folders[0].syncedName!]),
-    );
+        linkedIds: new Set([folders[1].syncedName!]),
+        unlinkedIds: new Set([folders[0].syncedName!]),
+    });
 
     const options = screen.getAllByRole('menuitem');
     expect(options.map((option) => option.textContent)).toEqual([
@@ -1695,12 +1703,8 @@ it('preserves supplied order regardless of performance report link status', asyn
     await expectSuppliedOrder(ReportKind.PERFORMANCE);
 });
 
-it('preserves supplied order regardless of memory report link status', async () => {
-    await expectSuppliedOrder(ReportKind.PROFILER);
-});
-
 it('tells apart ranks whose reports share a name', async () => {
-    await renderPerformanceSelector(multihostConnection);
+    await renderPerformanceSelector({ connectionList: multihostConnection });
 
     expect(screen.getByText(`Rank 0: ${TIMESTAMP}`)).toBeTruthy();
     expect(screen.getByText(`Rank 1: ${TIMESTAMP}`)).toBeTruthy();
@@ -1711,7 +1715,11 @@ it('tells apart ranks whose reports share a name', async () => {
 it('hands back the rank that was clicked', async () => {
     const onSelectFolder = vi.fn();
 
-    await renderPerformanceSelector(multihostConnection, multihostFolders, onSelectFolder);
+    await renderPerformanceSelector({
+        connectionList: multihostConnection,
+        folderList: multihostFolders,
+        onSelectFolder,
+    });
     screen.getByText(`Rank 1: ${TIMESTAMP}`).click();
 
     expect(onSelectFolder).toHaveBeenCalledTimes(1);
@@ -1748,7 +1756,10 @@ it('leaves single-host performance labels as paths', async () => {
         },
     ];
 
-    await renderPerformanceSelector(singleHostConnection, singleHostFolders);
+    await renderPerformanceSelector({
+        connectionList: singleHostConnection,
+        folderList: singleHostFolders,
+    });
 
     expect(screen.queryByText(`Rank 0: ${TIMESTAMP}`)).toBeNull();
     expect(screen.getByText(`/rank0/reports/${TIMESTAMP}`)).toBeTruthy();
@@ -1767,7 +1778,10 @@ it('labels an already-synced rank the same as the online listing', async () => {
         },
     ];
 
-    await renderPerformanceSelector(multihostConnection, syncedFolders);
+    await renderPerformanceSelector({
+        connectionList: multihostConnection,
+        folderList: syncedFolders,
+    });
 
     expect(screen.getByText(`Rank 0: ${TIMESTAMP}`)).toBeTruthy();
 });
@@ -1782,7 +1796,10 @@ it('falls back to the path when the listing reported no rank', async () => {
         },
     ];
 
-    await renderPerformanceSelector(multihostConnection, folderWithoutRank);
+    await renderPerformanceSelector({
+        connectionList: multihostConnection,
+        folderList: folderWithoutRank,
+    });
 
     expect(screen.getByText('/loose_report')).toBeTruthy();
 });

--- a/tests/reportLinks.spec.ts
+++ b/tests/reportLinks.spec.ts
@@ -15,12 +15,7 @@ import {
     upsertReportLink,
 } from '../src/functions/reportLinks';
 import { FolderLinkState } from '../src/definitions/FolderLinkStatus';
-import {
-    compareByFolderLinkState,
-    getFolderLinkState,
-    shouldShowFolderLinkStatus,
-    sortByFolderLinkState,
-} from '../src/functions/folderLinkStatus';
+import { getFolderLinkState, shouldShowFolderLinkStatus } from '../src/functions/folderLinkStatus';
 
 const link = (
     profilerId: string,
@@ -77,30 +72,11 @@ describe('getFolderLinkState', () => {
     });
 });
 
-describe('compareByFolderLinkState', () => {
-    it('orders linked before unknown before unlinked', () => {
-        const linkedIds = new Set(['linked']);
-        const unlinkedIds = new Set(['unlinked']);
-
-        expect(compareByFolderLinkState('linked', 'unknown', linkedIds, unlinkedIds)).toBeLessThan(0);
-        expect(compareByFolderLinkState('unknown', 'unlinked', linkedIds, unlinkedIds)).toBeLessThan(0);
-        expect(compareByFolderLinkState('linked', 'unlinked', linkedIds, unlinkedIds)).toBeLessThan(0);
-        expect(compareByFolderLinkState('unlinked', 'linked', linkedIds, unlinkedIds)).toBeGreaterThan(0);
-    });
-});
-
-describe('shouldShowFolderLinkStatus / sortByFolderLinkState', () => {
+describe('shouldShowFolderLinkStatus', () => {
     it('hides badges when both sets are empty or null', () => {
         expect(shouldShowFolderLinkStatus(new Set(), new Set())).toBe(false);
         expect(shouldShowFolderLinkStatus(null, null)).toBe(false);
         expect(shouldShowFolderLinkStatus(new Set(['a']), new Set())).toBe(true);
-    });
-
-    it('sorts items by link state using getId', () => {
-        const items = [{ id: 'unknown' }, { id: 'unlinked' }, { id: 'linked' }];
-        const sorted = sortByFolderLinkState(items, (item) => item.id, new Set(['linked']), new Set(['unlinked']));
-
-        expect(sorted.map((item) => item.id)).toEqual(['linked', 'unknown', 'unlinked']);
     });
 });
 


### PR DESCRIPTION
Removes the sorting behaviour that places previously linked reports at the top and failed links at the end of the list.

The pickers now preserve the order supplied by the backend. Link-status badges remain visible but no longer change row order. The resulting long-list discoverability trade-off is tracked in #1986.

Multihost rank ordering is out of scope for this change.

<img width="529" height="473" alt="Screenshot 2026-09-04 at 14 22 45" src="https://github.com/user-attachments/assets/d4a3944a-894a-491e-ad6b-44972fbf9c14" />
