### PR TITLE
Fix report linking when nested operations are in a different order

### DIFF
--- a/src/functions/deviceOperationMatching.ts
+++ b/src/functions/deviceOperationMatching.ts
@@ -112,3 +112,58 @@ export const matchDeviceOperationsToPerf = (
 
     return alignToPerfRows(collapseMultideviceOperations(deviceOperations, numDevices), alignableRows);
 };
+
+const hasSameDeviceOperations = (
+    functionStartOperations: DeviceOperationMapping[],
+    functionEndOperations: DeviceOperationMapping[],
+): boolean => {
+    if (functionStartOperations.length !== functionEndOperations.length) {
+        return false;
+    }
+
+    const operationCountByKey = new Map<string, number>();
+
+    for (const { id, name } of functionStartOperations) {
+        const key = JSON.stringify([id, name]);
+        operationCountByKey.set(key, (operationCountByKey.get(key) ?? 0) + 1);
+    }
+
+    for (const { id, name } of functionEndOperations) {
+        const key = JSON.stringify([id, name]);
+        const remaining = operationCountByKey.get(key);
+
+        if (!remaining) {
+            return false;
+        }
+
+        operationCountByKey.set(key, remaining - 1);
+    }
+
+    return true;
+};
+
+/**
+ * @description Try the captured graph's parent-first function-start order,
+ * then its child-first function-end order when both contain the same device
+ * operations. Each order retains the raw-then-multidevice-collapse fallback.
+ */
+export const matchDeviceOperationOrdersToPerf = (
+    functionStartOperations: DeviceOperationMapping[],
+    functionEndOperations: DeviceOperationMapping[],
+    perfRows: PerfTableRow[],
+    numDevices: number,
+): DeviceOperationMapping[] => {
+    const functionStartMatch = matchDeviceOperationsToPerf(functionStartOperations, perfRows, numDevices);
+
+    if (functionStartMatch.length > 0) {
+        return functionStartMatch;
+    }
+
+    // An interrupted capture can omit function-end events. Since alignment
+    // tolerates trailing perf rows, only a complete reordering is safe to retry.
+    if (!hasSameDeviceOperations(functionStartOperations, functionEndOperations)) {
+        return [];
+    }
+
+    return matchDeviceOperationsToPerf(functionEndOperations, perfRows, numDevices);
+};

