### PR TITLE
Compare against the operation range's lower bound in the Graph view

### DIFF
--- a/src/components/OperationList.tsx
+++ b/src/components/OperationList.tsx
@@ -39,6 +39,7 @@ import OperationPerfRowBar from './OperationPerfRowBar';
 import SearchField from './SearchField';
 import SimpleMultiselect from './SimpleMultiselect';
 import { useOpPerfRowScores } from '../hooks/useOpPerfRowScores';
+import { filterByOperationRange } from '../functions/filterByOperationRange';
 
 const PLACEHOLDER_ARRAY_SIZE = 50;
 const OPERATION_EL_HEIGHT = 39; // Height in px of each list item
@@ -68,9 +69,7 @@ const OperationList = () => {
 
     const operationsWithRange = useMemo(() => {
         if (fetchedOperations && selectedOperationRange) {
-            return fetchedOperations.filter(
-                (op) => op.id >= selectedOperationRange[0] && op.id <= selectedOperationRange[1],
-            );
+            return filterByOperationRange(fetchedOperations, selectedOperationRange);
         }
 
         return fetchedOperations;

--- a/src/functions/filterByOperationRange.ts
+++ b/src/functions/filterByOperationRange.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { type NumberRange } from '@blueprintjs/core';
+
+/**
+ * Both bounds are inclusive, and both are compared — never tested for truthiness.
+ * An operation id of 0 is legitimate, so `range[0] && …` drops the whole list. #1999
+ */
+export const filterByOperationRange = <T extends { id: number }>(items: T[], range: NumberRange): T[] =>
+    items.filter((item) => item.id >= range[0] && item.id <= range[1]);

--- a/src/hooks/useAPI.tsx
+++ b/src/hooks/useAPI.tsx
@@ -44,6 +44,7 @@ import { buildL1PressureResult } from '../functions/l1Pressure';
 import { StackedPerfRow } from '../definitions/StackedPerfTable';
 import { isDeviceOperation } from '../functions/filterOperations';
 import { normalizeBufferPagesResponse } from '../functions/normalizeBufferPagesResponse';
+import { filterByOperationRange } from '../functions/filterByOperationRange';
 import {
     activeMlirJsonAtom,
     activeNpeOpTraceAtom,
@@ -1135,9 +1136,7 @@ export const useBuffers = (bufferType: BufferType | null, useRange?: boolean) =>
 
     return useMemo(() => {
         if (response.data && range && useRange) {
-            const filteredData = response.data.filter(
-                (operation) => operation.id >= range[0] && operation.id <= range[1],
-            );
+            const filteredData = filterByOperationRange(response.data, range);
 
             return {
                 ...response,

--- a/src/routes/GraphView.tsx
+++ b/src/routes/GraphView.tsx
@@ -10,6 +10,7 @@ import { useAtomValue } from 'jotai';
 import { useGetDeviceOperationListPerf, useLinkedPerformanceReport, useOperationsList } from '../hooks/useAPI';
 import OperationGraph from '../components/operation-graph/OperationGraphReactFlow';
 import LoadingSpinner from '../components/LoadingSpinner';
+import { filterByOperationRange } from '../functions/filterByOperationRange';
 import useClearSelectedBuffer from '../hooks/useClearSelectedBuffer';
 import { activePerformanceReportFolderNameAtom, selectedOperationRangeAtom } from '../store/app';
 import { PerfOverlaySource } from '../functions/perfOverlay';
@@ -35,10 +36,8 @@ const GraphView = () => {
 
     const filteredOperationList = useMemo(
         () =>
-            selectedOperationRange
-                ? operationList?.filter(
-                      (op) => op.id >= selectedOperationRange[0] && op.id <= selectedOperationRange[1],
-                  )
+            selectedOperationRange && operationList
+                ? filterByOperationRange(operationList, selectedOperationRange)
                 : operationList,
         [operationList, selectedOperationRange],
     );
@@ -81,7 +80,9 @@ const GraphView = () => {
         <div className='data-padding'>
             <Helmet title='GraphTree' />
 
-            {isLoading || filteredOperationList === undefined || filteredOperationList.length === 0 ? (
+            {/* An empty list is a range that selected nothing, not a pending fetch: reading
+                it as loading left a spinner that never resolved. #1999 */}
+            {isLoading || filteredOperationList === undefined ? (
                 <div className='graph-tree-loader'>
                     <LoadingSpinner />
                 </div>

--- a/src/routes/GraphView.tsx
+++ b/src/routes/GraphView.tsx
@@ -36,7 +36,9 @@ const GraphView = () => {
     const filteredOperationList = useMemo(
         () =>
             selectedOperationRange
-                ? operationList?.filter((op) => selectedOperationRange[0] && op.id <= selectedOperationRange[1])
+                ? operationList?.filter(
+                      (op) => op.id >= selectedOperationRange[0] && op.id <= selectedOperationRange[1],
+                  )
                 : operationList,
         [operationList, selectedOperationRange],
     );

--- a/tests/GraphViewOperationRange.spec.tsx
+++ b/tests/GraphViewOperationRange.spec.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { Provider, createStore } from 'jotai';
+import type { NumberRange } from '@blueprintjs/core';
+
+import type { OperationDescription } from '../src/model/APIData';
+
+// The range filter is route-level and never reaches the DOM, so the graph is stubbed
+// to record the list the route actually handed it.
+const { mockUseOperationsList, mockUseLinkedPerformanceReport, mockUseMatchedPerfOps, graphProps } = vi.hoisted(() => ({
+    mockUseOperationsList: vi.fn(),
+    mockUseLinkedPerformanceReport: vi.fn(),
+    mockUseMatchedPerfOps: vi.fn(),
+    graphProps: [] as { operationList: OperationDescription[] }[],
+}));
+
+vi.mock('react-helmet-async', () => ({ Helmet: () => null }));
+vi.mock('../src/hooks/useClearSelectedBuffer', () => ({ default: () => {} }));
+vi.mock('../src/hooks/useAPI', () => ({
+    useOperationsList: () => mockUseOperationsList(),
+    useLinkedPerformanceReport: () => mockUseLinkedPerformanceReport(),
+    useGetDeviceOperationListPerf: () => mockUseMatchedPerfOps(),
+}));
+vi.mock('../src/components/operation-graph/OperationGraphReactFlow', () => ({
+    default: (props: { operationList: OperationDescription[] }) => {
+        graphProps.push(props);
+        return <div data-testid='op-graph' />;
+    },
+}));
+
+/* eslint-disable import/first */
+import GraphView from '../src/routes/GraphView';
+import { selectedOperationRangeAtom } from '../src/store/app';
+/* eslint-enable import/first */
+
+const operationsFrom = (firstId: number, count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+        id: firstId + index,
+        name: 'ttnn.matmul',
+    })) as unknown as OperationDescription[];
+
+const renderRoute = (operations: OperationDescription[], range: NumberRange | null) => {
+    const store = createStore();
+    store.set(selectedOperationRangeAtom, range);
+    mockUseOperationsList.mockReturnValue({ data: operations, isLoading: false });
+    mockUseLinkedPerformanceReport.mockReturnValue({ data: undefined });
+    mockUseMatchedPerfOps.mockReturnValue([]);
+
+    render(
+        <Provider store={store}>
+            <MemoryRouter>
+                <GraphView />
+            </MemoryRouter>
+        </Provider>,
+    );
+
+    return graphProps[graphProps.length - 1];
+};
+
+afterEach(() => {
+    cleanup();
+    graphProps.length = 0;
+    vi.clearAllMocks();
+});
+
+describe('GraphView operation range', () => {
+    it('honours the lower bound as well as the upper one', () => {
+        // The start used to be read as a truthiness guard rather than compared against,
+        // so the left-hand handle of the Range control moved nothing. #1999
+        const graph = renderRoute(operationsFrom(1, 1000), [500, 600]);
+
+        expect(graph.operationList).toHaveLength(101);
+        expect(graph.operationList[0].id).toBe(500);
+        expect(graph.operationList[graph.operationList.length - 1].id).toBe(600);
+    });
+
+    it('renders a report whose operation ids start at 0', () => {
+        // A start of 0 made the old guard falsy for every op, so the list came back empty
+        // and the route read that as still-loading: a spinner that never resolved. #1999
+        const graph = renderRoute(operationsFrom(0, 1184), [0, 1183]);
+
+        expect(screen.getByTestId('op-graph')).toBeInTheDocument();
+        expect(graph.operationList).toHaveLength(1184);
+    });
+
+    it('passes the whole list through when no range is selected', () => {
+        const graph = renderRoute(operationsFrom(1, 10), null);
+
+        expect(graph.operationList).toHaveLength(10);
+    });
+});

--- a/tests/GraphViewOperationRange.spec.tsx
+++ b/tests/GraphViewOperationRange.spec.tsx
@@ -10,6 +10,8 @@ import { Provider, createStore } from 'jotai';
 import type { NumberRange } from '@blueprintjs/core';
 
 import type { OperationDescription } from '../src/model/APIData';
+import GraphView from '../src/routes/GraphView';
+import { selectedOperationRangeAtom } from '../src/store/app';
 
 // The range filter is route-level and never reaches the DOM, so the graph is stubbed
 // to record the list the route actually handed it.
@@ -33,11 +35,6 @@ vi.mock('../src/components/operation-graph/OperationGraphReactFlow', () => ({
         return <div data-testid='op-graph' />;
     },
 }));
-
-/* eslint-disable import/first */
-import GraphView from '../src/routes/GraphView';
-import { selectedOperationRangeAtom } from '../src/store/app';
-/* eslint-enable import/first */
 
 const operationsFrom = (firstId: number, count: number) =>
     Array.from({ length: count }, (_, index) => ({
@@ -63,6 +60,14 @@ const renderRoute = (operations: OperationDescription[], range: NumberRange | nu
     return graphProps[graphProps.length - 1];
 };
 
+// The graph is stubbed, so its absence means the route rendered the spinner instead —
+// which is the failure the zero-based case exists to catch. Say so, rather than
+// letting it surface as a property read on undefined.
+const expectGraphRendered = (graph: { operationList: OperationDescription[] } | undefined) => {
+    expect(graph).toBeDefined();
+    return graph!;
+};
+
 afterEach(() => {
     cleanup();
     graphProps.length = 0;
@@ -73,7 +78,7 @@ describe('GraphView operation range', () => {
     it('honours the lower bound as well as the upper one', () => {
         // The start used to be read as a truthiness guard rather than compared against,
         // so the left-hand handle of the Range control moved nothing. #1999
-        const graph = renderRoute(operationsFrom(1, 1000), [500, 600]);
+        const graph = expectGraphRendered(renderRoute(operationsFrom(1, 1000), [500, 600]));
 
         expect(graph.operationList).toHaveLength(101);
         expect(graph.operationList[0].id).toBe(500);
@@ -83,15 +88,23 @@ describe('GraphView operation range', () => {
     it('renders a report whose operation ids start at 0', () => {
         // A start of 0 made the old guard falsy for every op, so the list came back empty
         // and the route read that as still-loading: a spinner that never resolved. #1999
-        const graph = renderRoute(operationsFrom(0, 1184), [0, 1183]);
+        const graph = expectGraphRendered(renderRoute(operationsFrom(0, 1184), [0, 1183]));
 
         expect(screen.getByTestId('op-graph')).toBeInTheDocument();
         expect(graph.operationList).toHaveLength(1184);
     });
 
     it('passes the whole list through when no range is selected', () => {
-        const graph = renderRoute(operationsFrom(1, 10), null);
+        const graph = expectGraphRendered(renderRoute(operationsFrom(1, 10), null));
 
         expect(graph.operationList).toHaveLength(10);
+    });
+
+    it('renders an empty graph when the range selects nothing', () => {
+        // The footer's min input is unclamped, so a min above the max is reachable and
+        // selects no ops. That must read as an empty graph, not as a pending fetch. #1999
+        const graph = expectGraphRendered(renderRoute(operationsFrom(1, 100), [2000, 50]));
+
+        expect(graph.operationList).toHaveLength(0);
     });
 });


### PR DESCRIPTION
## Summary

The Graph view filtered the operation list on `selectedOperationRange[0] && op.id <= selectedOperationRange[1]`, using the range's *start* as a truthiness guard rather than comparing against it. The lower bound was therefore never applied, and a report whose operation ids start at `0` filtered to nothing and never rendered. `OperationList.tsx:72` spells the same filter with both comparisons, which is what identifies this as a dropped `op.id >=`. This was never a regression: `git log -L36,44:src/routes/GraphView.tsx` traces the predicate to `3153d506` (Feb 2025), so the lower bound has never been applied.

Closes #1999

### Frontend

- `src/functions/filterByOperationRange.ts` — new. The predicate, shared. It existed verbatim in three places and this bug was the copy that drifted, so a fourth should not be possible. `TensorList` keeps its own — it tests producer and consumer arrays, not an id.
- `src/routes/GraphView.tsx` — compares `op.id` against both ends, and no longer reads an empty list as a pending fetch.
- `src/components/OperationList.tsx`, `src/hooks/useAPI.tsx` — call the shared helper.
- `tests/GraphViewOperationRange.spec.tsx` — new. Pins both bounds, the 0-based case, an empty range, and the unfiltered pass-through.

## Behaviour

Two symptoms, one cause.

**The Range control's lower handle moved nothing in this view.** On `bge_m3` with the range set to `[500, 600]`:

| | ops kept | ids |
| --- | --- | --- |
| before | 600 | 1 – 600 |
| after | 101 | 500 – 600 |

Every report is affected. It stayed hidden because the *upper* bound was applied, so the graph does visibly narrow when the right-hand handle moves.

**A report with 0-based operation ids rendered nothing.** `selectedOperationRange[0]` is then `0`, the guard is falsy for every op, and the empty filtered list reads as still-loading — so the view sits on its spinner indefinitely with the operations already fetched (`/api/operations` returns 200 with every row). Reproduced against a 1184-op device-op-level capture with ids 0–1183, which now renders.

## The empty-list dead end

Comparing both bounds made a previously unreachable state reachable, so it is closed here rather than deferred. The footer's min input writes the range atom unclamped, so a min above the max selects no operations — and `GraphView` read an empty list as a pending fetch, giving a spinner that never resolved with the data already fetched. While the lower bound was ignored, that input could not produce it.

The list is now rendered whenever the fetch is done, so a range selecting nothing draws an empty graph. `OperationGraphReactFlow` only maps and iterates `operationList`, with no non-empty assumption.

## Known limitations (out of scope, tracked separately)

The range inputs are still unclamped, so `min > max` remains typable — honest now in every view, but worth clamping (`clampSelectionToRange` already does this for the perf side). Listed on #1999 with the remaining instances of the "an operation id of `0` is legitimate but falsy" hazard: `OperationDetailsComponent.tsx:107`, `RangeSlider.tsx:163`, `:289` and `:304`.

## Test plan

- [x] Frontend: `pnpm vitest run` — 2646 passing, 225 files
- [x] The two new range cases fail against the previous predicate and pass with it fixed
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean on touched files
- [x] Manual: load a capture whose operation ids start at 0, open Graph — renders, with repeat detection working; then drag the Range lower handle on a normal report and confirm the graph narrows from the left
- [x] Manual: type a min above the max in the footer — an empty graph, not a spinner (this reproduced the spinner before the empty-list change)