--- a/src/functions/deviceOperationMatching.ts
+++ b/src/functions/deviceOperationMatching.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { PerfTableRow } from '../model/PerfTable';
-import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
+import { DeviceOperationMapping, DeviceOperationOrderCandidates } from '../model/DeviceOperationMapping';
 import { OpType } from '../definitions/Performance';
 
 /**
@@ -166,8 +166,7 @@ const hasSameDeviceOperations = (
  * cannot suppress the complete end-order match. See #1860.
  */
 export const matchDeviceOperationOrdersToPerf = (
-    functionStartOperations: DeviceOperationMapping[],
-    functionEndOperations: DeviceOperationMapping[],
+    { functionStartOperations, functionEndOperations }: DeviceOperationOrderCandidates,
     perfRows: PerfTableRow[],
     numDevices: number,
 ): DeviceOperationMapping[] => {

--- a/src/functions/deviceOperationMatching.ts
+++ b/src/functions/deviceOperationMatching.ts
@@ -83,6 +83,26 @@ const alignToPerfRows = (
 const alignableRowsOf = (perfRows: PerfTableRow[]): PerfTableRow[] =>
     perfRows.filter((perfRow) => perfRow.op_type !== OpType.SIGNPOST);
 
+const alignCollapsedToPerfRows = (
+    deviceOperations: DeviceOperationMapping[],
+    perfRows: PerfTableRow[],
+    numDevices: number,
+): DeviceOperationMapping[] => {
+    if (numDevices <= 1) {
+        return [];
+    }
+
+    const collapsedOperations = collapseMultideviceOperations(deviceOperations, numDevices);
+
+    // A valid per-device list contributes every operation exactly once per
+    // device. A smaller subset can prefix-match and falsely mark a report linked.
+    if (collapsedOperations.length * numDevices !== deviceOperations.length) {
+        return [];
+    }
+
+    return alignToPerfRows(collapsedOperations, perfRows);
+};
+
 /**
  * @description Match a memory report's device operations against a performance
  * report's rows, returning the mappings when the two sequences describe the same
@@ -104,13 +124,7 @@ export const matchDeviceOperationsToPerf = (
         return directMatch;
     }
 
-    // With nothing to collapse on, the fallback would repeat the pass that just
-    // failed.
-    if (numDevices <= 1) {
-        return [];
-    }
-
-    return alignToPerfRows(collapseMultideviceOperations(deviceOperations, numDevices), alignableRows);
+    return alignCollapsedToPerfRows(deviceOperations, alignableRows, numDevices);
 };
 
 const hasSameDeviceOperations = (
@@ -143,9 +157,13 @@ const hasSameDeviceOperations = (
 };
 
 /**
- * @description Try the captured graph's parent-first function-start order,
- * then its child-first function-end order when both contain the same device
- * operations. Each order retains the raw-then-multidevice-collapse fallback.
+ * TODO: remove once memory and performance reports carry a shared run id (#1800)
+ * @description Match nested device operations whose profiler events can be
+ * child-first because a child's workload is enqueued before its parent's. Start
+ * order remains preferred for reports whose profiler rows are parent-first;
+ * end order is the fallback when the same operations are child-first. Raw orders
+ * are tried before either multi-device collapse so a spurious collapsed prefix
+ * cannot suppress the complete end-order match. See #1860.
  */
 export const matchDeviceOperationOrdersToPerf = (
     functionStartOperations: DeviceOperationMapping[],
@@ -153,7 +171,8 @@ export const matchDeviceOperationOrdersToPerf = (
     perfRows: PerfTableRow[],
     numDevices: number,
 ): DeviceOperationMapping[] => {
-    const functionStartMatch = matchDeviceOperationsToPerf(functionStartOperations, perfRows, numDevices);
+    const alignableRows = alignableRowsOf(perfRows);
+    const functionStartMatch = alignToPerfRows(functionStartOperations, alignableRows);
 
     if (functionStartMatch.length > 0) {
         return functionStartMatch;
@@ -165,5 +184,17 @@ export const matchDeviceOperationOrdersToPerf = (
         return [];
     }
 
-    return matchDeviceOperationsToPerf(functionEndOperations, perfRows, numDevices);
+    const functionEndMatch = alignToPerfRows(functionEndOperations, alignableRows);
+
+    if (functionEndMatch.length > 0) {
+        return functionEndMatch;
+    }
+
+    const collapsedFunctionStartMatch = alignCollapsedToPerfRows(functionStartOperations, alignableRows, numDevices);
+
+    if (collapsedFunctionStartMatch.length > 0) {
+        return collapsedFunctionStartMatch;
+    }
+
+    return alignCollapsedToPerfRows(functionEndOperations, alignableRows, numDevices);
 };

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -854,16 +854,16 @@ export const useGetDeviceOperationsListByOp = () => {
     }, [operations]);
 };
 
-// Memoised across call sites, not per hook invocation: both derived values are
-// read by a handful of hooks and by one component instance per virtualised row,
-// and `useMemo` would run the flatMap and the O(rows) match once for each. The
-// inputs are React Query results, so their identity is shared by every caller in
-// a render pass. Callers must not mutate the results — they share them now.
 interface DeviceOperationOrderCandidates {
     functionStartOperations: DeviceOperationMapping[];
     functionEndOperations: DeviceOperationMapping[];
 }
 
+// Memoised across call sites, not per hook invocation:
+// `useGetDeviceOperationListPerf` is read by several hooks and by one component
+// instance per virtualised row, so `useMemo` would rebuild both order candidates
+// and rerun the O(rows) match for each. The inputs are shared React Query results.
+// Callers must not mutate the derived values — they share them now.
 const getDeviceOperationOrderCandidates = memoiseLatest(
     (operations?: OperationDescription[]): DeviceOperationOrderCandidates => {
         const functionStartOperations: DeviceOperationMapping[] = [];
@@ -930,17 +930,6 @@ export const clearReportCaches = (queryClient: QueryClient) => {
     getDeviceOperationListPerf.reset();
     getOpToPerfIds.reset();
     getDeviceOperationListPerfByOpId.reset();
-};
-
-/**
- * @description Every device operation in the memory report, flattened in report
- * order. Multi-device collapsing happens at match time, not here, because only
- * the performance report reveals which shape this report has (#1810).
- */
-export const useGetDeviceOperationsList = (): DeviceOperationMapping[] => {
-    const { data: operations } = useOperationsList();
-
-    return getDeviceOperationOrderCandidates(operations).functionStartOperations;
 };
 
 export const useGetDeviceOperationListPerf = () => {

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -30,7 +30,7 @@ import parseMemoryConfig, { memoryConfigPattern } from '../functions/parseMemory
 import { MemoryConfig } from '../model/MemoryConfig';
 import getServerConfig from '../functions/getServerConfig';
 import { PerfTableRow } from '../model/PerfTable';
-import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
+import { DeviceOperationMapping, DeviceOperationOrderCandidates } from '../model/DeviceOperationMapping';
 import { matchDeviceOperationOrdersToPerf } from '../functions/deviceOperationMatching';
 import memoiseLatest from '../functions/memoiseLatest';
 import {
@@ -854,11 +854,6 @@ export const useGetDeviceOperationsListByOp = () => {
     }, [operations]);
 };
 
-interface DeviceOperationOrderCandidates {
-    functionStartOperations: DeviceOperationMapping[];
-    functionEndOperations: DeviceOperationMapping[];
-}
-
 // Memoised across call sites, not per hook invocation:
 // `useGetDeviceOperationListPerf` is read by several hooks and by one component
 // instance per virtualised row, so `useMemo` would rebuild both order candidates
@@ -934,13 +929,12 @@ export const clearReportCaches = (queryClient: QueryClient) => {
 
 export const useGetDeviceOperationListPerf = () => {
     const { data: operations } = useOperationsList();
-    const { functionStartOperations, functionEndOperations } = getDeviceOperationOrderCandidates(operations);
+    const deviceOperationOrderCandidates = getDeviceOperationOrderCandidates(operations);
     const { data: devices } = useDevices();
     const { data } = useLinkedPerformanceReport();
 
     return getDeviceOperationListPerf(
-        functionStartOperations,
-        functionEndOperations,
+        deviceOperationOrderCandidates,
         (data ?? EMPTY_PERF_RETURN).report,
         devices?.length ?? 0,
     );

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -31,7 +31,7 @@ import { MemoryConfig } from '../model/MemoryConfig';
 import getServerConfig from '../functions/getServerConfig';
 import { PerfTableRow } from '../model/PerfTable';
 import { DeviceOperationMapping } from '../model/DeviceOperationMapping';
-import { matchDeviceOperationsToPerf } from '../functions/deviceOperationMatching';
+import { matchDeviceOperationOrdersToPerf } from '../functions/deviceOperationMatching';
 import memoiseLatest from '../functions/memoiseLatest';
 import {
     PerformanceReportParams,
@@ -184,21 +184,22 @@ const fetchOperationDetails = async (id: number | null): Promise<OperationDetail
     };
 };
 
+type DeviceOperationNodeType = NodeType.function_start | NodeType.function_end;
+
+const getDeviceOperationNameList = (operation: OperationDescription, nodeType: DeviceOperationNodeType): string[] => {
+    if (!Array.isArray(operation.device_operations)) {
+        return [];
+    }
+
+    return operation.device_operations
+        .filter((op) => op.node_type === nodeType && isDeviceOperation(op.params.name))
+        .map((op) => (op.params as DeviceOperationParams).name);
+};
+
 const fetchOperations = async (): Promise<OperationDescription[]> => {
     const tensorList: Map<number, Tensor> = new Map<number, Tensor>();
     const response = await axiosInstance.get<OperationDescription[]>(Endpoints.OPERATIONS_LIST);
     const operationList = response.data;
-
-    const getDeviceOperationNameList = (operation: OperationDescription) => {
-        if (!Array.isArray(operation.device_operations)) {
-            return [];
-        }
-        return operation.device_operations
-            .filter((op) => {
-                return op.node_type === NodeType.function_start && isDeviceOperation(op.params.name);
-            })
-            .map((op) => (op.params as DeviceOperationParams).name);
-    };
 
     return operationList.map((operation: OperationDescription) => {
         updateDeviceOperationId(operation.device_operations);
@@ -241,7 +242,7 @@ const fetchOperations = async (): Promise<OperationDescription[]> => {
             outputs,
             inputs,
             arguments: argumentsWithParsedValues,
-            deviceOperationNameList: getDeviceOperationNameList(operation),
+            deviceOperationNameList: getDeviceOperationNameList(operation, NodeType.function_start),
             processedConnections: processInputsOutputs(operation.device_operations),
         } as OperationDescription;
     });
@@ -858,21 +859,43 @@ export const useGetDeviceOperationsListByOp = () => {
 // and `useMemo` would run the flatMap and the O(rows) match once for each. The
 // inputs are React Query results, so their identity is shared by every caller in
 // a render pass. Callers must not mutate the results — they share them now.
-const getDeviceOperationsList = memoiseLatest((operations?: OperationDescription[]): DeviceOperationMapping[] => {
-    if (!operations) {
-        return [];
-    }
+interface DeviceOperationOrderCandidates {
+    functionStartOperations: DeviceOperationMapping[];
+    functionEndOperations: DeviceOperationMapping[];
+}
 
-    return operations.flatMap((operation) =>
-        operation.deviceOperationNameList.map((name) => ({
-            name,
-            id: operation.id,
-            operationName: operation.name,
-        })),
-    );
-});
+const getDeviceOperationOrderCandidates = memoiseLatest(
+    (operations?: OperationDescription[]): DeviceOperationOrderCandidates => {
+        const functionStartOperations: DeviceOperationMapping[] = [];
+        const functionEndOperations: DeviceOperationMapping[] = [];
 
-const getDeviceOperationListPerf = memoiseLatest(matchDeviceOperationsToPerf);
+        if (!operations) {
+            return { functionStartOperations, functionEndOperations };
+        }
+
+        for (const operation of operations) {
+            for (const name of operation.deviceOperationNameList) {
+                functionStartOperations.push({
+                    name,
+                    id: operation.id,
+                    operationName: operation.name,
+                });
+            }
+
+            for (const name of getDeviceOperationNameList(operation, NodeType.function_end)) {
+                functionEndOperations.push({
+                    name,
+                    id: operation.id,
+                    operationName: operation.name,
+                });
+            }
+        }
+
+        return { functionStartOperations, functionEndOperations };
+    },
+);
+
+const getDeviceOperationListPerf = memoiseLatest(matchDeviceOperationOrdersToPerf);
 
 const getOpToPerfIds = memoiseLatest((matched: DeviceOperationMapping[]) =>
     matched.map(({ id, perfData }) => ({ opId: id, perfId: perfData?.id })),
@@ -903,7 +926,7 @@ const getDeviceOperationListPerfByOpId = memoiseLatest((matched: DeviceOperation
  */
 export const clearReportCaches = (queryClient: QueryClient) => {
     queryClient.clear();
-    getDeviceOperationsList.reset();
+    getDeviceOperationOrderCandidates.reset();
     getDeviceOperationListPerf.reset();
     getOpToPerfIds.reset();
     getDeviceOperationListPerfByOpId.reset();
@@ -917,15 +940,21 @@ export const clearReportCaches = (queryClient: QueryClient) => {
 export const useGetDeviceOperationsList = (): DeviceOperationMapping[] => {
     const { data: operations } = useOperationsList();
 
-    return getDeviceOperationsList(operations);
+    return getDeviceOperationOrderCandidates(operations).functionStartOperations;
 };
 
 export const useGetDeviceOperationListPerf = () => {
-    const deviceOperations = useGetDeviceOperationsList();
+    const { data: operations } = useOperationsList();
+    const { functionStartOperations, functionEndOperations } = getDeviceOperationOrderCandidates(operations);
     const { data: devices } = useDevices();
     const { data } = useLinkedPerformanceReport();
 
-    return getDeviceOperationListPerf(deviceOperations, (data ?? EMPTY_PERF_RETURN).report, devices?.length ?? 0);
+    return getDeviceOperationListPerf(
+        functionStartOperations,
+        functionEndOperations,
+        (data ?? EMPTY_PERF_RETURN).report,
+        devices?.length ?? 0,
+    );
 };
 
 /**

--- a/src/model/DeviceOperationMapping.ts
+++ b/src/model/DeviceOperationMapping.ts
@@ -14,3 +14,8 @@ export interface DeviceOperationMapping {
     operationName: string;
     perfData?: PerfTableRow;
 }
+
+export interface DeviceOperationOrderCandidates {
+    functionStartOperations: DeviceOperationMapping[];
+    functionEndOperations: DeviceOperationMapping[];
+}

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -3,7 +3,11 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { describe, expect, it } from 'vitest';
-import { collapseMultideviceOperations, matchDeviceOperationsToPerf } from '../src/functions/deviceOperationMatching';
+import {
+    collapseMultideviceOperations,
+    matchDeviceOperationOrdersToPerf,
+    matchDeviceOperationsToPerf,
+} from '../src/functions/deviceOperationMatching';
 import { PerfTableRow } from '../src/model/PerfTable';
 import { DeviceOperationMapping } from '../src/model/DeviceOperationMapping';
 import { OpType } from '../src/definitions/Performance';
@@ -189,6 +193,64 @@ describe('matchDeviceOperationsToPerf', () => {
 
         expect(matched).toEqual([]);
         expect(deviceOperations.every(({ perfData }) => perfData === undefined)).toBe(true);
+    });
+});
+
+describe('matchDeviceOperationOrdersToPerf', () => {
+    it('falls back to function-end order for nested device operations (#1860)', () => {
+        const functionStartOperations = [
+            mapping('SparseMatmulDeviceOperation', 59),
+            mapping('UnaryDeviceOperation', 59),
+        ];
+        const functionEndOperations = [mapping('UnaryDeviceOperation', 59), mapping('SparseMatmulDeviceOperation', 59)];
+        const perfRows = perfRowsFor(['UnaryDeviceOperation', 'SparseMatmulDeviceOperation']);
+
+        const matched = matchDeviceOperationOrdersToPerf(functionStartOperations, functionEndOperations, perfRows, 1);
+
+        expect(matched.map(({ name }) => name)).toEqual(['UnaryDeviceOperation', 'SparseMatmulDeviceOperation']);
+        expect(matched.map(({ perfData }) => perfData?.id)).toEqual(['0', '1']);
+        expect(functionStartOperations.every(({ perfData }) => perfData === undefined)).toBe(true);
+        expect(functionEndOperations.every(({ perfData }) => perfData === undefined)).toBe(true);
+        expect(matched[0]).not.toBe(functionEndOperations[0]);
+    });
+
+    it('prefers function-start order when both candidates align', () => {
+        const functionStartOperations = [mapping('Alpha', 10), mapping('Alpha', 20)];
+        const functionEndOperations = [mapping('Alpha', 20), mapping('Alpha', 10)];
+
+        const matched = matchDeviceOperationOrdersToPerf(
+            functionStartOperations,
+            functionEndOperations,
+            perfRowsFor(['Alpha', 'Alpha']),
+            1,
+        );
+
+        expect(matched.map(({ id }) => id)).toEqual([10, 20]);
+    });
+
+    it.each([
+        {
+            label: 'is incomplete',
+            functionStartOperations: [mapping('Outer', 1), mapping('Inner', 1)],
+            functionEndOperations: [mapping('Inner', 1)],
+            perfRows: perfRowsFor(['Inner', 'Outer']),
+        },
+        {
+            label: 'contains a different operation',
+            functionStartOperations: [mapping('Outer', 1), mapping('Inner', 1)],
+            functionEndOperations: [mapping('Inner', 1), mapping('Different', 1)],
+            perfRows: perfRowsFor(['Inner', 'Different']),
+        },
+        {
+            label: 'has different duplicate counts',
+            functionStartOperations: [mapping('Alpha', 1), mapping('Alpha', 1), mapping('Beta', 1)],
+            functionEndOperations: [mapping('Alpha', 1), mapping('Beta', 1), mapping('Beta', 1)],
+            perfRows: perfRowsFor(['Alpha', 'Beta', 'Beta']),
+        },
+    ])('rejects function-end order when it $label', ({ functionStartOperations, functionEndOperations, perfRows }) => {
+        expect(matchDeviceOperationOrdersToPerf(functionStartOperations, functionEndOperations, perfRows, 1)).toEqual(
+            [],
+        );
     });
 });
 

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -34,6 +34,11 @@ const signpostRow = (label: string, id: number): PerfTableRow => perfRow(label, 
 const duplicatedPerDevice = (names: string[], numDevices: number): DeviceOperationMapping[] =>
     names.flatMap((name, index) => Array.from({ length: numDevices }, () => mapping(name, index + 1)));
 
+const orderCandidates = (
+    functionStartOperations: DeviceOperationMapping[],
+    functionEndOperations: DeviceOperationMapping[],
+) => ({ functionStartOperations, functionEndOperations });
+
 describe('matchDeviceOperationsToPerf', () => {
     it('matches a multi-device report that records each device op once (#1810)', () => {
         // Shape of resnet50_jul28_1524: two devices, one entry per device op, and
@@ -205,7 +210,11 @@ describe('matchDeviceOperationOrdersToPerf', () => {
         const functionEndOperations = [mapping('UnaryDeviceOperation', 59), mapping('SparseMatmulDeviceOperation', 59)];
         const perfRows = perfRowsFor(['UnaryDeviceOperation', 'SparseMatmulDeviceOperation']);
 
-        const matched = matchDeviceOperationOrdersToPerf(functionStartOperations, functionEndOperations, perfRows, 1);
+        const matched = matchDeviceOperationOrdersToPerf(
+            orderCandidates(functionStartOperations, functionEndOperations),
+            perfRows,
+            1,
+        );
 
         expect(matched.map(({ name }) => name)).toEqual(['UnaryDeviceOperation', 'SparseMatmulDeviceOperation']);
         expect(matched.map(({ perfData }) => perfData?.id)).toEqual(['0', '1']);
@@ -231,7 +240,11 @@ describe('matchDeviceOperationOrdersToPerf', () => {
         ];
         const perfRows = perfRowsFor(['Pad', 'Pad', 'Matmul', 'Inner', 'Outer']);
 
-        const matched = matchDeviceOperationOrdersToPerf(functionStartOperations, functionEndOperations, perfRows, 2);
+        const matched = matchDeviceOperationOrdersToPerf(
+            orderCandidates(functionStartOperations, functionEndOperations),
+            perfRows,
+            2,
+        );
 
         expect(matched.map(({ name }) => name)).toEqual(['Pad', 'Pad', 'Matmul', 'Inner', 'Outer']);
     });
@@ -251,8 +264,7 @@ describe('matchDeviceOperationOrdersToPerf', () => {
         ];
 
         const matched = matchDeviceOperationOrdersToPerf(
-            functionStartOperations,
-            functionEndOperations,
+            orderCandidates(functionStartOperations, functionEndOperations),
             perfRowsFor(['Inner', 'Outer']),
             2,
         );
@@ -277,8 +289,7 @@ describe('matchDeviceOperationOrdersToPerf', () => {
         ];
 
         const matched = matchDeviceOperationOrdersToPerf(
-            functionStartOperations,
-            functionEndOperations,
+            orderCandidates(functionStartOperations, functionEndOperations),
             perfRowsFor(['Inner', 'Outer', 'Matmul']),
             2,
         );
@@ -291,8 +302,7 @@ describe('matchDeviceOperationOrdersToPerf', () => {
         const functionEndOperations = [mapping('Alpha', 20), mapping('Alpha', 10)];
 
         const matched = matchDeviceOperationOrdersToPerf(
-            functionStartOperations,
-            functionEndOperations,
+            orderCandidates(functionStartOperations, functionEndOperations),
             perfRowsFor(['Alpha', 'Alpha']),
             1,
         );
@@ -320,9 +330,13 @@ describe('matchDeviceOperationOrdersToPerf', () => {
             perfRows: perfRowsFor(['Alpha', 'Beta', 'Beta']),
         },
     ])('rejects function-end order when it $label', ({ functionStartOperations, functionEndOperations, perfRows }) => {
-        expect(matchDeviceOperationOrdersToPerf(functionStartOperations, functionEndOperations, perfRows, 1)).toEqual(
-            [],
-        );
+        expect(
+            matchDeviceOperationOrdersToPerf(
+                orderCandidates(functionStartOperations, functionEndOperations),
+                perfRows,
+                1,
+            ),
+        ).toEqual([]);
     });
 });
 

--- a/tests/deviceOperationMatching.spec.ts
+++ b/tests/deviceOperationMatching.spec.ts
@@ -214,6 +214,78 @@ describe('matchDeviceOperationOrdersToPerf', () => {
         expect(matched[0]).not.toBe(functionEndOperations[0]);
     });
 
+    it('tries complete function-end order before a spurious collapsed start prefix', () => {
+        const functionStartOperations = [
+            mapping('Pad', 1),
+            mapping('Pad', 1),
+            mapping('Matmul', 2),
+            mapping('Outer', 3),
+            mapping('Inner', 3),
+        ];
+        const functionEndOperations = [
+            mapping('Pad', 1),
+            mapping('Pad', 1),
+            mapping('Matmul', 2),
+            mapping('Inner', 3),
+            mapping('Outer', 3),
+        ];
+        const perfRows = perfRowsFor(['Pad', 'Pad', 'Matmul', 'Inner', 'Outer']);
+
+        const matched = matchDeviceOperationOrdersToPerf(functionStartOperations, functionEndOperations, perfRows, 2);
+
+        expect(matched.map(({ name }) => name)).toEqual(['Pad', 'Pad', 'Matmul', 'Inner', 'Outer']);
+    });
+
+    it('matches a per-device duplicated nested sequence on the collapsed end-order pass', () => {
+        const functionStartOperations = [
+            mapping('Outer', 1),
+            mapping('Outer', 1),
+            mapping('Inner', 1),
+            mapping('Inner', 1),
+        ];
+        const functionEndOperations = [
+            mapping('Inner', 1),
+            mapping('Inner', 1),
+            mapping('Outer', 1),
+            mapping('Outer', 1),
+        ];
+
+        const matched = matchDeviceOperationOrdersToPerf(
+            functionStartOperations,
+            functionEndOperations,
+            perfRowsFor(['Inner', 'Outer']),
+            2,
+        );
+
+        expect(matched.map(({ name }) => name)).toEqual(['Inner', 'Outer']);
+    });
+
+    it('rejects a collapsed end-order prefix that omits non-duplicated operations', () => {
+        const functionStartOperations = [
+            mapping('Outer', 1),
+            mapping('Inner', 1),
+            mapping('Outer', 1),
+            mapping('Inner', 1),
+            mapping('Matmul', 2),
+        ];
+        const functionEndOperations = [
+            mapping('Inner', 1),
+            mapping('Outer', 1),
+            mapping('Inner', 1),
+            mapping('Outer', 1),
+            mapping('Matmul', 2),
+        ];
+
+        const matched = matchDeviceOperationOrdersToPerf(
+            functionStartOperations,
+            functionEndOperations,
+            perfRowsFor(['Inner', 'Outer', 'Matmul']),
+            2,
+        );
+
+        expect(matched).toEqual([]);
+    });
+
     it('prefers function-start order when both candidates align', () => {
         const functionStartOperations = [mapping('Alpha', 10), mapping('Alpha', 20)];
         const functionEndOperations = [mapping('Alpha', 20), mapping('Alpha', 10)];

--- a/tests/useLinkedPerformanceReport.spec.tsx
+++ b/tests/useLinkedPerformanceReport.spec.tsx
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     useGetDeviceOperationListPerf,
     useGetDeviceOperationListPerfByOpId,
+    useGetDeviceOperationsList,
     useLinkedPerformanceReport,
     usePerformanceReport,
 } from '../src/hooks/useAPI';
@@ -257,6 +258,24 @@ const memoryOperations = DEVICE_OP_NAMES.map((name, index) => ({
     device_operations: [{ node_type: 'function_start', params: { name } }],
 }));
 
+const NESTED_DEVICE_OP_NAMES = ['SparseMatmulDeviceOperation', 'UnaryDeviceOperation'];
+const nestedMemoryOperations = [
+    {
+        id: 59,
+        name: 'ttnn.sparse_matmul',
+        stack_trace: '',
+        inputs: [],
+        outputs: [],
+        arguments: [],
+        device_operations: [
+            { node_type: 'function_start', params: { name: NESTED_DEVICE_OP_NAMES[0] } },
+            { node_type: 'function_start', params: { name: NESTED_DEVICE_OP_NAMES[1] } },
+            { node_type: 'function_end', params: { name: NESTED_DEVICE_OP_NAMES[1] } },
+            { node_type: 'function_end', params: { name: NESTED_DEVICE_OP_NAMES[0] } },
+        ],
+    },
+];
+
 describe('report matching under a filtered performance tab', () => {
     beforeEach(() => {
         // The endpoint really does return roughly one row per device when merging
@@ -319,6 +338,43 @@ describe('report matching under a filtered performance tab', () => {
 
         expect(result.current.get(1)?.map((operation) => operation.perfData?.raw_op_code)).toEqual(['Matmul']);
         expect(result.current.get(2)?.map((operation) => operation.perfData?.raw_op_code)).toEqual(['Softmax']);
+    });
+
+    it('links nested operations in function-end order while preserving the public start-order list (#1860)', async () => {
+        const functionEndNames = [...NESTED_DEVICE_OP_NAMES].reverse();
+
+        vi.mocked(axiosInstance.get).mockImplementation((url: string) => {
+            if (url.includes(Endpoints.PERFORMANCE_RESULTS_REPORT)) {
+                return Promise.resolve({
+                    data: {
+                        report: functionEndNames.map((name, index) => perfRow(index, name)),
+                        stacked_report: [],
+                        signposts: [],
+                    },
+                });
+            }
+
+            if (url.includes(Endpoints.OPERATIONS_LIST)) {
+                return Promise.resolve({ data: [...nestedMemoryOperations] });
+            }
+
+            if (url.includes(Endpoints.DEVICES)) {
+                return Promise.resolve({ data: [{ device_id: 0 }] });
+            }
+
+            return Promise.resolve({ data: [] });
+        });
+
+        const { result } = renderWithView(
+            () => [useGetDeviceOperationsList(), useGetDeviceOperationListPerf()] as const,
+            [[activeProfilerReportAtom, ACTIVE_REPORT]],
+        );
+
+        await waitFor(() => expect(result.current[1]).toHaveLength(NESTED_DEVICE_OP_NAMES.length));
+
+        expect(result.current[0].map(({ name }) => name)).toEqual(NESTED_DEVICE_OP_NAMES);
+        expect(result.current[1].map(({ name }) => name)).toEqual(functionEndNames);
+        expect(result.current[1].map(({ perfData }) => perfData?.raw_op_code)).toEqual(functionEndNames);
     });
 
     // The match is memoised across call sites rather than per invocation, and

--- a/tests/useLinkedPerformanceReport.spec.tsx
+++ b/tests/useLinkedPerformanceReport.spec.tsx
@@ -17,7 +17,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     useGetDeviceOperationListPerf,
     useGetDeviceOperationListPerfByOpId,
-    useGetDeviceOperationsList,
     useLinkedPerformanceReport,
     usePerformanceReport,
 } from '../src/hooks/useAPI';
@@ -340,7 +339,7 @@ describe('report matching under a filtered performance tab', () => {
         expect(result.current.get(2)?.map((operation) => operation.perfData?.raw_op_code)).toEqual(['Softmax']);
     });
 
-    it('links nested operations in function-end order while preserving the public start-order list (#1860)', async () => {
+    it('links nested operations in function-end order (#1860)', async () => {
         const functionEndNames = [...NESTED_DEVICE_OP_NAMES].reverse();
 
         vi.mocked(axiosInstance.get).mockImplementation((url: string) => {
@@ -366,15 +365,14 @@ describe('report matching under a filtered performance tab', () => {
         });
 
         const { result } = renderWithView(
-            () => [useGetDeviceOperationsList(), useGetDeviceOperationListPerf()] as const,
+            () => useGetDeviceOperationListPerf(),
             [[activeProfilerReportAtom, ACTIVE_REPORT]],
         );
 
-        await waitFor(() => expect(result.current[1]).toHaveLength(NESTED_DEVICE_OP_NAMES.length));
+        await waitFor(() => expect(result.current).toHaveLength(NESTED_DEVICE_OP_NAMES.length));
 
-        expect(result.current[0].map(({ name }) => name)).toEqual(NESTED_DEVICE_OP_NAMES);
-        expect(result.current[1].map(({ name }) => name)).toEqual(functionEndNames);
-        expect(result.current[1].map(({ perfData }) => perfData?.raw_op_code)).toEqual(functionEndNames);
+        expect(result.current.map(({ name }) => name)).toEqual(functionEndNames);
+        expect(result.current.map(({ perfData }) => perfData?.raw_op_code)).toEqual(functionEndNames);
     });
 
     // The match is memoised across call sites rather than per invocation, and


### PR DESCRIPTION
This pull request refactors the logic for matching device operations to performance data, improving support for nested and reordered device operations. It introduces a new matching strategy that first tries to match using the "function start" order and, if that fails but both orders contain the same operations, falls back to the "function end" order. The update also enhances test coverage for these scenarios and adapts the hooks and memoization to support the new matching logic.

**Device Operation Matching Enhancements:**

* Added `matchDeviceOperationOrdersToPerf` to prefer matching device operations in "function start" order, with a fallback to "function end" order when both contain the same operations. This improves alignment for nested or reordered operations.
* Updated hooks and memoization (`useGetDeviceOperationListPerf`, `getDeviceOperationOrderCandidates`, etc.) to use the new matching function and support both operation orders. [[1]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L34-R34) [[2]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L861-R898) [[3]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L906-R929) [[4]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L920-R957)

**API and Data Handling Updates:**

* Refactored how device operation names are extracted, now parameterized by node type (function start or end), and updated data flow in `fetchOperations` and related code. [[1]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L187-R203) [[2]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L244-R245)

**Testing Improvements:**

* Added comprehensive tests for the new matching logic, including fallback behavior, preference for start order, and rejection of mismatched cases.
* Extended integration tests to verify that nested operations are correctly matched and linked in both orders, ensuring public APIs remain consistent. [[1]](diffhunk://#diff-187f5177dcfca23ad809d6d54c3bcdde3d8d3fd871a2046aa574a94a949894f1R261-R278) [[2]](diffhunk://#diff-187f5177dcfca23ad809d6d54c3bcdde3d8d3fd871a2046aa574a94a949894f1R343-R379)

**Code Maintenance:**

* Updated imports and cache clearing to reflect the new function and memoization structure. [[1]](diffhunk://#diff-ddfd37f198b2396809dd223191aea15d18d1967abd65138c898cfc80556d0806L6-R10) [[2]](diffhunk://#diff-187f5177dcfca23ad809d6d54c3bcdde3d8d3fd871a2046aa574a94a949894f1R20) [[3]](diffhunk://#diff-28aac87d93df3e1b341a768b2c4850fe92744b5954a9afb7ef5962a6107ac604L906-R929)

These changes improve the robustness and flexibility of device operation to performance row matching, especially for complex nested cases.

Fixes https://github.com/tenstorrent/ttnn-visualizer/issues/1860.